### PR TITLE
fix: avoid adding a second grid to a crud when using a constructor without the grid argument

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -9,6 +9,7 @@ import com.vaadin.flow.component.crud.CrudGrid;
 import com.vaadin.flow.component.crud.CrudI18n;
 import com.vaadin.flow.component.crud.CrudI18nUpdatedEvent;
 import com.vaadin.flow.component.crud.CrudVariant;
+import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
@@ -88,6 +89,15 @@ public class MainView extends VerticalLayout {
                 });
         toggleBordersButton.setId("toggleBorders");
 
+        final Button addGridButton = new Button("Add grid", event -> {
+            Grid<Person> grid = new Grid<>(Person.class);
+            grid.addColumn(Person::getId).setHeader("Id");
+            grid.addColumn(Person::getFirstName).setHeader("First Name");
+            grid.addColumn(Person::getLastName).setHeader("Last Name");
+            crud.setGrid(grid);
+        });
+        addGridButton.setId("addGrid");
+
         crud.addNewListener(e -> addEvent("New: " + e.getItem()));
         crud.addEditListener(e -> addEvent("Edit: " + e.getItem()));
         crud.addCancelListener(e -> addEvent("Cancel: " + e.getItem()));
@@ -100,7 +110,7 @@ public class MainView extends VerticalLayout {
 
         setHeight("100%");
         add(crud, serverSideNewButton, serverSideEditButton, showFiltersButton,
-                updateI18nButton, toggleBordersButton, eventsPanel);
+                updateI18nButton, toggleBordersButton, addGridButton, eventsPanel);
     }
 
     private void addEvent(String event) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -110,7 +110,8 @@ public class MainView extends VerticalLayout {
 
         setHeight("100%");
         add(crud, serverSideNewButton, serverSideEditButton, showFiltersButton,
-                updateI18nButton, toggleBordersButton, addGridButton, eventsPanel);
+                updateI18nButton, toggleBordersButton, addGridButton,
+                eventsPanel);
     }
 
     private void addEvent(String event) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -5,13 +5,9 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.crud.examples.Person;
 import com.vaadin.flow.component.crud.testbench.CrudElement;
-import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.testbench.TestBenchElement;
@@ -33,7 +29,6 @@ public class BasicUseIT extends AbstractParallelTest {
 
     @Test
     public void crudReplacesGrid() {
-        CrudElement crud = $(CrudElement.class).waitForFirst();
         getTestButton("addGrid").click();
         List<GridElement> grids = $(GridElement.class).all();
         Assert.assertEquals(1, grids.size());

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -5,9 +5,13 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.crud.examples.Person;
 import com.vaadin.flow.component.crud.testbench.CrudElement;
+import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.testbench.TestBenchElement;
@@ -25,6 +29,14 @@ public class BasicUseIT extends AbstractParallelTest {
     public void crudIsPresent() {
         Assert.assertTrue($(CrudElement.class).exists());
         Assert.assertNotNull($(CrudElement.class).first().getGrid());
+    }
+
+    @Test
+    public void crudReplacesGrid() {
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+        getTestButton("addGrid").click();
+        List<GridElement> grids = $(GridElement.class).all();
+        Assert.assertEquals(1, grids.size());
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -360,7 +360,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
         Objects.requireNonNull(grid, "Grid cannot be null");
 
         if (this.grid != null
-                && this.grid.getElement().getParent() == getElement()) {
+                && getElement().equals(this.grid.getElement().getParent())) {
             this.grid.getElement().removeFromParent();
         }
 


### PR DESCRIPTION
## Description

When creating a Crud using the following constructor and using the `setGrid()` method: 

```java
crud = new Crud<>(
  Person.class,
  createEditor()
);
crud.setGrid(createGrid());
```

Two grids would show, instead of just one. The problem is that the first grid is added by default when the constructor runs but it is **not** removed when the `setGrid()` method is called. The crud fails to remove the grid because of an equality check (using the equality operator `==`) instead of the `equals()` method, when checking if the Grid's parent is the Crud itself.

Fixes #1005

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.