### PR TITLE
feat: suppress template warning

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -292,6 +292,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         addAttachListener(e -> initConnector());
 
         setItems(new DataCommunicator.EmptyDataProvider<>());
+
+        getElement().setAttribute("suppress-template-warning", true);
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -91,6 +91,14 @@ public class ComboBoxTest {
     }
 
     @Test
+    public void templateWarningSuppressed() {
+        ComboBox<Object> comboBox = new ComboBox<>();
+
+        Assert.assertTrue("Template warning is not suppressed", comboBox
+                .getElement().hasAttribute("suppress-template-warning"));
+    }
+
+    @Test
     public void setItems_jsonItemsAreSet() {
         TestComboBox comboBox = new TestComboBox();
         comboBox.setItems(Arrays.asList("foo", "bar"));

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -33,6 +33,7 @@ public class ContextMenu extends ContextMenuBase<ContextMenu, MenuItem, SubMenu>
      * Creates an empty context menu.
      */
     public ContextMenu() {
+        getElement().setAttribute("suppress-template-warning", true);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
@@ -34,6 +34,13 @@ import com.vaadin.flow.component.html.Label;
  * Unit tests for the ContextMenu.
  */
 public class ContextMenuTest {
+    @Test
+    public void templateWarningSuppressed() {
+        ContextMenu contextMenu = new ContextMenu();
+
+        Assert.assertTrue("Template warning is not suppressed", contextMenu
+                .getElement().hasAttribute("suppress-template-warning"));
+    }
 
     @Test
     public void createContextMenuWithTargetAndChildren_getChildrenReturnsChildren() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -64,6 +64,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      * Creates an empty dialog.
      */
     public Dialog() {
+        getElement().setAttribute("suppress-template-warning", true);
+
         template = new Element("template");
         getElement().appendChild(template);
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -95,6 +95,14 @@ public class DialogTest {
         Assert.assertEquals(dialog.getHeight(), "100px");
     }
 
+    @Test
+    public void templateWarningSuppressed() {
+        Dialog dialog = new Dialog();
+
+        Assert.assertTrue("Template warning is not suppressed",
+                dialog.getElement().hasAttribute("suppress-template-warning"));
+    }
+
     @Test(expected = IllegalStateException.class)
     public void setOpened_noUi() {
         UI.setCurrent(null);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
@@ -60,6 +60,8 @@ class ColumnGroup extends AbstractColumn<ColumnGroup> {
         super(grid);
         columns.forEach(
                 column -> getElement().appendChild(column.getElement()));
+
+        getElement().setAttribute("suppress-template-warning", true);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -391,6 +391,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 columnDataGeneratorRegistration = grid
                         .addDataGenerator(dataGenerator.get());
             }
+
+            getElement().setAttribute("suppress-template-warning", true);
         }
 
         protected void destroyDataGenerators() {
@@ -1366,6 +1368,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         addDragStartListener(this::onDragStart);
         addDragEndListener(this::onDragEnd);
+
+        getElement().setAttribute("suppress-template-warning", true);
     }
 
     private void generateUniqueKeyData(T item, JsonObject jsonObject) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnGroupTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 Vaadin Ltd.
+ * Copyright 2000-2021 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnGroupTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnGroupTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GridColumnGroupTest {
+    @Test
+    public void templateWarningSuppressed() {
+        Grid<String> grid = new Grid<>();
+
+        ColumnGroup columnGroup = new ColumnGroup(grid);
+
+        Assert.assertTrue("Template warning is not suppressed", columnGroup
+                .getElement().hasAttribute("suppress-template-warning"));
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -59,6 +59,12 @@ public class GridColumnTest {
     }
 
     @Test
+    public void templateWarningSuppressed() {
+        Assert.assertTrue("Template warning is not suppressed", firstColumn
+                .getElement().hasAttribute("suppress-template-warning"));
+    }
+
+    @Test
     public void setKey_getByKey() {
         firstColumn.setKey("foo");
         secondColumn.setKey("bar");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -33,6 +33,14 @@ public class GridTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
+    public void templateWarningSuppressed() {
+        Grid<String> grid = new Grid<>();
+
+        Assert.assertTrue("Template warning is not suppressed",
+                grid.getElement().hasAttribute("suppress-template-warning"));
+    }
+
+    @Test
     public void dataViewForFaultyDataProvider_throwsException() {
         exceptionRule.expect(IllegalStateException.class);
         exceptionRule.expectMessage(

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -193,6 +193,8 @@ public class Notification extends GeneratedVaadinNotification<Notification>
     }
 
     private void initBaseElementsAndListeners() {
+        getElement().setAttribute("suppress-template-warning", true);
+
         getElement().appendChild(templateElement);
         getElement().appendVirtualChild(container);
 

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -135,6 +135,14 @@ public class NotificationTest {
         }
     }
 
+    @Test
+    public void templateWarningSuppressed() {
+        Notification notification = new Notification();
+
+        Assert.assertTrue("Template warning is not suppressed", notification
+                .getElement().hasAttribute("suppress-template-warning"));
+    }
+
     @Test(expected = IllegalStateException.class)
     public void setOpened_noUiInstance() {
         UI.setCurrent(null);
@@ -165,7 +173,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void setText_notifictionHasAddedComponents_innerHtmlIsTextValue() {
+    public void setText_notificationHasAddedComponents_innerHtmlIsTextValue() {
         Notification notification = new Notification();
 
         notification.add(new Div());
@@ -183,7 +191,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void add_notifictionHasText_innerHtmlIsTemplateValue() {
+    public void add_notificationHasText_innerHtmlIsTemplateValue() {
         Notification notification = new Notification();
 
         notification.setText("foo");

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -123,6 +123,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
 
         getElement().setProperty("invalid", false);
         getElement().setProperty("opened", false);
+        getElement().setAttribute("suppress-template-warning", true);
         // Trigger model-to-presentation conversion in constructor, so that
         // the client side component has a correct initial value of an empty
         // string

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -116,6 +116,12 @@ public class SelectTest {
     }
 
     @Test
+    public void templateWarningSuppressed() {
+        Assert.assertTrue("Template warning is not suppressed",
+                select.getElement().hasAttribute("suppress-template-warning"));
+    }
+
+    @Test
     public void defaultValue_clearSetsToNull() {
         select.setItems("foo", "bar");
         select.setValue("foo");

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -137,6 +137,8 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
      * Creates an empty list.
      */
     public VirtualList() {
+        getElement().setAttribute("suppress-template-warning", true);
+
         dataGenerator.addDataGenerator(
                 (item, jsonObject) -> renderer.getValueProviders()
                         .forEach((property, provider) -> jsonObject.put(

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListTest.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListTest.java
@@ -27,6 +27,14 @@ public class VirtualListTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
+    public void templateWarningSuppressed() {
+        VirtualList<String> virtualList = new VirtualList<>();
+
+        Assert.assertTrue("Template warning is not suppressed", virtualList
+                .getElement().hasAttribute("suppress-template-warning"));
+    }
+
+    @Test
     public void paging_pagingDisabledByDefault() {
         VirtualList<String> virtualList = new VirtualList<>();
         Assert.assertFalse("VirtualList is not supposed to support the paging",


### PR DESCRIPTION
## Description

Adds the `suppress-template-warning` attribute for the Flow components in order to suppress the template warning that the template renderer shows when `<template>` is used with a component (https://github.com/vaadin/web-components/pull/2103).

- [x] `vaadin-select-flow`
- [x] `vaadin-context-menu-flow`
- [x] `vaadin-notification-flow` 
- [x] `vaadin-dialog-flow`
- [x] `vaadin-combo-box-flow` 
- [x] `vaadin-virtual-list-flow`
- [x] `vaadin-grid-flow`
- [x] `vaadin-grid-pro-flow` *

_* Grid Pro doesn't require any specific changes since it extends Grid and we've suppressed the warning for Grid._

Closes #1746

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
