### PR TITLE
Override __isSaveBtnDisabled to preserve server side enabled state

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/DetachAttachView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/examples/DetachAttachView.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.crud.examples;
+
+import com.vaadin.flow.component.crud.Crud;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+import static com.vaadin.flow.component.crud.examples.Helper.createPersonEditor;
+
+@Route("vaadin-crud/detach-attach")
+public class DetachAttachView extends Div {
+
+    public DetachAttachView() {
+        final Crud<Person> crud = new Crud<>(Person.class,
+                createPersonEditor());
+
+        final PersonCrudDataProvider dataProvider = new PersonCrudDataProvider();
+        crud.setDataProvider(dataProvider);
+
+        NativeButton detach = new NativeButton("detach", e -> remove(crud));
+        detach.setId("detach");
+        NativeButton attach = new NativeButton("attach", e -> add(crud));
+        attach.setId("attach");
+
+        NativeButton disableSaveBtn = new NativeButton("disable save button",
+                e -> crud.getSaveButton().setEnabled(false));
+        disableSaveBtn.setId("disable-save-button");
+
+        add(crud, detach, attach, disableSaveBtn);
+    }
+
+}

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/DetachAttachIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/DetachAttachIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.crud.test;
+
+import com.vaadin.flow.component.crud.testbench.CrudElement;
+import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-crud/detach-attach")
+public class DetachAttachIT extends AbstractComponentIT {
+
+    CrudElement crud;
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void disableSaveBtn_detach_reattach_btnDisabled() {
+        editItemAndChangeField();
+        Assert.assertTrue(crud.getEditorSaveButton().isEnabled());
+
+        findElement(By.id("disable-save-button")).click();
+
+        Assert.assertFalse(crud.getEditorSaveButton().isEnabled());
+
+        findElement(By.id("detach")).click();
+        findElement(By.id("attach")).click();
+
+        editItemAndChangeField();
+        Assert.assertFalse(crud.getEditorSaveButton().isEnabled());
+    }
+
+    private void editItemAndChangeField() {
+        crud = $(CrudElement.class).waitForFirst();
+        crud.openRowForEditing(0);
+        TextFieldElement lastNameField = crud.getEditor()
+                .$(TextFieldElement.class).attribute("editor-role", "last-name")
+                .first();
+        lastNameField.setValue("Otto");
+    }
+}

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EditorButtonsIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/test/EditorButtonsIT.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -21,6 +22,27 @@ public class EditorButtonsIT extends AbstractParallelTest {
         String url = getBaseURL().replace(super.getBaseURL(),
                 super.getBaseURL() + "/vaadin-crud") + "/editorbuttons";
         getDriver().get(url);
+    }
+
+    @Test
+    public void saveBtnIsAlwaysEnabled() {
+        getTestButton("enable-save-button").click();
+        CrudElement crud = getCrud();
+        crud.openRowForEditing(0);
+        Assert.assertTrue(crud.getEditorSaveButton().isEnabled());
+    }
+
+    @Test
+    public void saveBtnIsAlwaysDisabled() {
+        getTestButton("disable-save-button").click();
+        CrudElement crud = getCrud();
+        crud.openRowForEditing(0);
+        TextFieldElement lastNameField = crud.getEditor()
+                .$(TextFieldElement.class).attribute("editor-role", "last-name")
+                .first();
+        lastNameField.setValue("Otto");
+
+        Assert.assertFalse(crud.getEditorSaveButton().isEnabled());
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -89,6 +89,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     private Grid<E> grid;
     private CrudEditor<E> editor;
     private E gridActiveItem;
+    private boolean toolbarVisible = true;
     private boolean saveBtnDisabledOverridden;
 
     final private Button saveButton;
@@ -583,7 +584,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
     /**
      * Controls visiblity of toolbar
-     * 
+     *
      * @param value
      */
     public void setToolbarVisible(boolean value) {
@@ -597,7 +598,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
     /**
      * Gets visiblity state of toolbar
-     * 
+     *
      * @param
      * @return true if toolbar is visible false otherwise
      */
@@ -1001,7 +1002,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
         /**
          * Gets new item being created
-         * 
+         *
          * @return a new instance of bean type
          */
         @Override

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -16,6 +16,7 @@ package com.vaadin.flow.component.crud;
  * #L%
  */
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -25,10 +26,10 @@ import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.dom.Element;
@@ -61,10 +62,9 @@ import java.util.stream.Collectors;
  * }
  * </pre>
  *
- * @author Vaadin Ltd
- *
  * @param <E>
  *            the bean type
+ * @author Vaadin Ltd
  */
 @Tag("vaadin-crud")
 @NpmPackage(value = "@vaadin/vaadin-crud", version = "22.0.0-alpha6")
@@ -89,7 +89,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     private Grid<E> grid;
     private CrudEditor<E> editor;
     private E gridActiveItem;
-    private boolean toolbarVisible = true;
+    private boolean saveBtnDisabledOverridden;
 
     final private Button saveButton;
 
@@ -197,12 +197,23 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
         @Override
         public void onEnabledStateChanged(boolean enabled) {
             super.onEnabledStateChanged(enabled);
+            saveBtnDisabledOverridden = true;
             overrideSaveDisabled(enabled);
         }
     }
 
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        if (saveBtnDisabledOverridden) {
+            overrideSaveDisabled(getSaveButton().isEnabled());
+        }
+        getElement().executeJs("this.__validate = function () {return true;}");
+    }
+
     private void overrideSaveDisabled(boolean enabled) {
-        getElement().executeJs("this.__isSaveBtnDisabled = () => {return $0;}", !enabled);
+        getElement().executeJs("this.__isSaveBtnDisabled = () => {return $0;}",
+                !enabled);
     }
 
     private void registerHandlers() {
@@ -324,15 +335,15 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
     /**
      * Set the dirty state of the Crud.
-     *
+     * <p>
      * A dirty Crud has its editor Save button enabled. Ideally a Crud
      * automatically detects if it is dirty based on interactions with the form
      * fields within it but in some special cases (e.g with composites) this
      * might not be automatically detected. For such cases this method could be
      * used to explicitly set the dirty state of the Crud editor.
      * <p>
-     * NOTE: editor Save button will not be automatically enabled
-     * in case its enabled state was changed with {@link Crud#getSaveButton()}
+     * NOTE: editor Save button will not be automatically enabled in case its
+     * enabled state was changed with {@link Crud#getSaveButton()}
      *
      * @param dirty
      *            true if dirty and false if otherwise.
@@ -596,7 +607,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
     /**
      * Gets the Crud editor delete button
-     * 
+     *
      * @return the delete button
      */
     public Button getDeleteButton() {
@@ -606,8 +617,9 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
     /**
      * Gets the Crud save button
      * <p>
-     * NOTE: State of the button set with {@link com.vaadin.flow.component.HasEnabled#setEnabled(boolean)}
-     * will remain even if dirty state of the crud changes
+     * NOTE: State of the button set with
+     * {@link com.vaadin.flow.component.HasEnabled#setEnabled(boolean)} will
+     * remain even if dirty state of the crud changes
      *
      * @return the save button
      * @see Crud#setDirty(boolean)
@@ -618,7 +630,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
     /**
      * Gets the Crud cancel button
-     * 
+     *
      * @return the cancel button
      */
     public Button getCancelButton() {


### PR DESCRIPTION
Doesn't allow client to override save button disabled state when form is dirty