### PR TITLE
fix: make flow-component-renderer import dom-if

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -1,3 +1,4 @@
+import '@polymer/polymer/lib/elements/dom-if.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { idlePeriod } from '@polymer/polymer/lib/utils/async.js';


### PR DESCRIPTION
`flow-component-renderer.js` uses `dom-if` so it needs to import it. Without the import, the `<dom-if>` doesn't upgrade and ComponentRenderer renders empty content.