### PR TITLE
fix: disable client side validation

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -94,6 +94,17 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-polymer-template</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-grid-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-grid-testbench</artifactId>
+            <version>21.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-grid-testbench</artifactId>
-            <version>21.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
@@ -21,35 +21,23 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.Select;
-import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-select/override-client-validation")
 public class OverrideClientValidationPage extends Div {
     public OverrideClientValidationPage() {
-        Select<Integer> select = new Select<>(1, 2, 3, 4, 5);
-
-        NumberContainer numberContainer = new NumberContainer();
-        Binder<NumberContainer> binder = new Binder<>(NumberContainer.class);
-        binder.forField(select).asRequired("Please select a number")
-                .bind(model -> model.number, (model, value) -> model.number = value);
-        binder.readBean(numberContainer);
-
+        Select<String> select = new Select<>("a", "b", "c");
         Span validationStateSpan = new Span();
         validationStateSpan.setId("validation-state-span");
 
-        NativeButton validateButton = new NativeButton("Validate",
-                e -> binder.validate());
-        validateButton.setId("validate-button");
+        NativeButton setInvalidButton = new NativeButton("Set invalid",
+                e -> select.setInvalid(true));
+        setInvalidButton.setId("set-invalid-button");
 
         NativeButton logValidationStateButton = new NativeButton("Log validation state",
                 e -> validationStateSpan.setText(select.isInvalid() ? "invalid" : "valid"));
         logValidationStateButton.setId("log-validation-state-button");
 
-        add(select, validationStateSpan, validateButton, logValidationStateButton);
-    }
-
-    static class NumberContainer {
-        public Integer number;
+        add(select, validationStateSpan, setInvalidButton, logValidationStateButton);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
@@ -28,6 +28,8 @@ public class OverrideClientValidationPage extends Div {
 
     public static final String ID_SET_INVALID_BUTTON = "set-invalid-button";
     public static final String ID_LOG_BUTTON = "log-button";
+    public static final String ID_DETACH_BUTTON = "detach-button";
+    public static final String ID_REATTACH_BUTTON = "reattach-button";
     public static final String ID_RESULT_SPAN = "result-span";
 
     public OverrideClientValidationPage() {
@@ -44,6 +46,15 @@ public class OverrideClientValidationPage extends Div {
                         .setText(select.isInvalid() ? "invalid" : "valid"));
         logButton.setId(ID_LOG_BUTTON);
 
-        add(select, resultSpan, setInvalidButton, logButton);
+        NativeButton detachButton = new NativeButton("Detach select",
+                e -> this.remove(select));
+        detachButton.setId(ID_DETACH_BUTTON);
+
+        NativeButton reattachButton = new NativeButton("Reattach select",
+                e -> this.addComponentAsFirst(select));
+        reattachButton.setId(ID_REATTACH_BUTTON);
+
+        add(select, resultSpan, setInvalidButton, logButton, detachButton,
+                reattachButton);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
@@ -25,19 +25,25 @@ import com.vaadin.flow.router.Route;
 
 @Route("vaadin-select/override-client-validation")
 public class OverrideClientValidationPage extends Div {
+
+    public static final String ID_SET_INVALID_BUTTON = "set-invalid-button";
+    public static final String ID_LOG_BUTTON = "log-button";
+    public static final String ID_RESULT_SPAN = "result-span";
+
     public OverrideClientValidationPage() {
         Select<String> select = new Select<>("a", "b", "c");
-        Span validationStateSpan = new Span();
-        validationStateSpan.setId("validation-state-span");
+        Span resultSpan = new Span();
+        resultSpan.setId(ID_RESULT_SPAN);
 
         NativeButton setInvalidButton = new NativeButton("Set invalid",
                 e -> select.setInvalid(true));
-        setInvalidButton.setId("set-invalid-button");
+        setInvalidButton.setId(ID_SET_INVALID_BUTTON);
 
-        NativeButton logValidationStateButton = new NativeButton("Log validation state",
-                e -> validationStateSpan.setText(select.isInvalid() ? "invalid" : "valid"));
-        logValidationStateButton.setId("log-validation-state-button");
+        NativeButton logButton = new NativeButton("Log validation state",
+                e -> resultSpan
+                        .setText(select.isInvalid() ? "invalid" : "valid"));
+        logButton.setId(ID_LOG_BUTTON);
 
-        add(select, validationStateSpan, setInvalidButton, logValidationStateButton);
+        add(select, resultSpan, setInvalidButton, logButton);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
@@ -17,44 +17,76 @@
 
 package com.vaadin.flow.component.select.examples;
 
+import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-select/override-client-validation")
 public class OverrideClientValidationPage extends Div {
 
+    public static final String ID_BASIC_SELECT = "basic-select";
+    public static final String ID_BASIC_SELECT_RESULT_SPAN = "basic-select-result-span";
     public static final String ID_SET_INVALID_BUTTON = "set-invalid-button";
     public static final String ID_LOG_BUTTON = "log-button";
     public static final String ID_DETACH_BUTTON = "detach-button";
     public static final String ID_REATTACH_BUTTON = "reattach-button";
-    public static final String ID_RESULT_SPAN = "result-span";
+
+    private Select<String> basicSelect;
+    private Span basicSelectResultSpan;
+    private Select<String> selectInGrid;
 
     public OverrideClientValidationPage() {
-        Select<String> select = new Select<>("a", "b", "c");
-        Span resultSpan = new Span();
-        resultSpan.setId(ID_RESULT_SPAN);
+        createBasicSetup();
+        createGridSetup();
+        createActions();
+    }
 
-        NativeButton setInvalidButton = new NativeButton("Set invalid",
-                e -> select.setInvalid(true));
+    private void createBasicSetup() {
+        basicSelect = new Select<>("a", "b", "c");
+        basicSelect.setId(ID_BASIC_SELECT);
+
+        basicSelectResultSpan = new Span();
+        basicSelectResultSpan.setId(ID_BASIC_SELECT_RESULT_SPAN);
+
+        add(new H1("Basic select usage"), basicSelect, basicSelectResultSpan);
+    }
+
+    private void createGridSetup() {
+        selectInGrid = new Select<>();
+        Grid<String> grid = new Grid<>();
+        grid.setItems("test");
+        grid.addColumn(new ComponentRenderer<>(item -> selectInGrid,
+                (component, item) -> component));
+        add(new H1("Grid select usage"), grid);
+    }
+
+    private void createActions() {
+        NativeButton setInvalidButton = new NativeButton("Set all invalid",
+                e -> {
+                    basicSelect.setInvalid(true);
+                    selectInGrid.setInvalid(true);
+                });
         setInvalidButton.setId(ID_SET_INVALID_BUTTON);
 
         NativeButton logButton = new NativeButton("Log validation state",
-                e -> resultSpan
-                        .setText(select.isInvalid() ? "invalid" : "valid"));
+                e -> basicSelectResultSpan.setText(
+                        basicSelect.isInvalid() ? "invalid" : "valid"));
         logButton.setId(ID_LOG_BUTTON);
 
         NativeButton detachButton = new NativeButton("Detach select",
-                e -> this.remove(select));
+                e -> this.remove(basicSelect));
         detachButton.setId(ID_DETACH_BUTTON);
 
         NativeButton reattachButton = new NativeButton("Reattach select",
-                e -> this.addComponentAsFirst(select));
+                e -> this.addComponentAsFirst(basicSelect));
         reattachButton.setId(ID_REATTACH_BUTTON);
 
-        add(select, resultSpan, setInvalidButton, logButton, detachButton,
-                reattachButton);
+        addComponentAsFirst(new Div(setInvalidButton, logButton, detachButton,
+                reattachButton));
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/OverrideClientValidationPage.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.select.examples;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-select/override-client-validation")
+public class OverrideClientValidationPage extends Div {
+    public OverrideClientValidationPage() {
+        Select<Integer> select = new Select<>(1, 2, 3, 4, 5);
+
+        NumberContainer numberContainer = new NumberContainer();
+        Binder<NumberContainer> binder = new Binder<>(NumberContainer.class);
+        binder.forField(select).asRequired("Please select a number")
+                .bind(model -> model.number, (model, value) -> model.number = value);
+        binder.readBean(numberContainer);
+
+        Span validationStateSpan = new Span();
+        validationStateSpan.setId("validation-state-span");
+
+        NativeButton validateButton = new NativeButton("Validate",
+                e -> binder.validate());
+        validateButton.setId("validate-button");
+
+        NativeButton logValidationStateButton = new NativeButton("Log validation state",
+                e -> validationStateSpan.setText(select.isInvalid() ? "invalid" : "valid"));
+        logValidationStateButton.setId("log-validation-state-button");
+
+        add(select, validationStateSpan, validateButton, logValidationStateButton);
+    }
+
+    static class NumberContainer {
+        public Integer number;
+    }
+}

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/BasicFeaturesIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/BasicFeaturesIT.java
@@ -9,6 +9,11 @@ import org.openqa.selenium.By;
 public class BasicFeaturesIT extends AbstractSelectIT {
 
     @Test
+    public void test_initialClientValue() {
+        Assert.assertEquals("", selectElement.getProperty("value"));
+    }
+
+    @Test
     public void testEnabled_disabling_userCannotSelect() {
         page.toggleEnabled(false);
         verify.selectDisabled();

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
@@ -32,10 +32,10 @@ public class OverrideClientValidationIT extends AbstractComponentIT {
     @Test
     public void testTriggeringClientValidationShouldNotOverrideBinderValidationResults() {
         open();
-        WebElement validateButton = findElement(By.id("validate-button"));
+        WebElement setInvalidButton = findElement(By.id("set-invalid-button"));
 
-        // Trigger binder validation and assert invalid state
-        validateButton.click();
+        // Set server state to invalid
+        setInvalidButton.click();
         getCommandExecutor().waitForVaadin();
         assertClientSideSelectValidationState(false);
         // Trigger client side validation
@@ -47,14 +47,14 @@ public class OverrideClientValidationIT extends AbstractComponentIT {
     @Test
     public void testModifyingClientSideValidationStateShouldNotAffectServerSideValidationState() {
         open();
-        WebElement validateButton = findElement(By.id("validate-button"));
+        WebElement setInvalidButton = findElement(By.id("set-invalid-button"));
         WebElement logValidationStateButton = findElement(
                 By.id("log-validation-state-button"));
         WebElement validationStateSpan = findElement(
                 By.id("validation-state-span"));
 
-        // Trigger binder validation and assert invalid state
-        validateButton.click();
+        // Set server state to invalid
+        setInvalidButton.click();
         getCommandExecutor().waitForVaadin();
         logValidationStateButton.click();
         getCommandExecutor().waitForVaadin();

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.select.test;
+
+import com.vaadin.flow.component.select.testbench.SelectElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+
+@TestPath("vaadin-select/override-client-validation")
+public class OverrideClientValidationIT extends AbstractComponentIT {
+
+    @Test
+    public void testTriggeringClientValidationShouldNotOverrideBinderValidationResults() {
+        open();
+        WebElement validateButton = findElement(By.id("validate-button"));
+
+        // Trigger binder validation and assert invalid state
+        validateButton.click();
+        getCommandExecutor().waitForVaadin();
+        assertClientSideSelectValidationState(false);
+        // Trigger client side validation
+        triggerClientSideValidation();
+        // Client side state should still be invalid
+        assertClientSideSelectValidationState(false);
+    }
+
+    @Test
+    public void testModifyingClientSideValidationStateShouldNotAffectServerSideValidationState() {
+        open();
+        WebElement validateButton = findElement(By.id("validate-button"));
+        WebElement logValidationStateButton = findElement(
+                By.id("log-validation-state-button"));
+        WebElement validationStateSpan = findElement(
+                By.id("validation-state-span"));
+
+        // Trigger binder validation and assert invalid state
+        validateButton.click();
+        getCommandExecutor().waitForVaadin();
+        logValidationStateButton.click();
+        getCommandExecutor().waitForVaadin();
+        Assert.assertEquals("invalid", validationStateSpan.getText());
+        // Overwrite client side validation state to be valid
+        overwriteClientSideValidationState(true);
+        getCommandExecutor().waitForVaadin();
+        // Server state should still be invalid
+        logValidationStateButton.click();
+        Assert.assertEquals("invalid", validationStateSpan.getText());
+    }
+
+    private void assertClientSideSelectValidationState(boolean valid) {
+        SelectElement selectElement = getSelectElement();
+        Boolean validationState = selectElement.getPropertyBoolean("invalid");
+
+        Assert.assertEquals("Validation state did not match", !valid,
+                validationState);
+    }
+
+    private void triggerClientSideValidation() {
+        SelectElement selectElement = getSelectElement();
+        selectElement.getCommandExecutor()
+                .executeScript("arguments[0].validate()", selectElement);
+        getCommandExecutor().waitForVaadin();
+    }
+
+    private void overwriteClientSideValidationState(boolean valid) {
+        SelectElement selectElement = getSelectElement();
+        selectElement.setProperty("invalid", !valid);
+    }
+
+    private SelectElement getSelectElement() {
+        SelectElement selectElement = $(SelectElement.class).first();
+        if (selectElement == null) {
+            throw new NoSuchElementException("Can not find select");
+        }
+        return selectElement;
+    }
+}

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
@@ -32,6 +32,8 @@ public class OverrideClientValidationIT extends AbstractComponentIT {
     private SelectElement selectElement;
     private TestBenchElement setInvalidButton;
     private TestBenchElement logButton;
+    private TestBenchElement detachButton;
+    private TestBenchElement reattachButton;
     private TestBenchElement resultSpan;
 
     @Before
@@ -41,6 +43,10 @@ public class OverrideClientValidationIT extends AbstractComponentIT {
         setInvalidButton = $("button")
                 .id(OverrideClientValidationPage.ID_SET_INVALID_BUTTON);
         logButton = $("button").id(OverrideClientValidationPage.ID_LOG_BUTTON);
+        detachButton = $("button")
+                .id(OverrideClientValidationPage.ID_DETACH_BUTTON);
+        reattachButton = $("button")
+                .id(OverrideClientValidationPage.ID_REATTACH_BUTTON);
         resultSpan = $("span").id(OverrideClientValidationPage.ID_RESULT_SPAN);
     }
 
@@ -68,6 +74,27 @@ public class OverrideClientValidationIT extends AbstractComponentIT {
         // Server state should still be invalid
         logButton.click();
         Assert.assertEquals("invalid", resultSpan.getText());
+    }
+
+    @Test
+    public void testDetachingAndReattachingShouldStillOverrideClientValidation() {
+        // Set server state to invalid
+        setInvalidButton.click();
+        assertClientSideSelectValidationState(false);
+
+        // Detach and reattach
+        detachButton.click();
+        reattachButton.click();
+        selectElement = $(SelectElement.class).first();
+
+        // Client side state should still be invalid after reattaching
+        assertClientSideSelectValidationState(false);
+
+        // Trigger client side validation after reattaching
+        triggerClientSideValidation();
+        // Client side state should still be invalid after reattaching and
+        // triggering validation
+        assertClientSideSelectValidationState(false);
     }
 
     private void assertClientSideSelectValidationState(boolean valid) {

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/FieldValidationUtil.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/FieldValidationUtil.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.select;
+
+import com.vaadin.flow.internal.StateNode;
+
+/**
+ * Utility class for select Flow component to disable client side
+ * validation.
+ *
+ * @author Vaadin Ltd
+ */
+final class FieldValidationUtil {
+
+    private FieldValidationUtil() {
+        // utility class should not be instantiated
+    }
+
+    static void disableClientValidation(Select component) {
+        // Since this method should be called for every time when the component
+        // is attached to the UI, lets check that it is actually so
+        if (!component.isAttached()) {
+            throw new IllegalStateException(String.format(
+                    "Component %s is not attached. Client side "
+                            + "validation can only be disabled for a component "
+                            + "when it has been attached to the UI and because "
+                            + "it should be called again once the component is "
+                            + "removed/added, you should call this method from "
+                            + "the onAttach() method of the component.",
+                    component.toString()));
+        }
+        // Wait until the response is being written as the validation state
+        // should not change after that
+        final StateNode componentNode = component.getElement().getNode();
+        componentNode.runWhenAttached(ui -> ui.getInternals().getStateTree()
+                .beforeClientResponse(componentNode,
+                        executionContext -> overrideClientValidation(
+                                component)));
+    }
+
+    private static void overrideClientValidation(Select component) {
+        // Overwrite client validation method to simply return validation state set from server
+        StringBuilder expression = new StringBuilder(
+                "this.validate = function () {return !this.invalid;};");
+
+        if (component.isInvalid()) {
+            /*
+             * By default the invalid flag is set to false. Workaround the case
+             * where the client side validation overrides the invalid state
+             * before the validation function itself is overridden above.
+             */
+            expression.append("this.invalid = true;");
+        }
+        component.getElement().executeJs(expression.toString());
+    }
+}

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/FieldValidationUtil.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/FieldValidationUtil.java
@@ -18,8 +18,7 @@ package com.vaadin.flow.component.select;
 import com.vaadin.flow.internal.StateNode;
 
 /**
- * Utility class for select Flow component to disable client side
- * validation.
+ * Utility class for select Flow component to disable client side validation.
  *
  * @author Vaadin Ltd
  */
@@ -52,7 +51,8 @@ final class FieldValidationUtil {
     }
 
     private static void overrideClientValidation(Select component) {
-        // Overwrite client validation method to simply return validation state set from server
+        // Overwrite client validation method to simply return validation state
+        // set from server
         StringBuilder expression = new StringBuilder(
                 "this.validate = function () {return !this.invalid;};");
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -15,14 +15,6 @@
  */
 package com.vaadin.flow.component.select;
 
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
-
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
@@ -58,6 +50,14 @@ import com.vaadin.flow.dom.PropertyChangeListener;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 /**
  * A customizable drop-down select component similar to a native browser select.
@@ -746,20 +746,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
-
-        // TODO: Refactor: Override client validation
-        StringBuilder expression = new StringBuilder(
-                "this.validate = function () {};");
-
-        if (this.isInvalid()) {
-            /*
-             * By default the invalid flag is set to false. Workaround the case
-             * where the client side validation overrides the invalid state
-             * before the validation function itself is overridden above.
-             */
-            expression.append("this.invalid = true;");
-        }
-        this.getElement().executeJs(expression.toString());
+        FieldValidationUtil.disableClientValidation(this);
     }
 
     /**

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -123,6 +123,10 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
 
         getElement().setProperty("invalid", false);
         getElement().setProperty("opened", false);
+        // Trigger model-to-presentation conversion in constructor, so that
+        // the client side component has a correct initial value of an empty
+        // string
+        setPresentationValue(null);
 
         getElement().appendChild(listBox.getElement());
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -746,6 +746,20 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
+
+        // TODO: Refactor: Override client validation
+        StringBuilder expression = new StringBuilder(
+                "this.validate = function () {};");
+
+        if (this.isInvalid()) {
+            /*
+             * By default the invalid flag is set to false. Workaround the case
+             * where the client side validation overrides the invalid state
+             * before the validation function itself is overridden above.
+             */
+            expression.append("this.invalid = true;");
+        }
+        this.getElement().executeJs(expression.toString());
     }
 
     /**

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
@@ -394,13 +394,12 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * <p>
      * Set to true if the value is invalid.
      * <p>
-     * This property is synchronized automatically from client side when a
-     * 'invalid-changed' event happens.
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
      * </p>
      *
      * @return the {@code invalid} property from the webcomponent
      */
-    @Synchronize(property = "invalid", value = "invalid-changed")
     protected boolean isInvalidBoolean() {
         return getElement().getProperty("invalid", false);
     }


### PR DESCRIPTION
## Description

The original issue occurs because the select web component triggers its own client-side validation in several places (specifically to the issue, when the dropdown is closed), which then overwrites the validation state set by the server. Investigating this also lead to another issue that changing the validation state on the client through JS / dev tools also changed the validation state on the server, which should not be allowed.

This change fixes that by:
- overwriting the client-side validation method with a no-op, as is done for other field components
- disabling synchronization of the client side validation state to the server
- semi-related change: fixes the initial value of the client side component to be an empty string instead of the string `null` which initially lead the client side component to pass validation, because the value was not empty

Fixes https://github.com/vaadin/vaadin-select/issues/265

## Type of change

- [x] Bugfix