### PR TITLE
fix: Remove old data provider listener on component attach

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -942,7 +942,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         DataProvider<T, ?> dataProvider = getDataProvider();
-        if (dataProvider != null && dataProviderListener == null) {
+        if (dataProvider != null) {
             setupDataProviderListener(dataProvider);
         }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -17,7 +17,10 @@ package com.vaadin.flow.component.combobox;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -36,6 +39,7 @@ import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.DataProviderListener;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.di.Instantiator;
@@ -451,6 +455,62 @@ public class ComboBoxTest {
         listDataView.removeItem("First");
         listDataView.removeItem("Third");
         Assert.assertEquals(2L, listDataView.getItemCount());
+    }
+
+    @Test
+    public void dataProviderListeners_comboBoxAttached_oldDataProviderListenerRemoved() {
+        AtomicInteger listenersCount = new AtomicInteger(0);
+        AtomicBoolean oldListenerRemoved = new AtomicBoolean();
+
+        // given
+        ComboBox<String> comboBox = new ComboBox<>();
+        ListDataProvider<String> dataProvider = new ListDataProvider<String>(
+                Collections.emptyList()) {
+            @Override
+            public Registration addDataProviderListener(
+                    DataProviderListener<String> listener) {
+                listenersCount.incrementAndGet();
+                Registration registration = super.addDataProviderListener(
+                        listener);
+                // the second listener is added by ComboBox and it is the one
+                // we want to be removed.
+                return listenersCount.get() == 2
+                        ? Registration.combine(registration,
+                                () -> oldListenerRemoved.set(true))
+                        : registration;
+            }
+        };
+
+        // when
+        comboBox.setDataProvider(dataProvider);
+
+        // then
+        Assert.assertEquals(
+                "Expected exactly two data provider listeners added by "
+                        + "DataCommunicator's and ComboBox's 'setDataProvider' methods",
+                2, listenersCount.get());
+        Assert.assertFalse(
+                "Expected data provider listener added by ComboBox not to be "
+                        + "removed before ComboBox being attached",
+                oldListenerRemoved.get());
+
+        // given
+        listenersCount.set(0);
+
+        // when
+        DataCommunicatorTest.MockUI mockUI = new DataCommunicatorTest.MockUI();
+        mockUI.add(comboBox);
+        fakeClientCommunication(mockUI);
+
+        // then
+        Assert.assertEquals(
+                "Expected exactly two data provider listeners added by "
+                        + "DataCommunicator's and ComboBox's attach handle methods",
+                2, listenersCount.get());
+        Assert.assertTrue(
+                "Expected old data provider listener to be removed after "
+                        + "combobox being attached",
+                oldListenerRemoved.get());
     }
 
     private void assertItem(TestComboBox comboBox, int index, String caption) {

--- a/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/DataProviderListenersTest.java
+++ b/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/DataProviderListenersTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.data.provider.DataProviderListener;
+import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Util class for testing how components with data provider handles the data
+ * provider listener on attaching/detaching and on setting a new data provider.
+ */
+public final class DataProviderListenersTest {
+
+    private DataProviderListenersTest() {
+    }
+
+    /**
+     * Checks the old data provider listeners of the component are removed after
+     * component attach/detach and a new ones are added.
+     * 
+     * @param component
+     *            to be attached/detached
+     * @param expectedListenersCountAfterDataProviderSetup
+     *            expected listeners count after setting a data provider to
+     *            component
+     * @param expectedListenersCountAfterComponentAttach
+     *            expected listeners count after attaching the component
+     * @param expectedRemovedListenerIndexes
+     *            indexes of listeners which are supposed to be removed after
+     *            attach and detach of component, index starts from 0.
+     * @param mockUI
+     *            UI the component is attached to
+     * @param <C>
+     *            component type
+     */
+    public static <C extends HasListDataView<Object, ?>> void checkOldListenersRemovedOnComponentAttachAndDetach(
+            C component, int expectedListenersCountAfterDataProviderSetup,
+            int expectedListenersCountAfterComponentAttach,
+            int[] expectedRemovedListenerIndexes, UI mockUI) {
+
+        // given
+        DataProviderProxy dataProviderProxy = new DataProviderProxy();
+
+        // when
+        component.setItems(dataProviderProxy);
+
+        // then
+        Assert.assertEquals(
+                "Unexpected count of added data provider listeners after "
+                        + "setting a data provider to the component",
+                expectedListenersCountAfterDataProviderSetup,
+                dataProviderProxy.getListenersCounter());
+
+        // given
+        dataProviderProxy.resetListenersCounter();
+
+        // when
+        mockUI.add((Component) component);
+        fakeClientCommunication(mockUI);
+
+        // then
+        Assert.assertEquals(
+                "Unexpected count of added data provider "
+                        + "listeners after attaching the component",
+                expectedListenersCountAfterComponentAttach,
+                dataProviderProxy.getListenersCounter());
+
+        // when
+        mockUI.remove((Component) component);
+        fakeClientCommunication(mockUI);
+
+        // then
+        Arrays.stream(expectedRemovedListenerIndexes)
+                .forEach(listenerIndex -> Assert.assertTrue(String.format(
+                        "Expected old data provider listener with index '%d' to"
+                                + " be removed",
+                        listenerIndex),
+                        dataProviderProxy.getListenerRemoved()
+                                .get(listenerIndex)));
+    }
+
+    private static void fakeClientCommunication(UI ui) {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    private static class DataProviderProxy extends ListDataProvider<Object> {
+        private final List<Boolean> listenerRemoved;
+        private int listenersCounter = 0;
+        private int registrationsCounter = 0;
+
+        public DataProviderProxy() {
+            super(Collections.emptyList());
+            final int maxListenerNumberExpected = 4;
+            listenerRemoved = Stream.of(new Boolean[maxListenerNumberExpected])
+                    .map(item -> Boolean.FALSE).collect(Collectors.toList());
+        }
+
+        @Override
+        public Registration addDataProviderListener(
+                DataProviderListener<Object> listener) {
+            listenersCounter++;
+            int registrationIndex = registrationsCounter++;
+            Registration registration = super.addDataProviderListener(listener);
+            return Registration.combine(registration,
+                    () -> listenerRemoved.set(registrationIndex, Boolean.TRUE));
+        }
+
+        public int getListenersCounter() {
+            return listenersCounter;
+        }
+
+        public List<Boolean> getListenerRemoved() {
+            return listenerRemoved;
+        }
+
+        public void resetListenersCounter() {
+            listenersCounter = 0;
+        }
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3201,8 +3201,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         updateClientSideSorterIndicators(sortOrder);
-        if (getDataProvider() != null
-                && dataProviderChangeRegistration == null) {
+        if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -17,6 +17,9 @@
 package com.vaadin.flow.component.grid;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
@@ -24,8 +27,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.DataProviderListener;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.shared.Registration;
 
 public class GridTest {
 
@@ -100,5 +108,67 @@ public class GridTest {
 
         Assert.assertTrue(grid.isHeightByRows());
         Assert.assertTrue(grid.isAllRowsVisible());
+    }
+
+    @Test
+    public void dataProviderListeners_gridAttached_oldDataProviderListenerRemoved() {
+        AtomicInteger listenersCount = new AtomicInteger(0);
+        AtomicBoolean oldListenerRemoved = new AtomicBoolean();
+
+        // given
+        Grid<String> grid = new Grid<>();
+        ListDataProvider<String> dataProvider = new ListDataProvider<String>(
+                Collections.emptyList()) {
+            @Override
+            public Registration addDataProviderListener(
+                    DataProviderListener<String> listener) {
+                listenersCount.incrementAndGet();
+                Registration registration = super.addDataProviderListener(
+                        listener);
+                // the first listener is added by Grid in 'setDataProvider'
+                // and it is the one we want to be removed.
+                return listenersCount.get() == 1
+                        ? Registration.combine(registration,
+                                () -> oldListenerRemoved.set(true))
+                        : registration;
+            }
+        };
+
+        // when
+        grid.setDataProvider(dataProvider);
+
+        // then
+        Assert.assertEquals(
+                "Expected exactly two data provider listeners added by "
+                        + "DataCommunicator's and Grid's 'setDataProvider' methods",
+                2, listenersCount.get());
+        Assert.assertFalse(
+                "Expected data provider listener added by Grid not to be "
+                        + "removed before Grid being attached",
+                oldListenerRemoved.get());
+
+        // given
+        listenersCount.set(0);
+
+        // when
+        DataCommunicatorTest.MockUI mockUI = new DataCommunicatorTest.MockUI();
+        mockUI.add(grid);
+        fakeClientCommunication(mockUI);
+
+        // then
+        Assert.assertEquals(
+                "Expected exactly two data provider listeners added by "
+                        + "DataCommunicator's and Grid's attach handle methods",
+                2, listenersCount.get());
+        Assert.assertTrue(
+                "Expected old data provider listener to be removed after "
+                        + "grid being attached",
+                oldListenerRemoved.get());
+    }
+
+    private void fakeClientCommunication(UI ui) {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -124,8 +124,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        if (getDataProvider() != null
-                && dataProviderListenerRegistration == null) {
+        if (getDataProvider() != null) {
             setupDataProviderListener(getDataProvider());
         }
     }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -102,6 +102,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
         this.dataProvider.set(Objects.requireNonNull(dataProvider));
         DataViewUtils.removeComponentFilterAndSortComparator(this);
         clear();
+        rebuild();
         setupDataProviderListener(this.dataProvider.get());
     }
 
@@ -118,7 +119,6 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
                         rebuild();
                     }
                 });
-        rebuild();
     }
 
     @Override

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -2,10 +2,7 @@ package com.vaadin.flow.component.listbox.test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -13,13 +10,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
-import com.vaadin.flow.data.provider.DataProviderListener;
-import com.vaadin.flow.data.provider.ListDataProvider;
-import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.DataProviderListenersTest;
 
 public class ListBoxUnitTest {
 
@@ -172,62 +166,11 @@ public class ListBoxUnitTest {
     }
 
     @Test
-    public void dataProviderListeners_listBoxAttached_oldDataProviderListenerRemoved() {
-        AtomicInteger listenersCount = new AtomicInteger(0);
-        AtomicBoolean oldListenerRemoved = new AtomicBoolean();
-
-        // given
-        ListBox<String> listBox = new ListBox<>();
-        ListDataProvider<String> dataProvider = new ListDataProvider<String>(
-                Collections.emptyList()) {
-            @Override
-            public Registration addDataProviderListener(
-                    DataProviderListener<String> listener) {
-                listenersCount.incrementAndGet();
-                Registration registration = super.addDataProviderListener(
-                        listener);
-                // the first listener is added by ListBox in 'setDataProvider'
-                // and it is the one we want to be removed.
-                return listenersCount.get() == 1
-                        ? Registration.combine(registration,
-                                () -> oldListenerRemoved.set(true))
-                        : registration;
-            }
-        };
-
-        // when
-        listBox.setDataProvider(dataProvider);
-
-        // then
-        Assert.assertEquals(
-                "Expected exactly one data provider listener added by "
-                        + "ListBox's 'setDataProvider' method",
-                1, listenersCount.get());
-        Assert.assertFalse(
-                "Expected data provider listener added by ListBox not to be "
-                        + "removed before ListBox being attached",
-                oldListenerRemoved.get());
-
-        // when
-        DataCommunicatorTest.MockUI mockUI = new DataCommunicatorTest.MockUI();
-        mockUI.add(listBox);
-        fakeClientCommunication(mockUI);
-
-        // then
-        Assert.assertEquals(
-                "Expected exactly one data provider listener added by "
-                        + "ListBox's attach handle method",
-                2, listenersCount.get());
-        Assert.assertTrue(
-                "Expected old data provider listener to be removed after "
-                        + "ListBox being attached",
-                oldListenerRemoved.get());
-    }
-
-    private void fakeClientCommunication(UI ui) {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
+    public void dataProviderListeners_listBoxAttachedAndDetached_oldDataProviderListenerRemoved() {
+        DataProviderListenersTest
+                .checkOldListenersRemovedOnComponentAttachAndDetach(
+                        new ListBox<>(), 1, 1, new int[] { 0, 1 },
+                        new DataCommunicatorTest.MockUI());
     }
 
     private void assertDisabledItem(int index, boolean disabled) {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -245,8 +245,7 @@ public class RadioButtonGroup<T>
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        if (getDataProvider() != null
-                && dataProviderListenerRegistration == null) {
+        if (getDataProvider() != null) {
             setupDataProviderListener(getDataProvider());
         }
         FieldValidationUtil.disableClientValidation(this);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -17,10 +17,7 @@ package com.vaadin.flow.component.radiobutton;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,13 +36,11 @@ import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataVi
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.data.provider.DataProviderListener;
-import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.DataProviderListenersTest;
 
 public class RadioButtonGroupTest {
 
@@ -426,61 +421,10 @@ public class RadioButtonGroupTest {
     }
 
     @Test
-    public void dataProviderListeners_radioButtonGroupAttached_oldDataProviderListenerRemoved() {
-        AtomicInteger listenersCount = new AtomicInteger(0);
-        AtomicBoolean oldListenerRemoved = new AtomicBoolean();
-
-        // given
-        RadioButtonGroup<String> rbg = new RadioButtonGroup<>();
-        ListDataProvider<String> dataProvider = new ListDataProvider<String>(
-                Collections.emptyList()) {
-            @Override
-            public Registration addDataProviderListener(
-                    DataProviderListener<String> listener) {
-                listenersCount.incrementAndGet();
-                Registration registration = super.addDataProviderListener(
-                        listener);
-                // the first listener is added by RBG in 'setDataProvider'
-                // and it is the one we want to be removed.
-                return listenersCount.get() == 1
-                        ? Registration.combine(registration,
-                                () -> oldListenerRemoved.set(true))
-                        : registration;
-            }
-        };
-
-        // when
-        rbg.setDataProvider(dataProvider);
-
-        // then
-        Assert.assertEquals(
-                "Expected exactly one data provider listener added by RBG's "
-                        + "'setDataProvider' method",
-                1, listenersCount.get());
-        Assert.assertFalse(
-                "Expected data provider listener added by RBG not to be "
-                        + "removed before RBG being attached",
-                oldListenerRemoved.get());
-
-        // when
-        DataCommunicatorTest.MockUI mockUI = new DataCommunicatorTest.MockUI();
-        mockUI.add(rbg);
-        fakeClientCommunication(mockUI);
-
-        // then
-        Assert.assertEquals(
-                "Expected exactly one data provider listener added by "
-                        + "RBG's attach handle method",
-                2, listenersCount.get());
-        Assert.assertTrue(
-                "Expected old data provider listener to be removed after "
-                        + "RBG being attached",
-                oldListenerRemoved.get());
-    }
-
-    private void fakeClientCommunication(UI ui) {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
+    public void dataProviderListeners_radioButtonGroupAttachedAndDetached_oldDataProviderListenerRemoved() {
+        DataProviderListenersTest
+                .checkOldListenersRemovedOnComponentAttachAndDetach(
+                        new RadioButtonGroup<>(), 1, 1, new int[] { 0, 1 },
+                        new DataCommunicatorTest.MockUI());
     }
 }


### PR DESCRIPTION
## Description

This change is a fix for ComboBox and related to the fix made on the flow side to get rid of memory leaks caused by old listeners being hanging in the list - https://github.com/vaadin/flow/pull/11471.

Null-value checking of `dataProviderListener` is not needed in attach handler because:
1. Calling to a `remove()` is more robust and this is a normal way of handling listeners registrations in flow. Additionally, if, for some reason, a new data provider will be set up to the component, it's more correct to remove the old listener sitting in the old data provider.
2. Not calling of `remove()` method gives an inconsistency with the flow, which now (with the above fix) removes the listener on attach event.

The inconsistency described in 2. causes the ComboBox's and DataCommunicator data provider listeners order violation.
This causes a side-effects in client-side filtering, it's seen from the failed tests.
I didn't dig deeply into the details what a the side effect in deep, but it's clear that it is somehow overrides/cleans filter/items/size variables in data communicator -> break it's internal state.

How it worked before both fixes:
1. DataCommunicator adds a data provider listener upon its `setDataProvider` method.
2. ComboBox adds a data provider listener upon its `setDataProvider` method.
3. DataCommunicator adds one more data provider listener upon attach event.
4. ComboBox adds one more data provider listener upon attach event.

So finally DC listener comes before CB listener and this work fine.

How it worked after the fix in Flow:
1. DataCommunicator adds a data provider listener upon its `setDataProvider` method.
2. ComboBox adds a data provider listener upon its `setDataProvider` method.
3. DataCommunicator REMOVES the old data provider listener upon attach event and adds a new one.
4. ComboBox adds one more data provider listener upon attach event.

So now the CB listener comes first (because the first listener in the queue has been removed), and this violates the order of listener execution. And this causes a side-effects and test failures.

How it works after the fix in Flow and ComboBox:
1. DataCommunicator adds a data provider listener upon its `setDataProvider` method.
2. ComboBox adds a data provider listener upon its `setDataProvider` method.
3. DataCommunicator REMOVES the old data provider listener upon attach event and adds a new one.
4. ComboBox REMOVES the old data provider listener upon attach event and adds a new one.

Thus, there are only two listeners in the end and they are in the right order -> works fine.

No tests added, because this change is covered by tests in `FilteringIT`.

Related-to https://github.com/vaadin/flow-components/issues/1914

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
