### PR TITLE
chore: regenerate pom files in renderer module to align with other modules

### DIFF
--- a/vaadin-renderer-flow-parent/pom.xml
+++ b/vaadin-renderer-flow-parent/pom.xml
@@ -6,12 +6,9 @@
         <artifactId>vaadin-flow-components</artifactId>
         <version>22.0-SNAPSHOT</version>
     </parent>
-    <!-- With the current CI setup, all modules in this repo should follow
-         the same naming pattern: vaadin-[name]-flow
-         https://vaadin.slack.com/archives/C020AE8T02Z/p1625214456273000?thread_ts=1624431063.244300&cid=C020AE8T02Z -->
     <artifactId>vaadin-renderer-flow-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Flow Renderer Parent</name>
+    <name>Vaadin Renderer Parent</name>
     <modules>
         <module>vaadin-renderer-flow</module>
     </modules>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>vaadin-renderer-flow-integration-tests</artifactId>
     <packaging>war</packaging>
-    <name>Flow Renderer Integration Tests</name>
+    <name>Vaadin Renderer Integration Tests</name>
     <dependencies>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
@@ -140,9 +140,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <configuration>
-                            <scanIntervalSeconds>5</scanIntervalSeconds>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>vaadin-renderer-flow</artifactId>
     <packaging>jar</packaging>
-    <name>Flow Renderer</name>
+    <name>Vaadin Renderer</name>
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
I just run `./scripts/updateJavaPOMs.sh` so as all pom files are regenerated and formatted.