### PR TITLE
fix: synchronize column width recalculation with data refresh

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Route("vaadin-grid/recalculate-column-widths")
+public class RecalculateColumnWidthsPage extends VerticalLayout {
+
+    public RecalculateColumnWidthsPage() {
+        ThreeString ts1 = new ThreeString("111", "222", "333");
+        ThreeString ts2 = new ThreeString("444", "555", "667");
+
+        Collection<ThreeString> itemList = new ArrayList<ThreeString>();
+        itemList.add(ts1);
+        itemList.add(ts2);
+
+        Grid<ThreeString> grid1 = new Grid<>();
+        grid1.setId("grid");
+        grid1.setHeightByRows(true);
+        grid1.setItems(itemList);
+
+        grid1.addColumn(ThreeString::getA).setAutoWidth(true);
+        grid1.addColumn(ThreeString::getB).setAutoWidth(true);
+        grid1.addColumn(ThreeString::getC).setAutoWidth(true);
+
+        add(grid1);
+
+        // Ensure _recalculateColumnWidthOnceLoadingFinished flag is cleared, otherwise the flag
+        // would trigger the column recalculation automatically when refreshing the data
+        // The web component has some flaky behaviour where the flag is not always cleared
+        // after the initial data load
+        // See https://github.com/vaadin/web-components/issues/268
+        grid1.getElement().executeJs(
+                "$0._recalculateColumnWidthOnceLoadingFinished = false");
+
+        Button button = new Button("Add Text");
+        button.setId("change-data-button");
+        button.addClickListener(event -> {
+
+            ts2.setB(
+                    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.");
+            grid1.getDataProvider().refreshAll();
+            grid1.recalculateColumnWidths();
+        });
+
+        add(button);
+    }
+
+    static class ThreeString {
+        private String a;
+        private String b;
+        private String c;
+
+        public ThreeString(String a, String b, String c) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+
+        public String getA() {
+            return a;
+        }
+
+        public void setA(String a) {
+            this.a = a;
+        }
+
+        public String getB() {
+            return b;
+        }
+
+        public void setB(String b) {
+            this.b = b;
+        }
+
+        public String getC() {
+            return c;
+        }
+
+        public void setC(String c) {
+            this.c = c;
+        }
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -31,7 +31,7 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         ThreeString ts1 = new ThreeString("111", "222", "333");
         ThreeString ts2 = new ThreeString("444", "555", "667");
 
-        Collection<ThreeString> itemList = new ArrayList<ThreeString>();
+        Collection<ThreeString> itemList = new ArrayList<>();
         itemList.add(ts1);
         itemList.add(ts2);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -21,9 +21,6 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 @Route("vaadin-grid/recalculate-column-widths")
 public class RecalculateColumnWidthsPage extends VerticalLayout {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -57,9 +57,7 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         button.setId("change-data-button");
         button.addClickListener(event -> {
 
-
-            ts2.b = 
-                    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+            ts2.b = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
             grid1.getDataProvider().refreshAll();
             grid1.recalculateColumnWidths();
         });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -53,16 +53,16 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         button.addClickListener(event -> {
 
             ts2.b = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,"
-                + " sed diam nonumy eirmod tempor invidunt ut labore et dolore"
-                + " magna aliquyam erat, sed diam voluptua. At vero eos et"
-                + " accusam et justo duo dolores et ea rebum. Stet clita kasd"
-                + " gubergren, no sea takimata sanctus est Lorem ipsum dolor"
-                + " sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing"
-                + " elitr, sed diam nonumy eirmod tempor invidunt ut labore et"
-                + " dolore magna aliquyam erat, sed diam voluptua. At vero eos"
-                + " et accusam et justo duo dolores et ea rebum. Stet clita"
-                + " kasd gubergren, no sea takimata sanctus est Lorem ipsum"
-                + " dolor sit amet.";
+                    + " sed diam nonumy eirmod tempor invidunt ut labore et dolore"
+                    + " magna aliquyam erat, sed diam voluptua. At vero eos et"
+                    + " accusam et justo duo dolores et ea rebum. Stet clita kasd"
+                    + " gubergren, no sea takimata sanctus est Lorem ipsum dolor"
+                    + " sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing"
+                    + " elitr, sed diam nonumy eirmod tempor invidunt ut labore et"
+                    + " dolore magna aliquyam erat, sed diam voluptua. At vero eos"
+                    + " et accusam et justo duo dolores et ea rebum. Stet clita"
+                    + " kasd gubergren, no sea takimata sanctus est Lorem ipsum"
+                    + " dolor sit amet.";
 
             grid1.getDataProvider().refreshAll();
             grid1.recalculateColumnWidths();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -46,9 +46,12 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
 
         add(grid1);
 
-        // Ensure _recalculateColumnWidthOnceLoadingFinished flag is cleared, otherwise the flag
-        // would trigger the column recalculation automatically when refreshing the data
-        // The web component has some flaky behaviour where the flag is not always cleared
+        // Ensure _recalculateColumnWidthOnceLoadingFinished flag is cleared,
+        // otherwise the flag
+        // would trigger the column recalculation automatically when refreshing
+        // the data
+        // The web component has some flaky behaviour where the flag is not
+        // always cleared
         // after the initial data load
         // See https://github.com/vaadin/web-components/issues/268
         grid1.getElement().executeJs(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -43,12 +43,10 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         add(grid1);
 
         // Ensure _recalculateColumnWidthOnceLoadingFinished flag is cleared,
-        // otherwise the flag
-        // would trigger the column recalculation automatically when refreshing
-        // the data
+        // otherwise the flag would trigger the column recalculation
+        // automatically when refreshing the data
         // The web component has some flaky behaviour where the flag is not
-        // always cleared
-        // after the initial data load
+        // always cleared after the initial data load
         // See https://github.com/vaadin/web-components/issues/268
         grid1.getElement().executeJs(
                 "$0._recalculateColumnWidthOnceLoadingFinished = false");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -52,7 +52,18 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         button.setId("change-data-button");
         button.addClickListener(event -> {
 
-            ts2.b = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+            ts2.b = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,"
+                + " sed diam nonumy eirmod tempor invidunt ut labore et dolore"
+                + " magna aliquyam erat, sed diam voluptua. At vero eos et"
+                + " accusam et justo duo dolores et ea rebum. Stet clita kasd"
+                + " gubergren, no sea takimata sanctus est Lorem ipsum dolor"
+                + " sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing"
+                + " elitr, sed diam nonumy eirmod tempor invidunt ut labore et"
+                + " dolore magna aliquyam erat, sed diam voluptua. At vero eos"
+                + " et accusam et justo duo dolores et ea rebum. Stet clita"
+                + " kasd gubergren, no sea takimata sanctus est Lorem ipsum"
+                + " dolor sit amet.";
+
             grid1.getDataProvider().refreshAll();
             grid1.recalculateColumnWidths();
         });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -31,18 +31,14 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         ThreeString ts1 = new ThreeString("111", "222", "333");
         ThreeString ts2 = new ThreeString("444", "555", "667");
 
-        Collection<ThreeString> itemList = new ArrayList<>();
-        itemList.add(ts1);
-        itemList.add(ts2);
-
         Grid<ThreeString> grid1 = new Grid<>();
         grid1.setId("grid");
         grid1.setHeightByRows(true);
-        grid1.setItems(itemList);
+        grid1.setItems(ts1, ts2);
 
-        grid1.addColumn(ThreeString::getA).setAutoWidth(true);
-        grid1.addColumn(ThreeString::getB).setAutoWidth(true);
-        grid1.addColumn(ThreeString::getC).setAutoWidth(true);
+        grid1.addColumn(item -> item.a).setAutoWidth(true);
+        grid1.addColumn(item -> item.b).setAutoWidth(true);
+        grid1.addColumn(item -> item.c).setAutoWidth(true);
 
         add(grid1);
 
@@ -61,8 +57,9 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         button.setId("change-data-button");
         button.addClickListener(event -> {
 
-            ts2.setB(
-                    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.");
+
+            ts2.b = 
+                    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
             grid1.getDataProvider().refreshAll();
             grid1.recalculateColumnWidths();
         });
@@ -78,30 +75,6 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         public ThreeString(String a, String b, String c) {
             this.a = a;
             this.b = b;
-            this.c = c;
-        }
-
-        public String getA() {
-            return a;
-        }
-
-        public void setA(String a) {
-            this.a = a;
-        }
-
-        public String getB() {
-            return b;
-        }
-
-        public void setB(String b) {
-            this.b = b;
-        }
-
-        public String getC() {
-            return c;
-        }
-
-        public void setC(String c) {
             this.c = c;
         }
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-grid/recalculate-column-widths")
+public class RecalculateColumnWidthsIT extends AbstractComponentIT {
+    @Test
+    public void columnsRecalculateAfterDataChange() {
+        open();
+
+        waitForElementPresent(By.id("grid"));
+
+        GridElement grid = $(GridElement.class).id("grid");
+        TestBenchElement button = $(TestBenchElement.class)
+                .id("change-data-button");
+
+        GridTHTDElement cell = grid.getCell(1, 1);
+
+        Integer scrollWidthBefore = cell.getPropertyInteger("scrollWidth");
+
+        button.click();
+
+        Integer scrollWidthAfter = cell.getPropertyInteger("scrollWidth");
+        Integer offsetWidthAfter = cell.getPropertyInteger("offsetWidth");
+
+        Assert.assertTrue("Scroll width should have increased",
+                scrollWidthAfter > scrollWidthBefore);
+        Assert.assertTrue("Cell content should not be cut off with ellipsis",
+                offsetWidthAfter <= scrollWidthAfter);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3612,13 +3612,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see Column#setAutoWidth(boolean)
      */
     public void recalculateColumnWidths() {
-        // Defer column width recalculation to occur after the data was refreshed
-        // The data communicator will insert the JS call to refresh the client side
+        // Defer column width recalculation to occur after the data was
+        // refreshed
+        // The data communicator will insert the JS call to refresh the client
+        // side
         // grid in the beforeClientResponse hook, we need to match this here so
         // that the column width recalculation runs after the data was updated.
-        getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this, ctx -> getElement()
-                        .callJsFunction("recalculateColumnWidths")));
+        getElement().getNode().runWhenAttached(ui -> ui.beforeClientResponse(
+                this,
+                ctx -> getElement().callJsFunction("recalculateColumnWidths")));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3613,11 +3613,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void recalculateColumnWidths() {
         // Defer column width recalculation to occur after the data was
-        // refreshed
-        // The data communicator will insert the JS call to refresh the client
-        // side
-        // grid in the beforeClientResponse hook, we need to match this here so
-        // that the column width recalculation runs after the data was updated.
+        // refreshed. The data communicator will insert the JS call to refresh
+        // the client side grid in the beforeClientResponse hook, we need to
+        // match this here so that the column width recalculation runs after the
+        // data was updated.
         getElement().getNode().runWhenAttached(ui -> ui.beforeClientResponse(
                 this,
                 ctx -> getElement().callJsFunction("recalculateColumnWidths")));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3612,7 +3612,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see Column#setAutoWidth(boolean)
      */
     public void recalculateColumnWidths() {
-        getElement().callJsFunction("recalculateColumnWidths");
+        // Defer column width recalculation to occur after the data was refreshed
+        // The data communicator will insert the JS call to refresh the client side
+        // grid in the beforeClientResponse hook, we need to match this here so
+        // that the column width recalculation runs after the data was updated.
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, ctx -> getElement()
+                        .callJsFunction("recalculateColumnWidths")));
     }
 
     /**


### PR DESCRIPTION
The grid collects all data provider updates (`refreshItem`, `refreshAll`) and defers them into a single client side update that is injected in the `beforeClientResponse` hook, which I assume is done to improve performance. This can be a problem when scheduling other client side calls that expect the data update to have already happened (like `recalculateColumnWidths`) because this will actually run on the client-side before that data was changed. Consider this example:
```
grid.getDataProvider().refreshAll();
grid.recalculateColumnWidths();
```
which on the client will actually run `recalculateColumnWidths` before updating the grid data through the grid connector.

This change modifies the `recalculateColumnWidths` behavior to also defer scheduling the client-side call into the `beforeClientResponse` hook, so that the grid can update the data and redraw before updating the column size.

Fixes: https://github.com/vaadin/vaadin-grid/issues/1864