### PR TITLE
chore: deprecate IronList in favor of VirtualList

### DIFF
--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
@@ -73,7 +73,8 @@ import elemental.json.JsonValue;
  *      "https://www.webcomponents.org/element/PolymerElements/iron-list">iron-list
  *      webcomponent documentation</a>
  *
- * @deprecated since Vaadin 21, {@code IronList} is deprecated in favor of {@code VirtualList}
+ * @deprecated since Vaadin 21, {@code IronList} is deprecated in favor of
+ *             {@code VirtualList}
  */
 @Tag("iron-list")
 @NpmPackage(value = "@polymer/iron-list", version = "3.1.0")

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
@@ -72,6 +72,8 @@ import elemental.json.JsonValue;
  * @see <a href=
  *      "https://www.webcomponents.org/element/PolymerElements/iron-list">iron-list
  *      webcomponent documentation</a>
+ *
+ * @deprecated {@code IronList} is deprecated in favor of {@code VirtualList}
  */
 @Tag("iron-list")
 @NpmPackage(value = "@polymer/iron-list", version = "3.1.0")
@@ -79,6 +81,7 @@ import elemental.json.JsonValue;
 @JsModule("./flow-component-renderer.js")
 @JsModule("./ironListConnector.js")
 @JsModule("./ironListStyles.js")
+@Deprecated
 public class IronList<T> extends Component implements HasDataProvider<T>,
         HasStyle, HasSize, Focusable<IronList<T>> {
 

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
@@ -73,7 +73,7 @@ import elemental.json.JsonValue;
  *      "https://www.webcomponents.org/element/PolymerElements/iron-list">iron-list
  *      webcomponent documentation</a>
  *
- * @deprecated {@code IronList} is deprecated in favor of {@code VirtualList}
+ * @deprecated since Vaadin 21, {@code IronList} is deprecated in favor of {@code VirtualList}
  */
 @Tag("iron-list")
 @NpmPackage(value = "@polymer/iron-list", version = "3.1.0")


### PR DESCRIPTION
This PR deprecates `IronList` component and adds a recommendation to use `VirtualList` instead

Closes #854 