### PR TITLE
chore: remove broken cell click implementation

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridCellFocusPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridCellFocusPageIT.java
@@ -35,21 +35,21 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
     public void focusBodyCell() {
         open();
 
-        getGrid().getCell(0, 0).click();
+        getGrid().getCell(0, 0).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT, "A");
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
                 GridCellFocusPage.KEY_FIRST_COLUMN);
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.BODY.getClientSideName());
 
-        getGrid().getCell(1, 0).click();
+        getGrid().getCell(1, 0).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT, "B");
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
                 GridCellFocusPage.KEY_FIRST_COLUMN);
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.BODY.getClientSideName());
 
-        getGrid().getCell(2, 1).click();
+        getGrid().getCell(2, 1).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT, "C");
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
                 GridCellFocusPage.KEY_SECOND_COLUMN);
@@ -61,7 +61,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
     public void focusHeaderCell() {
         open();
 
-        getGrid().getHeaderCell(0).click();
+        getGrid().getHeaderCell(0).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
@@ -69,7 +69,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.HEADER.getClientSideName());
 
-        getGrid().getHeaderCell(1).click();
+        getGrid().getHeaderCell(1).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
@@ -82,7 +82,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
     public void focusFooterCell() {
         open();
 
-        getGrid().getFooterCell(0).click();
+        getGrid().getFooterCell(0).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,
@@ -90,7 +90,7 @@ public class GridCellFocusPageIT extends AbstractComponentIT {
         assertTextResult(GridCellFocusPage.ID_SECTION_RESULT,
                 CellFocusEvent.GridSection.FOOTER.getClientSideName());
 
-        getGrid().getFooterCell(1).click();
+        getGrid().getFooterCell(1).click(0, 0);
         assertTextResult(GridCellFocusPage.ID_ITEM_RESULT,
                 GridCellFocusPage.NO_ITEM);
         assertTextResult(GridCellFocusPage.ID_COLUMN_RESULT,

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
@@ -43,18 +43,6 @@ public class GridTHTDElement extends TestBenchElement {
         }
     }
 
-    @Override
-    public void click() {
-        // Click cell content in the shadow DOM to prevent Chrome Driver
-        // complaining about the click location not targeting the cell itself
-        TestBenchElement contentElement = (TestBenchElement) this.getContext();
-        // The default TestBench element click implementation just calls
-        // .click() on the element which does not trigger default browser
-        // behaviour, like focus events. Instead use Selenium implementation
-        // which simulates an actual click in the browser UI.
-        contentElement.getWrappedElement().click();
-    }
-
     public String getInnerHTML() {
         // The first child element of a cell is a slot. The following JS finds
         // the elements assigned to that slot and then joins the `innerHTML`


### PR DESCRIPTION
## Description

Currently [platform tests](https://teamcity.vaadin.com/viewLog.html?buildId=82090&buildTypeId=VaadinPlatform_VaadinPlatformPrValidation&tab=buildResultsDiv) are failing due to the custom cell click implementation introduced in #1770.

This change removes the custom cell click implementation and instead uses an existing overload of `TestBenchElement.click`, which also uses Selenium API to trigger a native click.
