### PR TITLE
fix: build on JDK 11+ (#772)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <jetty.version>9.4.15.v20190215</jetty.version>
     <jetty.http.port>8080</jetty.http.port>
     <jetty.stop.port>9999</jetty.stop.port>
-    <maven.failsafe.plugin.version>2.20</maven.failsafe.plugin.version>
+    <maven.failsafe.plugin.version>2.22.1</maven.failsafe.plugin.version>
     <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
     <failsafe.forkCount>4</failsafe.forkCount>


### PR DESCRIPTION
Use a JDK11-compatible version of the maven-failsafe-plugin

Fixes #771

Co-authored-by: Zhe Sun <31067185+ZheSun88@users.noreply.github.com>

