### PR TITLE
feat: add menu bar i18n Java API

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/src/main/java/com/vaadin/flow/component/menubar/demo/MenuBarView.java
@@ -42,6 +42,7 @@ public class MenuBarView extends DemoView {
         createBasicDemo();
         createOpenOnHover();
         createOverflowingButtons();
+        createOverflowI18n();
         createDisabledItems();
         createCheckableItems();
         createUsingComponents();
@@ -132,6 +133,20 @@ public class MenuBarView extends DemoView {
         // end-source-example
 
         addCard("Overflowing Buttons", menuBar);
+    }
+
+    private void createOverflowI18n() {
+        // begin-source-example
+        // source-example-heading: Overflow Button Accessible i18n
+        MenuBar menuBar = new MenuBar();
+        Stream.of("Home", "Dashboard", "Content", "Structure", "Appearance",
+                "Modules", "Users", "Configuration", "Reports", "Help")
+                .forEach(menuBar::addItem);
+        menuBar.setI18n(
+                new MenuBar.MenuBarI18n().setMoreOptions("Lisää vaihtoehtoja"));
+        // end-source-example
+
+        addCard("Overflow Button Accessible i18n", menuBar);
     }
 
     private void createDisabledItems() {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -103,9 +103,14 @@ public class MenuBarTestPage extends Div {
                 });
         toggleAttachedButton.setId("toggle-attached");
 
+        NativeButton setI18nButton = new NativeButton("set i18n",
+                e -> menuBar.setI18n(new MenuBar.MenuBarI18n()
+                        .setMoreOptions("more-options")));
+        setI18nButton.setId("set-i18n");
+
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableButton, visibleButton, checkedButton,
-                toggleAttachedButton);
+                toggleAttachedButton, setI18nButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -378,6 +378,26 @@ public class MenuBarPageIT extends AbstractComponentIT {
                 overflowButton.getAttribute("aria-label"));
     }
 
+    @Test
+    public void setI18n_detach_attach_i18nIsPersisted() {
+        click("set-width");
+        click("add-root-item");
+        click("set-i18n");
+        TestBenchElement overflowButton = menuBar.getOverflowButton();
+
+        Assert.assertEquals("more-options",
+                overflowButton.getAttribute("aria-label"));
+
+        click("toggle-attached");
+        click("toggle-attached");
+
+        menuBar = $(MenuBarElement.class).first();
+        overflowButton = menuBar.getOverflowButton();
+
+        Assert.assertEquals("more-options",
+                overflowButton.getAttribute("aria-label"));
+    }
+
     @After
     public void afterTest() {
         checkLogsForErrors();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -363,6 +363,21 @@ public class MenuBarPageIT extends AbstractComponentIT {
         assertButtonContents("item 1");
     }
 
+    @Test
+    public void setI18n_i18nIsUpdated() {
+        click("set-width");
+        click("add-root-item");
+        TestBenchElement overflowButton = menuBar.getOverflowButton();
+
+        Assert.assertEquals("More options",
+                overflowButton.getAttribute("aria-label"));
+
+        click("set-i18n");
+
+        Assert.assertEquals("more-options",
+                overflowButton.getAttribute("aria-label"));
+    }
+
     @After
     public void afterTest() {
         checkLogsForErrors();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.flow.component.menubar;
 
+import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,6 +37,10 @@ import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JsonSerializer;
+
+import elemental.json.JsonObject;
+import elemental.json.JsonType;
 
 /**
  * Server-side component for the <code>vaadin-menu-bar</code> element.
@@ -50,6 +56,8 @@ public class MenuBar extends Component
 
     private MenuManager<MenuBar, MenuItem, SubMenu> menuManager;
     private MenuItemsArrayGenerator<MenuItem> menuItemsArrayGenerator;
+
+    private MenuBarI18n i18n;
 
     private boolean updateScheduled = false;
 
@@ -254,6 +262,60 @@ public class MenuBar extends Component
                         .collect(Collectors.toList()));
     }
 
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * Note: updating the object content that is gotten from this method will
+     * not update the lang on the component if not set back using
+     * {@link MenuBar#setI18n(MenuBarI18n)}
+     *
+     * @return the i18n object. It will be <code>null</code>, If the i18n
+     *         properties weren't set.
+     */
+    public MenuBarI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization properties for this component.
+     *
+     * @param i18n
+     *            the internationalized properties, not <code>null</code>
+     */
+    public void setI18n(MenuBarI18n i18n) {
+        Objects.requireNonNull(i18n,
+                "The I18N properties object should not be null");
+        this.i18n = i18n;
+
+        runBeforeClientResponse(ui -> {
+            if (i18n == this.i18n) {
+                setI18nWithJS();
+            }
+        });
+    }
+
+    private void setI18nWithJS() {
+        JsonObject i18nJson = (JsonObject) JsonSerializer.toJson(this.i18n);
+
+        // Remove properties with null values to prevent errors in web
+        // component
+        removeNullValuesFromJsonObject(i18nJson);
+
+        // Assign new I18N object to WC, by merging the existing
+        // WC I18N, and the values from the new MenuBarI18n instance,
+        // into an empty object
+        getElement().executeJs("this.i18n = Object.assign({}, this.i18n, $0);",
+                i18nJson);
+    }
+
+    private void removeNullValuesFromJsonObject(JsonObject jsonObject) {
+        for (String key : jsonObject.keys()) {
+            if (jsonObject.get(key).getType() == JsonType.NULL) {
+                jsonObject.remove(key);
+            }
+        }
+    }
+
     void resetContent() {
         menuItemsArrayGenerator.generate();
         updateButtons();
@@ -278,5 +340,35 @@ public class MenuBar extends Component
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, context -> command.accept(ui)));
+    }
+
+    /**
+     * The internationalization properties for {@link MenuBar}
+     */
+    public static class MenuBarI18n implements Serializable {
+        private String moreOptions;
+
+        /**
+         * Gets the text that is used on the overflow button to make it
+         * accessible.
+         *
+         * @return the overflow button aria-label
+         */
+        public String getMoreOptions() {
+            return moreOptions;
+        }
+
+        /**
+         * Sets the text that is used on the overflow button to make it
+         * accessible.
+         *
+         * @param moreOptions
+         *            the overflow button aria-label
+         * @return this instance for method chaining
+         */
+        public MenuBarI18n setMoreOptions(String moreOptions) {
+            this.moreOptions = moreOptions;
+            return this;
+        }
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -306,6 +307,16 @@ public class MenuBar extends Component
         // into an empty object
         getElement().executeJs("this.i18n = Object.assign({}, this.i18n, $0);",
                 i18nJson);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+
+        // Element state is not persisted across attach/detach
+        if (this.i18n != null) {
+            setI18nWithJS();
+        }
     }
 
     private void removeNullValuesFromJsonObject(JsonObject jsonObject) {


### PR DESCRIPTION
I18n for the menu bar was recently introduced to the web component, in order to customize the accessible aria-label of the overflow button. This adds a Java API for the same.

Depends on https://github.com/vaadin/web-components/pull/2384

Fixes #2043

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
