### PR TITLE
feat: add theme API to MessageListItem

### DIFF
--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/main/java/com/vaadin/flow/component/messages/tests/MessageListPage.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/main/java/com/vaadin/flow/component/messages/tests/MessageListPage.java
@@ -51,6 +51,8 @@ public class MessageListPage extends Div {
         addButton("setUserImage", () -> foo.setUserImage("/test2.jpg"));
         addButton("setAbbreviation", () -> foo.setUserAbbreviation("CD"));
         addButton("setUserColorIndex", () -> foo.setUserColorIndex(2));
+        addButton("addThemeNames", () -> foo.addThemeNames("foo", "bar"));
+        addButton("removeThemeNames", () -> foo.removeThemeNames("foo", "bar"));
 
         addButton("setItems", () -> messageList
                 .setItems(new MessageListItem(null, null, "sender3")));

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
@@ -93,6 +93,14 @@ public class MessageListIT extends AbstractComponentIT {
         clickElementWithJs("setUserColorIndex");
         Assert.assertEquals("Unexpected userColorIndex prop", 2,
                 msg.getUserColorIndex());
+
+        clickElementWithJs("addThemeNames");
+        Assert.assertEquals("Unexpected theme prop after adding theme names",
+                "foo bar", msg.getTheme());
+
+        clickElementWithJs("removeThemeNames");
+        Assert.assertEquals("Unexpected theme prop after removing theme names",
+                null, msg.getTheme());
     }
 
     @Test

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -18,9 +18,14 @@ package com.vaadin.flow.component.messages;
 import java.io.Serializable;
 import java.net.URI;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -57,6 +62,8 @@ public class MessageListItem implements Serializable {
     private Registration pendingRegistration;
     private Command pendingHandle;
     private AbstractStreamResource imageResource;
+
+    private Set<String> themeNames = new LinkedHashSet<>();
 
     /**
      * Creates an empty message list item. Use the setter methods to configure
@@ -280,6 +287,40 @@ public class MessageListItem implements Serializable {
     public void setUserColorIndex(Integer userColorIndex) {
         this.userColorIndex = userColorIndex;
         propsChanged();
+    }
+
+    /**
+     * Adds one or more theme names to this message. Multiple theme names can be
+     * specified by using multiple parameters.
+     *
+     * @param themeNames
+     *            the theme name or theme names to be added to the message
+     */
+    public void addThemeNames(String... themeNames) {
+        this.themeNames.addAll(Arrays.asList(themeNames));
+        propsChanged();
+    }
+
+    /**
+     * Removes one or more theme names from this message. Multiple theme names
+     * can be specified by using multiple parameters.
+     *
+     * @param themeNames
+     *            the theme name or theme names to be removed from the message
+     */
+    public void removeThemeNames(String... themeNames) {
+        this.themeNames.removeAll(Arrays.asList(themeNames));
+        propsChanged();
+    }
+
+    // Used only for Jackson serialization
+    @JsonGetter
+    private String getTheme() {
+        if (themeNames.isEmpty()) {
+            return null;
+        } else {
+            return themeNames.stream().collect(Collectors.joining(" "));
+        }
     }
 
     /**

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -313,6 +313,18 @@ public class MessageListItem implements Serializable {
         propsChanged();
     }
 
+    /**
+     * Checks if the message has the given theme name.
+     *
+     * @param themeName
+     *            the theme name to check for
+     * @return <code>true</code> if the message has the given theme name,
+     *         <code>false</code> otherwise
+     */
+    public boolean hasThemeName(String themeName) {
+        return themeNames.contains(themeName);
+    }
+
     // Used only for Jackson serialization
     @JsonGetter
     private String getTheme() {

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -289,6 +289,13 @@ public class MessageListItem implements Serializable {
         propsChanged();
     }
 
+    /*
+     * The following theme-related methods are copied from the HasTheme
+     * interface, because the interface is compatible only with components. For
+     * more detailed reasoning, see the discussion in:
+     * https://github.com/vaadin/flow-components/pull/979#discussion_r634097080
+     */
+
     /**
      * Adds one or more theme names to this message. Multiple theme names can be
      * specified by using multiple parameters.

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -29,7 +29,11 @@ import org.junit.Test;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.messages.MessageListItem;
+import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.server.StreamResource;
+
+import elemental.json.JsonType;
+import elemental.json.JsonValue;
 
 public class MessageListTest {
 
@@ -90,5 +94,41 @@ public class MessageListTest {
                 () -> getClass().getResourceAsStream("baz/qux")));
         item1.setUserImage("foo/bar");
         Assert.assertNull(item1.getUserImageResource());
+    }
+
+    @Test
+    public void addThemeNames_serialize_separatedBySpaces() {
+        item1.addThemeNames("foo", "bar");
+        item1.addThemeNames("baz");
+        Assert.assertEquals("foo bar baz", getSerializedThemeProperty(item1));
+    }
+
+    @Test
+    public void addThemeNames_serialize_noDuplicates() {
+        item1.addThemeNames("foo", "foo");
+        Assert.assertEquals("foo", getSerializedThemeProperty(item1));
+    }
+
+    @Test
+    public void removeThemeNames_serialize_themeNamesRemoved() {
+        item1.addThemeNames("foo", "bar", "baz");
+        item1.removeThemeNames("foo", "bar", "qux");
+        Assert.assertEquals("baz", getSerializedThemeProperty(item1));
+    }
+
+    @Test
+    public void clearThemeNames_serialize_nullProperty() {
+        item1.addThemeNames("foo");
+        item1.removeThemeNames("foo");
+        Assert.assertNull(getSerializedThemeProperty(item1));
+    }
+
+    private String getSerializedThemeProperty(MessageListItem item) {
+        JsonValue theme = JsonUtils.beanToJson(item).get("theme");
+        if (theme.getType() == JsonType.NULL) {
+            return null;
+        } else {
+            return theme.asString();
+        }
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -123,6 +123,17 @@ public class MessageListTest {
         Assert.assertNull(getSerializedThemeProperty(item1));
     }
 
+    @Test
+    public void hasThemeName_falseForNonExistingThemeName() {
+        Assert.assertFalse(item1.hasThemeName("foo"));
+    }
+
+    @Test
+    public void hasThemeName_trueForExistingThemeName() {
+        item1.addThemeNames("foo");
+        Assert.assertTrue(item1.hasThemeName("foo"));
+    }
+
     private String getSerializedThemeProperty(MessageListItem item) {
         JsonValue theme = JsonUtils.beanToJson(item).get("theme");
         if (theme.getType() == JsonType.NULL) {

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageElement.java
@@ -82,4 +82,13 @@ public class MessageElement extends TestBenchElement {
         return getPropertyInteger("userColorIndex");
     }
 
+    /**
+     * Gets the {@code theme} attribute of this element.
+     *
+     * @return the {@code theme} attribute
+     */
+    public String getTheme() {
+        return getAttribute("theme");
+    }
+
 }


### PR DESCRIPTION
**NOTE**: This depends on https://github.com/vaadin/flow-components/pull/978 and won't pass in CI before that is merged.

## Description

Feature: add and remove `theme` attribute values to messages in a `MessageList`. Only with strings at this point, since no theme variants have been implemented so far. The API is copied from `HasTheme` interface, which can be directly implemented only by component classes.

This enables developers to apply custom theming per each message in a MessageList.

Related issue: https://github.com/vaadin/collaboration-engine/issues/30

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
