### PR TITLE
fix: change enabled state of radio-buttons when enabled state of radio-button-group changes (#774) (CP: 14.6)

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPage.java
@@ -24,14 +24,19 @@ import com.vaadin.flow.router.Route;
 public class DisabledItemsPage extends Div {
 
     public DisabledItemsPage() {
-        RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup();
+        RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup<>();
         radioButtonGroup.setId("button-group");
+        radioButtonGroup.setItemEnabledProvider("one"::equals);
         radioButtonGroup.setEnabled(false);
 
         NativeButton nativeButton = new NativeButton("add",
                 event -> radioButtonGroup.setItems("one", "two"));
         nativeButton.setId("add-button");
 
-        add(radioButtonGroup, nativeButton);
+        NativeButton enableButton = new NativeButton("enable",
+                event -> radioButtonGroup.setEnabled(true));
+        enableButton.setId("enable-button");
+
+        add(radioButtonGroup, nativeButton, enableButton);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPageIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPageIT.java
@@ -49,4 +49,25 @@ public class DisabledItemsPageIT extends AbstractComponentIT {
                     Boolean.TRUE.toString(), button.getAttribute("disabled"));
         }
     }
+
+    @Test
+    public void disabled_items_with_item_enabled_provider_should_stay_disabled_after_enabling_group() {
+        open();
+        WebElement group = findElement(By.id("button-group"));
+        // Click button to add items
+        findElement(By.id("add-button")).click();
+        for (WebElement radioButton : group.findElements(By.tagName("vaadin-radio-button"))) {
+            Assert.assertEquals("All buttons should be disabled", Boolean.TRUE.toString(), radioButton.getAttribute("disabled"));
+        }
+
+        // Click button to enable items
+        findElement(By.id("enable-button")).click();
+        List<WebElement> radioButtons = group.findElements(By.tagName("vaadin-radio-button"));
+        WebElement firstButton = radioButtons.get(0);
+        WebElement secondButton = radioButtons.get(1);
+        Assert.assertNull("First button should not be disabled", firstButton.getAttribute("disabled"));
+        Assert.assertEquals("Second button should be disabled", Boolean.TRUE.toString(), secondButton.getAttribute("disabled"));
+    }
+
+
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -360,6 +360,7 @@ public class RadioButtonGroup<T>
     private void updateEnabled(RadioButton<T> button) {
         boolean disabled = isDisabledBoolean()
                 || !getItemEnabledProvider().test(button.getItem());
+        button.setEnabled(!disabled);
         Serializable rawValue = button.getElement().getPropertyRaw("disabled");
         if (rawValue instanceof Boolean) {
             // convert the boolean value to a String to force update the

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -131,6 +131,32 @@ public class RadioButtonGroupTest {
     }
 
     @Test
+    public void disabledItems_itemEnabledProvider_stayDisabled() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setItems("enabled", "disabled");
+        group.setItemEnabledProvider("enabled"::equals);
+
+        List<RadioButton<String>> children = group.getChildren()
+                .map(child -> (RadioButton<String>) child)
+                .collect(Collectors.toList());
+
+        Assert.assertTrue(children.get(0).isEnabled());
+        Assert.assertFalse(children.get(1).isEnabled());
+
+        group.setEnabled(false);
+        Assert.assertFalse(children.get(0).isEnabled());
+        Assert.assertFalse(children.get(1).isEnabled());
+
+        group.setEnabled(true);
+        Assert.assertTrue(children.get(0).isEnabled());
+        Assert.assertFalse(children.get(1).isEnabled());
+
+        group.setEnabled(false);
+        Assert.assertFalse(children.get(0).isEnabled());
+        Assert.assertFalse(children.get(1).isEnabled());
+    }
+
+    @Test
     public void changeItems_selectionIsReset() {
         RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup<>();
         radioButtonGroup.setItems("Foo","Bar");


### PR DESCRIPTION
ItemEnableProvider is no longer ignored when re-enabling a disabled radio-button-group.