### PR TITLE
refactor: use new methods instead of deprecated render() and update()

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
@@ -189,7 +189,7 @@ public class Chart extends Component implements HasStyle, HasSize {
         final JsonObject configurationNode = getJsonFactory()
                 .parse(ChartSerialization.toJSON(configuration));
 
-        getElement().callJsFunction("update", configurationNode,
+        getElement().callJsFunction("updateConfiguration", configurationNode,
                 resetConfiguration);
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
@@ -1118,18 +1118,6 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      * Description copied from corresponding location in WebComponent:
      * </p>
      * <p>
-     * Manually invoke existing renderer.
-     * </p>
-     */
-    protected void render() {
-        getElement().callJsFunction("render");
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
      * Opens the dropdown list.
      * </p>
      */

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -200,18 +200,6 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * Description copied from corresponding location in WebComponent:
      * </p>
      * <p>
-     * Manually invoke existing renderer.
-     * </p>
-     */
-    protected void render() {
-        getElement().callJsFunction("render");
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
      * Opens the notification.
      * </p>
      */

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -824,7 +824,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         }
         updateItemEnabled(vaadinItem);
 
-        callClientSideRenderIfNotPending();
+        requestClientSideContentUpdateIfNotPending();
     }
 
     private void updateItemEnabled(VaadinItem<T> item) {
@@ -854,7 +854,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         keyMapper.removeAll();
         listBox.removeAll();
         clear();
-        callClientSideRenderIfNotPending();
+        requestClientSideContentUpdateIfNotPending();
 
         if (isEmptySelectionAllowed()) {
             addEmptySelectionItem();
@@ -883,13 +883,13 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         }
     }
 
-    private void callClientSideRenderIfNotPending() {
+    private void requestClientSideContentUpdateIfNotPending() {
 
         // reset added at this point to avoid unnecessary selected item update
         if (!resetPending) {
             resetPending = true;
             runBeforeClientResponse(ui -> {
-                ui.getPage().executeJs("$0.render();", getElement());
+                ui.getPage().executeJs("$0.requestContentUpdate();", getElement());
                 resetPending = false;
             });
         }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -889,7 +889,8 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         if (!resetPending) {
             resetPending = true;
             runBeforeClientResponse(ui -> {
-                ui.getPage().executeJs("$0.requestContentUpdate();", getElement());
+                ui.getPage().executeJs("$0.requestContentUpdate();",
+                        getElement());
                 resetPending = false;
             });
         }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
@@ -527,18 +527,6 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * Description copied from corresponding location in WebComponent:
      * </p>
      * <p>
-     * Manually invoke existing renderer.
-     * </p>
-     */
-    protected void render() {
-        getElement().callJsFunction("render");
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
      * Returns true if {@code value} is valid, and sets the {@code invalid} flag
      * appropriately.
      * </p>


### PR DESCRIPTION
## Description

`render()` and `update()` methods are deprecated for the Web Components so that means we don't want to use them in the Flow repository anymore.

- Replaces `render()` with `requestUpdateContent()`
- Replaces `update()` with `updateConfiguration()`

Closes https://github.com/vaadin/web-components/issues/73

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
