### PR TITLE
chore: remove normalization of deprecated icons

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
@@ -90,7 +90,7 @@ public class IconIT extends AbstractComponentIT {
             String enumName = VaadinIcon.values()[i].name();
             Assert.assertEquals(enumName, label.getText());
             assertIconProperty(icon, "vaadin",
-                enumName.toLowerCase().replace('_', '-'));
+                    enumName.toLowerCase().replace('_', '-'));
         }
     }
 

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
@@ -88,33 +88,9 @@ public class IconIT extends AbstractComponentIT {
             WebElement label = labels.get(i);
             WebElement icon = icons.get(i);
             String enumName = VaadinIcon.values()[i].name();
-            String normalizedIconName = normalize(VaadinIcon.values()[i])
-                    .name();
             Assert.assertEquals(enumName, label.getText());
             assertIconProperty(icon, "vaadin",
-                    normalizedIconName.toLowerCase().replace('_', '-'));
-        }
-    }
-
-    /**
-     * In case a the given icon is one of the deprecated values, the
-     * corresponding updated VaadinIcon is returned. Otherwise the given
-     * VaadinIcon is returned as such.
-     */
-    private static VaadinIcon normalize(VaadinIcon icon) {
-        switch (icon) {
-        case BUSS:
-            return VaadinIcon.BUS;
-        case FUNCION:
-            return VaadinIcon.FUNCTION;
-        case MEGAFONE:
-            return VaadinIcon.MEGAPHONE;
-        case PALETE:
-            return VaadinIcon.PALETTE;
-        case TRENDIND_DOWN:
-            return VaadinIcon.TRENDING_DOWN;
-        default:
-            return icon;
+                enumName.toLowerCase().replace('_', '-'));
         }
     }
 

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -57,30 +57,8 @@ public class Icon extends Component implements HasStyle, ClickNotifier<Icon> {
      *            the icon to display
      */
     public Icon(VaadinIcon icon) {
-        this(ICON_COLLECTION_NAME, normalize(icon).name()
+        this(ICON_COLLECTION_NAME, icon.name()
                 .toLowerCase(Locale.ENGLISH).replace('_', '-'));
-    }
-
-    /**
-     * In case a the given icon is one of the deprecated values, the
-     * corresponding updated VaadinIcon is returned. Otherwise the given
-     * VaadinIcon is returned as such.
-     */
-    private static VaadinIcon normalize(VaadinIcon icon) {
-        switch (icon) {
-        case BUSS:
-            return VaadinIcon.BUS;
-        case FUNCION:
-            return VaadinIcon.FUNCTION;
-        case MEGAFONE:
-            return VaadinIcon.MEGAPHONE;
-        case PALETE:
-            return VaadinIcon.PALETTE;
-        case TRENDIND_DOWN:
-            return VaadinIcon.TRENDING_DOWN;
-        default:
-            return icon;
-        }
     }
 
     /**

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -57,8 +57,8 @@ public class Icon extends Component implements HasStyle, ClickNotifier<Icon> {
      *            the icon to display
      */
     public Icon(VaadinIcon icon) {
-        this(ICON_COLLECTION_NAME, icon.name()
-                .toLowerCase(Locale.ENGLISH).replace('_', '-'));
+        this(ICON_COLLECTION_NAME,
+                icon.name().toLowerCase(Locale.ENGLISH).replace('_', '-'));
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/vaadin/web-components/issues/2108

This is no longer required since the deprecated icons were restored to the iconset in https://github.com/vaadin/web-components/pull/2111