### PR TITLE
fix: emptyItem now always uses emptySelectionCaption value for its label and text (value)

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/EmptySelectionItemIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/EmptySelectionItemIT.java
@@ -90,9 +90,8 @@ public class EmptySelectionItemIT extends AbstractSelectIT {
         verify.selectedItem("caption", "caption");
 
         page.toggleItemLabelGenerator(true);
-        // the selected label should be updated accordingly to replace the
-        // caption
-        verify.selectedItem("caption", "null-LABEL");
+        // the selected label should stay the same
+        verify.selectedItem("caption", "caption");
 
         page.toggleItemLabelGenerator(false);
         verify.selectedItem("caption", "caption");

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -804,6 +804,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         vaadinItem.removeAll();
         T item = vaadinItem.getItem();
 
+        // handle the item's text
         if (vaadinItem == emptySelectionItem) {
             vaadinItem.setText(emptySelectionCaption);
         } else if (getItemRenderer() != null) {
@@ -814,11 +815,13 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
             vaadinItem.setText(item.toString());
         }
 
-        if (getItemLabelGenerator() != null) {
+        // handle the item's label attribute
+        if (vaadinItem == emptySelectionItem) {
+            vaadinItem.getElement().setAttribute(LABEL_ATTRIBUTE,
+                    getEmptySelectionCaption());
+        } else if (getItemLabelGenerator() != null) {
             vaadinItem.getElement().setAttribute(LABEL_ATTRIBUTE,
                     getItemLabelGenerator().apply(item));
-        } else if (item == emptySelectionItem) {
-            vaadinItem.getElement().setAttribute(LABEL_ATTRIBUTE, "");
         } else {
             vaadinItem.getElement().removeAttribute(LABEL_ATTRIBUTE);
         }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -312,10 +312,10 @@ public class SelectTest {
 
         // getOuterHTML jsoup interprets the property value with "" as value as
         // a boolean
-        Assert.assertEquals("<vaadin-item value></vaadin-item>",
+        Assert.assertEquals("<vaadin-item value label></vaadin-item>",
                 getListBoxChild(0).getOuterHTML());
 
-        validateItem(0, "", null, true);
+        validateItem(0, "", "", true);
         validateItem(1, "foo", null, true);
         validateItem(2, "bar", null, true);
 
@@ -327,18 +327,19 @@ public class SelectTest {
         select.setEmptySelectionAllowed(true);
         select.setEmptySelectionCaption("EMPTY");
 
-        Assert.assertEquals("<vaadin-item value>\n EMPTY\n</vaadin-item>",
+        Assert.assertEquals(
+                "<vaadin-item value label=\"EMPTY\">\n EMPTY\n</vaadin-item>",
                 getListBoxChild(0).getOuterHTML());
 
-        validateItem(0, "EMPTY", null, true);
+        validateItem(0, "EMPTY", "EMPTY", true);
         validateItem(1, "foo", null, true);
         validateItem(2, "bar", null, true);
 
         select.setEmptySelectionCaption("changed");
-        validateItem(0, "changed", null, true);
+        validateItem(0, "changed", "changed", true);
 
         select.setItems("1", "2");
-        validateItem(0, "changed", null, true);
+        validateItem(0, "changed", "changed", true);
         validateItem(1, "1", null, true);
         validateItem(2, "2", null, true);
     }
@@ -349,19 +350,31 @@ public class SelectTest {
         select.setEmptySelectionAllowed(true);
         select.setItemEnabledProvider(Objects::nonNull);
 
-        validateItem(0, "", null, false);
+        validateItem(0, "", "", false);
         validateItem(1, "foo", null, true);
         validateItem(2, "bar", null, true);
     }
 
     @Test
-    public void emptySelectionItem_itemLabelGeneratorCanCustomizeIt() {
+    public void emptySelectionItemNull_itemLabelGeneratorSkipsNullCaption() {
         select.setItems("foo", "bar");
         select.setEmptySelectionAllowed(true);
-        select.setItemLabelGenerator(
-                string -> string == null ? "FOOBAR" : string + "!");
+        select.setItemLabelGenerator(string -> string + "!");
 
-        validateItem(0, "", "FOOBAR", true);
+        // emptySelectionCaption == null
+        validateItem(0, "", "", true);
+        validateItem(1, "foo!", "foo!", true);
+        validateItem(2, "bar!", "bar!", true);
+    }
+
+    @Test
+    public void emptySelectionItemNull_itemLabelGeneratorShowsCaption() {
+        select.setItems("foo", "bar");
+        select.setEmptySelectionAllowed(true);
+        select.setEmptySelectionCaption("FOOBAR");
+        select.setItemLabelGenerator(string -> string + "!");
+
+        validateItem(0, "FOOBAR", "FOOBAR", true);
         validateItem(1, "foo!", "foo!", true);
         validateItem(2, "bar!", "bar!", true);
     }


### PR DESCRIPTION
## Description

Using an `ItemLabelGenerator` with empty item selection allowed (`setEmptySelectionAllowed(true)`), the label generator must do null checks to avoid throwing a `NullPointerException`. The `emptySelectionCaption` is completely ignored in this scenario. Users should be able to use `emptySelectionCaption` to customize the label for the "empty" selection, instead of the label generator.

Fixes #1085 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
