### PR TITLE
chore: fix build script after repo renaming [skip ci]

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ fi
 ## compute modules that were modified in this PR
 if [ -z "$modules" -a -n "$PR" ]
 then
-  modified=`curl -s https://api.github.com/repos/vaadin/vaadin-flow-components/pulls/$PR/files \
+  modified=`curl -s https://api.github.com/repos/vaadin/flow-components/pulls/$PR/files \
     | jq -r '.[] | .filename' | grep 'vaadin.*parent' | perl -pe 's,^vaadin-(.*)-flow-parent.*,$1,g' | sort -u`
   if [ `echo "$modified" | wc -w` -lt 5 ]
   then
@@ -73,7 +73,7 @@ saveFailedTests() {
 
 computeFastBuild() {
   [ -z "$PR" ] && return 1
-  ghUrl="https://api.github.com/repos/vaadin/vaadin-flow-components/pulls/$PR"
+  ghUrl="https://api.github.com/repos/vaadin/flow-components/pulls/$PR"
   prTitle=`curl -s $ghUrl | jq -r .title`
   echo "$prTitle" | grep -v '\[skip ci\]' >/dev/null || return 0
   prMessages=`curl -s $ghUrl/commits | jq -r '.[] | .commit.message'`

--- a/scripts/prepareDeploy.sh
+++ b/scripts/prepareDeploy.sh
@@ -51,7 +51,7 @@ versionBase=`getBaseVersion $version`
 pomBase=`getBaseVersion $pomVersion`
 
 ### Get the master branch version for components
-masterPom=`curl -s "https://raw.githubusercontent.com/vaadin/vaadin-flow-components/master/pom.xml"`
+masterPom=`curl -s "https://raw.githubusercontent.com/vaadin/flow-components/master/pom.xml"`
 masterMajorMinor=`echo "$masterPom" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | grep "^$base" | head -1 | cut -d '-' -f1`
 
 ### Load versions file for this platform release


### PR DESCRIPTION
this fix the issue with validation build error `jq: error (at <stdin>:5): Cannot index string with string "xxxxx"`
https://teamcity.vaadin.com/viewLog.html?buildId=75771&buildTypeId=VaadinFlowComponents_PullRequestValidation&tab=buildLog&_focus=2413#_state=2398