### PR TITLE
chore: fix icon and treegrid namespaces for OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,10 +171,13 @@
                     <configuration>
                         <bnd><![CDATA[
                           regexArtifactId: vaadin-(.*)-flow(-.*)?
-                          dash: -
                           replacementPattern: $1
-                          packageNameDash: ${replacestring;${project.artifactId};${regexArtifactId};${replacementPattern}}
-                          packageNameTmp: ${replacestring;${packageNameDash};${dash}}
+                          packageNameWithDash: ${replacestring;${project.artifactId};${regexArtifactId};${replacementPattern}}
+
+                          dash: -
+                          packageNameWithoutDash: ${replacestring;${packageNameWithDash};${dash};}
+
+                          packageNameTmp: ${replacestring;${packageNameWithoutDash};icons;icon}
 
                           isDemoPattern: .*-flow-demo
                           isDemo: ${matches;${project.artifactId};${isDemoPattern}}

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                           Bundle-Name: ${project.artifactId}
                           Bundle-SymbolicName: ${project.groupId}.flow.component.${packageName}
                           Import-Package: *
-                          Export-Package: ${project.groupId}.flow.component.${packageName}.*;-noimport:=true
+                          Export-Package: ${project.groupId}.flow.component.*${packageName}.*;-noimport:=true
                           Bundle-License: ${osgi.bundle.license}
                           Implementation-Title: ${project.name}
                           Vaadin-Package-Version: 1


### PR DESCRIPTION
Fixes two issues when building platform OSGi smoke tests
```
 ⇒ osgi.wiring.package: (osgi.wiring.package=com.vaadin.flow.component.icon)
 ⇒ osgi.wiring.package: (osgi.wiring.package=com.vaadin.flow.component.treegrid)
```
First problem is because module name is `icons` and namespace `icon` 
Second is because `vaadin-grid` has an additional component `treegrid` which does not share namespace with grid

ping @stbischof 
