### PR TITLE
feat: allow theming individual menu items

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
+import java.io.Serializable;
+import java.util.Objects;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
@@ -154,12 +157,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
 
         getElement().setProperty("_checked", checked);
 
-        getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this, context -> {
-                    ui.getPage().executeJavaScript(
-                            "window.Vaadin.Flow.contextMenuConnector.setChecked($0, $1)",
-                            getElement(), checked);
-                }));
+        executeJsWhenAttached("window.Vaadin.Flow.contextMenuConnector.setChecked($0, $1)",
+                getElement(), checked);
     }
 
     /**
@@ -175,5 +174,27 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         return getElement().getProperty("_checked", false);
     }
 
+    public void setThemeName(String theme) {
+        if (theme != null) {
+            getElement().setProperty("_theme", theme);
+        } else {
+            getElement().removeProperty("_theme");
+        }
+
+        executeJsWhenAttached("window.Vaadin.Flow.contextMenuConnector.setTheme($0, $1)",
+                getElement(), theme);
+    }
+
+    public String getThemeName() {
+        return getElement().getProperty("_theme");
+    }
+
     protected abstract S createSubMenu();
+
+    protected void executeJsWhenAttached(String expression,
+            Serializable... parameters) {
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this,
+                        context -> ui.getPage().executeJs(expression, parameters)));
+    }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -157,7 +157,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
 
         getElement().setProperty("_checked", checked);
 
-        executeJsWhenAttached("window.Vaadin.Flow.contextMenuConnector.setChecked($0, $1)",
+        executeJsWhenAttached(
+                "window.Vaadin.Flow.contextMenuConnector.setChecked($0, $1)",
                 getElement(), checked);
     }
 
@@ -181,7 +182,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
             getElement().removeProperty("_theme");
         }
 
-        executeJsWhenAttached("window.Vaadin.Flow.contextMenuConnector.setTheme($0, $1)",
+        executeJsWhenAttached(
+                "window.Vaadin.Flow.contextMenuConnector.setTheme($0, $1)",
                 getElement(), theme);
     }
 
@@ -193,8 +195,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
 
     protected void executeJsWhenAttached(String expression,
             Serializable... parameters) {
-        getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this,
-                        context -> ui.getPage().executeJs(expression, parameters)));
+        getElement().getNode().runWhenAttached(ui -> ui.beforeClientResponse(
+                this,
+                context -> ui.getPage().executeJs(expression, parameters)));
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -43,6 +43,8 @@ import com.vaadin.flow.component.Tag;
 public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
         extends Component implements HasText, HasComponents, HasEnabled {
 
+    private static final String PRIVATE_THEME_ATTRIBUTE = "_theme";
+
     private final C contextMenu;
     private S subMenu;
 
@@ -177,9 +179,9 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
 
     public void setThemeName(String theme) {
         if (theme != null) {
-            getElement().setProperty("_theme", theme);
+            getElement().setProperty(PRIVATE_THEME_ATTRIBUTE, theme);
         } else {
-            getElement().removeProperty("_theme");
+            getElement().removeProperty(PRIVATE_THEME_ATTRIBUTE);
         }
 
         executeJsWhenAttached(
@@ -188,7 +190,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     }
 
     public String getThemeName() {
-        return getElement().getProperty("_theme");
+        return getElement().getProperty(PRIVATE_THEME_ATTRIBUTE);
     }
 
     protected abstract S createSubMenu();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -15,19 +15,16 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
 
+import java.io.Serializable;
+
 /**
  * Base class for item component used inside {@link ContextMenu}s.
- *
- * @see MenuItem
  *
  * @param <C>
  *            the context menu type
@@ -35,8 +32,8 @@ import com.vaadin.flow.component.Tag;
  *            the menu item type
  * @param <S>
  *            the sub menu type
- *
  * @author Vaadin Ltd.
+ * @see MenuItem
  */
 @SuppressWarnings("serial")
 @Tag("vaadin-context-menu-item")
@@ -177,18 +174,32 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         return getElement().getProperty("_checked", false);
     }
 
-    public void setThemeName(String theme) {
-        if (theme != null) {
-            getElement().setProperty(PRIVATE_THEME_ATTRIBUTE, theme);
+    /**
+     * Sets the theme names of the item. This method overwrites any previous set
+     * theme names.
+     *
+     * @param themeName
+     *            a space-separated string of theme names to set, or empty
+     *            string to remove all theme names
+     */
+    public void setThemeName(String themeName) {
+        if (themeName != null) {
+            getElement().setProperty(PRIVATE_THEME_ATTRIBUTE, themeName);
         } else {
             getElement().removeProperty(PRIVATE_THEME_ATTRIBUTE);
         }
 
         executeJsWhenAttached(
                 "window.Vaadin.Flow.contextMenuConnector.setTheme($0, $1)",
-                getElement(), theme);
+                getElement(), themeName);
     }
 
+    /**
+     * Gets the theme names for this component.
+     *
+     * @return a space-separated string of theme names, empty string if there
+     *         are no theme names or null if attribute (theme) is not set at all
+     */
     public String getThemeName() {
         return getElement().getProperty(PRIVATE_THEME_ATTRIBUTE);
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -22,6 +22,10 @@ import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Base class for item component used inside {@link ContextMenu}s.
@@ -46,6 +50,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     private S subMenu;
 
     private boolean checkable = false;
+
+    private Set<String> themeNames = new LinkedHashSet<>();
 
     /**
      * Default constructor
@@ -175,14 +181,43 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     }
 
     /**
-     * Sets the theme names of the item. This method overwrites any previous set
-     * theme names.
+     * Adds one or more theme names to this item. Multiple theme names can be
+     * specified by using multiple parameters.
+     *
+     * @param themeNames
+     *            the theme name or theme names to be added to the item
+     */
+    public void addThemeNames(String... themeNames) {
+        this.themeNames.addAll(Arrays.asList(themeNames));
+        setThemeName();
+    }
+
+    /**
+     * Removes one or more theme names from this item. Multiple theme names can
+     * be specified by using multiple parameters.
+     *
+     * @param themeNames
+     *            the theme name or theme names to be removed from the item
+     */
+    public void removeThemeNames(String... themeNames) {
+        this.themeNames.removeAll(Arrays.asList(themeNames));
+        setThemeName();
+    }
+
+    /**
+     * Checks if the item has the given theme name.
      *
      * @param themeName
-     *            a space-separated string of theme names to set, or empty
-     *            string to remove all theme names
+     *            the theme name to check for
+     * @return <code>true</code> if the item has the given theme name,
+     *         <code>false</code> otherwise
      */
-    public void setThemeName(String themeName) {
+    public boolean hasThemeName(String themeName) {
+        return themeNames.contains(themeName);
+    }
+
+    private void setThemeName() {
+        String themeName = themeNames.stream().collect(Collectors.joining(" "));
         if (themeName != null) {
             getElement().setProperty(PRIVATE_THEME_ATTRIBUTE, themeName);
         } else {
@@ -192,16 +227,6 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         executeJsWhenAttached(
                 "window.Vaadin.Flow.contextMenuConnector.setTheme($0, $1)",
                 getElement(), themeName);
-    }
-
-    /**
-     * Gets the theme names for this component.
-     *
-     * @return a space-separated string of theme names, empty string if there
-     *         are no theme names or null if attribute (theme) is not set at all
-     */
-    public String getThemeName() {
-        return getElement().getProperty(PRIVATE_THEME_ATTRIBUTE);
     }
 
     protected abstract S createSubMenu();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -94,7 +94,11 @@ import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
           const items =
             container &&
             Array.from(container.children).map(child => {
-              const item = { component: child, checked: child._checked };
+              const item = {
+                  component: child,
+                  checked: child._checked,
+                  theme: child._theme
+              };
               if (
                 child.tagName == "VAADIN-CONTEXT-MENU-ITEM" &&
                 child._containerNodeId
@@ -116,6 +120,13 @@ import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
         if (component._item) {
           component._item.checked = checked;
         }
-      })(component, checked)
+      })(component, checked),
+
+    setTheme: (component, theme) =>
+        tryCatchWrapper((component, theme) => {
+            if (component._item) {
+                component._item.theme = theme;
+            }
+        })(component, theme)
   };
 })();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
@@ -50,6 +50,7 @@ public class MenuBarView extends DemoView {
         createTertiaryThemeVariant();
         createTertiaryInlineThemeVariant();
         createSmallThemeVariant();
+        createSingleButtonPrimaryThemeVariant();
     }
 
     private void createBasicDemo() {
@@ -398,4 +399,39 @@ public class MenuBarView extends DemoView {
         addCard("Theme Variants", "Small Buttons", menuBar, message);
     }
 
+    private void createSingleButtonPrimaryThemeVariant() {
+        // begin-source-example
+        // source-example-heading: Individual Button Themes
+        MenuBar menuBar = new MenuBar();
+
+        Text selected = new Text("");
+        Div message = new Div(new Text("Selected: "), selected);
+
+        MenuItem project = menuBar.addItem("Project");
+        project.setThemeName(MenuBarVariant.LUMO_PRIMARY.getVariantName());
+        MenuItem account = menuBar.addItem("Account");
+        MenuItem signOut = menuBar.addItem(VaadinIcon.SIGN_OUT.create(), e -> selected.setText("Sign Out"));
+        signOut.setThemeName(MenuBarVariant.LUMO_TERTIARY.getVariantName());
+
+        SubMenu projectSubMenu = project.getSubMenu();
+        MenuItem users = projectSubMenu.addItem("Users");
+        MenuItem billing = projectSubMenu.addItem("Billing");
+
+        SubMenu usersSubMenu = users.getSubMenu();
+        usersSubMenu.addItem("List", e -> selected.setText("List"));
+        usersSubMenu.addItem("Add", e -> selected.setText("Add"));
+
+        SubMenu billingSubMenu = billing.getSubMenu();
+        billingSubMenu.addItem("Invoices", e -> selected.setText("Invoices"));
+        billingSubMenu.addItem("Balance Events",
+                e -> selected.setText("Balance Events"));
+
+        account.getSubMenu().addItem("Edit Profile",
+                e -> selected.setText("Edit Profile"));
+        account.getSubMenu().addItem("Privacy Settings",
+                e -> selected.setText("Privacy Settings"));
+
+        // end-source-example
+        addCard("Theme Variants", "Individual Button Themes", menuBar, message);
+    }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
@@ -410,7 +410,8 @@ public class MenuBarView extends DemoView {
         MenuItem project = menuBar.addItem("Project");
         project.setThemeName(MenuBarVariant.LUMO_PRIMARY.getVariantName());
         MenuItem account = menuBar.addItem("Account");
-        MenuItem signOut = menuBar.addItem(VaadinIcon.SIGN_OUT.create(), e -> selected.setText("Sign Out"));
+        MenuItem signOut = menuBar.addItem(VaadinIcon.SIGN_OUT.create(),
+                e -> selected.setText("Sign Out"));
         signOut.setThemeName(MenuBarVariant.LUMO_TERTIARY.getVariantName());
 
         SubMenu projectSubMenu = project.getSubMenu();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
@@ -408,11 +408,11 @@ public class MenuBarView extends DemoView {
         Div message = new Div(new Text("Selected: "), selected);
 
         MenuItem project = menuBar.addItem("Project");
-        project.setThemeName(MenuBarVariant.LUMO_PRIMARY.getVariantName());
+        project.addThemeNames(MenuBarVariant.LUMO_PRIMARY.getVariantName());
         MenuItem account = menuBar.addItem("Account");
         MenuItem signOut = menuBar.addItem(VaadinIcon.SIGN_OUT.create(),
                 e -> selected.setText("Sign Out"));
-        signOut.setThemeName(MenuBarVariant.LUMO_TERTIARY.getVariantName());
+        signOut.addThemeNames(MenuBarVariant.LUMO_TERTIARY.getVariantName());
 
         SubMenu projectSubMenu = project.getSubMenu();
         MenuItem users = projectSubMenu.addItem("Users");

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -122,8 +122,8 @@ public class MenuBarTestPage extends Div {
                 });
         toggleMenuBarThemeButton.setId("toggle-theme");
 
-        NativeButton toggleMenuItemThemeButton = new NativeButton("toggle item theme",
-                e -> {
+        NativeButton toggleMenuItemThemeButton = new NativeButton(
+                "toggle item theme", e -> {
                     if (MENU_ITEM_THEME.equals(item1.getThemeName())) {
                         item1.setThemeName(null);
                     } else {
@@ -132,8 +132,8 @@ public class MenuBarTestPage extends Div {
                 });
         toggleMenuItemThemeButton.setId("toggle-item-theme");
 
-        NativeButton toggleSubItemThemeButton = new NativeButton("toggle sub theme",
-                e -> {
+        NativeButton toggleSubItemThemeButton = new NativeButton(
+                "toggle sub theme", e -> {
                     if (SUB_ITEM_THEME.equals(subItem2.getThemeName())) {
                         subItem2.setThemeName(null);
                     } else {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -145,8 +145,8 @@ public class MenuBarTestPage extends Div {
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableButton, visibleButton, checkedButton,
-                toggleAttachedButton, setI18nButton,
-                toggleAttachedButton, toggleMenuBarThemeButton,
-                toggleMenuItemThemeButton, toggleSubItemThemeButton);
+                toggleAttachedButton, setI18nButton, toggleAttachedButton,
+                toggleMenuBarThemeButton, toggleMenuItemThemeButton,
+                toggleSubItemThemeButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -28,6 +28,10 @@ import com.vaadin.flow.router.Route;
 @PreserveOnRefresh
 public class MenuBarTestPage extends Div {
 
+    public static final String MENU_BAR_THEME = "menu-bar-theme";
+    public static final String MENU_ITEM_THEME = "menu-item-theme";
+    public static final String SUB_ITEM_THEME = "sub-item-theme";
+
     public MenuBarTestPage() {
         MenuBar menuBar = new MenuBar();
         add(menuBar);
@@ -108,9 +112,41 @@ public class MenuBarTestPage extends Div {
                         .setMoreOptions("more-options")));
         setI18nButton.setId("set-i18n");
 
+        NativeButton toggleMenuBarThemeButton = new NativeButton("toggle theme",
+                e -> {
+                    if (menuBar.hasThemeName(MENU_BAR_THEME)) {
+                        menuBar.removeThemeName(MENU_BAR_THEME);
+                    } else {
+                        menuBar.addThemeName(MENU_BAR_THEME);
+                    }
+                });
+        toggleMenuBarThemeButton.setId("toggle-theme");
+
+        NativeButton toggleMenuItemThemeButton = new NativeButton("toggle item theme",
+                e -> {
+                    if (MENU_ITEM_THEME.equals(item1.getThemeName())) {
+                        item1.setThemeName(null);
+                    } else {
+                        item1.setThemeName(MENU_ITEM_THEME);
+                    }
+                });
+        toggleMenuItemThemeButton.setId("toggle-item-theme");
+
+        NativeButton toggleSubItemThemeButton = new NativeButton("toggle sub theme",
+                e -> {
+                    if (SUB_ITEM_THEME.equals(subItem2.getThemeName())) {
+                        subItem2.setThemeName(null);
+                    } else {
+                        subItem2.setThemeName(SUB_ITEM_THEME);
+                    }
+                });
+        toggleSubItemThemeButton.setId("toggle-sub-theme");
+
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableButton, visibleButton, checkedButton,
-                toggleAttachedButton, setI18nButton);
+                toggleAttachedButton, setI18nButton,
+                toggleAttachedButton, toggleMenuBarThemeButton,
+                toggleMenuItemThemeButton, toggleSubItemThemeButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -124,20 +124,20 @@ public class MenuBarTestPage extends Div {
 
         NativeButton toggleMenuItemThemeButton = new NativeButton(
                 "toggle item theme", e -> {
-                    if (MENU_ITEM_THEME.equals(item1.getThemeName())) {
-                        item1.setThemeName(null);
+                    if (item1.hasThemeName(MENU_ITEM_THEME)) {
+                        item1.removeThemeNames(MENU_ITEM_THEME);
                     } else {
-                        item1.setThemeName(MENU_ITEM_THEME);
+                        item1.addThemeNames(MENU_ITEM_THEME);
                     }
                 });
         toggleMenuItemThemeButton.setId("toggle-item-theme");
 
         NativeButton toggleSubItemThemeButton = new NativeButton(
                 "toggle sub theme", e -> {
-                    if (SUB_ITEM_THEME.equals(subItem2.getThemeName())) {
-                        subItem2.setThemeName(null);
+                    if (subItem2.hasThemeName(SUB_ITEM_THEME)) {
+                        subItem2.removeThemeNames(SUB_ITEM_THEME);
                     } else {
-                        subItem2.setThemeName(SUB_ITEM_THEME);
+                        subItem2.addThemeNames(SUB_ITEM_THEME);
                     }
                 });
         toggleSubItemThemeButton.setId("toggle-sub-theme");

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -408,6 +408,54 @@ public class MenuBarPageIT extends AbstractComponentIT {
         verifyClosed();
     }
 
+    public void toggleMenuBarTheme_themeIsToggled() {
+        Assert.assertFalse(menuBar.hasAttribute("theme"));
+        click("toggle-theme");
+        Assert.assertEquals(menuBar.getAttribute("theme"), MenuBarTestPage.MENU_BAR_THEME);
+        click("toggle-theme");
+        Assert.assertFalse(menuBar.hasAttribute("theme"));
+    }
+
+    @Test
+    public void toggleMenuItemTheme_themeIsToggled() {
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("theme"));
+        click("toggle-item-theme");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertEquals(menuButton1.getAttribute("theme"), MenuBarTestPage.MENU_ITEM_THEME);
+        click("toggle-item-theme");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("theme"));
+    }
+
+    @Test
+    public void toggleSubMenuItemTheme_themeIsToggled() {
+        menuBar.getButtons().get(0).click();
+        Assert.assertFalse(getOverlayMenuItems().get(1).hasAttribute("theme"));
+
+        click("toggle-sub-theme");
+        verifyClosed();
+
+        menuBar.getButtons().get(0).click();
+        Assert.assertEquals(getOverlayMenuItems().get(1).getAttribute("theme"), MenuBarTestPage.SUB_ITEM_THEME);
+
+        click("toggle-sub-theme");
+        verifyClosed();
+
+        menuBar.getButtons().get(0).click();
+        Assert.assertFalse(getOverlayMenuItems().get(1).hasAttribute("theme"));
+    }
+
+    @Test
+    public void toggleMenuBarTheme_toggleMenuItemTheme_themesAreMerged() {
+        click("toggle-theme");
+        click("toggle-item-theme");
+
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertTrue(menuButton1.getAttribute("theme").contains(MenuBarTestPage.MENU_BAR_THEME));
+        Assert.assertTrue(menuButton1.getAttribute("theme").contains(MenuBarTestPage.MENU_ITEM_THEME));
+    }
+
     @After
     public void afterTest() {
         checkLogsForErrors();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -450,15 +450,13 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void toggleMenuBarTheme_toggleMenuItemTheme_themesAreMerged() {
+    public void toggleMenuBarTheme_toggleMenuItemTheme_themeIsOverridden() {
         click("toggle-theme");
         click("toggle-item-theme");
 
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertTrue(menuButton1.getAttribute("theme")
-                .contains(MenuBarTestPage.MENU_BAR_THEME));
-        Assert.assertTrue(menuButton1.getAttribute("theme")
-                .contains(MenuBarTestPage.MENU_ITEM_THEME));
+        Assert.assertEquals(MenuBarTestPage.MENU_ITEM_THEME,
+                menuButton1.getAttribute("theme"));
     }
 
     @After

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -411,7 +411,8 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void toggleMenuBarTheme_themeIsToggled() {
         Assert.assertFalse(menuBar.hasAttribute("theme"));
         click("toggle-theme");
-        Assert.assertEquals(menuBar.getAttribute("theme"), MenuBarTestPage.MENU_BAR_THEME);
+        Assert.assertEquals(menuBar.getAttribute("theme"),
+                MenuBarTestPage.MENU_BAR_THEME);
         click("toggle-theme");
         Assert.assertFalse(menuBar.hasAttribute("theme"));
     }
@@ -422,7 +423,8 @@ public class MenuBarPageIT extends AbstractComponentIT {
         Assert.assertFalse(menuButton1.hasAttribute("theme"));
         click("toggle-item-theme");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("theme"), MenuBarTestPage.MENU_ITEM_THEME);
+        Assert.assertEquals(menuButton1.getAttribute("theme"),
+                MenuBarTestPage.MENU_ITEM_THEME);
         click("toggle-item-theme");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertFalse(menuButton1.hasAttribute("theme"));
@@ -437,7 +439,8 @@ public class MenuBarPageIT extends AbstractComponentIT {
         verifyClosed();
 
         menuBar.getButtons().get(0).click();
-        Assert.assertEquals(getOverlayMenuItems().get(1).getAttribute("theme"), MenuBarTestPage.SUB_ITEM_THEME);
+        Assert.assertEquals(getOverlayMenuItems().get(1).getAttribute("theme"),
+                MenuBarTestPage.SUB_ITEM_THEME);
 
         click("toggle-sub-theme");
         verifyClosed();
@@ -452,8 +455,10 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-item-theme");
 
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertTrue(menuButton1.getAttribute("theme").contains(MenuBarTestPage.MENU_BAR_THEME));
-        Assert.assertTrue(menuButton1.getAttribute("theme").contains(MenuBarTestPage.MENU_ITEM_THEME));
+        Assert.assertTrue(menuButton1.getAttribute("theme")
+                .contains(MenuBarTestPage.MENU_BAR_THEME));
+        Assert.assertTrue(menuButton1.getAttribute("theme")
+                .contains(MenuBarTestPage.MENU_ITEM_THEME));
     }
 
     @After

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.menubar;
 
+import java.util.Objects;
+
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.function.SerializableRunnable;
 
@@ -51,5 +53,14 @@ class MenuBarRootItem extends MenuItem {
         }
         super.setVisible(visible);
         menuBar.resetContent();
+    }
+
+    @Override
+    public void setThemeName(String theme) {
+        if (Objects.equals(theme, getThemeName())) {
+            return;
+        }
+        super.setThemeName(theme);
+        menuBar.updateButtons();
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -55,12 +55,23 @@ class MenuBarRootItem extends MenuItem {
         menuBar.resetContent();
     }
 
+    /**
+     * Sets the theme names of the item. This method overwrites any previous set
+     * theme names.
+     * <p>
+     * Note that the themes set via {@link MenuBar#setThemeName(String)} will be
+     * overridden when using this method.
+     *
+     * @param themeName
+     *            a space-separated string of theme names to set, or empty
+     *            string to remove all theme names
+     */
     @Override
-    public void setThemeName(String theme) {
-        if (Objects.equals(theme, getThemeName())) {
+    public void setThemeName(String themeName) {
+        if (Objects.equals(themeName, getThemeName())) {
             return;
         }
-        super.setThemeName(theme);
+        super.setThemeName(themeName);
         menuBar.updateButtons();
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.menubar;
 
-import java.util.Objects;
-
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.function.SerializableRunnable;
 
@@ -56,22 +54,31 @@ class MenuBarRootItem extends MenuItem {
     }
 
     /**
-     * Sets the theme names of the item. This method overwrites any previous set
-     * theme names.
+     * Adds one or more theme names to this item. Multiple theme names can be
+     * specified by using multiple parameters.
      * <p>
      * Note that the themes set via {@link MenuBar#setThemeName(String)} will be
      * overridden when using this method.
      *
-     * @param themeName
-     *            a space-separated string of theme names to set, or empty
-     *            string to remove all theme names
+     * @param themeNames
+     *            the theme name or theme names to be added to the item
      */
     @Override
-    public void setThemeName(String themeName) {
-        if (Objects.equals(themeName, getThemeName())) {
-            return;
-        }
-        super.setThemeName(themeName);
+    public void addThemeNames(String... themeNames) {
+        super.addThemeNames(themeNames);
+        menuBar.updateButtons();
+    }
+
+    /**
+     * Removes one or more theme names from this item. Multiple theme names can
+     * be specified by using multiple parameters.
+     *
+     * @param themeNames
+     *            the theme name or theme names to be removed from the item
+     */
+    @Override
+    public void removeThemeNames(String... themeNames) {
+        super.removeThemeNames(themeNames);
         menuBar.updateButtons();
     }
 }


### PR DESCRIPTION
This change enables theming individual menu bar items, for example to display one item as the primary item. As the menu bar uses the context menu to display submenus, most of the changes are in there.

Depends on https://github.com/vaadin/web-components/pull/2401

Part of vaadin/flow-components#880

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
