### PR TITLE
perf: remove the unnecessary span wrapper from virtual list items

### DIFF
--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -380,7 +380,7 @@ public class VirtualListIT extends AbstractComponentIT {
     @Test
     public void numberRenderer() {
         List<TestBenchElement> items = $("vaadin-virtual-list")
-                .id("list-with-numbers").$("span").all();
+                .id("list-with-numbers").$("div[style*=\"position: absolute;\"]").all();
         Assert.assertEquals(3, items.size());
         IntStream.range(0, 3).forEach(i -> {
             Assert.assertEquals("" + (i + 1), items.get(i).getText());
@@ -390,7 +390,7 @@ public class VirtualListIT extends AbstractComponentIT {
     @Test
     public void localDateRenderer() {
         List<TestBenchElement> items = $("vaadin-virtual-list")
-                .id("list-with-local-dates").$("span").all();
+                .id("list-with-local-dates").$("div[style*=\"position: absolute;\"]").all();
         Assert.assertEquals(3, items.size());
 
         Assert.assertEquals("January 1, 2001", items.get(0).getText());
@@ -401,7 +401,7 @@ public class VirtualListIT extends AbstractComponentIT {
     @Test
     public void localDateTimeRenderer() {
         List<TestBenchElement> items = $("vaadin-virtual-list")
-                .id("list-with-local-date-times").$("span").all();
+                .id("list-with-local-date-times").$("div[style*=\"position: absolute;\"]").all();
         Assert.assertEquals(3, items.size());
 
         Assert.assertEquals("January 1, 2001 1:01 AM", items.get(0).getText());

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -380,7 +380,8 @@ public class VirtualListIT extends AbstractComponentIT {
     @Test
     public void numberRenderer() {
         List<TestBenchElement> items = $("vaadin-virtual-list")
-                .id("list-with-numbers").$("div[style*=\"position: absolute;\"]").all();
+                .id("list-with-numbers")
+                .$("div[style*=\"position: absolute;\"]").all();
         Assert.assertEquals(3, items.size());
         IntStream.range(0, 3).forEach(i -> {
             Assert.assertEquals("" + (i + 1), items.get(i).getText());
@@ -390,7 +391,8 @@ public class VirtualListIT extends AbstractComponentIT {
     @Test
     public void localDateRenderer() {
         List<TestBenchElement> items = $("vaadin-virtual-list")
-                .id("list-with-local-dates").$("div[style*=\"position: absolute;\"]").all();
+                .id("list-with-local-dates")
+                .$("div[style*=\"position: absolute;\"]").all();
         Assert.assertEquals(3, items.size());
 
         Assert.assertEquals("January 1, 2001", items.get(0).getText());
@@ -401,7 +403,8 @@ public class VirtualListIT extends AbstractComponentIT {
     @Test
     public void localDateTimeRenderer() {
         List<TestBenchElement> items = $("vaadin-virtual-list")
-                .id("list-with-local-date-times").$("div[style*=\"position: absolute;\"]").all();
+                .id("list-with-local-date-times")
+                .$("div[style*=\"position: absolute;\"]").all();
         Assert.assertEquals(3, items.size());
 
         Assert.assertEquals("January 1, 2001 1:01 AM", items.get(0).getText());

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -56,9 +56,6 @@ import elemental.json.JsonValue;
  * It supports {@link DataProvider}s to load data asynchronously and
  * {@link TemplateRenderer}s to render the markup for each item.
  * <p>
- * For this component to work properly, it needs to have a well defined
- * {@code height}. It can be an absolute height, like {@code 100px}, or a
- * relative height inside a container with well defined height.
  *
  *
  * @author Vaadin Ltd.
@@ -327,10 +324,8 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
          */
         template.setProperty("innerHTML", String.format(
         //@formatter:off
-            "<span>"
-                + "<template is='dom-if' if='[[item.__placeholder]]'>%s</template>"
-                + "<template is='dom-if' if='[[!item.__placeholder]]'>%s</template>"
-            + "</span>",
+            "<template is='dom-if' if='[[item.__placeholder]]'>%s</template>"
+            + "<template is='dom-if' if='[[!item.__placeholder]]'>%s</template>",
         //@formatter:on
                 placeholderTemplate, originalTemplate));
     }


### PR DESCRIPTION
While building `VirtualList` on top of a copy of `IronList` an extra `<span>` wrapper inside the item template should've been removed but wasn't. This PR removes the unnecessary wrapper element.

Before:
<img width="488" alt="Screenshot 2021-06-17 at 12 03 18" src="https://user-images.githubusercontent.com/1222264/122367029-c264d780-cf64-11eb-90ce-c2ee7cfbe535.png">

After:
<img width="492" alt="Screenshot 2021-06-17 at 12 02 01" src="https://user-images.githubusercontent.com/1222264/122367054-c7298b80-cf64-11eb-91d3-2d266c28e562.png">
