### PR TITLE
chore: make `ComboBoxLazyDataViewTest` platform-independent

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -44,8 +44,8 @@ public class ComboBoxLazyDataViewTest {
 
     private static final String TYPE_ERROR_MESSAGE = "ComboBoxLazyDataView "
             + "only supports 'BackEndDataProvider' or it's subclasses, "
-            + "but was given a 'ListDataProvider'.\nUse either "
-            + "'getLazyDataView()', 'getListDataView()' or "
+            + "but was given a 'ListDataProvider'." + System.lineSeparator()
+            + "Use either 'getLazyDataView()', 'getListDataView()' or "
             + "'getGenericDataView()' according to the used data type.";
 
     private String[] items = { "foo", "bar", "baz" };


### PR DESCRIPTION
## Description

It's not OK to expect the Unix line separator (`\n`) when running the test on Windows that uses (`\r\n`).

## Type of change

- [x] Internal change
- [ ] Feature