### PR TITLE
test: fix listBoxRetainValueWhenRemovedAndAdded test

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
@@ -34,9 +34,9 @@ public class ListBoxRetainValuePage extends VerticalLayout {
         listBox.setItems(listBoxItems);
         listBox.setValue("2");
         Button addButton = new Button("add");
-        addButton.setId("button");
+        addButton.setId("add-button");
         Div value = new Div();
-        value.setId("value");
+        value.setId("list-box-value");
         add(value, addButton, listBox);
         value.setText(listBox.getValue());
         addButton.addClickListener(event -> {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -29,9 +29,9 @@ public class ListBoxRetainValueIT extends AbstractComponentIT {
     @Test
     public void listBoxRetainValueWhenRemovedAndAdded() {
         open();
-        WebElement value = findElement(By.id("value"));
+        WebElement value = findElement(By.id("list-box-value"));
         Assert.assertEquals(value.getText(),"2");
-        findElement(By.id("button")).click();
+        findElement(By.id("add-button")).click();
         Assert.assertEquals(value.getText(),"2");		
     }
 }


### PR DESCRIPTION
On the page, there are two elements with id "button" and `findElement(By.id("button"))` is actually getting the wrong one, which causes the test to fail.