### PR TITLE
feat: allow setting the bean type after the Grid has been created

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3421,15 +3421,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
-     * Sets the bean type this grid is bound to and optionally adds a set of columns for each of the bean's
-     * properties. 
+     * Sets the bean type this grid is bound to and optionally adds a set of
+     * columns for each of the bean's properties.
      * 
-     * The property-values of the bean will be converted to Strings.
-     * Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}. The
-     * generated columns will be sortable by default, if the property is
-     * {@link Comparable}.
+     * The property-values of the bean will be converted to Strings. Full names
+     * of the properties will be used as the {@link Column#setKey(String) column
+     * keys} and the property captions will be used as the
+     * {@link Column#setHeader(String) column headers}. The generated columns
+     * will be sortable by default, if the property is {@link Comparable}.
      * <p>
      * When autoCreateColumns is <code>true</code>, only the direct properties
      * of the bean are included and they will be in alphabetical order. Use
@@ -3438,22 +3437,27 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * with {@link #addColumn(String)}. Both of these methods support also
      * sub-properties with dot-notation, eg.
      * <code>"property.nestedProperty"</code>.
-     *<p>
-     This method can only be called for a newly instanced Grid without any beanType or columns set.
+     * <p>
+     * This method can only be called for a newly instanced Grid without any
+     * beanType or columns set.
+     * 
      * @param beanType
      *            the bean type to use, not <code>null</code>
      * @param autoCreateColumns
      *            when <code>true</code>, columns are created automatically for
      *            the properties of the beanType
      */
-    public void configureBeanType(Class<T> beanType, boolean autoCreateColumns) {
+    public void configureBeanType(Class<T> beanType,
+            boolean autoCreateColumns) {
         Objects.requireNonNull(beanType, "Bean type can't be null");
-        
+
         if (this.beanType != null) {
-            throw new IllegalStateException("configureBeanType can only be called for a Grid without a beanType set");
+            throw new IllegalStateException(
+                    "configureBeanType can only be called for a Grid without a beanType set");
         }
         if (!this.getColumns().isEmpty()) {
-            throw new IllegalStateException("configureBeanType can only be called for a Grid without any columns");
+            throw new IllegalStateException(
+                    "configureBeanType can only be called for a Grid without any columns");
         }
         this.beanType = beanType;
         propertySet = BeanPropertySet.get(beanType);
@@ -3466,6 +3470,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
     }
+
     /**
      * Returns the Class of bean this Grid is constructed with via
      * {@link #Grid(Class)}. Or null if not constructed from a bean type.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1248,7 +1248,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public Grid(Class<T> beanType, boolean autoCreateColumns) {
         this();
-        setBeanType(beanType, autoCreateColumns);
+        configureBeanType(beanType, autoCreateColumns);
     }
 
     /**
@@ -3446,14 +3446,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            when <code>true</code>, columns are created automatically for
      *            the properties of the beanType
      */
-    public void setBeanType(Class<T> beanType, boolean autoCreateColumns) {
+    public void configureBeanType(Class<T> beanType, boolean autoCreateColumns) {
         Objects.requireNonNull(beanType, "Bean type can't be null");
         
         if (this.beanType != null) {
-            throw new IllegalStateException("setBeanType can only be called for a Grid without a beanType set");
+            throw new IllegalStateException("configureBeanType can only be called for a Grid without a beanType set");
         }
         if (!this.getColumns().isEmpty()) {
-            throw new IllegalStateException("setBeanType can only be called for a Grid without any columns");
+            throw new IllegalStateException("configureBeanType can only be called for a Grid without any columns");
         }
         this.beanType = beanType;
         propertySet = BeanPropertySet.get(beanType);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1248,16 +1248,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public Grid(Class<T> beanType, boolean autoCreateColumns) {
         this();
-        Objects.requireNonNull(beanType, "Bean type can't be null");
-        this.beanType = beanType;
-        propertySet = BeanPropertySet.get(beanType);
-        if (autoCreateColumns) {
-            propertySet.getProperties()
-                    .filter(property -> !property.isSubProperty())
-                    .sorted((prop1, prop2) -> prop1.getName()
-                            .compareTo(prop2.getName()))
-                    .forEach(this::addColumn);
-        }
+        setBeanType(beanType, autoCreateColumns);
     }
 
     /**
@@ -3429,6 +3420,52 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 Objects.toString(b, ""));
     }
 
+    /**
+     * Sets the bean type this grid is bound to and optionally adds a set of columns for each of the bean's
+     * properties. 
+     * 
+     * The property-values of the bean will be converted to Strings.
+     * Full names of the properties will be used as the
+     * {@link Column#setKey(String) column keys} and the property captions will
+     * be used as the {@link Column#setHeader(String) column headers}. The
+     * generated columns will be sortable by default, if the property is
+     * {@link Comparable}.
+     * <p>
+     * When autoCreateColumns is <code>true</code>, only the direct properties
+     * of the bean are included and they will be in alphabetical order. Use
+     * {@link Grid#setColumns(String...)} to define which properties to include
+     * and in which order. You can also add a column for an individual property
+     * with {@link #addColumn(String)}. Both of these methods support also
+     * sub-properties with dot-notation, eg.
+     * <code>"property.nestedProperty"</code>.
+     *<p>
+     This method can only be called for a newly instanced Grid without any beanType or columns set.
+     * @param beanType
+     *            the bean type to use, not <code>null</code>
+     * @param autoCreateColumns
+     *            when <code>true</code>, columns are created automatically for
+     *            the properties of the beanType
+     */
+    public void setBeanType(Class<T> beanType, boolean autoCreateColumns) {
+        Objects.requireNonNull(beanType, "Bean type can't be null");
+        
+        if (this.beanType != null) {
+            throw new IllegalStateException("setBeanType can only be called for a Grid without a beanType set");
+        }
+        if (!this.getColumns().isEmpty()) {
+            throw new IllegalStateException("setBeanType can only be called for a Grid without any columns");
+        }
+        this.beanType = beanType;
+        propertySet = BeanPropertySet.get(beanType);
+        if (autoCreateColumns) {
+            propertySet.getProperties()
+                    .filter(property -> !property.isSubProperty())
+                    .sorted((prop1, prop2) -> prop1.getName()
+                            .compareTo(prop2.getName()))
+                    .forEach(this::addColumn);
+        }
+
+    }
     /**
      * Returns the Class of bean this Grid is constructed with via
      * {@link #Grid(Class)}. Or null if not constructed from a bean type.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
@@ -228,34 +228,34 @@ public class BeanGridTest {
     }
 
     @Test
-    public void setBeanTypeAfterInit(){
+    public void configureBeanTypeAfterInit() {
         extendedGrid = new ExtendedGrid();
         Assert.assertNull(extendedGrid.getBeanType());
         Assert.assertEquals(0, extendedGrid.getColumns().size());
-        extendedGrid.setBeanType(Person.class, false);
+        extendedGrid.configureBeanType(Person.class, false);
         Assert.assertEquals(Person.class, extendedGrid.getBeanType());
         Assert.assertEquals(0, extendedGrid.getColumns().size());
     }
 
     @Test
-    public void setBeanTypeAndAddColumnsAfterInit(){
+    public void configureBeanTypeAndAddColumnsAfterInit() {
         extendedGrid = new ExtendedGrid();
         Assert.assertNull(extendedGrid.getBeanType());
         Assert.assertEquals(0, extendedGrid.getColumns().size());
-        extendedGrid.setBeanType(Person.class, true);
+        extendedGrid.configureBeanType(Person.class, true);
         Assert.assertEquals(Person.class, extendedGrid.getBeanType());
         Assert.assertEquals(5, extendedGrid.getColumns().size());
     }
 
     @Test(expected = IllegalStateException.class)
-    public void setBeanFailsWhenTypeIsSet(){
-        extendedGrid.setBeanType(Person.class, true);
+    public void configureBeanTypeFailsWhenTypeIsSet() {
+        extendedGrid.configureBeanType(Person.class, true);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void setBeanFailsWhenColumnsExist(){
+    public void configureBeanTypeFailsWhenColumnsExist() {
         extendedGrid = new ExtendedGrid();
         extendedGrid.addColumn((p) -> "hello");
-        extendedGrid.setBeanType(Person.class, true);
+        extendedGrid.configureBeanType(Person.class, true);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
@@ -74,6 +74,9 @@ public class BeanGridTest {
     }
 
     private static class ExtendedGrid<T> extends Grid<T> {
+        public ExtendedGrid() {
+            super();
+        }
         public ExtendedGrid(Class<T> beanType) {
             super(beanType, false);
         }
@@ -224,4 +227,35 @@ public class BeanGridTest {
         Assert.assertEquals(Person.class, grid.getBeanType());
     }
 
+    @Test
+    public void setBeanTypeAfterInit(){
+        extendedGrid = new ExtendedGrid();
+        Assert.assertNull(extendedGrid.getBeanType());
+        Assert.assertEquals(0, extendedGrid.getColumns().size());
+        extendedGrid.setBeanType(Person.class, false);
+        Assert.assertEquals(Person.class, extendedGrid.getBeanType());
+        Assert.assertEquals(0, extendedGrid.getColumns().size());
+    }
+
+    @Test
+    public void setBeanTypeAndAddColumnsAfterInit(){
+        extendedGrid = new ExtendedGrid();
+        Assert.assertNull(extendedGrid.getBeanType());
+        Assert.assertEquals(0, extendedGrid.getColumns().size());
+        extendedGrid.setBeanType(Person.class, true);
+        Assert.assertEquals(Person.class, extendedGrid.getBeanType());
+        Assert.assertEquals(5, extendedGrid.getColumns().size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void setBeanFailsWhenTypeIsSet(){
+        extendedGrid.setBeanType(Person.class, true);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void setBeanFailsWhenColumnsExist(){
+        extendedGrid = new ExtendedGrid();
+        extendedGrid.addColumn((p) -> "hello");
+        extendedGrid.setBeanType(Person.class, true);
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
@@ -77,6 +77,7 @@ public class BeanGridTest {
         public ExtendedGrid() {
             super();
         }
+
         public ExtendedGrid(Class<T> beanType) {
             super(beanType, false);
         }


### PR DESCRIPTION
This allows you to use a typed Grid instance together with a template as e.g.
```
@Id
private Grid<Person> grid;
...

grid.setBeanType(Person.class, true);
```

Without this, the properties based `addColumn` methods of Grid cannot be used, not can columns be added automatically from the bean