### PR TITLE
chore: use fixed webdrivermanager versions (#2073) (CP:14.6)

### DIFF
--- a/scripts/templates/pom-bower-mode.xml
+++ b/scripts/templates/pom-bower-mode.xml
@@ -22,7 +22,7 @@
       <dependency>
           <groupId>io.github.bonigarcia</groupId>
           <artifactId>webdrivermanager</artifactId>
-          <version>LATEST</version>
+          <version>4.4.3</version>
           <scope>test</scope>
           <exclusions>
               <exclusion>

--- a/scripts/templates/pom-integration-tests.xml
+++ b/scripts/templates/pom-integration-tests.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
-      <version>LATEST</version>
+      <version>4.4.3</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-flow-components-shared/pom.xml
+++ b/vaadin-flow-components-shared/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
-      <version>LATEST</version>
+      <version>4.4.3</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllIT.java
@@ -66,7 +66,9 @@ public class TreeGridExpandAllIT extends AbstractTreeGridIT {
         grid.collapseWithClick(1);
         waitUntil(e -> {
             int widthAfterCollapse = grid.getCell(1, 0).getSize().getWidth();
-            return widthBeforeExpend == widthAfterCollapse;
+            // accept a delta of 2 pixels to avoid failing when running
+            // in bower mode in the CI
+            return Math.abs(widthBeforeExpend - widthAfterCollapse) <= 2;
         }, 200);
     }
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom-bower-mode.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
* chore: use fixed webdrivermanager versions

* chore: use fixed web-driver-manager version
