### PR TITLE
Fix: make axisRescaled null safe

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-demo/src/main/java/com/vaadin/flow/component/charts/demo/examples/dynamic/DynamicExtremes.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-demo/src/main/java/com/vaadin/flow/component/charts/demo/examples/dynamic/DynamicExtremes.java
@@ -1,8 +1,5 @@
 package com.vaadin.flow.component.charts.demo.examples.dynamic;
 
-import com.vaadin.flow.component.ClickEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.demo.AbstractChartExample;
 import com.vaadin.flow.component.charts.model.AxisTitle;
@@ -16,7 +13,7 @@ import com.vaadin.flow.component.charts.model.ListSeries;
 import com.vaadin.flow.component.charts.model.PlotOptionsLine;
 import com.vaadin.flow.component.charts.model.VerticalAlign;
 import com.vaadin.flow.component.charts.model.YAxis;
-import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
 
 public class DynamicExtremes extends AbstractChartExample {
 
@@ -79,12 +76,8 @@ public class DynamicExtremes extends AbstractChartExample {
                 4.8);
         configuration.addSeries(ls);
 
-        Input toggleExtremesButton = new Input();
-        toggleExtremesButton.setValue("Toggle extremes");
-        toggleExtremesButton.setId("toggleExtremesButton");
-        toggleExtremesButton.setType("button");
-        ComponentUtil.addListener(toggleExtremesButton, ClickEvent.class,
-                (ComponentEventListener) e -> {
+        NativeButton toggleExtremesButton = new NativeButton("Toggle extremes",
+                e -> {
                     if (setExtremes) {
                         chart.getConfiguration().getyAxes().getAxis(0)
                                 .setExtremes(10, 15);
@@ -93,6 +86,7 @@ public class DynamicExtremes extends AbstractChartExample {
                     }
                     setExtremes = !setExtremes;
                 });
+        toggleExtremesButton.setId("toggleExtremesButton");
 
         add(chart, toggleExtremesButton);
     }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
@@ -17,8 +17,10 @@ import com.vaadin.flow.component.charts.demo.examples.dynamic.DynamicExtremes;
 import com.vaadin.flow.component.charts.testbench.ChartElement;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertEquals;
 
 public class DynamicExtremesIT extends AbstractTBTest {
 
@@ -30,9 +32,14 @@ public class DynamicExtremesIT extends AbstractTBTest {
     @Test
     public void axisFunction_toggleExtremesPoint_pointHidden() {
         ChartElement chart = getChartElement();
+        WebElement toggleExtremesButton = findElement(
+                By.id("toggleExtremesButton"));
         int initialVisiblePointsCount = chart.getVisiblePoints().size();
-        findElement(By.id("toggleExtremesButton")).click();
+        toggleExtremesButton.click();
         assertNotEquals(initialVisiblePointsCount,
+                chart.getVisiblePoints().size());
+        toggleExtremesButton.click();
+        assertEquals(initialVisiblePointsCount,
                 chart.getVisiblePoints().size());
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ProxyChangeForwarder.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ProxyChangeForwarder.java
@@ -81,9 +81,11 @@ class ProxyChangeForwarder implements ConfigurationChangeListener {
     public void axisRescaled(AxisRescaledEvent event) {
         chart.getElement().callJsFunction("__callAxisFunction", "setExtremes",
                 event.getAxis(), event.getAxisIndex(),
-                event.getMinimum().doubleValue(),
-                event.getMaximum().doubleValue(), event.isRedrawingNeeded(),
-                event.isAnimated());
+                event.getMinimum() == null ? null
+                        : event.getMinimum().doubleValue(),
+                event.getMaximum() == null ? null
+                        : event.getMaximum().doubleValue(),
+                event.isRedrawingNeeded(), event.isAnimated());
     }
 
     @Override


### PR DESCRIPTION
Axis#setExtremes can be called with null params to reset to previous configuration.

Fixes #1915

## Description

Axis#setExtremes can be called with null params to reset to previous configuration and shouldn't throw NPE

## Type of change

- [x] Bugfix
- [ ] Feature

