### PR TITLE
Make items-buffer in vaadin-iron-list configurable

### DIFF
--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
@@ -124,6 +124,7 @@ public class IronList<T> extends Component implements HasDataProvider<T>,
         }
     };
 
+    private static final String ITEMS_BUFFER = "items-buffer";
     private final Element template;
     private Renderer<T> renderer;
     private String originalTemplate;
@@ -372,6 +373,35 @@ public class IronList<T> extends Component implements HasDataProvider<T>,
          * rendering
          */
         setRenderer(renderer);
+    }
+
+    /**
+     * Sets the number of items which are fetched as a buffer. The first fetch
+     * of the iron-list fetches per default minimum 3 items. Therefore the total
+     * number of items in the first fetch is minimum 3 + itemsBuffer.
+     *
+     * @param itemsBuffer
+     *            number of buffered items
+     */
+    public void setItemsBuffer(int itemsBuffer) {
+        if (itemsBuffer < 0) {
+            throw new IllegalArgumentException(
+              "Items buffer cannot be negative");
+        }
+        getElement().setAttribute(ITEMS_BUFFER, String.valueOf(itemsBuffer));
+    }
+
+    /**
+     * Returns the number of items, which are fetched as a buffer. If there is
+     * no custom value set, the default value of 20, defined in the connector is
+     * returned.
+     *
+     * @return number of buffered items
+     */
+    public int getItemsBuffer() {
+        return getElement().hasAttribute(ITEMS_BUFFER)
+          ? Integer.parseInt(getElement().getAttribute(ITEMS_BUFFER))
+          : 20;
     }
 
     @ClientCallable(DisabledUpdateMode.ALWAYS)

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/resources/META-INF/resources/frontend/ironListConnector.js
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/resources/META-INF/resources/frontend/ironListConnector.js
@@ -26,6 +26,16 @@ window.Vaadin.Flow.ironListConnector = {
       let firstNeededItem = list._virtualStart;
       let lastNeededItem = list._virtualEnd;
 
+      let extraItemsBuffer = 20;
+
+      if(list.hasAttribute('items-buffer')){
+        extraItemsBuffer = parseInt(list.getAttribute('items-buffer'));
+        if (extraItemsBuffer < 0) {
+          console.warn("Items buffer cannot be negative. 0 is used as default value.");
+          extraItemsBuffer = 0;
+        }
+      }
+
       let first = Math.max(0, firstNeededItem - extraItemsBuffer);
       let last = Math.min(lastNeededItem + extraItemsBuffer, list.items.length);
 

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/resources/META-INF/resources/frontend/ironListConnector.js
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/resources/META-INF/resources/frontend/ironListConnector.js
@@ -8,7 +8,15 @@ window.Vaadin.Flow.ironListConnector = {
       return;
     }
 
-    const extraItemsBuffer = 20;
+    let extraItemsBuffer = 20;
+
+    if(list.hasAttribute('items-buffer')){
+      extraItemsBuffer = parseInt(list.getAttribute('items-buffer'));
+      if (extraItemsBuffer < 0) {
+        console.warn("Items buffer cannot be negative. 0 is used as default value.");
+        extraItemsBuffer = 0;
+      }
+    }
 
     let lastRequestedRange = [0, 0];
 
@@ -25,16 +33,6 @@ window.Vaadin.Flow.ironListConnector = {
        */
       let firstNeededItem = list._virtualStart;
       let lastNeededItem = list._virtualEnd;
-
-      let extraItemsBuffer = 20;
-
-      if(list.hasAttribute('items-buffer')){
-        extraItemsBuffer = parseInt(list.getAttribute('items-buffer'));
-        if (extraItemsBuffer < 0) {
-          console.warn("Items buffer cannot be negative. 0 is used as default value.");
-          extraItemsBuffer = 0;
-        }
-      }
 
       let first = Math.max(0, firstNeededItem - extraItemsBuffer);
       let last = Math.min(lastNeededItem + extraItemsBuffer, list.items.length);


### PR DESCRIPTION
- Allows to configure the number of initially fetched items by the iron-list.

This is a continuation of the pull request: https://github.com/vaadin/vaadin-iron-list-flow/pull/116
I faced the same problem as stated in https://github.com/vaadin/vaadin-flow-components/issues/173 so we made a first implementation serving our needs.

