### PR TITLE
feat: deprecate setHeightByRows in favor of setAllRowsVisible in Grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -915,14 +915,14 @@ public class GridDemo extends DemoView {
         // Providing a bean-type generates columns for all of it's properties
         Grid<Person> grid = new Grid<>();
 
-        // When using heightByRows, all items are fetched and
+        // When using allRowsVisible, all items are fetched and
         // Grid uses all the space needed to render everything.
         //
-        // Note: heightByRows disables the grid's virtual scrolling so that all
+        // Note: allRowsVisible disables the grid's virtual scrolling so that all
         // the rows are rendered in the DOM at once.
         // If the grid has a large number of items, using the feature is
         // discouraged to avoid performance issues.
-        grid.setHeightByRows(true);
+        grid.setAllRowsVisible(true);
 
         final GridListDataView<Person> dataView = grid.setItems(personList);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -918,8 +918,8 @@ public class GridDemo extends DemoView {
         // When using allRowsVisible, all items are fetched and
         // Grid uses all the space needed to render everything.
         //
-        // Note: allRowsVisible disables the grid's virtual scrolling so that all
-        // the rows are rendered in the DOM at once.
+        // Note: allRowsVisible disables the grid's virtual scrolling so that
+        // all the rows are rendered in the DOM at once.
         // If the grid has a large number of items, using the feature is
         // discouraged to avoid performance issues.
         grid.setAllRowsVisible(true);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ColumnResizeEventPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ColumnResizeEventPage.java
@@ -41,7 +41,7 @@ public class ColumnResizeEventPage extends Div {
 
     public ColumnResizeEventPage() {
         Grid<Person> grid = new Grid<>();
-        grid.setHeightByRows(true);
+        grid.setAllRowsVisible(true);
         grid.setId(GRID_ID);
 
         grid.setItems(new Person("Jorma", "Testaaja", "jorma@testaaja.com",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionPage.java
@@ -66,7 +66,7 @@ public class GridSingleSelectionPage extends VerticalLayout {
         grid.addColumn(string -> String.valueOf(Math.random()))
                 .setHeader("column 1");
         grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf));
-        grid.setHeightByRows(true);
+        grid.setAllRowsVisible(true);
         if (!deselectAllowed) {
             ((GridSingleSelectionModel) grid.getSelectionModel())
                     .setDeselectAllowed(deselectAllowed);
@@ -80,7 +80,7 @@ public class GridSingleSelectionPage extends VerticalLayout {
         grid.addColumn(string -> String.valueOf(Math.random()))
                 .setHeader("column 1");
         grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf));
-        grid.setHeightByRows(true);
+        grid.setAllRowsVisible(true);
         grid.setId(id);
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridView.java
@@ -887,9 +887,9 @@ public class GridView extends DemoView {
         // source-example-heading: Using height by rows
         Grid<Person> grid = new Grid<>();
 
-        // When using heightByRows, all items are fetched and
+        // When using allRowsVisible, all items are fetched and
         // Grid uses all the space needed to render everything.
-        grid.setHeightByRows(true);
+        grid.setAllRowsVisible(true);
 
         List<Person> people = createItems(50);
         grid.setItems(people);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -30,7 +30,7 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
 
         Grid<ThreeString> grid1 = new Grid<>();
         grid1.setId("grid");
-        grid1.setHeightByRows(true);
+        grid1.setAllRowsVisible(true);
         grid1.setItems(ts1, ts2);
 
         grid1.addColumn(item -> item.a).setAutoWidth(true);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridInitialExpandPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridInitialExpandPage.java
@@ -19,7 +19,7 @@ public class TreeGridInitialExpandPage extends Div {
         data.addItem(null, "parent2");
         data.addItem("parent2", "parent2-child2");
         treeGrid.setDataProvider(new TreeDataProvider<>(data));
-        treeGrid.setHeightByRows(true);
+        treeGrid.setAllRowsVisible(true);
         treeGrid.expand("parent1");
         treeGrid.expand("parent2");
         add(treeGrid);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -803,7 +803,7 @@ public class GridViewIT extends GridViewBase {
         waitUntil(driver -> grid.getRowCount() == 50);
 
         Assert.assertEquals("Grid should have heightByRows set to true", "true",
-                grid.getAttribute("heightByRows"));
+                grid.getAttribute("allRowsVisible"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3358,7 +3358,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     @Deprecated
     public void setHeightByRows(boolean heightByRows) {
-        getElement().setProperty("heightByRows", heightByRows);
+        setAllRowsVisible(heightByRows);
     }
 
     /**
@@ -3371,7 +3371,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *         rows, <code>false</code> otherwise
      */
     @Deprecated
-    @Synchronize("height-by-rows-changed")
     public boolean isHeightByRows() {
         return isAllRowsVisible();
     }
@@ -3402,8 +3401,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     @Synchronize("all-rows-visible-changed")
     public boolean isAllRowsVisible() {
-        return getElement().getProperty("heightByRows", false)
-                || getElement().getProperty("allRowsVisible", false);
+        return getElement().getProperty("allRowsVisible", false);
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3381,10 +3381,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * are fetched from the {@link DataProvider}, and the Grid shows no vertical
      * scroll bar.
      * <p>
-     * Note: <code>setAllRowsVisible</code> disables the grid's virtual scrolling
-     * so that all the rows are rendered in the DOM at once. If the grid has a
-     * large number of items, using the feature is discouraged to avoid
-     * performance issues.
+     * Note: <code>setAllRowsVisible</code> disables the grid's virtual
+     * scrolling so that all the rows are rendered in the DOM at once. If the
+     * grid has a large number of items, using the feature is discouraged to
+     * avoid performance issues.
      *
      * @param allRowsVisible
      *            <code>true</code> to make Grid compute its height by the
@@ -3402,8 +3402,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     @Synchronize("all-rows-visible-changed")
     public boolean isAllRowsVisible() {
-        return getElement().getProperty("heightByRows", false) ||
-                getElement().getProperty("allRowsVisible", false);
+        return getElement().getProperty("heightByRows", false)
+                || getElement().getProperty("allRowsVisible", false);
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3349,12 +3349,49 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * large number of items, using the feature is discouraged to avoid
      * performance issues.
      *
+     * @deprecated since 14.7 - use {@link #setAllRowsVisible(boolean)}
+     * @see #setAllRowsVisible(boolean)
+     *
      * @param heightByRows
      *            <code>true</code> to make Grid compute its height by the
      *            number of rows, <code>false</code> for the default behavior
      */
+    @Deprecated
     public void setHeightByRows(boolean heightByRows) {
         getElement().setProperty("heightByRows", heightByRows);
+    }
+
+    /**
+     * Gets whether grid's height is defined by the number of its rows.
+     *
+     * @deprecated since 14.7 - use {@link #isAllRowsVisible()}
+     * @see #isAllRowsVisible()
+     *
+     * @return <code>true</code> if Grid computes its height by the number of
+     *         rows, <code>false</code> otherwise
+     */
+    @Deprecated
+    @Synchronize("height-by-rows-changed")
+    public boolean isHeightByRows() {
+        return isAllRowsVisible();
+    }
+
+    /**
+     * If <code>true</code>, the grid's height is defined by its rows. All items
+     * are fetched from the {@link DataProvider}, and the Grid shows no vertical
+     * scroll bar.
+     * <p>
+     * Note: <code>setAllRowsVisible</code> disables the grid's virtual scrolling
+     * so that all the rows are rendered in the DOM at once. If the grid has a
+     * large number of items, using the feature is discouraged to avoid
+     * performance issues.
+     *
+     * @param allRowsVisible
+     *            <code>true</code> to make Grid compute its height by the
+     *            number of rows, <code>false</code> for the default behavior
+     */
+    public void setAllRowsVisible(boolean allRowsVisible) {
+        getElement().setProperty("allRowsVisible", allRowsVisible);
     }
 
     /**
@@ -3363,9 +3400,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @return <code>true</code> if Grid computes its height by the number of
      *         rows, <code>false</code> otherwise
      */
-    @Synchronize("height-by-rows-changed")
-    public boolean isHeightByRows() {
-        return getElement().getProperty("heightByRows", false);
+    @Synchronize("all-rows-visible-changed")
+    public boolean isAllRowsVisible() {
+        return getElement().getProperty("heightByRows", false) ||
+                getElement().getProperty("allRowsVisible", false);
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -61,4 +61,39 @@ public class GridTest {
         Assert.assertTrue(grid.getSelectedItems().contains("foo"));
     }
 
+    @Test
+    public void make_all_rows_visible_by_setHeightByRows() {
+        final Grid<String> grid = new Grid<>();
+
+        Assert.assertEquals(null, grid.getElement().getProperty("heightByRows"));
+        grid.setHeightByRows(true);
+        Assert.assertEquals("true", grid.getElement().getProperty("heightByRows"));
+    }
+
+    @Test
+    public void make_all_rows_visible_by_setAllRowsVisible() {
+        final Grid<String> grid = new Grid<>();
+
+        Assert.assertEquals(null, grid.getElement().getProperty("allRowsVisible"));
+        grid.setAllRowsVisible(true);
+        Assert.assertEquals("true", grid.getElement().getProperty("allRowsVisible"));
+    }
+
+    @Test
+    public void check_if_all_rows_visible_with_heightByRows_property() {
+        final Grid<String> grid = new Grid<>();
+        grid.getElement().setProperty("heightByRows", true);
+
+        Assert.assertTrue(grid.isHeightByRows());
+        Assert.assertTrue(grid.isAllRowsVisible());
+    }
+
+    @Test
+    public void check_if_all_rows_visible_with_allRowsVisible_property() {
+        final Grid<String> grid = new Grid<>();
+        grid.getElement().setProperty("allRowsVisible", true);
+
+        Assert.assertTrue(grid.isAllRowsVisible());
+        Assert.assertTrue(grid.isHeightByRows());
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -62,7 +62,7 @@ public class GridTest {
     }
 
     @Test
-    public void make_all_rows_visible_by_setHeightByRows() {
+    public void setHeightByRows_allRowsAreVisible() {
         final Grid<String> grid = new Grid<>();
 
         Assert.assertEquals(null,
@@ -74,7 +74,7 @@ public class GridTest {
     }
 
     @Test
-    public void make_all_rows_visible_by_setAllRowsVisible() {
+    public void setAllRowsVisible_allRowsAreVisible() {
         final Grid<String> grid = new Grid<>();
 
         Assert.assertEquals(null,
@@ -86,7 +86,7 @@ public class GridTest {
     }
 
     @Test
-    public void check_if_all_rows_visible() {
+    public void setAllRowsVisibleProperty_isHeightByRowsAndIsAllRowsVisibleWork() {
         final Grid<String> grid = new Grid<>();
         grid.getElement().setProperty("allRowsVisible", true);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -65,18 +65,22 @@ public class GridTest {
     public void make_all_rows_visible_by_setHeightByRows() {
         final Grid<String> grid = new Grid<>();
 
-        Assert.assertEquals(null, grid.getElement().getProperty("heightByRows"));
+        Assert.assertEquals(null,
+                grid.getElement().getProperty("heightByRows"));
         grid.setHeightByRows(true);
-        Assert.assertEquals("true", grid.getElement().getProperty("heightByRows"));
+        Assert.assertEquals("true",
+                grid.getElement().getProperty("heightByRows"));
     }
 
     @Test
     public void make_all_rows_visible_by_setAllRowsVisible() {
         final Grid<String> grid = new Grid<>();
 
-        Assert.assertEquals(null, grid.getElement().getProperty("allRowsVisible"));
+        Assert.assertEquals(null,
+                grid.getElement().getProperty("allRowsVisible"));
         grid.setAllRowsVisible(true);
-        Assert.assertEquals("true", grid.getElement().getProperty("allRowsVisible"));
+        Assert.assertEquals("true",
+                grid.getElement().getProperty("allRowsVisible"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -66,10 +66,11 @@ public class GridTest {
         final Grid<String> grid = new Grid<>();
 
         Assert.assertEquals(null,
-                grid.getElement().getProperty("heightByRows"));
+                grid.getElement().getProperty("allRowsVisible"));
+
         grid.setHeightByRows(true);
         Assert.assertEquals("true",
-                grid.getElement().getProperty("heightByRows"));
+                grid.getElement().getProperty("allRowsVisible"));
     }
 
     @Test
@@ -78,26 +79,18 @@ public class GridTest {
 
         Assert.assertEquals(null,
                 grid.getElement().getProperty("allRowsVisible"));
+
         grid.setAllRowsVisible(true);
         Assert.assertEquals("true",
                 grid.getElement().getProperty("allRowsVisible"));
     }
 
     @Test
-    public void check_if_all_rows_visible_with_heightByRows_property() {
-        final Grid<String> grid = new Grid<>();
-        grid.getElement().setProperty("heightByRows", true);
-
-        Assert.assertTrue(grid.isHeightByRows());
-        Assert.assertTrue(grid.isAllRowsVisible());
-    }
-
-    @Test
-    public void check_if_all_rows_visible_with_allRowsVisible_property() {
+    public void check_if_all_rows_visible() {
         final Grid<String> grid = new Grid<>();
         grid.getElement().setProperty("allRowsVisible", true);
 
-        Assert.assertTrue(grid.isAllRowsVisible());
         Assert.assertTrue(grid.isHeightByRows());
+        Assert.assertTrue(grid.isAllRowsVisible());
     }
 }


### PR DESCRIPTION

Fixes: #1009
related: [web-components PR 2099](https://github.com/vaadin/web-components/pull/2099)


- [X] Feature

## Checklist

- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] I have performed self-review and corrected misspellings.
