### PR TITLE
fix: import Vaadin iconset for IronIcon

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/main/java/com/vaadin/flow/component/icon/demo/IconView.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/main/java/com/vaadin/flow/component/icon/demo/IconView.java
@@ -59,7 +59,8 @@ public class IconView extends Div {
         // end-source-example
 
         close.getStyle().set("marginRight", "5px");
-        addCard("Creating a new icon", new HorizontalLayout(close, clock, ironIcon));
+        addCard("Creating a new icon",
+                new HorizontalLayout(close, clock, ironIcon));
 
         close.setId("close-icon");
         clock.setId("clock-icon");

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/main/java/com/vaadin/flow/component/icon/demo/IconView.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/main/java/com/vaadin/flow/component/icon/demo/IconView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.IronIcon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -52,13 +53,17 @@ public class IconView extends Div {
         // Creating an icon from the Lumo icons collection
         Icon clock = new Icon("lumo", "clock");
 
+        // Creating an IronIcon with an icon from the Vaadin icons collection
+        IronIcon ironIcon = new IronIcon("vaadin", "palette");
+
         // end-source-example
 
         close.getStyle().set("marginRight", "5px");
-        addCard("Creating a new icon", new HorizontalLayout(close, clock));
+        addCard("Creating a new icon", new HorizontalLayout(close, clock, ironIcon));
 
         close.setId("close-icon");
         clock.setId("clock-icon");
+        ironIcon.setId("iron-icon");
     }
 
     private void createStyledIconView() {

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
@@ -44,11 +44,11 @@ public class IconIT extends AbstractComponentIT {
     @Test
     public void basicIcons() {
         assertIconProperty("close-icon", "vaadin", "close");
-        assetHasIconSvg("close-icon");
+        assertHasIconSvg("close-icon");
         assertIconProperty("clock-icon", "lumo", "clock");
-        assetHasIconSvg("clock-icon");
+        assertHasIconSvg("clock-icon");
         assertIconProperty("iron-icon", "vaadin", "palette");
-        assetHasIconSvg("iron-icon");
+        assertHasIconSvg("iron-icon");
     }
 
     @Test
@@ -129,7 +129,7 @@ public class IconIT extends AbstractComponentIT {
         assertIconProperty(findElement(By.id(id)), collection, iconName);
     }
 
-    private void assetHasIconSvg(String id) {
+    private void assertHasIconSvg(String id) {
         WebElement icon = findElement(By.id(id));
         List<WebElement> svgs = findInShadowRoot(icon, By.tagName("svg"));
         assertTrue("The icon has no svg inside", svgs.size() == 1);

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.icon.tests;
 
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.junit.Assert;
@@ -132,7 +130,7 @@ public class IconIT extends AbstractComponentIT {
     private void assertHasIconSvg(String id) {
         WebElement icon = findElement(By.id(id));
         List<WebElement> svgs = findInShadowRoot(icon, By.tagName("svg"));
-        assertTrue("The icon has no svg inside", svgs.size() == 1);
+        Assert.assertTrue("The icon has no svg inside", svgs.size() == 1);
     }
 
     private void assertIconProperty(WebElement icon, String collection,

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.icon.tests;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.junit.Assert;
@@ -42,7 +44,11 @@ public class IconIT extends AbstractComponentIT {
     @Test
     public void basicIcons() {
         assertIconProperty("close-icon", "vaadin", "close");
+        assetHasIconSvg("close-icon");
         assertIconProperty("clock-icon", "lumo", "clock");
+        assetHasIconSvg("clock-icon");
+        assertIconProperty("iron-icon", "vaadin", "palette");
+        assetHasIconSvg("iron-icon");
     }
 
     @Test
@@ -121,6 +127,12 @@ public class IconIT extends AbstractComponentIT {
     private void assertIconProperty(String id, String collection,
             String iconName) {
         assertIconProperty(findElement(By.id(id)), collection, iconName);
+    }
+
+    private void assetHasIconSvg(String id) {
+        WebElement icon = findElement(By.id(id));
+        List<WebElement> svgs = findInShadowRoot(icon, By.tagName("svg"));
+        assertTrue("The icon has no svg inside", svgs.size() == 1);
     }
 
     private void assertIconProperty(WebElement icon, String collection,

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/IronIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/IronIcon.java
@@ -34,6 +34,8 @@ import com.vaadin.flow.dom.ElementConstants;
  *             {@link Icon}
  */
 @Tag("iron-icon")
+@NpmPackage(value = "@vaadin/vaadin-icons", version = "21.0.0-alpha6")
+@JsModule("@vaadin/vaadin-icons/iconset.js")
 @NpmPackage(value = "@polymer/iron-icon", version = "3.0.1")
 @JsModule("@polymer/iron-icon/iron-icon.js")
 @Deprecated


### PR DESCRIPTION
This PR will make `IronIcon` automatically import `<iron-icon>` compatible Vaadin iconset. The iconset was previously imported by `Icon` component (via `vaadin-icons.js` bundle) but since [this change](https://github.com/vaadin/flow-components/pull/1785/files#diff-d425dd0b959631c4b1bb08068a77c4e9aaa9e3a4f8f8c8534a710602c16d09b5L36) `Icon` has been using `<vaadin-iconset>` based set instead.