### PR TITLE
test: fix listBoxRetainValueWhenRemovedAndAdded test (#814)

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
@@ -34,9 +34,9 @@ public class ListBoxRetainValuePage extends VerticalLayout {
         listBox.setItems(listBoxItems);
         listBox.setValue("2");
         Button addButton = new Button("add");
-        addButton.setId("button");
+        addButton.setId("add-button");
         Div value = new Div();
-        value.setId("value");
+        value.setId("list-box-value");
         add(value, addButton, listBox);
         value.setText(listBox.getValue());
         addButton.addClickListener(event -> {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -29,9 +29,9 @@ public class ListBoxRetainValueIT extends AbstractComponentIT {
     @Test
     public void listBoxRetainValueWhenRemovedAndAdded() {
         open();
-        WebElement value = findElement(By.id("value"));
-        Assert.assertEquals(value.getText(), "2");
-        findElement(By.id("button")).click();
-        Assert.assertEquals(value.getText(), "2");
+        WebElement value = findElement(By.id("list-box-value"));
+        Assert.assertEquals(value.getText(),"2");
+        findElement(By.id("add-button")).click();
+        Assert.assertEquals(value.getText(),"2");		
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -30,8 +30,8 @@ public class ListBoxRetainValueIT extends AbstractComponentIT {
     public void listBoxRetainValueWhenRemovedAndAdded() {
         open();
         WebElement value = findElement(By.id("list-box-value"));
-        Assert.assertEquals(value.getText(),"2");
+        Assert.assertEquals(value.getText(), "2");
         findElement(By.id("add-button")).click();
-        Assert.assertEquals(value.getText(),"2");		
+        Assert.assertEquals(value.getText(), "2");
     }
 }


### PR DESCRIPTION
On the page, there are two elements with id "button" and
`findElement(By.id("button"))` is actually getting the wrong one, which
causes the test to fail.

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
