### PR TITLE
fix: read valueProviders dynamically in LitRenderer's data generator

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
@@ -103,9 +103,12 @@ public class LitRendererPage extends Div {
     }
 
     private void setDetailsLitRenderer(LitRendererTestComponent component) {
-        component.setDetailsRenderer(LitRenderer.<String> of(
-                "<div id=\"details-${index}\">Details: ${item.value}</div>")
-                .withProperty("value", item -> item + " (details)"));
+        LitRenderer<String> renderer = LitRenderer.<String> of(
+                "<div id=\"details-${index}\">Details: ${item.value}</div>");
+        component.setDetailsRenderer(renderer);
+        // Even though the properties are typically defined using the fluent API,
+        // it should be possible to set them even after the renderer has been set.
+        renderer.withProperty("value", item -> item + " (details)");
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
@@ -106,8 +106,9 @@ public class LitRendererPage extends Div {
         LitRenderer<String> renderer = LitRenderer.<String> of(
                 "<div id=\"details-${index}\">Details: ${item.value}</div>");
         component.setDetailsRenderer(renderer);
-        // Even though the properties are typically defined using the fluent API,
-        // it should be possible to set them even after the renderer has been set.
+        // Even though the properties are typically defined using the fluent
+        // API, it should be possible to set them even after the renderer has
+        // been set.
         renderer.withProperty("value", item -> item + " (details)");
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -270,15 +270,18 @@ public class LitRenderer<T> extends Renderer<T> {
 
     private DataGenerator<T> createDataGenerator() {
         CompositeDataGenerator<T> composite = new CompositeDataGenerator<>();
-        valueProviders.forEach((key, provider) -> composite
-                .addDataGenerator((item, jsonObject) -> jsonObject.put(
+        composite.addDataGenerator((item, jsonObject) -> {
+            valueProviders.forEach((key, provider) -> {
+                jsonObject.put(
                         // Prefix the property name with a LitRenderer
                         // instance specific namespace to avoid property
                         // name clashes.
                         // Fixes https://github.com/vaadin/flow/issues/8629
                         // in LitRenderer
                         propertyNamespace + key,
-                        JsonSerializer.toJson(provider.apply(item)))));
+                        JsonSerializer.toJson(provider.apply(item)));
+            });
+        });
         return composite;
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataGenerator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.dom.Element;
@@ -269,8 +268,7 @@ public class LitRenderer<T> extends Renderer<T> {
     }
 
     private DataGenerator<T> createDataGenerator() {
-        CompositeDataGenerator<T> composite = new CompositeDataGenerator<>();
-        composite.addDataGenerator((item, jsonObject) -> {
+        return (item, jsonObject) -> {
             valueProviders.forEach((key, provider) -> {
                 jsonObject.put(
                         // Prefix the property name with a LitRenderer
@@ -281,8 +279,7 @@ public class LitRenderer<T> extends Renderer<T> {
                         propertyNamespace + key,
                         JsonSerializer.toJson(provider.apply(item)));
             });
-        });
-        return composite;
+        };
     }
 
     /**


### PR DESCRIPTION
The previous logic had an issue where the `LitRenderer`'s properties/`valueProviders` were iterated only once (in `createDataGenerator()`) when the renderer got assigned to a component.

This basically made the `LitRenderer` ignore any `valueProviders` that got defined after the renderer was assigned:
```java
LitRenderer<String> renderer = LitRenderer.<String> of("<div>${item.value}</div>");
component.setRenderer(renderer);
renderer.withProperty("value", item -> item + " (details)"); // This would have no effect
```

After this change, the `valueProviders` are read dynamically whenever the data generator is invoked.