### PR TITLE
chore: fix package-name calculation by removing extra quotes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,9 +171,10 @@
                     <configuration>
                         <bnd><![CDATA[
                           regexArtifactId: vaadin-(.*)-flow(-.*)?
+                          dash: -
                           replacementPattern: $1
                           packageNameDash: ${replacestring;${project.artifactId};${regexArtifactId};${replacementPattern}}
-                          packageNameTmp: ${replacestring;${packageNameDash};'-'}
+                          packageNameTmp: ${replacestring;${packageNameDash};${dash}}
 
                           isDemoPattern: .*-flow-demo
                           isDemo: ${matches;${project.artifactId};${isDemoPattern}}


### PR DESCRIPTION
fixes #957

should also be added to v20

Alternatives:
- package-info.java with `@org.osgi.annotation.bundle.Export` Annotation in every bundle that should be exported.