### PR TITLE
chore: deprecate TemplateRenderer in favour of LitRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/TemplateRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/TemplateRenderer.java
@@ -36,7 +36,11 @@ import com.vaadin.flow.internal.JsonSerializer;
  * @see #of(String)
  * @see <a href=
  *      "https://www.polymer-project.org/2.0/docs/devguide/templates">https://www.polymer-project.org/2.0/docs/devguide/templates</a>
+ *
+ * @deprecated since Vaadin 22, {@code TemplateRenderer} is deprecated in favor of
+ *             {@link LitRenderer}
  */
+@Deprecated
 public final class TemplateRenderer<SOURCE> extends Renderer<SOURCE> {
 
     private static final Pattern BINDING_MISSING_DOLLAR = Pattern

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/TemplateRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/TemplateRenderer.java
@@ -37,8 +37,8 @@ import com.vaadin.flow.internal.JsonSerializer;
  * @see <a href=
  *      "https://www.polymer-project.org/2.0/docs/devguide/templates">https://www.polymer-project.org/2.0/docs/devguide/templates</a>
  *
- * @deprecated since Vaadin 22, {@code TemplateRenderer} is deprecated in favor of
- *             {@link LitRenderer}
+ * @deprecated since Vaadin 22, {@code TemplateRenderer} is deprecated in favor
+ *             of {@link LitRenderer}
  */
 @Deprecated
 public final class TemplateRenderer<SOURCE> extends Renderer<SOURCE> {


### PR DESCRIPTION
This PR deprecates `TemplateRenderer` component and adds a recommendation to use `LitRenderer` instead

Closes #857 