### PR TITLE
fix: disable on click behavior after detach and reattach

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonPage.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonPage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.button.tests;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-button/detach-reattach-disable-on-click-button")
+public class DetachReattachDisableOnClickButtonPage extends Div {
+
+  public DetachReattachDisableOnClickButtonPage() {
+    Button disableOnClickButton = new Button("Disable on click");
+    disableOnClickButton.setId("disable-on-click");
+    disableOnClickButton.setDisableOnClick(true);
+    disableOnClickButton.addClickListener(
+        event -> {
+          try {
+            Thread.sleep(1500);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          } finally {
+            event.getSource().setEnabled(true);
+          }
+        });
+
+    Button removeFromViewButton =
+        new Button("Remove from view", event -> remove(disableOnClickButton));
+    removeFromViewButton.setId("remove-from-view");
+    Button addToViewButton = new Button("Add to view", event -> add(disableOnClickButton));
+    addToViewButton.setId("add-to-view");
+
+    add(removeFromViewButton, addToViewButton, disableOnClickButton);
+  }
+}

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonPage.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonPage.java
@@ -22,27 +22,27 @@ import com.vaadin.flow.router.Route;
 @Route("vaadin-button/detach-reattach-disable-on-click-button")
 public class DetachReattachDisableOnClickButtonPage extends Div {
 
-  public DetachReattachDisableOnClickButtonPage() {
-    Button disableOnClickButton = new Button("Disable on click");
-    disableOnClickButton.setId("disable-on-click");
-    disableOnClickButton.setDisableOnClick(true);
-    disableOnClickButton.addClickListener(
-        event -> {
-          try {
-            Thread.sleep(1500);
-          } catch (InterruptedException e) {
-            e.printStackTrace();
-          } finally {
-            event.getSource().setEnabled(true);
-          }
+    public DetachReattachDisableOnClickButtonPage() {
+        Button disableOnClickButton = new Button("Disable on click");
+        disableOnClickButton.setId("disable-on-click");
+        disableOnClickButton.setDisableOnClick(true);
+        disableOnClickButton.addClickListener(event -> {
+            try {
+                Thread.sleep(1500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } finally {
+                event.getSource().setEnabled(true);
+            }
         });
 
-    Button removeFromViewButton =
-        new Button("Remove from view", event -> remove(disableOnClickButton));
-    removeFromViewButton.setId("remove-from-view");
-    Button addToViewButton = new Button("Add to view", event -> add(disableOnClickButton));
-    addToViewButton.setId("add-to-view");
+        Button removeFromViewButton = new Button("Remove from view",
+                event -> remove(disableOnClickButton));
+        removeFromViewButton.setId("remove-from-view");
+        Button addToViewButton = new Button("Add to view",
+                event -> add(disableOnClickButton));
+        addToViewButton.setId("add-to-view");
 
-    add(removeFromViewButton, addToViewButton, disableOnClickButton);
-  }
+        add(removeFromViewButton, addToViewButton, disableOnClickButton);
+    }
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.button.tests;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+@TestPath("vaadin-button/detach-reattach-disable-on-click-button")
+public class DetachReattachDisableOnClickButtonIT extends AbstractComponentIT {
+
+  private ButtonElement getDisableOnClickButton() {
+    return $(ButtonElement.class).id("disable-on-click");
+  }
+
+  private void assertDisableOnClickButtonEnabled(ButtonElement disableOnClickButton) {
+    Assert.assertTrue(
+        "'Disable on click' button should be enabled", disableOnClickButton.isEnabled());
+  }
+
+  private void assertDisableOnClickButtonDisabled(ButtonElement disableOnClickButton) {
+    Assert.assertFalse(
+        "'Disable on click' button should be disabled", disableOnClickButton.isEnabled());
+  }
+
+  private void clickDisableOnClickButton(ButtonElement disableOnClickButton) {
+    getCommandExecutor().disableWaitForVaadin();
+
+    // Click 'Disable on click' button
+    disableOnClickButton.click();
+
+    // Check 'Disable on click' button is disabled
+    assertDisableOnClickButtonDisabled(disableOnClickButton);
+
+    waitUntil(
+        ExpectedConditions.elementToBeClickable($(ButtonElement.class).id("disable-on-click")),
+        2000);
+
+    // Check 'Disable on click' button is enabled again
+    assertDisableOnClickButtonEnabled(disableOnClickButton);
+
+    getCommandExecutor().enableWaitForVaadin();
+  }
+
+  @Test
+  public void detachReattachDisableOnClickButtonTest() {
+    open();
+
+    ButtonElement disableOnClickButton = getDisableOnClickButton();
+
+    // Check 'Disable on click' button should be enabled
+    assertDisableOnClickButtonEnabled(disableOnClickButton);
+
+    // Remove 'Disable on click' button
+    ButtonElement removeFromViewButton = $(ButtonElement.class).id("remove-from-view");
+    removeFromViewButton.click();
+
+    waitUntil(
+        ExpectedConditions.numberOfElementsToBe(By.id("disable-on-click"), 0),
+        2000);
+
+    // Re-attach 'Disable on click" button
+    ButtonElement addToViewButton = $(ButtonElement.class).id("add-to-view");
+    addToViewButton.click();
+
+    waitUntil(
+        ExpectedConditions.numberOfElementsToBe(By.id("disable-on-click"), 1),
+        2000);
+
+    disableOnClickButton = getDisableOnClickButton();
+
+    // Check 'Disable on click' button is enabled
+    assertDisableOnClickButtonEnabled(disableOnClickButton);
+
+    // Click 'Disable on click' button
+    clickDisableOnClickButton(disableOnClickButton);
+  }
+}

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonIT.java
@@ -61,7 +61,7 @@ public class DetachReattachDisableOnClickButtonIT extends AbstractComponentIT {
     }
 
     @Test
-    public void detachReattachDisableOnClickButtonTest() {
+    public void testDetachingAndReattachingShouldKeepDisabledOnClick() {
         open();
 
         ButtonElement disableOnClickButton = getDisableOnClickButton();

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/DetachReattachDisableOnClickButtonIT.java
@@ -26,70 +26,71 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 @TestPath("vaadin-button/detach-reattach-disable-on-click-button")
 public class DetachReattachDisableOnClickButtonIT extends AbstractComponentIT {
 
-  private ButtonElement getDisableOnClickButton() {
-    return $(ButtonElement.class).id("disable-on-click");
-  }
+    private ButtonElement getDisableOnClickButton() {
+        return $(ButtonElement.class).id("disable-on-click");
+    }
 
-  private void assertDisableOnClickButtonEnabled(ButtonElement disableOnClickButton) {
-    Assert.assertTrue(
-        "'Disable on click' button should be enabled", disableOnClickButton.isEnabled());
-  }
+    private void assertDisableOnClickButtonEnabled(
+            ButtonElement disableOnClickButton) {
+        Assert.assertTrue("'Disable on click' button should be enabled",
+                disableOnClickButton.isEnabled());
+    }
 
-  private void assertDisableOnClickButtonDisabled(ButtonElement disableOnClickButton) {
-    Assert.assertFalse(
-        "'Disable on click' button should be disabled", disableOnClickButton.isEnabled());
-  }
+    private void assertDisableOnClickButtonDisabled(
+            ButtonElement disableOnClickButton) {
+        Assert.assertFalse("'Disable on click' button should be disabled",
+                disableOnClickButton.isEnabled());
+    }
 
-  private void clickDisableOnClickButton(ButtonElement disableOnClickButton) {
-    getCommandExecutor().disableWaitForVaadin();
+    private void clickDisableOnClickButton(ButtonElement disableOnClickButton) {
+        getCommandExecutor().disableWaitForVaadin();
 
-    // Click 'Disable on click' button
-    disableOnClickButton.click();
+        // Click 'Disable on click' button
+        disableOnClickButton.click();
 
-    // Check 'Disable on click' button is disabled
-    assertDisableOnClickButtonDisabled(disableOnClickButton);
+        // Check 'Disable on click' button is disabled
+        assertDisableOnClickButtonDisabled(disableOnClickButton);
 
-    waitUntil(
-        ExpectedConditions.elementToBeClickable($(ButtonElement.class).id("disable-on-click")),
-        2000);
+        waitUntil(ExpectedConditions.elementToBeClickable(
+                $(ButtonElement.class).id("disable-on-click")), 2000);
 
-    // Check 'Disable on click' button is enabled again
-    assertDisableOnClickButtonEnabled(disableOnClickButton);
+        // Check 'Disable on click' button is enabled again
+        assertDisableOnClickButtonEnabled(disableOnClickButton);
 
-    getCommandExecutor().enableWaitForVaadin();
-  }
+        getCommandExecutor().enableWaitForVaadin();
+    }
 
-  @Test
-  public void detachReattachDisableOnClickButtonTest() {
-    open();
+    @Test
+    public void detachReattachDisableOnClickButtonTest() {
+        open();
 
-    ButtonElement disableOnClickButton = getDisableOnClickButton();
+        ButtonElement disableOnClickButton = getDisableOnClickButton();
 
-    // Check 'Disable on click' button should be enabled
-    assertDisableOnClickButtonEnabled(disableOnClickButton);
+        // Check 'Disable on click' button should be enabled
+        assertDisableOnClickButtonEnabled(disableOnClickButton);
 
-    // Remove 'Disable on click' button
-    ButtonElement removeFromViewButton = $(ButtonElement.class).id("remove-from-view");
-    removeFromViewButton.click();
+        // Remove 'Disable on click' button
+        ButtonElement removeFromViewButton = $(ButtonElement.class)
+                .id("remove-from-view");
+        removeFromViewButton.click();
 
-    waitUntil(
-        ExpectedConditions.numberOfElementsToBe(By.id("disable-on-click"), 0),
-        2000);
+        waitUntil(ExpectedConditions
+                .numberOfElementsToBe(By.id("disable-on-click"), 0), 2000);
 
-    // Re-attach 'Disable on click" button
-    ButtonElement addToViewButton = $(ButtonElement.class).id("add-to-view");
-    addToViewButton.click();
+        // Re-attach 'Disable on click" button
+        ButtonElement addToViewButton = $(ButtonElement.class)
+                .id("add-to-view");
+        addToViewButton.click();
 
-    waitUntil(
-        ExpectedConditions.numberOfElementsToBe(By.id("disable-on-click"), 1),
-        2000);
+        waitUntil(ExpectedConditions
+                .numberOfElementsToBe(By.id("disable-on-click"), 1), 2000);
 
-    disableOnClickButton = getDisableOnClickButton();
+        disableOnClickButton = getDisableOnClickButton();
 
-    // Check 'Disable on click' button is enabled
-    assertDisableOnClickButtonEnabled(disableOnClickButton);
+        // Check 'Disable on click' button is enabled
+        assertDisableOnClickButtonEnabled(disableOnClickButton);
 
-    // Click 'Disable on click' button
-    clickDisableOnClickButton(disableOnClickButton);
-  }
+        // Click 'Disable on click' button
+        clickDisableOnClickButton(disableOnClickButton);
+    }
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -319,7 +319,6 @@ public class Button extends GeneratedVaadinButton<Button>
     public void setDisableOnClick(boolean disableOnClick) {
         this.disableOnClick = disableOnClick;
         if (disableOnClick) {
-            initDisableOnClick();
             getElement().setAttribute("disableOnClick", "true");
         } else {
             getElement().removeAttribute("disableOnClick");

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -22,9 +22,11 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.html.Image;
@@ -420,5 +422,15 @@ public class Button extends GeneratedVaadinButton<Button>
                         }
                     }));
         }
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        initDisableOnClick();
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        disableOnClickConfigured = false;
     }
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -15,18 +15,10 @@
  */
 package com.vaadin.flow.component.button;
 
-import java.io.Serializable;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.html.Image;
@@ -34,6 +26,12 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.shared.Registration;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Server-side component for the <code>vaadin-button</code> element.
@@ -46,7 +44,6 @@ public class Button extends GeneratedVaadinButton<Button>
     private Component iconComponent;
     private boolean iconAfterText;
     private boolean disableOnClick = false;
-    private boolean disableOnClickConfigured = false;
 
     // Register immediately as first listener
     private Registration disableListener = addClickListener(
@@ -343,13 +340,10 @@ public class Button extends GeneratedVaadinButton<Button>
      * if server-side handling takes some time.
      */
     private void initDisableOnClick() {
-        if (!disableOnClickConfigured) {
-            getElement().executeJs("var disableEvent = function () {"
-                    + "if($0.getAttribute('disableOnClick')){"
-                    + " $0.setAttribute('disabled', 'true');" + "}" + "};"
-                    + "$0.addEventListener('click', disableEvent)");
-            disableOnClickConfigured = true;
-        }
+        getElement().executeJs("var disableEvent = function () {"
+                + "if($0.getAttribute('disableOnClick')){"
+                + " $0.setAttribute('disabled', 'true');" + "}" + "};"
+                + "$0.addEventListener('click', disableEvent)");
     }
 
     private void updateIconSlot() {
@@ -429,8 +423,4 @@ public class Button extends GeneratedVaadinButton<Button>
         initDisableOnClick();
     }
 
-    @Override
-    protected void onDetach(DetachEvent detachEvent) {
-        disableOnClickConfigured = false;
-    }
 }


### PR DESCRIPTION
## Description

When enabling disabledOnClick, a javascript function is configured so the button gets immediately disabled (on client side) on click.
When detaching and re attaching the button, this JavaScript function is not working anymore, so then the button is disabled by doDisableOnClick(), but after a server side roundrip. 
So in this case if a click listener takes too long to be processed, the button will behave differently after detaching and reattaching again.
With the proposed change, the JavaScript function will be configured again by initDisableOnClick() method and button will be disable inmediately on click.

An IT is provided that will fail if the button is not immediately disabled on click after the detach-reattach cycle, but works fine with the fix.

Fixes #1401

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
