### PR TITLE
docs: clarify use of setSeries for rendered chart

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -148,9 +148,10 @@ public class Configuration extends AbstractConfigurationObject
      * <br />
      * <br />
      * 
-     * If the chart is already rendered on the client, {@link Chart#drawChart(boolean)}
-     * needs to be called with <code>true</code> as parameter so the configuration
-     * object is resent to the client.
+     * If the chart is already rendered on the client,
+     * {@link Chart#drawChart(boolean)} needs to be called with
+     * <code>true</code> as parameter so the configuration object is resent to
+     * the client.
      * 
      * @param series
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -14,6 +14,7 @@ package com.vaadin.flow.component.charts.model;
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.events.internal.AxisRescaledEvent;
 import com.vaadin.flow.component.charts.events.internal.ConfigurationChangeListener;
 import com.vaadin.flow.component.charts.events.internal.DataAddedEvent;
@@ -143,6 +144,13 @@ public class Configuration extends AbstractConfigurationObject
      * example, even though a general lineWidth is specified in
      * AbstractPlotOptions, an individual lineWidth can be specified for each
      * series (e.g. to enable each series have different lineWidth).
+     * 
+     * <br />
+     * <br />
+     * 
+     * If the chart is already rendered on the client, {@link Chart#drawChart(boolean)}
+     * needs to be called with <code>true</code> as parameter so the configuration
+     * object is resent to the client.
      * 
      * @param series
      */


### PR DESCRIPTION
Add a paragraph to `Configuration#setSeries(List)` javadoc to clarrify that `Chart#drawChart(boolean)` needs to be called in case of the instance of `Chart` is already rendered on the client.

Fixes #vaadin/vaadin-charts#570