### PR TITLE
use bnd maven plugin for building osgi bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,37 +177,31 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>maven-bundle-plugin</artifactId>
-          <version>4.1.0</version>
-          <extensions>true</extensions>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>5.3.0</version>
+          <configuration>
+            <bnd><![CDATA[
+            Bundle-Name: ${osgi.bundle.name}
+            Bundle-SymbolicName: ${osgi.bundle.symbolic.name}
+            Import-Package: ${osgi.bundle.import.package}
+            Export-Package: ${osgi.bundle.export.package}
+            Private-Package: ${osgi.bundle.package.private}
+            Bundle-Activator: ${osgi.bundle.bundle.activator}
+            Bundle-License: ${osgi.bundle.license}
+            Bundle-Description: ${osgi.bundle.description}
+            Implementation-Title: ${osgi.bundle.title}
+            Vaadin-Package-Version: ${osgi.vaadin.package.version}
+            -includeresource.resources: -src/main/resources
+            ]]></bnd>
+          </configuration>
           <executions>
             <execution>
-              <id>bundle-manifest</id>
-              <phase>process-classes</phase>
               <goals>
-                <goal>manifest</goal>
+                <goal>bnd-process</goal>
               </goals>
             </execution>
           </executions>
-          <configuration>
-            <exportScr>true</exportScr>
-            <instructions>
-              <Bundle-Name>${osgi.bundle.name}</Bundle-Name>
-              <Bundle-SymbolicName>${osgi.bundle.symbolic.name}</Bundle-SymbolicName>
-              <Import-Package>${osgi.bundle.import.package}</Import-Package>
-              <Export-Package>${osgi.bundle.export.package}</Export-Package>
-              <Private-Package>${osgi.bundle.package.private}</Private-Package>
-              <Bundle-Activator>${osgi.bundle.bundle.activator}</Bundle-Activator>
-              <Bundle-License>${osgi.bundle.license}</Bundle-License>
-              <Bundle-Description>${osgi.bundle.description}</Bundle-Description>
-              <Implementation-Title>${osgi.bundle.title}</Implementation-Title>
-              <Vaadin-Package-Version>${osgi.vaadin.package.version}</Vaadin-Package-Version>
-              <_removeheaders>Built-By</_removeheaders>
-              <_dsannotations>*</_dsannotations>
-              <_metatypeannotations>*</_metatypeannotations>
-            </instructions>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>com.googlecode.maven-download-plugin</groupId>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-demo/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-demo/pom.xml
@@ -142,8 +142,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
@@ -68,8 +68,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-demo/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-demo/pom.xml
@@ -115,8 +115,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
@@ -94,8 +94,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-demo/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-demo/pom.xml
@@ -106,8 +106,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
@@ -59,8 +59,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-board-flow-parent/vaadin-board-flow-demo/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-demo/pom.xml
@@ -102,8 +102,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
@@ -69,8 +69,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-button-flow-parent/vaadin-button-flow-demo/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-demo/pom.xml
@@ -116,8 +116,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
@@ -65,8 +65,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-demo/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-demo/pom.xml
@@ -113,8 +113,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -67,8 +67,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-demo/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-demo/pom.xml
@@ -122,8 +122,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -88,8 +88,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/pom.xml
@@ -127,8 +127,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -66,8 +66,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-demo/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-demo/pom.xml
@@ -112,8 +112,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
@@ -68,8 +68,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-demo/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-demo/pom.xml
@@ -112,8 +112,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -65,8 +65,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-demo/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-demo/pom.xml
@@ -107,8 +107,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
@@ -67,8 +67,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-demo/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-demo/pom.xml
@@ -112,8 +112,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -82,8 +82,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-demo/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-demo/pom.xml
@@ -123,8 +123,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
@@ -64,8 +64,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-demo/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-demo/pom.xml
@@ -111,8 +111,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -65,8 +65,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-demo/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-demo/pom.xml
@@ -111,8 +111,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
@@ -75,8 +75,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-details-flow-parent/vaadin-details-flow-demo/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-demo/pom.xml
@@ -106,8 +106,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
@@ -66,8 +66,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-demo/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-demo/pom.xml
@@ -111,8 +111,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
@@ -76,8 +76,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-demo/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-demo/pom.xml
@@ -126,8 +126,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
@@ -58,8 +58,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-demo/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-demo/pom.xml
@@ -158,8 +158,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -111,8 +111,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-demo/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-demo/pom.xml
@@ -102,8 +102,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
@@ -86,8 +86,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-demo/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-demo/pom.xml
@@ -98,8 +98,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
@@ -59,8 +59,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-demo/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-demo/pom.xml
@@ -108,8 +108,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
@@ -54,8 +54,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-demo/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-demo/pom.xml
@@ -121,8 +121,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -77,8 +77,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-login-flow-parent/vaadin-login-flow-demo/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-demo/pom.xml
@@ -121,8 +121,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -66,8 +66,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
@@ -38,8 +38,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/pom.xml
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/pom.xml
@@ -38,8 +38,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/pom.xml
@@ -116,8 +116,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
@@ -64,8 +64,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
@@ -54,8 +54,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-demo/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-demo/pom.xml
@@ -117,8 +117,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -59,8 +59,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-demo/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-demo/pom.xml
@@ -106,8 +106,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
@@ -59,8 +59,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-demo/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-demo/pom.xml
@@ -96,8 +96,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
@@ -54,8 +54,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-demo/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-demo/pom.xml
@@ -117,8 +117,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -76,8 +76,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-demo/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-demo/pom.xml
@@ -107,8 +107,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
@@ -85,8 +85,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-select-flow-parent/vaadin-select-flow-demo/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-demo/pom.xml
@@ -126,8 +126,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -78,8 +78,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-demo/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-demo/pom.xml
@@ -96,8 +96,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
@@ -54,8 +54,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-demo/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-demo/pom.xml
@@ -116,8 +116,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -65,8 +65,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-demo/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-demo/pom.xml
@@ -116,8 +116,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
@@ -63,8 +63,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-demo/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-demo/pom.xml
@@ -111,8 +111,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
@@ -69,8 +69,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-demo/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-demo/pom.xml
@@ -106,8 +106,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -59,8 +59,8 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>maven-bundle-plugin</artifactId>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This pr switches from felix plugin to newer bnd plugin.

It is a bit hard to build with the build scripts. It would help a lot to understand why you have the different maven profiles. Think there is a lot of optimization possible.

For the momenti tried this the automatic build of PR. 

If i login as guest to the the result i got:

```
404
You do not have enough permissions to access project with internal id: project28

Check that the URL is correct.

Previous page
Overview page
```

So i cant see if the manifest and the resource working properly. I will squash the commits if somebody tells me that is work's or i can see it in the ci