### PR TITLE
feat: add API for showing/hiding toolbar of crud

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/MainView.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.crud.CrudI18nUpdatedEvent;
 import com.vaadin.flow.component.crud.CrudVariant;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -21,10 +22,12 @@ import static com.vaadin.flow.component.crud.examples.Helper.createYorubaI18n;
 public class MainView extends VerticalLayout {
 
     final VerticalLayout eventsPanel;
+    final HorizontalLayout buttons;
     boolean hasBorder = true;
 
     public MainView() {
         eventsPanel = new VerticalLayout();
+        buttons = new HorizontalLayout();
         eventsPanel.setId("events");
 
         final Crud<Person> crud = new Crud<>(Person.class,
@@ -34,18 +37,21 @@ public class MainView extends VerticalLayout {
                 CrudI18n.createDefault().getNewItem());
         newButton.setThemeName(ButtonVariant.LUMO_PRIMARY.getVariantName());
         newButton.getElement().setAttribute("new-button", "");
+        buttons.add(newButton);
 
         final Button serverSideNewButton = new Button(
                 CrudI18n.createDefault().getNewItem());
         serverSideNewButton.setId("newServerItem");
         serverSideNewButton.addClickListener(
                 e -> crud.edit(new Person(), Crud.EditMode.NEW_ITEM));
+        buttons.add(serverSideNewButton);
 
         final Button serverSideEditButton = new Button(
                 CrudI18n.createDefault().getEditItem());
         serverSideEditButton.setId("editServerItem");
         serverSideEditButton.addClickListener(e -> crud.edit(
                 new Person(1, "Sayo", "Oladeji"), Crud.EditMode.EXISTING_ITEM));
+        buttons.add(serverSideEditButton);
 
         final Span footer = new Span();
         crud.setToolbar(footer, newButton);
@@ -66,6 +72,7 @@ public class MainView extends VerticalLayout {
 
             addEvent(filterString);
         });
+        buttons.add(showFiltersButton);
 
         final Button updateI18nButton = new Button("Switch to Yoruba",
                 event -> {
@@ -74,6 +81,8 @@ public class MainView extends VerticalLayout {
                     newButton.setText(yorubaI18n.getNewItem());
                 });
         updateI18nButton.setId("updateI18n");
+        buttons.add(updateI18nButton);
+
         ComponentUtil.addListener(crud.getGrid(), CrudI18nUpdatedEvent.class,
                 e -> addEvent("I18n updated"));
 
@@ -88,6 +97,7 @@ public class MainView extends VerticalLayout {
                     hasBorder = !hasBorder;
                 });
         toggleBordersButton.setId("toggleBorders");
+        buttons.add(toggleBordersButton);
 
         final Button addGridButton = new Button("Add grid", event -> {
             Grid<Person> grid = new Grid<>(Person.class);
@@ -97,6 +107,19 @@ public class MainView extends VerticalLayout {
             crud.setGrid(grid);
         });
         addGridButton.setId("addGrid");
+        buttons.add(addGridButton);
+
+        final Button showToolbarButton = new Button("Show toolbar", event -> {
+            crud.setToolbarVisible(true);
+        });
+        showToolbarButton.setId("showToolbarButton");
+        buttons.add(showToolbarButton);
+
+        final Button hideToolbarButton = new Button("Hide toolbar", event -> {
+            crud.setToolbarVisible(false);
+        });
+        hideToolbarButton.setId("hideToolbarButton");
+        buttons.add(hideToolbarButton);
 
         crud.addNewListener(e -> addEvent("New: " + e.getItem()));
         crud.addEditListener(e -> addEvent("Edit: " + e.getItem()));
@@ -109,9 +132,7 @@ public class MainView extends VerticalLayout {
         crud.addSaveListener(e -> dataProvider.persist(e.getItem()));
 
         setHeight("100%");
-        add(crud, serverSideNewButton, serverSideEditButton, showFiltersButton,
-                updateI18nButton, toggleBordersButton, addGridButton,
-                eventsPanel);
+        add(crud, buttons, eventsPanel);
     }
 
     private void addEvent(String event) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -139,7 +139,6 @@ public class BasicUseIT extends AbstractParallelTest {
 
     @Test
     public void hideToolbar() {
-
         CrudElement crud = $(CrudElement.class).waitForFirst();
 
         ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -134,7 +134,7 @@ public class BasicUseIT extends AbstractParallelTest {
     @Test
     public void toolbarVisibleByDefault() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
-        Assert.assertNull(crud.getAttribute("hide-toolbar"));
+        Assert.assertNull(crud.getAttribute("no-toolbar"));
     }
 
     @Test
@@ -145,7 +145,7 @@ public class BasicUseIT extends AbstractParallelTest {
         ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");
         hideToolbarButton.click();
 
-        Assert.assertNotNull(crud.getAttribute("hide-toolbar"));
+        Assert.assertNotNull(crud.getAttribute("no-toolbar"));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class BasicUseIT extends AbstractParallelTest {
 
         hideToolbarButton.click();
         showToolbarButton.click();
-        Assert.assertNull(crud.getAttribute("hide-toolbar"));
+        Assert.assertNull(crud.getAttribute("no-toolbar"));
     }
 
     private ButtonElement getTestButton(String id) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -139,7 +139,6 @@ public class BasicUseIT extends AbstractParallelTest {
         ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");
         hideToolbarButton.click();
 
-
         Assert.assertNotNull(crud.getAttribute("hide-toolbar"));
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -145,7 +145,7 @@ public class BasicUseIT extends AbstractParallelTest {
         ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");
         hideToolbarButton.click();
 
-        TestBenchElement toolbar =  crud.$(TestBenchElement.class).id("toolbar");
+        TestBenchElement toolbar = crud.$(TestBenchElement.class).id("toolbar");
 
         Assert.assertEquals("none", toolbar.getCssValue("display"));
     }
@@ -160,7 +160,7 @@ public class BasicUseIT extends AbstractParallelTest {
         hideToolbarButton.click();
         showToolbarButton.click();
 
-        TestBenchElement toolbar =  crud.$(TestBenchElement.class).id("toolbar");
+        TestBenchElement toolbar = crud.$(TestBenchElement.class).id("toolbar");
         Assert.assertEquals("flex", toolbar.getCssValue("display"));
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -132,6 +132,12 @@ public class BasicUseIT extends AbstractParallelTest {
     }
 
     @Test
+    public void toolbarVisibleByDefault() {
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+        Assert.assertNull(crud.getAttribute("hide-toolbar"));
+    }
+
+    @Test
     public void hideToolbar() {
 
         CrudElement crud = $(CrudElement.class).waitForFirst();

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -145,7 +145,9 @@ public class BasicUseIT extends AbstractParallelTest {
         ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");
         hideToolbarButton.click();
 
-        Assert.assertNotNull(crud.getAttribute("no-toolbar"));
+        TestBenchElement toolbar =  crud.$(TestBenchElement.class).id("toolbar");
+
+        Assert.assertEquals("none", toolbar.getCssValue("display"));
     }
 
     @Test
@@ -157,7 +159,9 @@ public class BasicUseIT extends AbstractParallelTest {
 
         hideToolbarButton.click();
         showToolbarButton.click();
-        Assert.assertNull(crud.getAttribute("no-toolbar"));
+
+        TestBenchElement toolbar =  crud.$(TestBenchElement.class).id("toolbar");
+        Assert.assertEquals("flex", toolbar.getCssValue("display"));
     }
 
     private ButtonElement getTestButton(String id) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/BasicUseIT.java
@@ -131,6 +131,30 @@ public class BasicUseIT extends AbstractParallelTest {
         Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
     }
 
+    @Test
+    public void hideToolbar() {
+
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+
+        ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");
+        hideToolbarButton.click();
+
+
+        Assert.assertNotNull(crud.getAttribute("hide-toolbar"));
+    }
+
+    @Test
+    public void showToolbar() {
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+
+        ButtonElement hideToolbarButton = getTestButton("hideToolbarButton");
+        ButtonElement showToolbarButton = getTestButton("showToolbarButton");
+
+        hideToolbarButton.click();
+        showToolbarButton.click();
+        Assert.assertNull(crud.getAttribute("hide-toolbar"));
+    }
+
     private ButtonElement getTestButton(String id) {
         return $(ButtonElement.class).onPage().id(id);
     }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -533,7 +533,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     }
 
     /**
-     * Hides toolbar property of crud instance.
+     * Controls visiblity of toolbar
      * 
      * @param value
      */
@@ -547,7 +547,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     }
 
     /**
-     * Gets value of hide-toolbar attribute or return null if not present.
+     * Gets visiblity state of toolbar
      * 
      * @param
      * @return true if toolbar is visible false otherwise

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -540,9 +540,9 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     public void setToolbarVisible(boolean value) {
         toolbarVisible = value;
         if (value) {
-            getElement().setProperty("hideToolbar", false);
+            getElement().setProperty("noToolbar", false);
         } else {
-            getElement().setProperty("hideToolbar", true);
+            getElement().setProperty("noToolbar", true);
         }
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -88,6 +88,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     private Grid<E> grid;
     private CrudEditor<E> editor;
     private E gridActiveItem;
+    private boolean toolbarVisible = true;
 
     /**
      * Instantiates a new Crud using a custom grid.
@@ -529,6 +530,30 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
             ComponentUtil.fireEvent(this.grid,
                     new CrudI18nUpdatedEvent(this, false, i18n));
         }
+    }
+
+    /**
+     * Hides toolbar property of crud instance.
+     * 
+     * @param value
+     */
+    public void setToolbarVisible(boolean value) {
+        toolbarVisible = value;
+        if (value) {
+            getElement().setProperty("hideToolbar", false);
+        } else {
+            getElement().setProperty("hideToolbar", true);
+        }
+    }
+
+    /**
+     * Gets value of hide-toolbar attribute or return null if not present.
+     * 
+     * @param
+     * @return true if toolbar is visible false otherwise
+     */
+    public boolean getToolbarVisible() {
+        return toolbarVisible;
     }
 
     /**

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -57,6 +57,17 @@ public class CrudTest {
                 systemUnderTest.getEditorPosition());
     }
 
+    @Test
+    public void getCrudToolbarAttribute() {
+        Assert.assertTrue(systemUnderTest.getToolbarVisible());
+    }
+
+    @Test
+    public void hideToolbarAttributePresent() {
+        systemUnderTest.setToolbarVisible(false);
+        Assert.assertEquals(false, systemUnderTest.getToolbarVisible());
+    }
+
     private Grid<Thing> createFakeGrid() {
         Grid<Thing> grid = Mockito.spy(new Grid<>());
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -58,14 +58,15 @@ public class CrudTest {
     }
 
     @Test
-    public void getCrudToolbarAttribute() {
+    public void getToolbarVisible_defaultTrue() {
         Assert.assertTrue(systemUnderTest.getToolbarVisible());
     }
 
     @Test
-    public void hideToolbarAttributePresent() {
+    public void getToolbarVisible_setVisibleToFalse_returnsFalse() {
         systemUnderTest.setToolbarVisible(false);
         Assert.assertEquals(false, systemUnderTest.getToolbarVisible());
+        Assert.assertEquals("", );
     }
 
     private Grid<Thing> createFakeGrid() {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -66,7 +66,6 @@ public class CrudTest {
     public void getToolbarVisible_setVisibleToFalse_returnsFalse() {
         systemUnderTest.setToolbarVisible(false);
         Assert.assertEquals(false, systemUnderTest.getToolbarVisible());
-        Assert.assertEquals("", );
     }
 
     private Grid<Thing> createFakeGrid() {


### PR DESCRIPTION
## Description

This PR adds Java API for letting developers to hide/show toolbar of crud component. it is done by setting an attribute on crud component and the toolbar is hide/shown by changing css display property.

Fixes vaadin/flow-components#1592

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
