### PR TITLE
fix: change how setSeries converts array to ArrayList (#927) (#950)

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -147,7 +147,7 @@ public class Configuration extends AbstractConfigurationObject
      * @param series
      */
     public void setSeries(List<Series> series) {
-        this.series = series;
+        this.series = new ArrayList<>(series);
         for (Series s : series) {
             s.setConfiguration(this);
             addSeriesToDrilldownConfiguration(s);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationTest.java
@@ -1,0 +1,50 @@
+package com.vaadin.flow.component.charts;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.Series;
+
+/**
+ * Tests for the {@link Configuration}
+ *
+ */
+public class ConfigurationTest {
+
+    @Test(expected = Test.None.class)
+    public void configurationSetSeriesWithArraysAsListTest() {
+        Configuration conf = new Configuration();
+
+        conf.setSeries(Arrays.asList(new ListSeries()));
+        conf.addSeries(new ListSeries());
+
+        assertEquals(conf.getSeries().size(), 2);
+    }
+
+    @Test
+    public void configurationSetSeriesWithListShouldMakeShallowCopyTest() {
+        Configuration conf = new Configuration();
+
+        List<Series> series = new ArrayList<>();
+        conf.setSeries(series);
+
+        series.add(new ListSeries());
+
+        assertEquals(conf.getSeries().size(), 0);
+    }
+
+    @Test
+    public void configuration_setSeriesAddSeries_noExceptions() {
+        Configuration conf = new Configuration();
+        conf.setSeries(new ListSeries(), new ListSeries());
+        conf.addSeries(new ListSeries());
+        assertEquals(3, conf.getSeries().size());
+    }
+}


### PR DESCRIPTION
Because setSeries(...series) uses Arrays.asList to convert from array to List, one cannot call addSeries after calling setSeries(...series) since it throws a UnsupportedOperationException.

Fix vaadin/vaadin-charts#515

Co-authored-by: Knoobie <Knoobie@gmx.de>
