### PR TITLE
docs: improve SVGGenerator javadocs with DX test findings

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/ExportOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/ExportOptions.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.component.charts.model.style.Theme;
  * <li>theme: Theme used to style the chart. For example:
  * {@link com.vaadin.flow.component.charts.themes.LumoDarkTheme}</li>
  * <li>lang: Lang specifications for internationalization purposes.</li>
- * <li>isTimeline: Determines if the generated chart is in timeline mode.</li>
+ * <li>timeline: Determines if the generated chart is in timeline mode.</li>
  * <li>executeFunctions: execute JavaScript functions (for example: formatter
  * functions)</li>
  * </ul>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
@@ -79,8 +79,14 @@ public class SVGGenerator implements AutoCloseable {
     private final Path bundleTempPath;
 
     /**
-     * Creates a new instance of {@link SVGGenerator} which allocates resources
+     * <p>
+     *     Creates a new instance of {@link SVGGenerator} which allocates resources
      * used to transform a {@link Configuration} object to an SVG string.
+     * </p>
+     * <p>
+     *     <b>You must close the generator when you're done using it.</b>
+     *     Use a <code>try-with-resources</code> block or call the {@link SVGGenerator#close()} method.
+     * </p>
      *
      * @throws IOException
      *             if there's any issue allocating resources needed.

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.component.charts.util.ChartSerialization;
  * </p>
  * <br />
  * <p>
- *     CSS styling is not supported.
+ * CSS styling is not supported.
  * </p>
  * <br />
  * <p>
@@ -80,12 +80,13 @@ public class SVGGenerator implements AutoCloseable {
 
     /**
      * <p>
-     *     Creates a new instance of {@link SVGGenerator} which allocates resources
+     * Creates a new instance of {@link SVGGenerator} which allocates resources
      * used to transform a {@link Configuration} object to an SVG string.
      * </p>
      * <p>
-     *     <b>You must close the generator when you're done using it.</b>
-     *     Use a <code>try-with-resources</code> block or call the {@link SVGGenerator#close()} method.
+     * <b>You must close the generator when you're done using it.</b> Use a
+     * <code>try-with-resources</code> block or call the
+     * {@link SVGGenerator#close()} method.
      * </p>
      *
      * @throws IOException
@@ -121,8 +122,8 @@ public class SVGGenerator implements AutoCloseable {
      *             virtually render the chart.
      * @throws InterruptedException
      *             if the rendering process gets interrupted.
-     *             
-     * @see SVGGenerator#generate(Configuration, ExportOptions) 
+     * 
+     * @see SVGGenerator#generate(Configuration, ExportOptions)
      */
     public String generate(Configuration chartConfiguration)
             throws IOException, InterruptedException {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
@@ -121,6 +121,8 @@ public class SVGGenerator implements AutoCloseable {
      *             virtually render the chart.
      * @throws InterruptedException
      *             if the rendering process gets interrupted.
+     *             
+     * @see SVGGenerator#generate(Configuration, ExportOptions) 
      */
     public String generate(Configuration chartConfiguration)
             throws IOException, InterruptedException {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/SVGGenerator.java
@@ -31,6 +31,10 @@ import com.vaadin.flow.component.charts.util.ChartSerialization;
  * </p>
  * <br />
  * <p>
+ *     CSS styling is not supported.
+ * </p>
+ * <br />
+ * <p>
  * Example usage:
  * </p>
  *


### PR DESCRIPTION
* docs: add mention of CSS styling not supported 
* docs: mention of the need to close the generator in its constructor 
* docs: reference the overload of the default generate() method in its docs
* docs: rename timeline variable in its mention in the ExportOptions class' javadoc



