### PR TITLE
test: check notification cards by tag name

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
@@ -220,7 +220,7 @@ public class NotificationTestPageIT extends AbstractComponentIT {
         waitForElementPresent(By.id("notification-add-component-at-index"));
         assertButtonNumberInNotification(initialNumber);
         findElement(By.id("close-notification-add-component-at-index")).click();
-        waitForElementNotPresent(By.id(NOTIFICATION_CARD_TAG));
+        waitForElementNotPresent(By.tagName(NOTIFICATION_CARD_TAG));
     }
 
     private void assertButtonNumberInNotification(int expectedButtonNumber) {


### PR DESCRIPTION
## Description

The `ID` attribute should not be used for tests, it was removed by https://github.com/vaadin/web-components/commit/5f3feb456a908b42519b97fb967798bef830e6ce

## Type of change

- [x] Test