### PR TITLE
fix: Remove old data provider listener on component attach (CP: 21.0)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -942,7 +942,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         DataProvider<T, ?> dataProvider = getDataProvider();
-        if (dataProvider != null && dataProviderListener == null) {
+        if (dataProvider != null) {
             setupDataProviderListener(dataProvider);
         }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.DataProviderListenersTest;
 
 import elemental.json.Json;
 import static org.junit.Assert.assertEquals;
@@ -451,6 +452,14 @@ public class ComboBoxTest {
         listDataView.removeItem("First");
         listDataView.removeItem("Third");
         Assert.assertEquals(2L, listDataView.getItemCount());
+    }
+
+    @Test
+    public void dataProviderListeners_comboBoxAttachedAndDetached_oldDataProviderListenerRemoved() {
+        DataProviderListenersTest
+                .checkOldListenersRemovedOnComponentAttachAndDetach(
+                        new ComboBox<>(), 2, 2, new int[] { 1, 3 },
+                        new DataCommunicatorTest.MockUI());
     }
 
     private void assertItem(TestComboBox comboBox, int index, String caption) {

--- a/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/DataProviderListenersTest.java
+++ b/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/DataProviderListenersTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.data.provider.DataProviderListener;
+import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Util class for testing how components with data provider handles the data
+ * provider listener on attaching/detaching and on setting a new data provider.
+ */
+public final class DataProviderListenersTest {
+
+    private DataProviderListenersTest() {
+    }
+
+    /**
+     * Checks the old data provider listeners of the component are removed after
+     * component attach/detach and a new ones are added.
+     * 
+     * @param component
+     *            to be attached/detached
+     * @param expectedListenersCountAfterDataProviderSetup
+     *            expected listeners count after setting a data provider to
+     *            component
+     * @param expectedListenersCountAfterComponentAttach
+     *            expected listeners count after attaching the component
+     * @param expectedRemovedListenerIndexes
+     *            indexes of listeners which are supposed to be removed after
+     *            attach and detach of component, index starts from 0.
+     * @param mockUI
+     *            UI the component is attached to
+     * @param <C>
+     *            component type
+     */
+    public static <C extends HasListDataView<Object, ?>> void checkOldListenersRemovedOnComponentAttachAndDetach(
+            C component, int expectedListenersCountAfterDataProviderSetup,
+            int expectedListenersCountAfterComponentAttach,
+            int[] expectedRemovedListenerIndexes, UI mockUI) {
+
+        // given
+        DataProviderProxy dataProviderProxy = new DataProviderProxy();
+
+        // when
+        component.setItems(dataProviderProxy);
+
+        // then
+        Assert.assertEquals(
+                "Unexpected count of added data provider listeners after "
+                        + "setting a data provider to the component",
+                expectedListenersCountAfterDataProviderSetup,
+                dataProviderProxy.getListenersCounter());
+
+        // given
+        dataProviderProxy.resetListenersCounter();
+
+        // when
+        mockUI.add((Component) component);
+        fakeClientCommunication(mockUI);
+
+        // then
+        Assert.assertEquals(
+                "Unexpected count of added data provider "
+                        + "listeners after attaching the component",
+                expectedListenersCountAfterComponentAttach,
+                dataProviderProxy.getListenersCounter());
+
+        // when
+        mockUI.remove((Component) component);
+        fakeClientCommunication(mockUI);
+
+        // then
+        Arrays.stream(expectedRemovedListenerIndexes)
+                .forEach(listenerIndex -> Assert.assertTrue(String.format(
+                        "Expected old data provider listener with index '%d' to"
+                                + " be removed",
+                        listenerIndex),
+                        dataProviderProxy.getListenerRemoved()
+                                .get(listenerIndex)));
+    }
+
+    private static void fakeClientCommunication(UI ui) {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    private static class DataProviderProxy extends ListDataProvider<Object> {
+        private final List<Boolean> listenerRemoved;
+        private int listenersCounter = 0;
+        private int registrationsCounter = 0;
+
+        public DataProviderProxy() {
+            super(Collections.emptyList());
+            final int maxListenerNumberExpected = 4;
+            listenerRemoved = Stream.of(new Boolean[maxListenerNumberExpected])
+                    .map(item -> Boolean.FALSE).collect(Collectors.toList());
+        }
+
+        @Override
+        public Registration addDataProviderListener(
+                DataProviderListener<Object> listener) {
+            listenersCounter++;
+            int registrationIndex = registrationsCounter++;
+            Registration registration = super.addDataProviderListener(listener);
+            return Registration.combine(registration,
+                    () -> listenerRemoved.set(registrationIndex, Boolean.TRUE));
+        }
+
+        public int getListenersCounter() {
+            return listenersCounter;
+        }
+
+        public List<Boolean> getListenerRemoved() {
+            return listenerRemoved;
+        }
+
+        public void resetListenersCounter() {
+            listenersCounter = 0;
+        }
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3201,8 +3201,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         updateClientSideSorterIndicators(sortOrder);
-        if (getDataProvider() != null
-                && dataProviderChangeRegistration == null) {
+        if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.tests.DataProviderListenersTest;
 
 public class GridTest {
 
@@ -100,5 +102,13 @@ public class GridTest {
 
         Assert.assertTrue(grid.isHeightByRows());
         Assert.assertTrue(grid.isAllRowsVisible());
+    }
+
+    @Test
+    public void dataProviderListeners_gridAttachedAndDetached_oldDataProviderListenerRemoved() {
+        DataProviderListenersTest
+                .checkOldListenersRemovedOnComponentAttachAndDetach(
+                        new Grid<>(), 2, 2, new int[] { 0, 2 },
+                        new DataCommunicatorTest.MockUI());
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -102,6 +102,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
         this.dataProvider.set(Objects.requireNonNull(dataProvider));
         DataViewUtils.removeComponentFilterAndSortComparator(this);
         clear();
+        rebuild();
         setupDataProviderListener(this.dataProvider.get());
     }
 
@@ -118,14 +119,12 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
                         rebuild();
                     }
                 });
-        rebuild();
     }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        if (getDataProvider() != null
-                && dataProviderListenerRegistration == null) {
+        if (getDataProvider() != null) {
             setupDataProviderListener(getDataProvider());
         }
     }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -12,6 +12,8 @@ import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.tests.DataProviderListenersTest;
 
 public class ListBoxUnitTest {
 
@@ -161,6 +163,14 @@ public class ListBoxUnitTest {
         listDataView.setIdentifierProvider(CustomItem::getId);
 
         listBox.setValue(new CustomItem(null, "First"));
+    }
+
+    @Test
+    public void dataProviderListeners_listBoxAttachedAndDetached_oldDataProviderListenerRemoved() {
+        DataProviderListenersTest
+                .checkOldListenersRemovedOnComponentAttachAndDetach(
+                        new ListBox<>(), 1, 1, new int[] { 0, 1 },
+                        new DataCommunicatorTest.MockUI());
     }
 
     private void assertDisabledItem(int index, boolean disabled) {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-shared</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -245,8 +245,7 @@ public class RadioButtonGroup<T>
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        if (getDataProvider() != null
-                && dataProviderListenerRegistration == null) {
+        if (getDataProvider() != null) {
             setupDataProviderListener(getDataProvider());
         }
         FieldValidationUtil.disableClientValidation(this);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -33,12 +33,14 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.tests.DataProviderListenersTest;
 
 public class RadioButtonGroupTest {
 
@@ -416,5 +418,13 @@ public class RadioButtonGroupTest {
         group.setItems("enabled", "disabled", null);
         group.setValue(null);
         Assert.assertEquals(group.getValue(), null);
+    }
+
+    @Test
+    public void dataProviderListeners_radioButtonGroupAttachedAndDetached_oldDataProviderListenerRemoved() {
+        DataProviderListenersTest
+                .checkOldListenersRemovedOnComponentAttachAndDetach(
+                        new RadioButtonGroup<>(), 1, 1, new int[] { 0, 1 },
+                        new DataCommunicatorTest.MockUI());
     }
 }


### PR DESCRIPTION
## Description

Removes the old data provider listener and adds a new one upon setting up a data provider and attaching a component to the page.
Reorders and makes the 'rebuild' method for ListBox not to being called in attach handler method, because it leads to loosing the data in cache.

Follows up the memory leak issue in Flow (vaadin/flow#11471) and fixes the regression in components caused by the change in Flow.

Related-to https://github.com/vaadin/flow-components/issues/1914.

(cherry picked from commit d47cce44b3476e8ff778bc37f4c734ea4df5a8dc)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
