### PR TITLE
fix: move clear from rebuild to correct places

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.listbox.test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.listbox.ListBox;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-list-box/list-box-retain-value")
+public class ListBoxRetainValuePage extends VerticalLayout {
+
+    public ListBoxRetainValuePage() {
+        final List<String> listBoxItems = Arrays.asList("1", "2", "3", "4");
+        final ListBox<String> listBox = new ListBox<>();
+        listBox.setItems(listBoxItems);
+        listBox.setValue("2");
+        final Button addButton = new Button("add");
+        add(addButton);
+        add(listBox);
+        addButton.addClickListener(event -> {
+            remove(listBox);
+            add(listBox);
+        });
+    }
+
+}

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
@@ -34,6 +34,7 @@ public class ListBoxRetainValuePage extends VerticalLayout {
         listBox.setItems(listBoxItems);
         listBox.setValue("2");
         Button addButton = new Button("add");
+        addButton.setId("button");
         Div value = new Div();
         value.setId("value");
         add(value, addButton, listBox);

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
@@ -28,17 +29,19 @@ import com.vaadin.flow.router.Route;
 public class ListBoxRetainValuePage extends VerticalLayout {
 
     public ListBoxRetainValuePage() {
-        final List<String> listBoxItems = Arrays.asList("1", "2", "3", "4");
-        final ListBox<String> listBox = new ListBox<>();
+        List<String> listBoxItems = Arrays.asList("1", "2", "3", "4");
+        ListBox<String> listBox = new ListBox<>();
         listBox.setItems(listBoxItems);
         listBox.setValue("2");
-        final Button addButton = new Button("add");
-        add(addButton);
-        add(listBox);
+        Button addButton = new Button("add");
+        Div value = new Div();
+        value.setId("value");
+        add(value, addButton, listBox);
+        value.setText(listBox.getValue());
         addButton.addClickListener(event -> {
             remove(listBox);
             add(listBox);
+            value.setText(listBox.getValue());
         });
     }
-
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -28,6 +28,7 @@ public class ListBoxRetainValueIT extends AbstractComponentIT {
 
     @Test
     public void listBoxRetainValueWhenRemovedAndAdded() {
+        open();
         WebElement value = findElement(By.id("value"));
         Assert.assertEquals(value.getText(),"2");
         findElement(By.id("button")).click();

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ 
+package com.vaadin.flow.component.listbox.test;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@TestPath("vaadin-list-box/list-box-retain-value")
+public class ListBoxRetainValueIT extends AbstractComponentIT {
+
+    @Test
+    public void listBoxRetainValueWhenRemovedAndAdded() {
+        WebElement value = findElement(By.id("value"));
+        Assert.assertEquals(value.getText(),"2");
+        findElement(By.id("button")).click();
+        Assert.assertEquals(value.getText(),"2");		
+    }
+}

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -101,6 +101,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     public void setDataProvider(DataProvider<ITEM, ?> dataProvider) {
         this.dataProvider.set( Objects.requireNonNull(dataProvider) );
         DataViewUtils.removeComponentFilterAndSortComparator(this);
+        clear();
         setupDataProviderListener(this.dataProvider.get());
     }
 
@@ -214,7 +215,6 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
 
     @SuppressWarnings("unchecked")
     private void rebuild() {
-        clear();
         removeAll();
 
         synchronized (dataProvider) {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -113,6 +113,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
             if (event instanceof DataRefreshEvent) {
                 refresh(((DataRefreshEvent<ITEM>) event).getItem());
             } else {
+                clear();
                 rebuild();
             }
         });

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -10,10 +10,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 
 public class ListBoxUnitTest {
 
@@ -173,24 +171,5 @@ public class ListBoxUnitTest {
             Assert.assertNull(listBox.getElement().getChild(index)
                     .getAttribute("disabled"));
         }
-    }
-
-    @Test
-    public void listBoxRetainValueWhenRemovedAndAdded() {
-        VerticalLayout layout = new VerticalLayout();
-        final List<String> listBoxItems = Arrays.asList("1", "2", "3", "4");
-        final ListBox<String> listBox = new ListBox<>();
-        listBox.setItems(listBoxItems);
-        listBox.setValue("2");
-
-        layout.add(listBox);
-        Assert.assertTrue(listBox.getValue().equals("2"));
-        layout.remove(listBox);
-        // Mock onDetach
-        DetachEvent event = new DetachEvent(listBox);
-        listBox.onDetach(event);
-
-        layout.add(listBox);
-        Assert.assertTrue(listBox.getValue().equals("2"));        
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -10,8 +10,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 
 public class ListBoxUnitTest {
 
@@ -171,5 +173,24 @@ public class ListBoxUnitTest {
             Assert.assertNull(listBox.getElement().getChild(index)
                     .getAttribute("disabled"));
         }
+    }
+
+    @Test
+    public void listBoxRetainValueWhenRemovedAndAdded() {
+        VerticalLayout layout = new VerticalLayout();
+        final List<String> listBoxItems = Arrays.asList("1", "2", "3", "4");
+        final ListBox<String> listBox = new ListBox<>();
+        listBox.setItems(listBoxItems);
+        listBox.setValue("2");
+
+        layout.add(listBox);
+        Assert.assertTrue(listBox.getValue().equals("2"));
+        layout.remove(listBox);
+        // Mock onDetach
+        DetachEvent event = new DetachEvent(listBox);
+        listBox.onDetach(event);
+
+        layout.add(listBox);
+        Assert.assertTrue(listBox.getValue().equals("2"));        
     }
 }


### PR DESCRIPTION
The issue 93 is not occuring with ComboBox and I compared the logic of these two components. In ComboBox the value is cleared only when data provider is set first time, but not when attached. This PR makes the logic analogous to ComboBox.

Fixes: https://github.com/vaadin/vaadin-list-box/issues/93