### PR TITLE
feat: NewEvent provides a new item for setting pre-defined values.

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-demo/src/main/java/com/vaadin/flow/component/crud/demo/CrudView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-demo/src/main/java/com/vaadin/flow/component/crud/demo/CrudView.java
@@ -76,7 +76,10 @@ public class CrudView extends DemoView {
         crud.setDataProvider(dataProvider);
         crud.addSaveListener(e -> dataProvider.persist(e.getItem()));
         crud.addDeleteListener(e -> dataProvider.delete(e.getItem()));
-
+        crud.addNewListener(e -> {
+            e.getItem().setFirstName("noname");
+            crud.getEditor().setItem(e.getItem());
+        });
         crud.getGrid().removeColumnByKey("id");
         crud.addThemeVariants(CrudVariant.NO_BORDER);
         // end-source-example

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-demo/src/main/java/com/vaadin/flow/component/crud/demo/CrudView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-demo/src/main/java/com/vaadin/flow/component/crud/demo/CrudView.java
@@ -76,10 +76,6 @@ public class CrudView extends DemoView {
         crud.setDataProvider(dataProvider);
         crud.addSaveListener(e -> dataProvider.persist(e.getItem()));
         crud.addDeleteListener(e -> dataProvider.delete(e.getItem()));
-        crud.addNewListener(e -> {
-            e.getItem().setFirstName("noname");
-            crud.getEditor().setItem(e.getItem());
-        });
         crud.getGrid().removeColumnByKey("id");
         crud.addThemeVariants(CrudVariant.NO_BORDER);
         // end-source-example

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-demo/src/main/java/com/vaadin/flow/component/crud/demo/CrudView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-demo/src/main/java/com/vaadin/flow/component/crud/demo/CrudView.java
@@ -378,7 +378,7 @@ public class CrudView extends DemoView {
         }
 
         @Override
-        public Person clone() {
+        public Person clone() { // NOSONAR
             try {
                 return (Person) super.clone();
             } catch (CloneNotSupportedException e) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -98,6 +98,19 @@ public class MainView extends VerticalLayout {
         });
         addGridButton.setId("addGrid");
 
+
+        final Button addNewEventListener = new Button("Add New-Event listener", event -> {
+                crud.addNewListener(e -> {
+                        Person item = e.getItem();
+                        item.setId(0);
+                        item.setFirstName("firstName");
+                        item.setLastName("lastName");
+                        crud.getEditor().setItem(e.getItem());
+                });
+        });
+        addNewEventListener.setId("newEventListener");
+
+
         crud.addNewListener(e -> addEvent("New: " + e.getItem()));
         crud.addEditListener(e -> addEvent("Edit: " + e.getItem()));
         crud.addCancelListener(e -> addEvent("Cancel: " + e.getItem()));
@@ -110,7 +123,7 @@ public class MainView extends VerticalLayout {
 
         setHeight("100%");
         add(crud, serverSideNewButton, serverSideEditButton, showFiltersButton,
-                updateI18nButton, toggleBordersButton, addGridButton,
+                updateI18nButton, toggleBordersButton, addGridButton, addNewEventListener,
                 eventsPanel);
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.crud.CrudI18nUpdatedEvent;
 import com.vaadin.flow.component.crud.CrudVariant;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -21,6 +22,8 @@ import static com.vaadin.flow.component.crud.examples.Helper.createYorubaI18n;
 public class MainView extends VerticalLayout {
 
     final VerticalLayout eventsPanel;
+    final HorizontalLayout buttons;
+
     boolean hasBorder = true;
 
     public MainView() {
@@ -30,22 +33,26 @@ public class MainView extends VerticalLayout {
         final Crud<Person> crud = new Crud<>(Person.class,
                 createPersonEditor());
 
+        buttons = new HorizontalLayout();
         final Button newButton = new Button(
                 CrudI18n.createDefault().getNewItem());
         newButton.setThemeName(ButtonVariant.LUMO_PRIMARY.getVariantName());
         newButton.getElement().setAttribute("new-button", "");
 
+        buttons.add(newButton);
         final Button serverSideNewButton = new Button(
                 CrudI18n.createDefault().getNewItem());
         serverSideNewButton.setId("newServerItem");
         serverSideNewButton.addClickListener(
                 e -> crud.edit(new Person(), Crud.EditMode.NEW_ITEM));
+        buttons.add(serverSideNewButton);
 
         final Button serverSideEditButton = new Button(
                 CrudI18n.createDefault().getEditItem());
         serverSideEditButton.setId("editServerItem");
         serverSideEditButton.addClickListener(e -> crud.edit(
                 new Person(1, "Sayo", "Oladeji"), Crud.EditMode.EXISTING_ITEM));
+        buttons.add(serverSideEditButton);
 
         final Span footer = new Span();
         crud.setToolbar(footer, newButton);
@@ -66,6 +73,7 @@ public class MainView extends VerticalLayout {
 
             addEvent(filterString);
         });
+        buttons.add(showFiltersButton);
 
         final Button updateI18nButton = new Button("Switch to Yoruba",
                 event -> {
@@ -76,6 +84,7 @@ public class MainView extends VerticalLayout {
         updateI18nButton.setId("updateI18n");
         ComponentUtil.addListener(crud.getGrid(), CrudI18nUpdatedEvent.class,
                 e -> addEvent("I18n updated"));
+        buttons.add(updateI18nButton);
 
         // no-border should be reflected to the generated grid too
         final Button toggleBordersButton = new Button("Toggle borders",
@@ -88,6 +97,7 @@ public class MainView extends VerticalLayout {
                     hasBorder = !hasBorder;
                 });
         toggleBordersButton.setId("toggleBorders");
+        buttons.add(toggleBordersButton);
 
         final Button addGridButton = new Button("Add grid", event -> {
             Grid<Person> grid = new Grid<>(Person.class);
@@ -97,6 +107,7 @@ public class MainView extends VerticalLayout {
             crud.setGrid(grid);
         });
         addGridButton.setId("addGrid");
+        buttons.add(addGridButton);
 
         final Button addNewEventListener = new Button("Add New-Event listener",
                 event -> {
@@ -110,6 +121,8 @@ public class MainView extends VerticalLayout {
                 });
         addNewEventListener.setId("newEventListener");
 
+        buttons.add(addNewEventListener);
+
         crud.addNewListener(e -> addEvent("New: " + e.getItem()));
         crud.addEditListener(e -> addEvent("Edit: " + e.getItem()));
         crud.addCancelListener(e -> addEvent("Cancel: " + e.getItem()));
@@ -121,9 +134,7 @@ public class MainView extends VerticalLayout {
         crud.addSaveListener(e -> dataProvider.persist(e.getItem()));
 
         setHeight("100%");
-        add(crud, serverSideNewButton, serverSideEditButton, showFiltersButton,
-                updateI18nButton, toggleBordersButton, addGridButton,
-                addNewEventListener, eventsPanel);
+        add(crud, buttons, eventsPanel);
     }
 
     private void addEvent(String event) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -136,7 +136,6 @@ public class MainView extends VerticalLayout {
         hideToolbarButton.setId("hideToolbarButton");
         buttons.add(hideToolbarButton);
 
-
         crud.addNewListener(e -> addEvent("New: " + e.getItem()));
         crud.addEditListener(e -> addEvent("Edit: " + e.getItem()));
         crud.addCancelListener(e -> addEvent("Cancel: " + e.getItem()));

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -98,18 +98,17 @@ public class MainView extends VerticalLayout {
         });
         addGridButton.setId("addGrid");
 
-
-        final Button addNewEventListener = new Button("Add New-Event listener", event -> {
-                crud.addNewListener(e -> {
+        final Button addNewEventListener = new Button("Add New-Event listener",
+                event -> {
+                    crud.addNewListener(e -> {
                         Person item = e.getItem();
                         item.setId(0);
                         item.setFirstName("firstName");
                         item.setLastName("lastName");
                         crud.getEditor().setItem(e.getItem());
+                    });
                 });
-        });
         addNewEventListener.setId("newEventListener");
-
 
         crud.addNewListener(e -> addEvent("New: " + e.getItem()));
         crud.addEditListener(e -> addEvent("Edit: " + e.getItem()));
@@ -123,8 +122,8 @@ public class MainView extends VerticalLayout {
 
         setHeight("100%");
         add(crud, serverSideNewButton, serverSideEditButton, showFiltersButton,
-                updateI18nButton, toggleBordersButton, addGridButton, addNewEventListener,
-                eventsPanel);
+                updateI18nButton, toggleBordersButton, addGridButton,
+                addNewEventListener, eventsPanel);
     }
 
     private void addEvent(String event) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -132,18 +132,6 @@ public class BasicUseIT extends AbstractParallelTest {
         Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
     }
 
-    @Test
-    public void newEventItem() {
-        CrudElement crud = $(CrudElement.class).waitForFirst();
-        $("#newEventListener").onPage().first().click();
-        // we need to do this trick because the way `New` events are logged
-        crud.getNewItemButton().get().click();
-        crud.getEditorCancelButton().click();
-        Assert.assertEquals(
-                "Cancel: Person{id=0, firstName='firstName', lastName='lastName'}",
-                getLastEvent());
-    }
-
     private ButtonElement getTestButton(String id) {
         return $(ButtonElement.class).onPage().id(id);
     }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.crud.testbench.CrudElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.orderedlayout.testbench.VerticalLayoutElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -131,7 +132,23 @@ public class BasicUseIT extends AbstractParallelTest {
         Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
     }
 
+    @Test
+    public void newEventItem() {
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+        $("#newEventListener").onPage().first().click();
+        // we need to do this trick because the way `New` events are logged
+        crud.getNewItemButton().get().click();
+        crud.getEditorCancelButton().click();
+        Assert.assertEquals("Cancel: Person{id=0, firstName='firstName', lastName='lastName'}", getLastEvent());
+    }
+
     private ButtonElement getTestButton(String id) {
         return $(ButtonElement.class).onPage().id(id);
+    }
+
+    @Override
+    protected String getLastEvent() {
+        return $(VerticalLayoutElement.class).last()
+                .$("span").last().getText();
     }
 }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -135,9 +135,4 @@ public class BasicUseIT extends AbstractParallelTest {
     private ButtonElement getTestButton(String id) {
         return $(ButtonElement.class).onPage().id(id);
     }
-
-    @Override
-    protected String getLastEvent() {
-        return $(VerticalLayoutElement.class).last().$("span").last().getText();
-    }
 }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -1,17 +1,15 @@
 package com.vaadin.flow.component.crud.test;
 
-import java.util.List;
-
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.crud.testbench.CrudElement;
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.crud.testbench.CrudElement;
-import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.component.orderedlayout.testbench.VerticalLayoutElement;
-import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
-import com.vaadin.testbench.TestBenchElement;
+import java.util.List;
 
 public class BasicUseIT extends AbstractParallelTest {
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -139,7 +139,9 @@ public class BasicUseIT extends AbstractParallelTest {
         // we need to do this trick because the way `New` events are logged
         crud.getNewItemButton().get().click();
         crud.getEditorCancelButton().click();
-        Assert.assertEquals("Cancel: Person{id=0, firstName='firstName', lastName='lastName'}", getLastEvent());
+        Assert.assertEquals(
+                "Cancel: Person{id=0, firstName='firstName', lastName='lastName'}",
+                getLastEvent());
     }
 
     private ButtonElement getTestButton(String id) {
@@ -148,7 +150,6 @@ public class BasicUseIT extends AbstractParallelTest {
 
     @Override
     protected String getLastEvent() {
-        return $(VerticalLayoutElement.class).last()
-                .$("span").last().getText();
+        return $(VerticalLayoutElement.class).last().$("span").last().getText();
     }
 }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
@@ -227,12 +227,14 @@ public class EventHandlingIT extends AbstractParallelTest {
         crud.getNewItemButton().get().click();
 
         TestBenchElement editor = crud.getEditor();
-        TextFieldElement firstNameField = editor.$(TextFieldElement.class).attribute("editor-role", "first-name").first();
-        TextFieldElement lastNameField = editor.$(TextFieldElement.class).attribute("editor-role", "last-name").first();
+        TextFieldElement firstNameField = editor.$(TextFieldElement.class)
+                .attribute("editor-role", "first-name").first();
+        TextFieldElement lastNameField = editor.$(TextFieldElement.class)
+                .attribute("editor-role", "last-name").first();
 
         Assert.assertEquals("firstName", firstNameField.getValue());
         Assert.assertEquals("lastName", lastNameField.getValue());
-       
+
     }
 
     private static String getFooterText(CrudElement crud) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
@@ -220,7 +220,7 @@ public class EventHandlingIT extends AbstractParallelTest {
     }
 
     @Test
-    public void newEventItem() {
+    public void newItemDialogFields_ShouldPrefilledWithExpectedValues_SetInNewEventListener() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         getTestButton("newEventListener").click();
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
@@ -44,7 +44,7 @@ public class EventHandlingIT extends AbstractParallelTest {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         Assert.assertFalse(crud.isEditorOpen());
         crud.getNewItemButton().get().click();
-        Assert.assertEquals("New: null", getLastEvent());
+        Assert.assertEquals("New: Person{id=null, firstName='null', lastName='null'}", getLastEvent());
         Assert.assertTrue(crud.isEditorOpen());
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
@@ -44,7 +44,9 @@ public class EventHandlingIT extends AbstractParallelTest {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         Assert.assertFalse(crud.isEditorOpen());
         crud.getNewItemButton().get().click();
-        Assert.assertEquals("New: Person{id=null, firstName='null', lastName='null'}", getLastEvent());
+        Assert.assertEquals(
+                "New: Person{id=null, firstName='null', lastName='null'}",
+                getLastEvent());
         Assert.assertTrue(crud.isEditorOpen());
     }
 
@@ -161,7 +163,7 @@ public class EventHandlingIT extends AbstractParallelTest {
                 $(GridElement.class).first().getCell(0, 2).getText());
 
         // Valid input
-        lastNameField.setValue("Oladeji");
+        lastNameField.setValue("Obbbbbbbbbbb");
         Assert.assertFalse(lastNameField.hasAttribute("invalid"));
 
         crud.getEditorSaveButton().click();
@@ -174,7 +176,7 @@ public class EventHandlingIT extends AbstractParallelTest {
         }
 
         Assert.assertFalse(crud.isEditorOpen());
-        Assert.assertEquals("Oladeji",
+        Assert.assertEquals("Obbbbbbbbbbb",
                 $(GridElement.class).first().getCell(0, 2).getText());
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
@@ -163,7 +163,7 @@ public class EventHandlingIT extends AbstractParallelTest {
                 $(GridElement.class).first().getCell(0, 2).getText());
 
         // Valid input
-        lastNameField.setValue("Obbbbbbbbbbb");
+        lastNameField.setValue("Oladeji");
         Assert.assertFalse(lastNameField.hasAttribute("invalid"));
 
         crud.getEditorSaveButton().click();
@@ -176,7 +176,7 @@ public class EventHandlingIT extends AbstractParallelTest {
         }
 
         Assert.assertFalse(crud.isEditorOpen());
-        Assert.assertEquals("Obbbbbbbbbbb",
+        Assert.assertEquals("Oladeji",
                 $(GridElement.class).first().getCell(0, 2).getText());
     }
 
@@ -217,6 +217,18 @@ public class EventHandlingIT extends AbstractParallelTest {
         crud.getEditorSaveButton().click();
 
         Assert.assertTrue(lastNameField.hasAttribute("invalid"));
+    }
+
+    @Test
+    public void newEventItem() {
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+        getTestButton("newEventListener").click();
+        // we need to do this trick because the way `New` events are logged
+        crud.getNewItemButton().get().click();
+        crud.getEditorCancelButton().click();
+        Assert.assertEquals(
+                "Cancel: Person{id=0, firstName='firstName', lastName='lastName'}",
+                getLastEvent());
     }
 
     private static String getFooterText(CrudElement crud) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EventHandlingIT.java
@@ -223,12 +223,16 @@ public class EventHandlingIT extends AbstractParallelTest {
     public void newEventItem() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         getTestButton("newEventListener").click();
-        // we need to do this trick because the way `New` events are logged
+
         crud.getNewItemButton().get().click();
-        crud.getEditorCancelButton().click();
-        Assert.assertEquals(
-                "Cancel: Person{id=0, firstName='firstName', lastName='lastName'}",
-                getLastEvent());
+
+        TestBenchElement editor = crud.getEditor();
+        TextFieldElement firstNameField = editor.$(TextFieldElement.class).attribute("editor-role", "first-name").first();
+        TextFieldElement lastNameField = editor.$(TextFieldElement.class).attribute("editor-role", "last-name").first();
+
+        Assert.assertEquals("firstName", firstNameField.getValue());
+        Assert.assertEquals("lastName", lastNameField.getValue());
+       
     }
 
     private static String getFooterText(CrudElement crud) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/TemplateSupportIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/TemplateSupportIT.java
@@ -40,7 +40,7 @@ public class TemplateSupportIT extends AbstractParallelTest {
         CrudElement crud = getCrud().waitForFirst();
         Assert.assertFalse(crud.isEditorOpen());
         crud.getNewItemButton().get().click();
-        Assert.assertEquals("New: null", getLastEvent());
+        Assert.assertEquals("New: Person{id=null, firstName='null', lastName='null'}", getLastEvent());
         Assert.assertTrue(crud.isEditorOpen());
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/TemplateSupportIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/TemplateSupportIT.java
@@ -40,7 +40,9 @@ public class TemplateSupportIT extends AbstractParallelTest {
         CrudElement crud = getCrud().waitForFirst();
         Assert.assertFalse(crud.isEditorOpen());
         crud.getNewItemButton().get().click();
-        Assert.assertEquals("New: Person{id=null, firstName='null', lastName='null'}", getLastEvent());
+        Assert.assertEquals(
+                "New: Person{id=null, firstName='null', lastName='null'}",
+                getLastEvent());
         Assert.assertTrue(crud.isEditorOpen());
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -185,9 +185,10 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
                                 "Unable to instantiate new bean", ex);
                     }
 
-                    NewEvent modifiedEvent = new NewEvent(e.getSource(),e.isFromClient(),getEditor().getItem(),null);
-                    newListeners
-                            .forEach(listener -> listener.onComponentEvent(modifiedEvent));
+                    NewEvent modifiedEvent = new NewEvent(e.getSource(),
+                            e.isFromClient(), getEditor().getItem(), null);
+                    newListeners.forEach(listener -> listener
+                            .onComponentEvent(modifiedEvent));
                 }));
 
         ComponentUtil.addListener(this, EditEvent.class,

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -185,8 +185,9 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
                                 "Unable to instantiate new bean", ex);
                     }
 
+                    NewEvent modifiedEvent = new NewEvent(e.getSource(),e.isFromClient(),getEditor().getItem(),null);
                     newListeners
-                            .forEach(listener -> listener.onComponentEvent(e));
+                            .forEach(listener -> listener.onComponentEvent(modifiedEvent));
                 }));
 
         ComponentUtil.addListener(this, EditEvent.class,

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -185,10 +185,10 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
                                 "Unable to instantiate new bean", ex);
                     }
 
-                    NewEvent modifiedEvent = new NewEvent(e.getSource(),
+                    NewEvent eventWithNewItem = new NewEvent(e.getSource(),
                             e.isFromClient(), getEditor().getItem(), null);
                     newListeners.forEach(listener -> listener
-                            .onComponentEvent(modifiedEvent));
+                            .onComponentEvent(eventWithNewItem));
                 }));
 
         ComponentUtil.addListener(this, EditEvent.class,
@@ -898,7 +898,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
         /**
          * Gets new item being created
          * 
-         * @return a new object of bean type
+         * @return a new instance of bean type
          */
         @Override
         public E getItem() {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -895,6 +895,11 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
             this.item = item;
         }
 
+        /**
+         * Gets new item being created
+         * 
+         * @return a new object of bean type
+         */
         @Override
         public E getItem() {
             return item;

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -51,16 +51,18 @@ public class CrudTest {
 
     @Test
     public void sameItemInNewEvent() {
-       String value = "thing";
+        String value = "thing";
 
         systemUnderTest.addNewListener(e -> {
             Thing item = e.getItem();
             item.name = value;
         });
 
-        systemUnderTest.addNewListener(e -> Assert.assertEquals(value, e.getItem().name));
+        systemUnderTest.addNewListener(
+                e -> Assert.assertEquals(value, e.getItem().name));
 
-        ComponentUtil.fireEvent(systemUnderTest, new Crud.NewEvent<>(systemUnderTest, false, null));
+        ComponentUtil.fireEvent(systemUnderTest,
+                new Crud.NewEvent<>(systemUnderTest, false, null));
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -37,15 +37,15 @@ public class CrudTest {
 
         // Simulate a sequence of interactions.
         Arrays.asList(new Crud.NewEvent<>(systemUnderTest, false, null),
-                        new Crud.CancelEvent<>(systemUnderTest, false, null),
+                new Crud.CancelEvent<>(systemUnderTest, false, null),
 
-                        new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
-                                null),
-                        new Crud.DeleteEvent<>(systemUnderTest, false, null),
+                new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
+                        null),
+                new Crud.DeleteEvent<>(systemUnderTest, false, null),
 
-                        new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
-                                null),
-                        new Crud.SaveEvent<>(systemUnderTest, false, null))
+                new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
+                        null),
+                new Crud.SaveEvent<>(systemUnderTest, false, null))
                 .forEach(e -> ComponentUtil.fireEvent(systemUnderTest, e));
     }
 
@@ -61,16 +61,19 @@ public class CrudTest {
         ComponentUtil.fireEvent(systemUnderTest,
                 new Crud.NewEvent<>(systemUnderTest, false, null));
 
-        Assert.assertEquals("thing", systemUnderTest.getEditor().getItem().name);
+        Assert.assertEquals("thing",
+                systemUnderTest.getEditor().getItem().name);
     }
 
     @Test
     public void crudEditorIsItemEqualNewEventItem() {
         systemUnderTest.addNewListener(e -> {
-            Assert.assertEquals(systemUnderTest.getEditor().getItem(), e.getItem());
+            Assert.assertEquals(systemUnderTest.getEditor().getItem(),
+                    e.getItem());
         });
 
-        ComponentUtil.fireEvent(systemUnderTest, new Crud.NewEvent<>(systemUnderTest, false, null));
+        ComponentUtil.fireEvent(systemUnderTest,
+                new Crud.NewEvent<>(systemUnderTest, false, null));
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -29,9 +29,7 @@ public class CrudTest {
                 .addDeleteListener(e -> Assert.assertNotNull(e.getItem()));
         systemUnderTest.addEditListener(e -> Assert.assertNotNull(e.getItem()));
         systemUnderTest.addSaveListener(e -> Assert.assertNotNull(e.getItem()));
-
-        // Client side new should not come with an item
-        systemUnderTest.addNewListener(e -> Assert.assertNull(e.getItem()));
+        systemUnderTest.addNewListener(e -> Assert.assertNotNull(e.getItem()));
 
         // A client-side Grid item.
         final JsonObject selectedItem = new JreJsonFactory()

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -37,20 +37,20 @@ public class CrudTest {
 
         // Simulate a sequence of interactions.
         Arrays.asList(new Crud.NewEvent<>(systemUnderTest, false, null),
-                new Crud.CancelEvent<>(systemUnderTest, false, null),
+                        new Crud.CancelEvent<>(systemUnderTest, false, null),
 
-                new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
-                        null),
-                new Crud.DeleteEvent<>(systemUnderTest, false, null),
+                        new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
+                                null),
+                        new Crud.DeleteEvent<>(systemUnderTest, false, null),
 
-                new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
-                        null),
-                new Crud.SaveEvent<>(systemUnderTest, false, null))
+                        new Crud.EditEvent<>(systemUnderTest, false, selectedItem,
+                                null),
+                        new Crud.SaveEvent<>(systemUnderTest, false, null))
                 .forEach(e -> ComponentUtil.fireEvent(systemUnderTest, e));
     }
 
     @Test
-    public void sameItemInNewEvent() {
+    public void newItemPreFilledValueIsTheSameInEditor() {
         String value = "thing";
 
         systemUnderTest.addNewListener(e -> {
@@ -58,11 +58,19 @@ public class CrudTest {
             item.name = value;
         });
 
-        systemUnderTest.addNewListener(
-                e -> Assert.assertEquals(value, e.getItem().name));
-
         ComponentUtil.fireEvent(systemUnderTest,
                 new Crud.NewEvent<>(systemUnderTest, false, null));
+
+        Assert.assertEquals("thing", systemUnderTest.getEditor().getItem().name);
+    }
+
+    @Test
+    public void crudEditorIsItemEqualNewEventItem() {
+        systemUnderTest.addNewListener(e -> {
+            Assert.assertEquals(systemUnderTest.getEditor().getItem(), e.getItem());
+        });
+
+        ComponentUtil.fireEvent(systemUnderTest, new Crud.NewEvent<>(systemUnderTest, false, null));
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -50,6 +50,20 @@ public class CrudTest {
     }
 
     @Test
+    public void sameItemInNewEvent() {
+       String value = "thing";
+
+        systemUnderTest.addNewListener(e -> {
+            Thing item = e.getItem();
+            item.name = value;
+        });
+
+        systemUnderTest.addNewListener(e -> Assert.assertEquals(value, e.getItem().name));
+
+        ComponentUtil.fireEvent(systemUnderTest, new Crud.NewEvent<>(systemUnderTest, false, null));
+    }
+
+    @Test
     public void getEditorPosition_defaultOVERLAY() {
         Assert.assertEquals(CrudEditorPosition.OVERLAY,
                 systemUnderTest.getEditorPosition());


### PR DESCRIPTION
## Description

Provide new item in `NewEvent`. Inside of event handler for `NewEvent`,  when we call `e.getItem()`, it used to return `null` value, which wasn't any useful. This PR modifies the event object of `NewEvent` to include an empty instance of type of the crud, so that end user can provide some default values to newly added objects via CRUD component.

Fixes https://github.com/vaadin/flow-components/issues/1105

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
