### PR TITLE
test: fix listBoxRetainValueWhenRemovedAndAdded test (#814)

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom-bower-mode.xml
@@ -71,6 +71,11 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-button-flow</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-button-flow</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValuePage.java
@@ -19,8 +19,8 @@ package com.vaadin.flow.component.listbox.test;
 import java.util.Arrays;
 import java.util.List;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
@@ -33,10 +33,10 @@ public class ListBoxRetainValuePage extends VerticalLayout {
         ListBox<String> listBox = new ListBox<>();
         listBox.setItems(listBoxItems);
         listBox.setValue("2");
-        NativeButton addButton = new NativeButton("add");
-        addButton.setId("button");
+        Button addButton = new Button("add");
+        addButton.setId("add-button");
         Div value = new Div();
-        value.setId("value");
+        value.setId("list-box-value");
         add(value, addButton, listBox);
         value.setText(listBox.getValue());
         addButton.addClickListener(event -> {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -29,9 +29,9 @@ public class ListBoxRetainValueIT extends AbstractComponentIT {
     @Test
     public void listBoxRetainValueWhenRemovedAndAdded() {
         open();
-        WebElement value = findElement(By.id("value"));
-        Assert.assertEquals(value.getText(), "2");
-        findElement(By.id("button")).click();
-        Assert.assertEquals(value.getText(), "2");
+        WebElement value = findElement(By.id("list-box-value"));
+        Assert.assertEquals(value.getText(),"2");
+        findElement(By.id("add-button")).click();
+        Assert.assertEquals(value.getText(),"2");		
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxRetainValueIT.java
@@ -30,8 +30,8 @@ public class ListBoxRetainValueIT extends AbstractComponentIT {
     public void listBoxRetainValueWhenRemovedAndAdded() {
         open();
         WebElement value = findElement(By.id("list-box-value"));
-        Assert.assertEquals(value.getText(),"2");
+        Assert.assertEquals(value.getText(), "2");
         findElement(By.id("add-button")).click();
-        Assert.assertEquals(value.getText(),"2");		
+        Assert.assertEquals(value.getText(), "2");
     }
 }


### PR DESCRIPTION
On the page, there are two elements with id "button" and
`findElement(By.id("button"))` is actually getting the wrong one, which
causes the test to fail.

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
