### PR TITLE
refactor: merge LitRendering to Rendering

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -67,7 +67,6 @@ import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.data.renderer.LitRenderer;
-import com.vaadin.flow.data.renderer.LitRenderer.LitRendering;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -1631,10 +1630,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             renderingRegistrations.add(renderingDataGeneratorRegistration);
         });
 
-        if (rendering instanceof LitRendering) {
-            renderingRegistrations
-                    .add(((LitRendering<T>) rendering).getRegistration());
-        }
+        renderingRegistrations.add(rendering.getRegistration());
 
         reset();
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -122,7 +122,6 @@ import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.data.renderer.LitRenderer;
-import com.vaadin.flow.data.renderer.LitRenderer.LitRendering;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -2825,10 +2824,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     .add(detailsRenderingDataGeneratorRegistration);
         });
 
-        if (rendering instanceof LitRendering) {
-            detailsRenderingRegistrations
-                    .add(((LitRendering<T>) rendering).getRegistration());
-        }
+        detailsRenderingRegistrations.add(rendering.getRegistration());
     }
 
     /**

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererTestComponent.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererTestComponent.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.data.renderer.LitRenderer;
-import com.vaadin.flow.data.renderer.LitRenderer.LitRendering;
+import com.vaadin.flow.data.renderer.Rendering;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.JsonValue;
@@ -84,7 +84,7 @@ public class LitRendererTestComponent extends Div
         renderingRegistrations.clear();
 
         if (renderer != null) {
-            LitRendering<String> rendering = renderer.render(getElement(),
+            Rendering<String> rendering = renderer.render(getElement(),
                     dataCommunicator.getKeyMapper());
             renderingRegistrations.add(rendering.getRegistration());
             rendering.getDataGenerator()
@@ -99,7 +99,7 @@ public class LitRendererTestComponent extends Div
         detailsRenderingRegistrations.clear();
 
         if (renderer != null) {
-            LitRendering<String> rendering = renderer.render(getElement(),
+            Rendering<String> rendering = renderer.render(getElement(),
                     dataCommunicator.getKeyMapper(), "detailsRenderer");
             detailsRenderingRegistrations.add(rendering.getRegistration());
             rendering.getDataGenerator()

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -165,8 +165,7 @@ public class LitRenderer<T> extends Renderer<T> {
      *         to provide extra customization
      */
     @Override
-    public Rendering<T> render(Element container,
-            DataKeyMapper<T> keyMapper) {
+    public Rendering<T> render(Element container, DataKeyMapper<T> keyMapper) {
         return this.render(container, keyMapper, DEFAULT_RENDERER_NAME);
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -165,7 +165,7 @@ public class LitRenderer<T> extends Renderer<T> {
      *         to provide extra customization
      */
     @Override
-    public LitRendering<T> render(Element container,
+    public Rendering<T> render(Element container,
             DataKeyMapper<T> keyMapper) {
         return this.render(container, keyMapper, DEFAULT_RENDERER_NAME);
     }
@@ -187,13 +187,13 @@ public class LitRenderer<T> extends Renderer<T> {
      * @return the context of the rendering, that can be used by the components
      *         to provide extra customization
      */
-    public LitRendering<T> render(Element container, DataKeyMapper<T> keyMapper,
+    public Rendering<T> render(Element container, DataKeyMapper<T> keyMapper,
             String rendererName) {
         DataGenerator<T> dataGenerator = createDataGenerator();
         Registration registration = createJsRendererFunction(container,
                 keyMapper, rendererName);
 
-        return new LitRendering<T>() {
+        return new Rendering<T>() {
             @Override
             public Optional<DataGenerator<T>> getDataGenerator() {
                 return Optional.of(dataGenerator);
@@ -422,34 +422,5 @@ public class LitRenderer<T> extends Renderer<T> {
     public Map<String, SerializableBiConsumer<T, JsonArray>> getFunctions() {
         return clientCallables == null ? Collections.emptyMap()
                 : Collections.unmodifiableMap(clientCallables);
-    }
-
-    /**
-     * Defines the context of a given {@link LitRenderer} when building the
-     * output elements. Components that support Renderers can use the context to
-     * customize the rendering according to their needs.
-     *
-     * @author Vaadin Ltd
-     * @since 22.0.
-     *
-     * @param <T>
-     *            the type of the object model
-     *
-     * @see LitRenderer#render(Element,
-     *      com.vaadin.flow.data.provider.DataKeyMapper)
-     */
-    public interface LitRendering<T> extends Rendering<T> {
-
-        /**
-         * Gets a {@link Registration} that allows cleaning up resources
-         * associated with this rendering when the rendering is no longer used.
-         * It removes the listeners and properties added to the container
-         * element by this rendering.
-         *
-         * @return the associated Registration
-         * @see Registration#remove
-         */
-        Registration getRegistration();
-
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import com.vaadin.flow.data.provider.DataGenerator;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * Defines the context of a given {@link Renderer} when building the output
@@ -57,4 +58,14 @@ public interface Rendering<SOURCE> extends Serializable {
     @Deprecated
     Element getTemplateElement();
 
+    /**
+     * Gets a {@link Registration} that can be used to clean up resources
+     * associated with the renderer when it's no longer used.
+     *
+     * @return the Registration
+     * @see Registration#remove
+     */
+    default Registration getRegistration() {
+        return () -> {};
+    }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
@@ -66,6 +66,7 @@ public interface Rendering<SOURCE> extends Serializable {
      * @see Registration#remove
      */
     default Registration getRegistration() {
-        return () -> {};
+        return () -> {
+        };
     }
 }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -45,7 +45,6 @@ import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.data.renderer.LitRenderer;
-import com.vaadin.flow.data.renderer.LitRenderer.LitRendering;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.Registration;
 
@@ -227,10 +226,8 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
             renderingRegistrations.add(renderingDataGeneratorRegistration);
         });
 
-        if (rendering instanceof LitRendering) {
-            renderingRegistrations
-                    .add(((LitRendering<T>) rendering).getRegistration());
-        }
+        renderingRegistrations.add(rendering.getRegistration());
+
 
         this.renderer = renderer;
 

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -228,7 +228,6 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
 
         renderingRegistrations.add(rendering.getRegistration());
 
-
         this.renderer = renderer;
 
         rendererChanged = true;


### PR DESCRIPTION
LitRenderer currently has a dedicated rendering context called `LitRendering`. It only adds one method on top of the ones inherited from `Rendering`. The new one, `getRegistration()` returns a `Registration` instance which can be used to clean up after the renderer is no longer required. _In LitRenderer's case, it cleans up the `renderer` function from the element and the attach listener which adds it_.

Once we modify `ComponentRenderer` to also use `renderer` function instead of the `<template>` element, similar cleanup is most likely required, so it's better to have the API available for all Renderer types. _(In fact, removing the `<template>` element from the target component should already be handled by such cleanup registration instead of the component logic having to do the juggling)_.