### PR TITLE
chore: align npm version for vaadin-messages

### DIFF
--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
@@ -36,7 +36,7 @@ import com.vaadin.flow.shared.Registration;
  */
 @Tag("vaadin-message-input")
 @JsModule("@vaadin/vaadin-messages/src/vaadin-message-input.js")
-@NpmPackage(value = "@vaadin/vaadin-messages", version = "v2.0.0-alpha1")
+@NpmPackage(value = "@vaadin/vaadin-messages", version = "2.0.0-alpha1")
 public class MessageInput extends Component
         implements HasSize, HasStyle, HasEnabled {
 


### PR DESCRIPTION
to avoid warning about multiple versions because MessageInput imports "v2.0.0.alpha1" and MessageList imports "2.0.0.alpha1" (without "v").