### PR TITLE
fix: Ensure editor closing when page refreshed while using PreserveOnRefresh

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.router.Route;
 @PreserveOnRefresh
 public class PreserveOnRefreshPage extends Div {
 
+    int count = 0;
+
     public PreserveOnRefreshPage() {
         Grid<Person> grid = new Grid<>();
         Person foo = new Person("foo", 20);
@@ -61,11 +63,19 @@ public class PreserveOnRefreshPage extends Div {
 
         // Grid editor will fire close event, this will be tested
         grid.getEditor().addCloseListener(event -> {
-            Span span = new Span("Closed");
-            span.setId("closed");
-            add(span);
+            Span close = new Span("Closed");
+            close.setId("closed");
+            add(close);
         });
 
+        // Grid editor will fire open event, this will be tested after
+        // refresh
+        grid.getEditor().addOpenListener(event -> {
+            count++;
+            Span open = new Span("Open: "+count);
+            open.setId("open-"+count);
+            add(open);
+        });        
         add(grid, button);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -54,7 +54,7 @@ public class PreserveOnRefreshPage extends Div {
         firstNameColumn.setEditorComponent(firstNameField);
 
         Button button = new Button("Edit");
-        button.setId("edit");
+        button.setId("edit-button");
         button.addClickListener(event -> {
             grid.getEditor().editItem(foo);
         });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -16,9 +16,13 @@
 package com.vaadin.flow.component.grid.it;
 
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
 
@@ -51,6 +55,13 @@ public class PreserveOnRefreshPage extends Div {
         button.setId("edit");
         button.addClickListener(event -> {
             grid.getEditor().editItem(foo);
+        });
+
+        // Grid editor will fire close event, this will be tested
+        grid.getEditor().addCloseListener(event -> {
+            Span span = new Span("Closed");
+            span.setId("closed");
+            add(span);
         });
 
         add(grid,button);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -72,10 +72,10 @@ public class PreserveOnRefreshPage extends Div {
         // refresh
         grid.getEditor().addOpenListener(event -> {
             count++;
-            Span open = new Span("Open: "+count);
-            open.setId("open-"+count);
+            Span open = new Span("Open: " + count);
+            open.setId("open-" + count);
             add(open);
-        });        
+        });
         add(grid, button);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.editor.Editor;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -39,13 +39,14 @@ public class PreserveOnRefreshPage extends Div {
                 .setHeader(new Span("header")).setFooter(new Span("footer"));
 
         // Add editable column
-        Column<Person> firstNameColumn = grid.addColumn(Person::getFirstName).setHeader("First Name");
+        Column<Person> firstNameColumn = grid.addColumn(Person::getFirstName)
+                .setHeader("First Name");
 
         // define editor & binder for editor
         Binder<Person> binder = new Binder<>(Person.class);
-                Editor<Person> editor = grid.getEditor();
-                editor.setBinder(binder);
-                editor.setBuffered(true);
+        Editor<Person> editor = grid.getEditor();
+        editor.setBinder(binder);
+        editor.setBuffered(true);
 
         // define editor components for columns
         TextField firstNameField = new TextField();
@@ -65,7 +66,7 @@ public class PreserveOnRefreshPage extends Div {
             add(span);
         });
 
-        add(grid,button);
+        add(grid, button);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshPage.java
@@ -28,10 +28,32 @@ public class PreserveOnRefreshPage extends Div {
 
     public PreserveOnRefreshPage() {
         Grid<Person> grid = new Grid<>();
-        grid.setItems(new Person("foo", 20));
+        Person foo = new Person("foo", 20);
+        grid.setItems(foo);
         grid.addComponentColumn(person -> new Span(person.getFirstName()))
                 .setHeader(new Span("header")).setFooter(new Span("footer"));
-        add(grid);
+
+        // Add editable column
+        Column<Person> firstNameColumn = grid.addColumn(Person::getFirstName).setHeader("First Name");
+
+        // define editor & binder for editor
+        Binder<Person> binder = new Binder<>(Person.class);
+                Editor<Person> editor = grid.getEditor();
+                editor.setBinder(binder);
+                editor.setBuffered(true);
+
+        // define editor components for columns
+        TextField firstNameField = new TextField();
+        binder.bind(firstNameField, Person::getFirstName, Person::setFirstName);
+        firstNameColumn.setEditorComponent(firstNameField);
+
+        Button button = new Button("Edit");
+        button.setId("edit");
+        button.addClickListener(event -> {
+            grid.getEditor().editItem(foo);
+        });
+
+        add(grid,button);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -70,8 +70,8 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
 
         // Test that editor still works after refresh
         findElement(By.id("edit-button")).click();
-        WebElement closed = findElement(By.id("open-2"));
-        Assert.assertEquals(closed.getText(), "Open: 2");
+        WebElement open = findElement(By.id("open-2"));
+        Assert.assertEquals(open.getText(), "Open: 2");
     }
 
     private GridElement getGrid() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -63,7 +63,7 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
 
     @Test
     public void refresh_editorOpen() {
-        findElement(By.id("edit")).click();
+        findElement(By.id("edit-button")).click();
         getDriver().navigate().refresh();
         WebElement closed = findElement(By.id("closed"));
         Assert.assertEquals(closed.getText(), "Closed");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 @TestPath("vaadin-grid/preserve-on-refresh")
 public class PreserveOnRefreshIT extends AbstractComponentIT {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -59,6 +59,14 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
                 CoreMatchers.containsString("<span>footer</span>"));
     }
 
+    @Test
+    public void refresh_editorOpen() {
+        findElement(By.id("edit")).click();
+        getDriver().navigate().refresh();
+        WebElement closed = findElement(By.id("closed"));
+        Assert.assertEquals(closed.getText(),"Closed");
+    }
+
     private GridElement getGrid() {
         return $(GridElement.class).first();
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -66,7 +66,7 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
         findElement(By.id("edit")).click();
         getDriver().navigate().refresh();
         WebElement closed = findElement(By.id("closed"));
-        Assert.assertEquals(closed.getText(),"Closed");
+        Assert.assertEquals(closed.getText(), "Closed");
     }
 
     private GridElement getGrid() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -67,6 +67,11 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
         getDriver().navigate().refresh();
         WebElement closed = findElement(By.id("closed"));
         Assert.assertEquals(closed.getText(), "Closed");
+
+        // Test that editor still works after refresh
+        findElement(By.id("edit-button")).click();
+        WebElement closed = findElement(By.id("open-2"));
+        Assert.assertEquals(closed.getText(), "Open: 2");
     }
 
     private GridElement getGrid() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3206,11 +3206,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
-        if (!getEditor().isBuffered()) {
-            getEditor().closeEditor();
-        } else {
-            getEditor().cancel();
-        }
         if (dataProviderChangeRegistration != null) {
             dataProviderChangeRegistration.remove();
             dataProviderChangeRegistration = null;
@@ -3747,7 +3742,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         try {
             Editor<T> editor = getEditor();
             if (editor != null) {
-                getEditor().closeEditor();
+                if (getEditor().isBuffered()) {
+                    getEditor().cancel();
+                } else {
+                    getEditor().closeEditor();
+                }
             }
         } finally {
             editorFactory = factory;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3206,6 +3206,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
+        if (!getEditor().isBuffered()) {
+            getEditor().closeEditor();
+        } else {
+            getEditor().cancel();
+        }
         if (dataProviderChangeRegistration != null) {
             dataProviderChangeRegistration.remove();
             dataProviderChangeRegistration = null;


### PR DESCRIPTION
If Editor is not closed on detach and preserve on refresh is used, the ghost editor will cause an exception.

fixes: https://github.com/vaadin/vaadin-grid/issues/2176