### PR TITLE
fix: Update client side sort indicators after header is updated (#1841)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -65,7 +65,7 @@ public class SortingPage extends Div {
         add(grid, showGridBtn);
     }
 
-    private Grid createGrid(String gridId, String sortBtnId) {
+    private Grid<Person> createGrid(String gridId, String sortBtnId) {
         Grid<Person> grid = new Grid<>();
         grid.setMultiSort(true);
         grid.setId(gridId);
@@ -99,7 +99,19 @@ public class SortingPage extends Div {
         });
         reOrder.setId("reorder-button");
 
-        add(button, reOrder);
+        NativeButton changeHeaderText = new NativeButton("Change header text",
+                e -> {
+                    ageColumn.setHeader("Age (updated)");
+                });
+        changeHeaderText.setId("change-header-text");
+
+        NativeButton changeHeaderTextComponent = new NativeButton(
+                "Change header text component", e -> {
+                    ageColumn.setHeader(new Span("Age (updated)"));
+                });
+        changeHeaderTextComponent.setId("change-header-text-component");
+
+        add(button, reOrder, changeHeaderText, changeHeaderTextComponent);
 
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -78,6 +78,22 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInitialSortOrder_updateHeaderText_sortIndicatorsRemain() {
+        findElement(By.id("sort-by-age")).click();
+        assertAscendingSorter("Age");
+        findElement(By.id("change-header-text")).click();
+        assertAscendingSorter("Age (updated)");
+    }
+
+    @Test
+    public void setInitialSortOrder_updateHeaderTextComponent_sortIndicatorsRemain() {
+        findElement(By.id("sort-by-age")).click();
+        assertAscendingSorter("Age");
+        findElement(By.id("change-header-text-component")).click();
+        assertAscendingSorter("Age (updated)");
+    }
+
+    @Test
     public void indicatorsSortStateNumbersAndDirectionsAndContentOfRow() {
         WebElement btnAttach = findElement(By.id("btn-attach"));
         WebElement btnRemove = findElement(By.id("btn-detach"));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -745,6 +745,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 defaultHeaderRow = getGrid().addFirstHeaderRow();
             }
             defaultHeaderRow.getCell(this).setText(labelText);
+            grid.updateClientSideSorterIndicators();
             return this;
         }
 
@@ -784,6 +785,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 defaultHeaderRow = getGrid().addFirstHeaderRow();
             }
             defaultHeaderRow.getCell(this).setComponent(headerComponent);
+            grid.updateClientSideSorterIndicators();
             return this;
         }
 
@@ -3109,6 +3111,10 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     public List<GridSortOrder<T>> getSortOrder() {
         return Collections.unmodifiableList(sortOrder);
+    }
+
+    private void updateClientSideSorterIndicators() {
+        updateClientSideSorterIndicators(sortOrder);
     }
 
     private void updateClientSideSorterIndicators(


### PR DESCRIPTION
Add integration tests for sort column header change

Fixes: #1839

Co-authored-by: Sascha Ißbrücker <sascha.issbruecker@googlemail.com>

