### PR TITLE
fix: restore sorting indicators after column order change

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -94,9 +94,9 @@ public class SortingPage extends Div {
         NativeButton reOrder new NativeButton("Re-order", e-> {
             grid.setColumnOrder(ageColumn,nameColumn);
         });
-        reOrder.setId("reorder-button);
+        reOrder.setId("reorder-button");
 
-        add(button,reOrder);
+        add(button, reOrder);
 
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -91,7 +91,7 @@ public class SortingPage extends Div {
                 });
         button.setId(sortBtnId);
 
-        NativeButton reOrder = new NativeButton("Re-order", e-> {
+        NativeButton reOrder = new NativeButton("Re-order", e -> {
             grid.setColumnOrder(ageColumn, nameColumn);
         });
         reOrder.setId("reorder-button");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -91,8 +91,8 @@ public class SortingPage extends Div {
                 });
         button.setId(sortBtnId);
 
-        NativeButton reOrder new NativeButton("Re-order", e-> {
-            grid.setColumnOrder(ageColumn,nameColumn);
+        NativeButton reOrder = new NativeButton("Re-order", e-> {
+            grid.setColumnOrder(ageColumn, nameColumn);
         });
         reOrder.setId("reorder-button");
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -91,7 +91,12 @@ public class SortingPage extends Div {
                 });
         button.setId(sortBtnId);
 
-        add(button);
+        NativeButton reOrder new NativeButton("Re-order", e-> {
+            grid.setColumnOrder(ageColumn,nameColumn);
+        });
+        reOrder.setId("reorder-button);
+
+        add(button,reOrder);
 
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -73,7 +73,7 @@ public class SortingIT extends AbstractComponentIT {
     public void setInitialSortOrder_changeOrderFromServer_sortIndicatorsUpdated() {
         findElement(By.id("sort-by-age")).click();
         assertAscendingSorter("Age");
-        findElement(By.id("reorder-button")).click();        
+        findElement(By.id("reorder-button")).click();
         assertAscendingSorter("Age");
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -146,7 +146,7 @@ public class SortingIT extends AbstractComponentIT {
         TestBenchElement sorter = sorters.get(0);
         Assert.assertEquals("Expected ascending sort order.", "asc",
                 sorter.getAttribute("direction"));
-        Assert.assertEquals(expectedColumnHeader, sorter.getText());
+        Assert.assertTrue(sorter.getText().startsWith(expectedColumnHeader));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -73,6 +73,8 @@ public class SortingIT extends AbstractComponentIT {
     public void setInitialSortOrder_changeOrderFromServer_sortIndicatorsUpdated() {
         findElement(By.id("sort-by-age")).click();
         assertAscendingSorter("Age");
+        findElement(By.id("reorder-button")).click();        
+        assertAscendingSorter("Age");
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4166,6 +4166,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void setColumnOrder(List<Column<T>> columns) {
         new GridColumnOrderHelper<>(this).setColumnOrder(columns);
+        updateClientSideSorterIndicators(sortOrder);
         fireColumnReorderEvent(getColumns());
     }
 


### PR DESCRIPTION
Column reordering messes sort indicators, this should be the fix, testing for regressions, do not merge

fixes: https://github.com/vaadin/vaadin-grid/issues/2175