### PR TITLE
fix: run package before jetty:run

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NOTE: a valid unix terminal with a regular shell is needed for running the utili
 
 ## Running one component demo
 
-- `mvn -am -pl vaadin-checkbox-flow-parent/vaadin-checkbox-flow-demo -Pwar jetty:run`
+- `mvn -am -pl vaadin-checkbox-flow-parent/vaadin-checkbox-flow-demo -Pwar package jetty:run`
 
 Then navigate to `http://localhost:8080/vaadin-checkbox` to see the demo.
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -90,14 +90,14 @@ read option
 ## compose the mvn cli command based on the selected option
 case $option in
    1) askModule; cmd="mvn clean test-compile -amd -B $quiet -DskipFrontend -pl $module-flow-parent";;
-   2) askModule; cmd="mvn jetty:run -am -B $quiet -DskipTests -pl $module-flow-parent/$module-flow-demo -Pwar"; browser=true;;
+   2) askModule; cmd="mvn package jetty:run -am -B $quiet -DskipTests -pl $module-flow-parent/$module-flow-demo -Pwar"; browser=true;;
    3) askModule; askITests; askUTests; askJetty; runFrontend; cmd="mvn verify $quiet -am -B -pl $module-flow-parent/$module-flow-integration-tests $utests $itests $frontend $jetty $args";;
-   4) askModule; cmd="mvn jetty:run -am -B $quiet -DskipTests -pl $module-flow-parent/$module-flow-integration-tests"; browser=true;;
+   4) askModule; cmd="mvn package jetty:run -am -B $quiet -DskipTests -pl $module-flow-parent/$module-flow-integration-tests"; browser=true;;
    5) askSauce; askModule; askITests; askUTests; askJetty; runFrontend; cmd="mvn verify -am -B $quiet -pl $module-flow-parent/$module-flow-integration-tests $utests $itests $frontend $jetty $args -Dtest.use.hub=true -Psaucelabs -Dsauce.user=$SAUCE_USER -Dsauce.sauceAccessKey=$SAUCE_ACCESS_KEY";;
    6) cmd="mvn clean test-compile -DskipFrontend -B $quiet -T 1C";;
    7) cmd="mvn install -B -DskipTests -Drelease -T 1C";;
    8) mergeITs; askITests; askUTests; askJetty; runFrontend; cmd="mvn verify $quiet -am -B -Drun-it -pl integration-tests $utests $itests $frontend $jetty $args";;
-   9) mergeITs; cmd="mvn jetty:run -am -B $quiet -DskipTests -Drun-it -pl integration-tests"; browser=true;;
+   9) mergeITs; cmd="mvn package jetty:run -am -B $quiet -DskipTests -Drun-it -pl integration-tests"; browser=true;;
    10) askSauce; mergeITs; askITests; askUTests; askJetty; runFrontend; cmd="mvn verify -am -B $quiet -pl integration-tests -Drun-it $utests $itests $frontend $jetty $args -Dtest.use.hub=true -Psaucelabs -Dsauce.user=$SAUCE_USER -Dsauce.sauceAccessKey=$SAUCE_ACCESS_KEY";;
 esac
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/benchmark/run-benchmark.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/benchmark/run-benchmark.js
@@ -80,7 +80,7 @@ browsers.forEach((browserName) => {
 
 const startJetty = (cwd,port,stopPort) => {
   return new Promise((resolve) => {
-    const jetty = spawn('mvn', ['-B', '-q', 'jetty:run', `-Djetty.http.port=${port}`, `-Djetty.stop.port=${stopPort}`], { cwd });
+    const jetty = spawn('mvn', ['-B', '-q', 'package', 'jetty:run', `-Djetty.http.port=${port}`, `-Djetty.stop.port=${stopPort}`], { cwd });
     processes.push(jetty);
     jetty.stderr.on('data', (data) => console.error(data.toString()));
     jetty.stdout.on('data', (data) => {


### PR DESCRIPTION
Fixes the issue with the server starting up but client resources not getting processed when running with Jetty.

Demos:
<img width="1028" alt="Screenshot 2021-07-02 at 9 53 44" src="https://user-images.githubusercontent.com/1222264/124241814-c7a95100-db24-11eb-8c7b-b1479a183d74.png">

IT page:
<img width="1016" alt="Screenshot 2021-07-02 at 9 51 53" src="https://user-images.githubusercontent.com/1222264/124241832-cbd56e80-db24-11eb-8cd6-fa27db25c5aa.png">

Fixed as suggested [here](https://github.com/vaadin/flow/issues/11371#issuecomment-872774648)