### PR TITLE
chore: fix grid tests failing locally

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridCellFocusPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridCellFocusPageIT.java
@@ -15,14 +15,13 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.vaadin.flow.component.grid.CellFocusEvent;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * IT for grid's Flow based cell focus event.
@@ -36,21 +35,21 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
     public void focusBodyCell() {
         open();
 
-        getGrid().getCell(0, 0).focus();
+        getGrid().getCell(0, 0).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT, "A");
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
                 GridCellFocusPage.KEY_FIRST_COLUMN);
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.BODY.getClientSideName());
 
-        getGrid().getCell(1, 0).focus();
+        getGrid().getCell(1, 0).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT, "B");
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
                 GridCellFocusPage.KEY_FIRST_COLUMN);
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.BODY.getClientSideName());
 
-        getGrid().getCell(2, 1).focus();
+        getGrid().getCell(2, 1).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT, "C");
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
                 GridCellFocusPage.KEY_SECOND_COLUMN);
@@ -62,7 +61,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
     public void focusHeaderCell() {
         open();
 
-        getGrid().getHeaderCell(0).focus();
+        getGrid().getHeaderCell(0).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
@@ -70,7 +69,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.HEADER.getClientSideName());
 
-        getGrid().getHeaderCell(1).focus();
+        getGrid().getHeaderCell(1).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
@@ -83,7 +82,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
     public void focusFooterCell() {
         open();
 
-        getGrid().getFooterCell(0).focus();
+        getGrid().getFooterCell(0).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
@@ -91,7 +90,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.FOOTER.getClientSideName());
 
-        getGrid().getFooterCell(1).focus();
+        getGrid().getFooterCell(1).click();
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -330,13 +330,13 @@ public class GridViewIT extends GridViewBase {
         WebElement toggleIdColumnVisibility = findElement(
                 By.id("toggle-id-column-visibility"));
         String firstCellHiddenScript = "return arguments[0].shadowRoot.querySelectorAll('tr')[1].querySelectorAll('td').length;";
-        Assert.assertEquals(4l, getCommandExecutor()
+        Assert.assertEquals(4L, getCommandExecutor()
                 .executeScript(firstCellHiddenScript, grid));
         clickElementWithJs(toggleIdColumnVisibility);
-        Assert.assertEquals(3l, getCommandExecutor()
+        waitUntil(c -> 3L == (long) getCommandExecutor()
                 .executeScript(firstCellHiddenScript, grid));
         clickElementWithJs(toggleIdColumnVisibility);
-        Assert.assertEquals(4l, getCommandExecutor()
+        waitUntil(c -> 4L == (long) getCommandExecutor()
                 .executeScript(firstCellHiddenScript, grid));
 
         Assert.assertNotEquals("true",

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
@@ -43,6 +43,18 @@ public class GridTHTDElement extends TestBenchElement {
         }
     }
 
+    @Override
+    public void click() {
+        // Click cell content in the shadow DOM to prevent Chrome Driver
+        // complaining about the click location not targeting the cell itself
+        TestBenchElement contentElement = (TestBenchElement) this.getContext();
+        // The default TestBench element click implementation just calls
+        // .click() on the element which does not trigger default browser
+        // behaviour, like focus events. Instead use Selenium implementation
+        // which simulates an actual click in the browser UI.
+        contentElement.getWrappedElement().click();
+    }
+
     public String getInnerHTML() {
         // The first child element of a cell is a slot. The following JS finds
         // the elements assigned to that slot and then joins the `innerHTML`


### PR DESCRIPTION
## Description

Fixes two tests that were failing locally, probably due to specific combinations of OS, Chrome and Chrome Driver.

- Column API test
  - changes here just handle some possible delay before the grid has rerendered
- Cell focus test
  - This one was failing locally when the browser was running headless, or the browser window was not focused. In that case calling `.focus()` did not trigger the focus event on the cell element. Solved that by simulating an actual mouse click through Selenium.
