### PR TITLE
fix: update date picker overlay(#1742) (CP: 14.6)

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerI18nPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerI18nPage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-date-picker/date-picker-i18n")
+public class DatePickerI18nPage extends VerticalLayout {
+
+    public static final String ID_INITIAL_I18N_DATE_PICKER = "initial-i18n-date-picker";
+    public static final String ID_DYNAMIC_I18N_DATE_PICKER = "dynamic-i18n-date-picker";
+    public static final String ID_SET_FINNISH_BUTTON = "set-finnish-button";
+    public static final String ID_SET_PARTIAL_I18N_BUTTON = "set-partial-i18n-button";
+
+    public DatePickerI18nPage() {
+        DatePicker initialI18nDatePicker = new DatePicker();
+        initialI18nDatePicker.setId(ID_INITIAL_I18N_DATE_PICKER);
+        initialI18nDatePicker.setI18n(TestI18N.FINNISH);
+
+        DatePicker dynamicI18nDatePicker = new DatePicker();
+        dynamicI18nDatePicker.setId(ID_DYNAMIC_I18N_DATE_PICKER);
+
+        NativeButton setFinnishButton = new NativeButton("Set Finnish",
+                e -> dynamicI18nDatePicker.setI18n(TestI18N.FINNISH));
+        setFinnishButton.setId(ID_SET_FINNISH_BUTTON);
+
+        NativeButton setPartialI18nButton = new NativeButton(
+                "Set partial I18N config",
+                e -> dynamicI18nDatePicker.setI18n(TestI18N.FINNISH_PARTIAL));
+        setPartialI18nButton.setId(ID_SET_PARTIAL_I18N_BUTTON);
+
+        add(new H1("Initial I18N"), initialI18nDatePicker);
+        add(new H1("Dynamic I18N"), dynamicI18nDatePicker, setFinnishButton,
+                setPartialI18nButton);
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/TestI18N.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/TestI18N.java
@@ -32,6 +32,15 @@ public class TestI18N {
             .setWeekdaysShort(
                     Arrays.asList("su", "ma", "ti", "ke", "to", "pe", "la"));
 
+    /**
+     * Intentionally leaves some fields in the initial / null state
+     */
+    public static final DatePickerI18n FINNISH_PARTIAL = new DatePickerI18n()
+            .setWeekdays(Arrays.asList("sunnuntai", "maanantai", "tiistai",
+                    "keskiviikko", "torstai", "perjantai", "lauantai"))
+            .setWeekdaysShort(
+                    Arrays.asList("su", "ma", "ti", "ke", "to", "pe", "la"));
+
     private TestI18N() {
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerI18nIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerI18nIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@TestPath("vaadin-date-picker/date-picker-i18n")
+public class DatePickerI18nIT extends AbstractComponentIT {
+
+    @Test
+    public void testSetInitialI18n() {
+        open();
+
+        assertI18n(getInitialI18nDatePicker(), TestI18N.FINNISH);
+    }
+
+    @Test
+    public void testSetI18nAfterOpeningAndClosing() {
+        open();
+
+        // Open and close to force overlay to render with initial I18N settings
+        DatePickerElement datePicker = getDynamicI18nDatePicker();
+        datePicker.open();
+        datePicker.close();
+
+        // Then override settings and assert that overlay has updated
+        TestBenchElement setFinnishButton = getSetFinnishButton();
+        setFinnishButton.click();
+
+        assertI18n(datePicker, TestI18N.FINNISH);
+    }
+
+    @Test
+    public void testSetPartialI18nConfigShouldNotResultInError() {
+        open();
+
+        TestBenchElement setPartialI18nButton = getSetPartialI18nButton();
+        setPartialI18nButton.click();
+
+        DatePickerElement datePicker = getDynamicI18nDatePicker();
+        datePicker.open();
+
+        checkLogsForErrors();
+    }
+
+    private void assertI18n(DatePickerElement datePicker,
+            DatePicker.DatePickerI18n i18n) {
+
+        // Set to date in January and open
+        datePicker.setDate(LocalDate.of(2021, 1, 1));
+        datePicker.open();
+
+        DatePickerElement.OverlayContentElement overlayContent = datePicker
+                .getOverlayContent();
+
+        // Look for translation for January
+        String januaryText = i18n.getMonthNames().get(0);
+
+        List<DatePickerElement.MonthCalendarElement> visibleMonthCalendars = overlayContent
+                .getVisibleMonthCalendars();
+
+        waitUntil((c) -> {
+            Optional<DatePickerElement.MonthCalendarElement> maybeJanuaryMonthCalender = getMonthCalendarWithName(
+                    visibleMonthCalendars, januaryText);
+            return maybeJanuaryMonthCalender.isPresent();
+        });
+
+        // Verify week days translations
+        DatePickerElement.MonthCalendarElement januaryMonthCalender = getMonthCalendarWithName(
+                visibleMonthCalendars, januaryText).get();
+        List<DatePickerElement.WeekdayElement> weekdays = januaryMonthCalender
+                .getWeekdays();
+
+        for (String weekdayShortName : i18n.getWeekdaysShort()) {
+            Optional<DatePickerElement.WeekdayElement> weekday = getWeekdayByName(
+                    weekdays, weekdayShortName);
+
+            Assert.assertTrue(
+                    String.format("Can not find week day with short name: %s",
+                            weekdayShortName),
+                    weekday.isPresent());
+        }
+
+        // Verify buttons
+        ButtonElement todayButton = overlayContent.getTodayButton();
+        ButtonElement cancelButton = overlayContent.getCancelButton();
+
+        Assert.assertTrue(
+                String.format("Today button does not contain: %s",
+                        i18n.getToday()),
+                todayButton.getText().contains(i18n.getToday()));
+        Assert.assertTrue(
+                String.format("Cancel button does not contain: %s",
+                        i18n.getCancel()),
+                cancelButton.getText().contains(i18n.getCancel()));
+    }
+
+    private DatePickerElement getInitialI18nDatePicker() {
+        return $(DatePickerElement.class)
+                .id(DatePickerI18nPage.ID_INITIAL_I18N_DATE_PICKER);
+    }
+
+    private DatePickerElement getDynamicI18nDatePicker() {
+        return $(DatePickerElement.class)
+                .id(DatePickerI18nPage.ID_DYNAMIC_I18N_DATE_PICKER);
+    }
+
+    private TestBenchElement getSetFinnishButton() {
+        return $("button").id(DatePickerI18nPage.ID_SET_FINNISH_BUTTON);
+    }
+
+    private TestBenchElement getSetPartialI18nButton() {
+        return $("button").id(DatePickerI18nPage.ID_SET_PARTIAL_I18N_BUTTON);
+    }
+
+    private Optional<DatePickerElement.MonthCalendarElement> getMonthCalendarWithName(
+            List<DatePickerElement.MonthCalendarElement> monthCalendars,
+            String monthName) {
+        return monthCalendars.stream()
+                .filter(month -> month.getHeaderText().contains(monthName))
+                .findFirst();
+    }
+
+    private Optional<DatePickerElement.WeekdayElement> getWeekdayByName(
+            List<DatePickerElement.WeekdayElement> weekdays, String name) {
+        return weekdays.stream().filter(e -> e.getText().contains(name))
+                .findFirst();
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.JsonObject;
+import elemental.json.JsonType;
 
 /**
  * Server-side component that encapsulates the functionality of the
@@ -351,10 +352,17 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     private void setI18nWithJS() {
         runBeforeClientResponse(ui -> {
             JsonObject i18nObject = (JsonObject) JsonSerializer.toJson(i18n);
+            // Remove null values to prevent errors
             for (String key : i18nObject.keys()) {
-                getElement().executeJs("this.set('i18n." + key + "', $0)",
-                        i18nObject.get(key));
+                if (i18nObject.get(key).getType() == JsonType.NULL) {
+                    i18nObject.remove(key);
+                }
             }
+            // Assign new I18N object to WC, keep current values if they are not
+            // defined in the new object
+            getElement().executeJs(
+                    "this.i18n = Object.assign({}, this.i18n, $0);",
+                    i18nObject);
         });
     }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/pom.xml
@@ -15,6 +15,11 @@
       <artifactId>vaadin-testbench-core</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-button-testbench</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -15,12 +15,15 @@
  */
 package com.vaadin.flow.component.datepicker.testbench;
 
-import java.time.LocalDate;
-
+import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-date-picker&gt;</code>
@@ -29,6 +32,65 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("vaadin-date-picker")
 public class DatePickerElement extends TestBenchElement
         implements HasLabel, HasHelper {
+
+    public static class OverlayContentElement extends TestBenchElement {
+        /**
+         * Gets all visible month calendars that are currently rendered by the
+         * infinite scroller in the overlay.
+         *
+         * @return
+         */
+        public List<MonthCalendarElement> getVisibleMonthCalendars() {
+            return this.$("vaadin-month-calendar").all().stream()
+                    .map(el -> el.wrap(MonthCalendarElement.class))
+                    .collect(Collectors.toList());
+        }
+
+        /**
+         * Gets the today button from the overlays toolbar
+         *
+         * @return
+         */
+        public ButtonElement getTodayButton() {
+            return this.$(ButtonElement.class).attribute("part", "today-button")
+                    .first();
+        }
+
+        /**
+         * Gets the cancel button from the overlays toolbar
+         *
+         * @return
+         */
+        public ButtonElement getCancelButton() {
+            return this.$(ButtonElement.class)
+                    .attribute("part", "cancel-button").first();
+        }
+    }
+
+    public static class MonthCalendarElement extends TestBenchElement {
+        /**
+         * Gets the header text of the month calendar, e.g. `January 1999`
+         *
+         * @return
+         */
+        public String getHeaderText() {
+            return this.$(TestBenchElement.class)
+                    .attribute("part", "month-header").first().getText();
+        }
+
+        /**
+         * Gets the weekday headers that are rendered by the month calendar
+         *
+         * @return
+         */
+        public List<WeekdayElement> getWeekdays() {
+            return this.$(WeekdayElement.class).attribute("part", "weekday")
+                    .all();
+        }
+    }
+
+    public static class WeekdayElement extends TestBenchElement {
+    }
 
     /**
      * Clears the value of the date picker.
@@ -90,6 +152,27 @@ public class DatePickerElement extends TestBenchElement
     }
 
     /**
+     * Opens the overlay, sets the value to the inner input element as a string
+     * and closes the overlay. This simulates the user typing into the input and
+     * triggering an update of the value property.
+     */
+    public void setInputValue(String value) {
+        this.open();
+        setProperty("_inputValue", value);
+        this.close();
+    }
+
+    /**
+     * Gets the visible presentation value from the inner input element as a
+     * string. This value depends on the used Locale.
+     *
+     * @return
+     */
+    public String getInputValue() {
+        return getPropertyString("_inputValue");
+    }
+
+    /**
      * When auto open is enabled, the dropdown will open when the field is
      * clicked.
      *
@@ -98,5 +181,32 @@ public class DatePickerElement extends TestBenchElement
      */
     public boolean isAutoOpen() {
         return !getPropertyBoolean("autoOpenDisabled");
+    }
+
+    /**
+     * Opens the date picker overlay
+     */
+    public void open() {
+        executeScript("arguments[0].open();", this);
+    }
+
+    /**
+     * Closes the date picker overlay
+     */
+    public void close() {
+        executeScript("arguments[0].close();", this);
+    }
+
+    /**
+     * Gets the content of the first date picker overlay on the page Should only
+     * be used with a single date picker at a time, there is no check that the
+     * overlay belongs to this specific date picker
+     *
+     * @return
+     */
+    public OverlayContentElement getOverlayContent() {
+        return this.$("vaadin-date-picker-overlay").onPage().waitForFirst()
+                .$(TestBenchElement.class).id("content")
+                .$(OverlayContentElement.class).id("overlay-content");
     }
 }


### PR DESCRIPTION
Fixes: #1411
Warranty: Fixes date picker overlay not refreshing after changing I18N settings

* fix: update date picker overlay after setting I18N settings

* Extract date picker element helpers into TestBench element

* Add test for partial i18n configs

* Fix SonarQube issues

* Simplify shadow DOM interactions with test bench queries

(cherry picked from commit ec6054541b6fe1df6d40b044dc89059a9d3edbb2)
