### PR TITLE
feat: add support for custom formats to date picker (CP: 14.8)

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerFormatPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerFormatPage.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@Route("vaadin-date-picker/date-picker-format")
+public class DatePickerFormatPage extends VerticalLayout {
+    public static final String PRIMARY_FORMAT_DATE_PICKER = "PRIMARY_FORMAT_DATE_PICKER";
+    public static final String PRIMARY_FORMAT_OUTPUT = "PRIMARY_FORMAT_OUTPUT";
+    public static final String MULTIPLE_FORMAT_DATE_PICKER = "MULTIPLE_FORMAT_DATE_PICKER";
+    public static final String MULTIPLE_FORMAT_OUTPUT = "MULTIPLE_FORMAT_OUTPUT";
+    public static final String CHANGE_BETWEEN_FORMATS_DATE_PICKER = "CHANGE_BETWEEN_FORMATS_DATE_PICKER";
+    public static final String CHANGE_BETWEEN_FORMATS_BUTTON = "CHANGE_BETWEEN_FORMATS_BUTTON";
+    public static final String CHANGE_BETWEEN_FORMATS_OUTPUT = "CHANGE_BETWEEN_FORMATS_OUTPUT";
+    public static final String REMOVE_DATE_FORMAT_DATE_PICKER = "REMOVE_DATE_FORMAT_DATE_PICKER";
+    public static final String REMOVE_DATE_FORMAT_BUTTON = "REMOVE_DATE_FORMAT_BUTTON";
+    public static final String REMOVE_DATE_FORMAT_OUTPUT = "REMOVE_DATE_FORMAT_OUTPUT";
+    public static final String SET_LOCALE_AFTER_FORMAT_DATE_PICKER = "SET_LOCALE_AFTER_FORMAT_DATE_PICKER";
+    public static final String SET_LOCALE_AFTER_FORMAT_OUTPUT = "SET_LOCALE_AFTER_FORMAT_OUTPUT";
+    public static final String SET_DATE_FORMAT_AFTER_LOCALE_DATE_PICKER = "SET_DATE_FORMAT_AFTER_LOCALE_DATE_PICKER";
+    public static final String SET_DATE_FORMAT_AFTER_LOCALE_OUTPUT = "SET_DATE_FORMAT_AFTER_LOCALE_OUTPUT";
+    public static final String SERVER_SIDE_VALUE_CHANGE_DATE_PICKER = "SERVER_SIDE_VALUE_CHANGE_DATE_PICKER";
+    public static final String SERVER_SIDE_VALUE_CHANGE_BUTTON = "SERVER_SIDE_VALUE_CHANGE_BUTTON";
+
+    public static final LocalDate may13 = LocalDate.of(2018, Month.MAY, 13);
+
+    public DatePickerFormatPage() {
+        setupPrimaryFormat();
+        setupMultipleFormats();
+        setupChangeBetweenFormats();
+        setupRemoveDateFormat();
+        setupSetLocaleAfterFormat();
+        setupSetFormatAfterLocale();
+        setupServerSideValueChange();
+    }
+
+    public void setupPrimaryFormat() {
+        DatePicker datePicker = new DatePicker(may13);
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setDateFormat("yyyy-MM-dd");
+        datePicker.setI18n(i18n);
+
+        Span output = createOutputSpan(datePicker);
+        datePicker.setId(PRIMARY_FORMAT_DATE_PICKER);
+        output.setId(PRIMARY_FORMAT_OUTPUT);
+        add(datePicker, output);
+    }
+
+    private void setupMultipleFormats() {
+        DatePicker datePicker = new DatePicker(may13);
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setDateFormats("yyyy-MM-dd", "dd.MM.yyyy", "MM/dd/yyyy");
+        datePicker.setI18n(i18n);
+
+        Span output = createOutputSpan(datePicker);
+        datePicker.setId(MULTIPLE_FORMAT_DATE_PICKER);
+        output.setId(MULTIPLE_FORMAT_OUTPUT);
+        add(datePicker, output);
+    }
+
+    private void setupChangeBetweenFormats() {
+        DatePicker datePicker = new DatePicker(may13);
+
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setDateFormat("dd.yyyy.MM");
+        datePicker.setI18n(i18n);
+
+        NativeButton btn = new NativeButton("change format", clickEvent -> {
+            datePicker.setI18n(new DatePickerI18n().setDateFormat("M/d/yy"));
+        });
+
+        Span output = createOutputSpan(datePicker);
+        btn.setId(CHANGE_BETWEEN_FORMATS_BUTTON);
+        datePicker.setId(CHANGE_BETWEEN_FORMATS_DATE_PICKER);
+        output.setId(CHANGE_BETWEEN_FORMATS_OUTPUT);
+        add(datePicker, btn, output);
+    }
+
+    private void setupRemoveDateFormat() {
+        DatePicker datePicker = new DatePicker(may13);
+        datePicker.setLocale(Locale.GERMANY);
+
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setDateFormat("dd yyyy MM");
+        datePicker.setI18n(i18n);
+
+        NativeButton btn = new NativeButton("set format to null",
+                clickEvent -> {
+                    datePicker
+                            .setI18n(new DatePickerI18n().setDateFormat(null));
+                });
+
+        Span output = createOutputSpan(datePicker);
+        btn.setId(REMOVE_DATE_FORMAT_BUTTON);
+        datePicker.setId(REMOVE_DATE_FORMAT_DATE_PICKER);
+        output.setId(REMOVE_DATE_FORMAT_OUTPUT);
+        add(datePicker, btn, output);
+    }
+
+    private void setupSetLocaleAfterFormat() {
+        DatePicker datePicker = new DatePicker(may13);
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setDateFormat("yyyy/MM/dd");
+        datePicker.setI18n(i18n);
+
+        datePicker.setLocale(Locale.GERMANY); // should have no effect
+
+        Span output = createOutputSpan(datePicker);
+        datePicker.setId(SET_LOCALE_AFTER_FORMAT_DATE_PICKER);
+        output.setId(SET_LOCALE_AFTER_FORMAT_OUTPUT);
+        add(datePicker, output);
+    }
+
+    private void setupSetFormatAfterLocale() {
+        DatePicker datePicker = new DatePicker(may13);
+        DatePickerI18n i18n = new DatePickerI18n();
+        datePicker.setLocale(Locale.GERMANY);
+
+        i18n.setDateFormat("yyyy/MM/dd");
+        datePicker.setI18n(i18n);
+
+        Span output = createOutputSpan(datePicker);
+        datePicker.setId(SET_DATE_FORMAT_AFTER_LOCALE_DATE_PICKER);
+        output.setId(SET_DATE_FORMAT_AFTER_LOCALE_OUTPUT);
+        add(datePicker, output);
+    }
+
+    private void setupServerSideValueChange() {
+        DatePicker datePicker = new DatePicker();
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setDateFormat("d.M.yyyy");
+        datePicker.setI18n(i18n);
+
+        NativeButton btn = new NativeButton("change date", clickEvent -> {
+            datePicker.setValue(may13);
+        });
+
+        btn.setId(SERVER_SIDE_VALUE_CHANGE_BUTTON);
+        datePicker.setId(SERVER_SIDE_VALUE_CHANGE_DATE_PICKER);
+        add(datePicker, btn);
+    }
+
+    private static Span createOutputSpan(DatePicker datePicker) {
+        Span output = new Span();
+        datePicker.addValueChangeListener(event -> {
+            LocalDate newValue = datePicker.getValue();
+            if (newValue != null) {
+                output.setText(newValue.format(DateTimeFormatter.ISO_DATE));
+            } else {
+                output.setText("");
+            }
+        });
+        return output;
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerFormatIT.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import java.util.logging.Level;
+
+@TestPath("vaadin-date-picker/date-picker-format")
+public class DatePickerFormatIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void testWithPrimaryFormatShouldFormatWithPrimaryFormat() {
+        Assert.assertEquals("2018-05-13",
+                getInputValue(DatePickerFormatPage.PRIMARY_FORMAT_DATE_PICKER));
+    }
+
+    @Test
+    public void testWithPrimaryFormatShouldParseWithPrimaryFormat() {
+        submitValue(DatePickerFormatPage.PRIMARY_FORMAT_DATE_PICKER,
+                "2020-10-23");
+
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.PRIMARY_FORMAT_OUTPUT);
+        Assert.assertEquals("2020-10-23", output.getText());
+    }
+
+    @Test
+    public void testWithMultipleFormatsShouldFormatWithPrimaryFormat() {
+        Assert.assertEquals("2018-05-13", getInputValue(
+                DatePickerFormatPage.MULTIPLE_FORMAT_DATE_PICKER));
+    }
+
+    @Test
+    public void testWithMultipleFormatsShouldParseWithPrimaryFormat() {
+        submitValue(DatePickerFormatPage.MULTIPLE_FORMAT_DATE_PICKER,
+                "2020-10-23");
+
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.MULTIPLE_FORMAT_OUTPUT);
+        Assert.assertEquals("2020-10-23", output.getText());
+    }
+
+    @Test
+    public void testWithMultipleFormatsShouldParseWithAdditionalParsingFormats() {
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.MULTIPLE_FORMAT_OUTPUT);
+
+        submitValue(DatePickerFormatPage.MULTIPLE_FORMAT_DATE_PICKER,
+                "23.10.2020");
+        Assert.assertEquals("2020-10-23", output.getText());
+
+        submitValue(DatePickerFormatPage.MULTIPLE_FORMAT_DATE_PICKER,
+                "02/27/1999");
+        Assert.assertEquals("1999-02-27", output.getText());
+    }
+
+    @Test
+    public void testChangeBetweenFormatsShouldFormatWithNewFormat() {
+        String id = DatePickerFormatPage.CHANGE_BETWEEN_FORMATS_DATE_PICKER;
+
+        Assert.assertEquals("13.2018.05", getInputValue(id));
+        $("button").id(DatePickerFormatPage.CHANGE_BETWEEN_FORMATS_BUTTON)
+                .click();
+        Assert.assertEquals("5/13/18", getInputValue(id));
+    }
+
+    @Test
+    public void testChangeBetweenFormatsShouldParseInNewFormat() {
+        $("button").id(DatePickerFormatPage.CHANGE_BETWEEN_FORMATS_BUTTON)
+                .click();
+
+        submitValue(DatePickerFormatPage.CHANGE_BETWEEN_FORMATS_DATE_PICKER,
+                "2/27/21");
+
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.CHANGE_BETWEEN_FORMATS_OUTPUT);
+
+        Assert.assertEquals("2021-02-27", output.getText());
+    }
+
+    @Test
+    public void testRemovingDateFormatShouldFormatWithLocaleFormat() {
+        String id = DatePickerFormatPage.REMOVE_DATE_FORMAT_DATE_PICKER;
+
+        Assert.assertEquals("13 2018 05", getInputValue(id));
+        $("button").id(DatePickerFormatPage.REMOVE_DATE_FORMAT_BUTTON).click();
+        Assert.assertEquals("13.5.2018", getInputValue(id));
+    }
+
+    @Test
+    public void testRemovingDateFormatShouldParseWithLocaleFormat() {
+        $("button").id(DatePickerFormatPage.REMOVE_DATE_FORMAT_BUTTON).click();
+
+        submitValue(DatePickerFormatPage.REMOVE_DATE_FORMAT_DATE_PICKER,
+                "15.07.1999");
+
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.REMOVE_DATE_FORMAT_OUTPUT);
+
+        Assert.assertEquals("1999-07-15", output.getText());
+    }
+
+    @Test
+    public void testRemovingDateFormatShouldNotLogBrowserError() {
+        $("button").id(DatePickerFormatPage.REMOVE_DATE_FORMAT_BUTTON).click();
+
+        // Verify datePickerConnector.setLocale is not called with null
+        // parameter which would throw and log an error
+        Assert.assertFalse(
+                getLogEntries(Level.SEVERE).stream().findAny().isPresent());
+    }
+
+    @Test
+    public void testSetLocaleAfterFormatShouldFormatWithCustomFormat() {
+        Assert.assertEquals(getInputValue(
+                DatePickerFormatPage.SET_LOCALE_AFTER_FORMAT_DATE_PICKER),
+                "2018/05/13");
+    }
+
+    @Test
+    public void testSetLocaleAfterFormatShouldParseWithCustomFormat() {
+        submitValue(DatePickerFormatPage.SET_LOCALE_AFTER_FORMAT_DATE_PICKER,
+                "1999/07/15");
+
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.SET_LOCALE_AFTER_FORMAT_OUTPUT);
+
+        Assert.assertEquals("1999-07-15", output.getText());
+    }
+
+    @Test
+    public void testSetFormatAfterSetLocaleShouldFormatWithCustomFormat() {
+        Assert.assertEquals(getInputValue(
+                DatePickerFormatPage.SET_DATE_FORMAT_AFTER_LOCALE_DATE_PICKER),
+                "2018/05/13");
+    }
+
+    @Test
+    public void testSetFormatAfterSetLocaleShouldParseWithCustomFormat() {
+        submitValue(
+                DatePickerFormatPage.SET_DATE_FORMAT_AFTER_LOCALE_DATE_PICKER,
+                "1999/07/15");
+
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.SET_DATE_FORMAT_AFTER_LOCALE_OUTPUT);
+
+        Assert.assertEquals("1999-07-15", output.getText());
+    }
+
+    @Test
+    public void testServerSideValueChangeShouldFormatWithCustomFormat() {
+        String id = DatePickerFormatPage.SERVER_SIDE_VALUE_CHANGE_DATE_PICKER;
+
+        Assert.assertEquals("", getInputValue(id));
+        $("button").id(DatePickerFormatPage.SERVER_SIDE_VALUE_CHANGE_BUTTON)
+                .click();
+        Assert.assertEquals("13.5.2018", getInputValue(id));
+    }
+
+    @Test
+    public void testEnteringInvalidValueShouldKeepInvalidValue() {
+        String id = DatePickerFormatPage.MULTIPLE_FORMAT_DATE_PICKER;
+
+        Assert.assertEquals("2018-05-13", getInputValue(id));
+
+        submitValue(id, "foobar");
+
+        Assert.assertEquals("foobar", getInputValue(id));
+    }
+
+    @Test
+    public void testEnteringInvalidValueShouldNotSubmitToServer() {
+        TestBenchElement output = $("span")
+                .id(DatePickerFormatPage.MULTIPLE_FORMAT_OUTPUT);
+        String id = DatePickerFormatPage.MULTIPLE_FORMAT_DATE_PICKER;
+
+        Assert.assertEquals("2018-05-13", getInputValue(id));
+
+        submitValue(id, "foobar");
+
+        Assert.assertEquals("", output.getText());
+    }
+
+    private void submitValue(String id, String value) {
+        TestBenchElement input = $(DatePickerElement.class).id(id)
+                .$("vaadin-date-picker-text-field").first();
+
+        while (!input.getAttribute("value").isEmpty()) {
+            input.sendKeys(Keys.BACK_SPACE);
+        }
+        input.sendKeys(value);
+        input.sendKeys(Keys.ENTER);
+        getCommandExecutor().waitForVaadin();
+    }
+
+    private String getInputValue(String datePickerId) {
+        return $(DatePickerElement.class).id(datePickerId).getInputValue();
+    }
+
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/.gitignore
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/.gitignore
@@ -1,0 +1,7 @@
+node
+output
+node_modules
+
+# Include package.json, which is excluded by outer .gitignore
+!package.json
+!package-lock.json

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/README.md
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/README.md
@@ -1,0 +1,11 @@
+# Date picker date-fns custom bundle
+
+This folder contains a rollup build to create a custom bundle of the [date-fns](https://date-fns.org/) library.
+The custom bundle is used by the date picker's connector as part of the custom date format feature.
+The custom bundle contains only the date-fns functions that are required for that feature, and exposes those as a global under `window.Vaadin.Flow.datePickerDateFns`.
+The build automatically runs as part of the `generate-resources` Maven phase, and the resulting bundle is added as a resource to the date picker JAR file.
+
+We use a custom bundle, instead of `@NpmPackage`, to support the compatibility mode in Vaadin 14.
+The Vaadin 14 compatibility mode uses Bower and webjars instead of NPM, and does not support adding frontend dependencies as easily as the NPM mode does with `@NpmPackage`.
+Instead, we add the date-fns functions that are required by the feature into a custom bundle, and add that bundle to the date pickers JAR file, which makes it easily accessible.
+This workaround can be removed / replaced with `@NpmPackage` as soon as Vaadin 14 is not maintained anymore.

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/index.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/index.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+import isValid from 'date-fns/isValid';
+
+window.Vaadin = window.Vaadin || {};
+window.Vaadin.Flow = window.Vaadin.Flow || {};
+window.Vaadin.Flow.datepickerDateFns = {
+    format,
+    parse,
+    isValid,
+};

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package-lock.json
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package-lock.json
@@ -1,0 +1,349 @@
+{
+  "name": "vaadin-date-picker-date-fns",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.14.5"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
+      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.4.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
+      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "date-fns": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
+      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rollup": {
+      "version": "2.56.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
+      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "terser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      }
+    }
+  }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package.json
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vaadin-date-picker-date-fns",
+  "description": "Custom build of date-fns used by the Vaadin Flow Date Picker",
+  "scripts": {
+    "build": "rollup -c rollup.config.js"
+  },
+  "keywords": [],
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "date-fns": "^2.23.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^13.0.4",
+    "rollup": "^2.56.2",
+    "rollup-plugin-terser": "^7.0.2"
+  }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package.json
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package.json
@@ -8,11 +8,11 @@
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
   "dependencies": {
-    "date-fns": "^2.23.0"
+    "date-fns": "2.23.0"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^13.0.4",
-    "rollup": "^2.56.2",
-    "rollup-plugin-terser": "^7.0.2"
+    "@rollup/plugin-node-resolve": "13.0.4",
+    "rollup": "2.56.2",
+    "rollup-plugin-terser": "7.0.2"
   }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/rollup.config.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/rollup.config.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+import resolve from '@rollup/plugin-node-resolve';
+import {terser} from 'rollup-plugin-terser';
+
+export default {
+    input: 'index.js',
+    output: {
+        file: 'output/date-picker-datefns.js',
+        // Allows loading the bundle as a regular script file
+        format: 'iife',
+    },
+    plugins: [
+        // Support for resolving dependencies in node_modules
+        resolve({browser: true}),
+        // Minify output
+        terser(),
+    ],
+};

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -153,7 +153,66 @@
         </dependency>
     </dependencies>
     <build>
-        <plugins/>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <configuration>
+                    <nodeVersion>v14.17.4</nodeVersion>
+                    <workingDirectory>date-fns</workingDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm run build</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven.resources.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-datefns-bundle</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/date-fns/output</directory>
+                                    <targetPath>META-INF/resources/frontend</targetPath>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -51,7 +51,9 @@ import elemental.json.JsonType;
  * {@link DatePickerI18n} object.
  *
  */
+@JsModule("./date-picker-datefns.js")
 @JsModule("./datepickerConnector.js")
+@JavaScript("frontend://date-picker-datefns.js")
 @JavaScript("frontend://datepickerConnector.js")
 public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         implements HasSize, HasValidation, HasHelper {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -141,18 +141,23 @@
                     throw new Error("Array of custom date formats is null or empty");
                 }
 
+                const dateFns = window.Vaadin.Flow.datepickerDateFns;
+                if (!dateFns) {
+                    throw new Error("Custom date-fns bundle for date picker is not registered at window.Vaadin.Flow.datepickerDateFns");
+                }
+
                 function formatDate(dateParts) {
                     const format = formats[0];
                     const date = datepicker._parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
 
-                    return dateFnsFormat(date, format);
+                    return dateFns.format(date, format);
                 }
 
                 function parseDate(dateString) {
                     for (let format of formats) {
-                        const date = dateFnsParse(dateString, format, new Date());
+                        const date = dateFns.parse(dateString, format, new Date());
 
-                        if (dateFnsIsValid(date)) {
+                        if (dateFns.isValid(date)) {
                             return {day: date.getDate(), month: date.getMonth(), year: date.getFullYear()};
                         }
                     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -37,12 +37,6 @@
             datepicker.$connector.yearPart = new FlowDatePickerPart("1987");
             datepicker.$connector.parts = [datepicker.$connector.dayPart, datepicker.$connector.monthPart, datepicker.$connector.yearPart];
 
-            // Old locale should always be the default vaadin-date-picker component
-            // locale {English/US} as we init lazily and the date-picker formats
-            // the date using the default i18n settings and we need to use the input
-            // value as we may need to parse user input so we can't use the _selectedDate value.
-            let oldLocale = "en-us";
-
             datepicker.addEventListener('blur', tryCatchWrapper(e => {
                 if (!e.target.value && e.target.invalid) {
                     console.warn("Invalid value in the DatePicker.");
@@ -61,28 +55,20 @@
                 let inputValue = '';
                 try {
                     inputValue = datepicker._inputValue;
-                } catch(err) {
+                } catch (err) {
                     /* component not ready: falling back to stored value */
                     inputValue = datepicker.value || '';
                 }
                 return inputValue;
             });
 
-            datepicker.$connector.setLocale = tryCatchWrapper(function (locale) {
-
+            const createLocaleBasedFormatterAndParser = tryCatchWrapper(function (locale) {
                 try {
                     // Check whether the locale is supported or not
                     new Date().toLocaleDateString(locale);
                 } catch (e) {
                     locale = "en-US";
                     console.warn("The locale is not supported, using default locale setting(en-US).");
-                }
-
-                let currentDate = false;
-                let inputValue = getInputValue();
-                if (datepicker.i18n.parseDate !== 'undefined' && inputValue) {
-                    /* get current date with old parsing */
-                    currentDate = datepicker.i18n.parseDate(inputValue);
                 }
 
                 /* create test-string where to extract parsing regex */
@@ -97,22 +83,32 @@
                 * regex will be the date, so that:
                 * - day-part is '(\d{1,2})' (1 or 2 digits),
                 * - month-part is '(\d{1,2})' (1 or 2 digits),
-                * - year-part is '(\d{4})' (4 digits)
+                * - year-part is '(\d{1,4})' (1 to 4 digits)
                 *
                 * and everything else is left as is.
-                * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{4})".
+                * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{1,4})".
                 *
                 * The sorting part solves that which part is which (for example,
                 * here the first part is month, second day and third year)
                 *  */
-                datepicker.$connector.regex = testString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&').replace(datepicker.$connector.dayPart.initial, "(\\d{1,2})").replace(datepicker.$connector.monthPart.initial, "(\\d{1,2})").replace(datepicker.$connector.yearPart.initial, "(\\d{4})");
+                datepicker.$connector.regex = testString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+                    .replace(datepicker.$connector.dayPart.initial, "(\\d{1,2})")
+                    .replace(datepicker.$connector.monthPart.initial, "(\\d{1,2})")
+                    .replace(datepicker.$connector.yearPart.initial, "(\\d{1,4})");
 
-                datepicker.i18n.formatDate = tryCatchWrapper(function (date) {
-                    let rawDate = new Date(Date.UTC(date.year, date.month, date.day));
-                    return cleanString(rawDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
-                });
+                function formatDate(date) {
+                    let rawDate = datepicker._parseDate(`${date.year}-${date.month + 1}-${date.day}`);
 
-                datepicker.i18n.parseDate = tryCatchWrapper(function (dateString) {
+                    // Workaround for Safari DST offset issue when using Date.toLocaleDateString().
+                    // This is needed to keep the correct date in formatted result even if Safari
+                    // makes an error of an hour or more in the result with some past dates.
+                    // See https://github.com/vaadin/vaadin-date-picker-flow/issues/126#issuecomment-508169514
+                    rawDate.setHours(12)
+
+                    return cleanString(rawDate.toLocaleDateString(locale));
+                }
+
+                function parseDate(dateString) {
                     dateString = cleanString(dateString);
 
                     if (dateString.length == 0) {
@@ -122,24 +118,66 @@
                     let match = dateString.match(datepicker.$connector.regex);
                     if (match && match.length == 4) {
                         for (let i = 1; i < 4; i++) {
-                            datepicker.$connector.parts[i-1].value = parseInt(match[i]);
+                            datepicker.$connector.parts[i - 1].value = parseInt(match[i]);
                         }
                         return {
                             day: datepicker.$connector.dayPart.value,
                             month: datepicker.$connector.monthPart.value - 1,
                             year: datepicker.$connector.yearPart.value
                         };
-                    }  else {
+                    } else {
                         return false;
                     }
-                });
-
-                if (inputValue === "") {
-                    oldLocale = locale;
-                } else if (currentDate) {
-                    /* set current date to invoke use of new locale */
-                    datepicker._selectedDate = new Date(currentDate.year, currentDate.month, currentDate.day);
                 }
+
+                return {
+                    formatDate: formatDate,
+                    parseDate: parseDate,
+                };
+            });
+
+            const createCustomFormatBasedFormatterAndParser = tryCatchWrapper(function (formats) {
+                if (!formats || formats.length === 0) {
+                    throw new Error("Array of custom date formats is null or empty");
+                }
+
+                function formatDate(dateParts) {
+                    const format = formats[0];
+                    const date = datepicker._parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
+
+                    return dateFnsFormat(date, format);
+                }
+
+                function parseDate(dateString) {
+                    for (let format of formats) {
+                        const date = dateFnsParse(dateString, format, new Date());
+
+                        if (dateFnsIsValid(date)) {
+                            return {day: date.getDate(), month: date.getMonth(), year: date.getFullYear()};
+                        }
+                    }
+                    return false;
+                }
+
+                return {
+                    formatDate: formatDate,
+                    parseDate: parseDate,
+                };
+            });
+
+            datepicker.$connector.updateI18n = tryCatchWrapper(function (locale, i18n) {
+                // Create formatting and parsing functions, either based on custom formats set in i18n object,
+                // or based on the locale set in the date picker
+                // Custom formats take priority over locale
+                const hasDateFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
+                const formatterAndParser = hasDateFormats
+                    ? createCustomFormatBasedFormatterAndParser(i18n.dateFormats)
+                    : locale
+                        ? createLocaleBasedFormatterAndParser(locale)
+                        : null;
+
+                // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
+                datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
             });
         })(datepicker)
     };

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -16,18 +16,16 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
+import java.util.List;
 
-import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class DatePickerTest {
@@ -51,33 +49,35 @@ public class DatePickerTest {
     public void datePicker_basicCases() {
         DatePicker picker = new DatePicker();
 
-        assertEquals(null, picker.getValue());
-        assertFalse(picker.getElement().hasProperty("value"));
+        Assert.assertNull(picker.getValue());
+        Assert.assertFalse(picker.getElement().hasProperty("value"));
 
         picker.setValue(LocalDate.of(2018, 4, 25));
-        assertEquals("2018-04-25", picker.getElement().getProperty("value"));
+        Assert.assertEquals("2018-04-25",
+                picker.getElement().getProperty("value"));
 
         picker.getElement().setProperty("value", "2017-03-24");
-        assertEquals(LocalDate.of(2017, 3, 24), picker.getValue());
+        Assert.assertEquals(LocalDate.of(2017, 3, 24), picker.getValue());
 
         // Cannot do removeProperty because
         // https://github.com/vaadin/flow/issues/3994
         picker.getElement().setProperty("value", null);
-        assertEquals(null, picker.getValue());
+        Assert.assertNull(picker.getValue());
     }
 
     @Test
     public void defaultCtor_does_not_update_values() {
         DatePicker picker = new DatePicker();
-        assertNull(picker.getValue());
-        assertEquals(null, picker.getElement().getProperty("value"));
+        Assert.assertNull(picker.getValue());
+        Assert.assertNull(picker.getElement().getProperty("value"));
     }
 
     @Test
     public void setInitialValue() {
         DatePicker picker = new DatePicker(LocalDate.of(2018, 4, 25));
-        assertEquals(LocalDate.of(2018, 4, 25), picker.getValue());
-        assertEquals("2018-04-25", picker.getElement().getProperty("value"));
+        Assert.assertEquals(LocalDate.of(2018, 4, 25), picker.getValue());
+        Assert.assertEquals("2018-04-25",
+                picker.getElement().getProperty("value"));
     }
 
     @Test
@@ -87,35 +87,37 @@ public class DatePickerTest {
         picker.setValue(LocalDate.now());
         picker.setValue(null);
 
-        assertNull(picker.getValue());
-        assertEquals("", picker.getElement().getProperty("value"));
+        Assert.assertNull(picker.getValue());
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
     }
 
     @Test
     public void setOpened_openedPropertyIsUpdated() {
         DatePicker picker = new DatePicker();
-        assertFalse("Initially DatePicker should be closed", picker.isOpened());
+        Assert.assertFalse("Initially DatePicker should be closed",
+                picker.isOpened());
         picker.setOpened(true);
-        assertTrue(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
+        Assert.assertTrue(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
         picker.setOpened(false);
-        assertFalse(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
+        Assert.assertFalse(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
     }
 
     @Test
     public void openAndClose_openedPropertyIsUpdated() {
         DatePicker picker = new DatePicker();
-        assertFalse("Initially DatePicker should be closed", picker.isOpened());
+        Assert.assertFalse("Initially DatePicker should be closed",
+                picker.isOpened());
         picker.open();
-        assertTrue(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
+        Assert.assertTrue(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
         picker.close();
-        assertFalse(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
+        Assert.assertFalse(OPENED_PROPERTY_NOT_UPDATED, picker.isOpened());
     }
 
     @Test
     public void clearButtonVisiblePropertyValue() {
         DatePicker picker = new DatePicker();
 
-        assertFalse("Clear button should not be visible by default",
+        Assert.assertFalse("Clear button should not be visible by default",
                 picker.isClearButtonVisible());
         assertClearButtonPropertyValueEquals(picker, true);
         assertClearButtonPropertyValueEquals(picker, false);
@@ -124,21 +126,94 @@ public class DatePickerTest {
     public void assertClearButtonPropertyValueEquals(DatePicker picker,
             Boolean value) {
         picker.setClearButtonVisible(value);
-        assertEquals(value, picker.isClearButtonVisible());
-        assertEquals(picker.isClearButtonVisible(),
+        Assert.assertEquals(value, picker.isClearButtonVisible());
+        Assert.assertEquals(picker.isClearButtonVisible(),
                 picker.getElement().getProperty("clearButtonVisible", value));
     }
 
     @Test
     public void setAutoOpenEnabled() {
         DatePicker picker = new DatePicker();
-        assertTrue("Auto-open should be enabled by default",
+        Assert.assertTrue("Auto-open should be enabled by default",
                 picker.isAutoOpen());
         picker.setAutoOpen(false);
-        assertFalse("Should be possible to disable auto-open",
+        Assert.assertFalse("Should be possible to disable auto-open",
                 picker.isAutoOpen());
         picker.setAutoOpen(true);
-        assertTrue("Should be possible to enable auto-open",
+        Assert.assertTrue("Should be possible to enable auto-open",
                 picker.isAutoOpen());
     }
+
+    @Test
+    public void setDateFormat_dateFormatsIsUpdated() {
+        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
+        i18n.setDateFormat("MM-yyyy-dd");
+        List<String> dateFormats = i18n.getDateFormats();
+
+        Assert.assertNotNull(dateFormats);
+        Assert.assertEquals(1, dateFormats.size());
+        Assert.assertEquals("MM-yyyy-dd", dateFormats.get(0));
+    }
+
+    @Test
+    public void setDateFormats_dateFormatsIsUpdated() {
+        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
+        i18n.setDateFormats("MM-yyyy-dd", "MM.dd.yyyy", "MM§yyyy§dd");
+        List<String> dateFormats = i18n.getDateFormats();
+
+        Assert.assertNotNull(dateFormats);
+        Assert.assertEquals(3, dateFormats.size());
+        Assert.assertEquals("MM-yyyy-dd", dateFormats.get(0));
+        Assert.assertEquals("MM.dd.yyyy", dateFormats.get(1));
+        Assert.assertEquals("MM§yyyy§dd", dateFormats.get(2));
+    }
+
+    @Test
+    public void setDateFormats_nullIsRemovedFromDateFormats() {
+        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
+        i18n.setDateFormats("MM-yyyy-dd", null, "MM.dd.yyyy", "MM§yyyy§dd");
+        List<String> dateFormats = i18n.getDateFormats();
+
+        Assert.assertNotNull(dateFormats);
+        Assert.assertEquals(3, dateFormats.size());
+        Assert.assertEquals("MM-yyyy-dd", dateFormats.get(0));
+        Assert.assertEquals("MM.dd.yyyy", dateFormats.get(1));
+        Assert.assertEquals("MM§yyyy§dd", dateFormats.get(2));
+    }
+
+    @Test
+    public void setDateFormat_dateFormatsIsNull() {
+        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
+
+        Assert.assertNull(i18n.getDateFormats());
+
+        i18n.setDateFormat("MM-yyyy-dd");
+        Assert.assertNotNull(i18n.getDateFormats());
+
+        i18n.setDateFormat(null);
+
+        Assert.assertNull(i18n.getDateFormats());
+    }
+
+    @Test
+    public void setDateFormats_dateFormatsIsNull() {
+        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
+
+        Assert.assertNull(i18n.getDateFormats());
+
+        i18n.setDateFormats("MM-yyyy-dd");
+        Assert.assertNotNull(i18n.getDateFormats());
+
+        i18n.setDateFormats(null);
+        Assert.assertNull(i18n.getDateFormats());
+    }
+
+    @Test
+    public void setDateFormats_throwsExceptionWhenSecondArgIsNull() {
+        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
+
+        Assert.assertThrows(NullPointerException.class,
+                () -> i18n.setDateFormats("MM-yyyy-dd", null));
+    }
+
 }


### PR DESCRIPTION
## Description

Cherry pick of #1975 

Marked as draft as this is supposed to target `14.8`, which is not available yet. Instead this PR temporarily targets `14.7` in order to have a PR for discussion and reviews.

Changes the original implementation to include a custom bundle of the date-fns library to allow back-porting the custom date format feature to Vaadin 14. The reason for the change is that the current mechanism of including the date-fns dependency though `@NpmPackage` is not compatible with Vaadin 14 compatibility mode.

General solution outline:
- adds a `date-fns` folder to the Flow date picker Maven module
- that folder contains a node.js / rollup build that bundles only the required date-fns function into a single JS file
- the rollup build is automatically executed during the `generate-resources` Maven phase, using the `maven-frontend-plugin`
- the resulting bundle is copied to the target output, so that it will be packaged into the date picker JAR file, together with the date picker connector
- the bundle is imported using `@JsModule` (NPM mode) or `@Javascript` (Bower mode), same as the date picker connector
- the bundle exposes the date-fns functions as a global under `window.Vaadin.Flow.datepickerDateFns`
- the date picker connector uses this global to access these functions

TODO:
- [x] Check browser support for Vaadin 14 and if we need polyfills for the date-fns code
- [ ] Check with platform team regarding:
  - changes to the Maven build process
  - OSGI support
