### PR TITLE
chore: add deprecated withEventHandler to LitRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -139,17 +139,6 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
     }
 
     /**
-     * @deprecated LitRenderer doesn't support event handlers. Use functions
-     *             instead.
-     * @see LitRenderer#getFunctions()
-     */
-    @Deprecated
-    @Override
-    public Map<String, SerializableConsumer<SOURCE>> getEventHandlers() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * Sets up rendering of model objects inside a given {@param container}
      * element. The model objects are rendered using the Lit template literal
      * provided when creating this LitRenderer instance, and the Vaadin-default
@@ -328,6 +317,42 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
     }
 
     /**
+     * Adds an event handler that can be called from within the template expression.
+     * <p>
+     * Examples:
+     *
+     * <pre>
+     * {@code
+     * // Standard event
+     * LitRenderer.of("<button @click=${handleClick}>Click me</button>")
+     *          .withEventHandler("handleClick", object -> doSomething());
+     * }
+     * </pre>
+     *
+     * The name of the event handler used in the template expression should be the
+     * name used at the eventHandlerName parameter. This name must be a valid
+     * JavaScript function name.
+     *
+     * @param eventHandlerName
+     *            the name of the event handler used inside the template expression,
+     *            must be alphanumeric and not <code>null</code>, must not be
+     *            one of the JavaScript reserved words
+     *            (https://www.w3schools.com/js/js_reserved.asp)
+     * @param handler
+     *            the handler executed when the event handler is called, not
+     *            <code>null</code>
+     * @return this instance for method chaining
+     * @see <a href=
+     *      "https://lit.dev/docs/templates/expressions/#event-listener-expressions">https://lit.dev/docs/templates/expressions/#event-listener-expressions</a>
+     *
+     * @deprecated Use {@link #withFunction(String, SerializableConsumer)} instead.
+     */
+    public LitRenderer<SOURCE> withEventHandler(String eventHandlerName,
+            SerializableConsumer<SOURCE> handler) {
+        return withFunction(eventHandlerName, handler);
+    }
+
+    /**
      * Adds a function that can be called from within the template expression.
      * <p>
      * Examples:
@@ -410,17 +435,5 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         }
         clientCallables.put(functionName, handler);
         return this;
-    }
-
-    /**
-     * Gets the functions linked to this renderer. The returned map is
-     * immutable.
-     *
-     * @return the mapped functions, never <code>null</code>
-     * @see #withFunction(String, SerializableBiConsumer)
-     */
-    public Map<String, SerializableBiConsumer<SOURCE, JsonArray>> getFunctions() {
-        return clientCallables == null ? Collections.emptyMap()
-                : Collections.unmodifiableMap(clientCallables);
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -317,7 +317,8 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
     }
 
     /**
-     * Adds an event handler that can be called from within the template expression.
+     * Adds an event handler that can be called from within the template
+     * expression.
      * <p>
      * Examples:
      *
@@ -329,14 +330,14 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
      * }
      * </pre>
      *
-     * The name of the event handler used in the template expression should be the
-     * name used at the eventHandlerName parameter. This name must be a valid
-     * JavaScript function name.
+     * The name of the event handler used in the template expression should be
+     * the name used at the eventHandlerName parameter. This name must be a
+     * valid JavaScript function name.
      *
      * @param eventHandlerName
-     *            the name of the event handler used inside the template expression,
-     *            must be alphanumeric and not <code>null</code>, must not be
-     *            one of the JavaScript reserved words
+     *            the name of the event handler used inside the template
+     *            expression, must be alphanumeric and not <code>null</code>,
+     *            must not be one of the JavaScript reserved words
      *            (https://www.w3schools.com/js/js_reserved.asp)
      * @param handler
      *            the handler executed when the event handler is called, not
@@ -345,7 +346,8 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
      * @see <a href=
      *      "https://lit.dev/docs/templates/expressions/#event-listener-expressions">https://lit.dev/docs/templates/expressions/#event-listener-expressions</a>
      *
-     * @deprecated Use {@link #withFunction(String, SerializableConsumer)} instead.
+     * @deprecated Use {@link #withFunction(String, SerializableConsumer)}
+     *             instead.
      */
     public LitRenderer<SOURCE> withEventHandler(String eventHandlerName,
             SerializableConsumer<SOURCE> handler) {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -139,7 +139,8 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
     }
 
     /**
-     * @deprecated LitRenderer doesn't support getting the event handlers. Don't use.
+     * @deprecated LitRenderer doesn't support getting the event handlers. Don't
+     *             use.
      */
     @Deprecated
     @Override

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -139,6 +139,15 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
     }
 
     /**
+     * @deprecated LitRenderer doesn't support getting the event handlers. Don't use.
+     */
+    @Deprecated
+    @Override
+    public Map<String, SerializableConsumer<SOURCE>> getEventHandlers() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Sets up rendering of model objects inside a given {@param container}
      * element. The model objects are rendered using the Lit template literal
      * provided when creating this LitRenderer instance, and the Vaadin-default

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -247,7 +247,7 @@ public class Renderer<SOURCE> implements Serializable {
      * @deprecated since Vaadin 22
      */
     @Deprecated
-    Map<String, SerializableConsumer<SOURCE>> getEventHandlers() {
+    public Map<String, SerializableConsumer<SOURCE>> getEventHandlers() {
         return eventHandlers == null ? Collections.emptyMap()
                 : Collections.unmodifiableMap(eventHandlers);
     }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -247,7 +247,7 @@ public class Renderer<SOURCE> implements Serializable {
      * @deprecated since Vaadin 22
      */
     @Deprecated
-    public Map<String, SerializableConsumer<SOURCE>> getEventHandlers() {
+    Map<String, SerializableConsumer<SOURCE>> getEventHandlers() {
         return eventHandlers == null ? Collections.emptyMap()
                 : Collections.unmodifiableMap(eventHandlers);
     }


### PR DESCRIPTION
The primary purpose of this PR is to add a deprecated `withEventHandler` to the `LitRenderer` API to make the migrating experience from `TemplateRenderer` nicer:

<img width="653" alt="Screenshot 2021-08-24 at 14 59 30" src="https://user-images.githubusercontent.com/1222264/130612831-6c9405ca-c8f9-4770-b6d2-7a51ce13a839.png">

However, `getEventHandlers()` in `LitRenderer` currently throws an `UnsupportedOperationException` and using `getFunctions()` is recommended instead. Since neither of the getters really serve any purpose in the public renderer APIs, decided to
1. remove `getFunctions()` completely
2. keep the deprecated `getEventHandlers()` (updated the deprecation message, still throws an exception)