### PR TITLE
fix: only allow alphanumeric function names with LitRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -346,8 +346,9 @@ public class LitRenderer<T> extends Renderer<T> {
      *
      * @param functionName
      *            the name of the function used inside the template expression,
-     *            must be alphanumeric and not <code>null</code>,
-     *            must not be one of the JavaScript reserved words (https://www.w3schools.com/js/js_reserved.asp)
+     *            must be alphanumeric and not <code>null</code>, must not be
+     *            one of the JavaScript reserved words
+     *            (https://www.w3schools.com/js/js_reserved.asp)
      * @param handler
      *            the handler executed when the function is called, not
      *            <code>null</code>
@@ -388,8 +389,9 @@ public class LitRenderer<T> extends Renderer<T> {
      *
      * @param functionName
      *            the name of the function used inside the template expression,
-     *            must be alphanumeric and not <code>null</code>,
-     *            must not be one of the JavaScript reserved words (https://www.w3schools.com/js/js_reserved.asp)
+     *            must be alphanumeric and not <code>null</code>, must not be
+     *            one of the JavaScript reserved words
+     *            (https://www.w3schools.com/js/js_reserved.asp)
      * @param handler
      *            the handler executed when the function is called, not
      *            <code>null</code>
@@ -403,7 +405,8 @@ public class LitRenderer<T> extends Renderer<T> {
         Objects.requireNonNull(handler);
 
         if (!Pattern.matches(ALPHANUMERIC_REGEX, functionName)) {
-            throw new IllegalArgumentException("Function name must be alphanumeric");
+            throw new IllegalArgumentException(
+                    "Function name must be alphanumeric");
         }
         clientCallables.put(functionName, handler);
         return this;

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -69,6 +70,8 @@ public class LitRenderer<T> extends Renderer<T> {
 
     private final Map<String, ValueProvider<T, ?>> valueProviders = new HashMap<>();
     private final Map<String, SerializableBiConsumer<T, JsonArray>> clientCallables = new HashMap<>();
+
+    private final String ALPHANUMERIC_REGEX = "^[a-zA-Z0-9]+$";
 
     private LitRenderer(String templateExpression) {
         this.templateExpression = templateExpression;
@@ -343,9 +346,10 @@ public class LitRenderer<T> extends Renderer<T> {
      *
      * @param functionName
      *            the name of the function used inside the template expression,
-     *            not <code>null</code>
+     *            must be alphanumeric and not <code>null</code>,
+     *            must not be one of the JavaScript reserved words (https://www.w3schools.com/js/js_reserved.asp)
      * @param handler
-     *            the handler executed when the event is triggered, not
+     *            the handler executed when the function is called, not
      *            <code>null</code>
      * @return this instance for method chaining
      * @see <a href=
@@ -384,9 +388,10 @@ public class LitRenderer<T> extends Renderer<T> {
      *
      * @param functionName
      *            the name of the function used inside the template expression,
-     *            not <code>null</code>
+     *            must be alphanumeric and not <code>null</code>,
+     *            must not be one of the JavaScript reserved words (https://www.w3schools.com/js/js_reserved.asp)
      * @param handler
-     *            the handler executed when the event is triggered, not
+     *            the handler executed when the function is called, not
      *            <code>null</code>
      * @return this instance for method chaining
      * @see <a href=
@@ -396,6 +401,10 @@ public class LitRenderer<T> extends Renderer<T> {
             SerializableBiConsumer<T, JsonArray> handler) {
         Objects.requireNonNull(functionName);
         Objects.requireNonNull(handler);
+
+        if (!Pattern.matches(ALPHANUMERIC_REGEX, functionName)) {
+            throw new IllegalArgumentException("Function name must be alphanumeric");
+        }
         clientCallables.put(functionName, handler);
         return this;
     }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.renderer;
+
+import com.vaadin.flow.component.UI;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class LitRendererTest {
+
+    @Before
+    public void init() {
+        UI ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doNotAllowFunctionNamesWithFunctions() {
+        LitRenderer.of("").withFunction("foo=0; alert(\"gotcha\"); const bar", item -> {});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doNotAllowFunctionNamesWithSpaces() {
+        LitRenderer.of("").withFunction("illegal name", item -> {});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doNotAllowFunctionNamesWithDots() {
+        LitRenderer.of("").withFunction("illegal.name", item -> {});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doNotAllowFunctionNamesWithParenthesis() {
+        LitRenderer.of("").withFunction("illegalname()", item -> {});
+    }
+
+    @Test
+    public void allowAlphaNumericFunctionNames() {
+        LitRenderer.of("<div></div>").withFunction("legalName1", item -> {});
+    }
+
+}

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -30,27 +30,33 @@ public class LitRendererTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void doNotAllowFunctionNamesWithFunctions() {
-        LitRenderer.of("").withFunction("foo=0; alert(\"gotcha\"); const bar", item -> {});
+        LitRenderer.of("").withFunction("foo=0; alert(\"gotcha\"); const bar",
+                item -> {
+                });
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void doNotAllowFunctionNamesWithSpaces() {
-        LitRenderer.of("").withFunction("illegal name", item -> {});
+        LitRenderer.of("").withFunction("illegal name", item -> {
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void doNotAllowFunctionNamesWithDots() {
-        LitRenderer.of("").withFunction("illegal.name", item -> {});
+        LitRenderer.of("").withFunction("illegal.name", item -> {
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void doNotAllowFunctionNamesWithParenthesis() {
-        LitRenderer.of("").withFunction("illegalname()", item -> {});
+        LitRenderer.of("").withFunction("illegalname()", item -> {
+        });
     }
 
     @Test
     public void allowAlphaNumericFunctionNames() {
-        LitRenderer.of("<div></div>").withFunction("legalName1", item -> {});
+        LitRenderer.of("<div></div>").withFunction("legalName1", item -> {
+        });
     }
 
 }


### PR DESCRIPTION
The `LitRenderer().withFunction(name, function)`'s function name gets evaluated as such in the JS renderer function passed to the component. For safety reasons, it's better to only allow alphanumeric characters in the function name.