### PR TITLE
feat: suppress template warning

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -123,6 +123,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
 
         getElement().setProperty("invalid", false);
         getElement().setProperty("opened", false);
+        getElement().setAttribute("suppress-template-warning", true);
         // Trigger model-to-presentation conversion in constructor, so that
         // the client side component has a correct initial value of an empty
         // string

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -116,6 +116,13 @@ public class SelectTest {
     }
 
     @Test
+    public void templateWarningSuppressed() {
+        Assert.assertTrue("Template warning is not suppressed",
+                select.getElement().hasAttribute("suppress-template-warning")
+        );
+    }
+
+    @Test
     public void defaultValue_clearSetsToNull() {
         select.setItems("foo", "bar");
         select.setValue("foo");


### PR DESCRIPTION
## Description

Adds the `suppress-template-warning` attribute to the Flow component in order to suppress the template warning that is shown by the template renderer.

Closes #1746

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
