### PR TITLE
chore: allow Flow API issues to be reported to this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,14 +1,10 @@
 ---
-name: Repository issue
-about: An issue related to the vaadin-flow-components repository
+name: Issue
+about: An issue related to the Java API of a Vaadin component
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-This repository's issue tracker is reserved mainly for issues related to the monorepo automation. If you want to report a Vaadin component related issue, please use one of the component repositories, such as
-- https://github.com/vaadin/vaadin-grid (for Grid related issues)
-- https://github.com/vaadin/vaadin-text-field (Text Field, Text Area, Email Field...)
-- https://github.com/vaadin/vaadin-ordered-layout (Vertical/Horizontal Layout, Scroller)
-...
+This repository's issue tracker is reserved mainly for issues related to the Java API of Vaadin components. If an issue can be reproduced with just the web component (without Vaadin Flow involved) it should be reported in the https://github.com/vaadin/web-components monorepo.


### PR DESCRIPTION
Based on the [decision](https://docs.google.com/document/d/1Iy3tu4YrNi_Qcn-P3G7sjo7VwjbT3d5doUMK5dYUI78) to use flow-components and web-components monorepos for the component issues, this repo is the right place for the issues with the Java API of Vaadin components.