### PR TITLE
fix: change how setSeries converts array to ArrayList

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -147,7 +147,7 @@ public class Configuration extends AbstractConfigurationObject
      * @param series
      */
     public void setSeries(List<Series> series) {
-        this.series = series;
+        this.series = new ArrayList<>(series);
         for (Series s : series) {
             s.setConfiguration(this);
             addSeriesToDrilldownConfiguration(s);
@@ -159,7 +159,7 @@ public class Configuration extends AbstractConfigurationObject
      * @param series
      */
     public void setSeries(Series... series) {
-        setSeries(new ArrayList<>(Arrays.asList(series)));
+        setSeries(Arrays.asList(series));
     }
 
     /**

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -159,7 +159,7 @@ public class Configuration extends AbstractConfigurationObject
      * @param series
      */
     public void setSeries(Series... series) {
-        setSeries(Arrays.asList(series));
+        setSeries(new ArrayList<>(Arrays.asList(series)));
     }
 
     /**

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
@@ -110,10 +110,10 @@ public class ConfigurationJSONSerializationTest {
     @Test
     public void configurationJSONSerialization_setSeriesAddSeries_noExceptions() {
         Configuration conf = new Configuration();
-        conf.setSeries(new ListSeries(),new ListSeries());
+        conf.setSeries(new ListSeries(), new ListSeries());
         conf.addSeries(new ListSeries());
         assertEquals(
-          "{\"chart\":{\"styledMode\":false},\"plotOptions\":{},\"series\":[{\"data\":[]},{\"data\":[]},{\"data\":[]}],\"exporting\":{\"enabled\":false}}",
-          toJSON(conf));
+                "{\"chart\":{\"styledMode\":false},\"plotOptions\":{},\"series\":[{\"data\":[]},{\"data\":[]},{\"data\":[]}],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
@@ -15,6 +15,7 @@ import com.vaadin.flow.component.charts.events.internal.SeriesAddedEvent;
 import com.vaadin.flow.component.charts.events.internal.SeriesChangedEvent;
 import com.vaadin.flow.component.charts.events.internal.SeriesStateEvent;
 import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.ListSeries;
 import com.vaadin.flow.component.charts.model.YAxis;
 
 /**
@@ -104,5 +105,15 @@ public class ConfigurationJSONSerializationTest {
         assertEquals(
                 "{\"chart\":{\"styledMode\":true},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
                 toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_setSeriesAddSeries_noExceptions() {
+        Configuration conf = new Configuration();
+        conf.setSeries(new ListSeries(),new ListSeries());
+        conf.addSeries(new ListSeries());
+        assertEquals(
+          "{\"chart\":{\"styledMode\":false},\"plotOptions\":{},\"series\":[{\"data\":[]},{\"data\":[]},{\"data\":[]}],\"exporting\":{\"enabled\":false}}",
+          toJSON(conf));
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
@@ -24,7 +24,7 @@ public class ConfigurationTest {
 
         conf.setSeries(Arrays.asList(new ListSeries()));
         conf.addSeries(new ListSeries());
-        
+
         assertEquals(conf.getSeries().size(), 2);
     }
 
@@ -34,7 +34,7 @@ public class ConfigurationTest {
 
         List<Series> series = new ArrayList<>();
         conf.setSeries(series);
-        
+
         series.add(new ListSeries());
 
         assertEquals(conf.getSeries().size(), 0);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component.charts;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.Series;
+
+/**
+ * Tests for the {@link Configuration}
+ *
+ */
+public class ConfigurationTest {
+
+    @Test(expected = Test.None.class)
+    public void configurationSetSeriesWithArraysAsListTest() {
+        Configuration conf = new Configuration();
+
+        conf.setSeries(Arrays.asList(new ListSeries()));
+        conf.addSeries(new ListSeries());
+    }
+
+    @Test
+    public void configurationSetSeriesWithListShouldMakeShallowCopyTest() {
+        Configuration conf = new Configuration();
+
+        List<Series> series = new ArrayList<>();
+        conf.setSeries(series);
+        
+        series.add(new ListSeries());
+
+        assertEquals(conf.getSeries().size(), 0);
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
@@ -24,6 +24,8 @@ public class ConfigurationTest {
 
         conf.setSeries(Arrays.asList(new ListSeries()));
         conf.addSeries(new ListSeries());
+        
+        assertEquals(conf.getSeries().size(), 2);
     }
 
     @Test


### PR DESCRIPTION
Because `setSeries(...series)` uses `Arrays.asList` to convert from array to `List`, one cannot call `addSeries` after calling `setSeries(...series)` since it throws a `UnsupportedOperationException`.

Fix vaadin/vaadin-charts#515