### PR TITLE
docs: add warning about unreliable behaviour of scrollToIndex(int) in TreeGrid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -942,10 +942,12 @@ public class TreeGrid<T> extends Grid<T>
     }
 
     /**
-     * The effective index of an item depends on the complete hierarchy of the tree.
-     * {@link TreeGrid} uses lazy loading for performance reasons and does not know about the complete hierarchy.
-     * Without the knowledge of the complete hierarchy, {@link TreeGrid} can’t reliably calculate an exact scroll position.
-     * <b>This uncertainty makes this method unreliable and so should be avoided.</b>
+     * The effective index of an item depends on the complete hierarchy of the
+     * tree. {@link TreeGrid} uses lazy loading for performance reasons and does
+     * not know about the complete hierarchy. Without the knowledge of the
+     * complete hierarchy, {@link TreeGrid} can’t reliably calculate an exact
+     * scroll position. <b>This uncertainty makes this method unreliable and so
+     * should be avoided.</b>
      *
      * @param rowIndex
      *            zero based index of the item to scroll to in the current view.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -940,4 +940,18 @@ public class TreeGrid<T> extends Grid<T>
         }
         return (HierarchicalDataProvider<T, SerializablePredicate<T>>) super.getDataProvider();
     }
+
+    /**
+     * The effective index of an item depends on the complete hierarchy of the tree.
+     * {@link TreeGrid} uses lazy loading for performance reasons and does not know about the complete hierarchy.
+     * Without the knowledge of the complete hierarchy, {@link TreeGrid} can’t reliably calculate an exact scroll position.
+     * <b>This uncertainty makes this method unreliable and so should be avoided.</b>
+     *
+     * @param rowIndex
+     *            zero based index of the item to scroll to in the current view.
+     */
+    @Override
+    public void scrollToIndex(int rowIndex) {
+        super.scrollToIndex(rowIndex);
+    }
 }


### PR DESCRIPTION

## Description

The `scrollToIndex(int)` method in `TreeGrid` is directly inherited from `Grid` but has some issues. The grid needs to know the entire tree structure to accurately calculate a node's index (in a pre-order traversal method). Since it uses lazy loading for performance reasons, there is no reliable way to consistently scroll to a node's position.

Let's document this behavior in the `TreeGrid` class version of the method and discourage the use of it until we find a proper solution.

Related: #1016, https://github.com/vaadin/web-components/issues/2228
