### PR TITLE
fix: duplicate value changed event

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangePage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangePage.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+@Route("vaadin-date-time-picker/date-time-picker-value-change")
+public class DateTimePickerValueChangePage extends Div {
+
+    Div changeLog;
+
+    public DateTimePickerValueChangePage() {
+        createDatePicker();
+        createChangeLog();
+    }
+
+    private void createDatePicker() {
+        DateTimePicker dateTimePicker = new DateTimePicker();
+        dateTimePicker.setId("date-time-picker");
+        dateTimePicker.setLabel("Date time picker");
+        dateTimePicker.addValueChangeListener(this::logValueChangedEvent);
+
+        NativeButton setCurrentTimeButton = new NativeButton("Set current date and time", event -> {
+            dateTimePicker.setValue(LocalDateTime.now());
+        });
+        setCurrentTimeButton.setId("set-current-date-time");
+
+        NativeButton setSecondsPrecisionButton = new NativeButton("Set seconds precision", event -> {
+            dateTimePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
+        });
+        setSecondsPrecisionButton.setId("set-seconds-precision");
+
+        NativeButton setMillisPrecisionButton = new NativeButton("Set millisecond precision", event -> {
+            dateTimePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
+        });
+        setMillisPrecisionButton.setId("set-millis-precision");
+
+        add(dateTimePicker);
+        add(new Div(setCurrentTimeButton, setSecondsPrecisionButton, setMillisPrecisionButton));
+    }
+
+    private void createChangeLog() {
+        changeLog = new Div();
+        changeLog.setId("change-log");
+        changeLog.getStyle().set("whiteSpace", "pre");
+        add(changeLog);
+    }
+
+    private void logValueChangedEvent(AbstractField.ComponentValueChangeEvent<DateTimePicker, LocalDateTime> event) {
+        String source = event.isFromClient() ? "client" : "server";
+        String value = event.getValue().format(DateTimeFormatter.ISO_DATE_TIME);
+
+        String logEntry = String.format("source: %s; value: %s%n", source, value);
+
+        changeLog.setText(changeLog.getText() + logEntry);
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangePage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangePage.java
@@ -41,23 +41,27 @@ public class DateTimePickerValueChangePage extends Div {
         dateTimePicker.setLabel("Date time picker");
         dateTimePicker.addValueChangeListener(this::logValueChangedEvent);
 
-        NativeButton setCurrentTimeButton = new NativeButton("Set current date and time", event -> {
-            dateTimePicker.setValue(LocalDateTime.now());
-        });
+        NativeButton setCurrentTimeButton = new NativeButton(
+                "Set current date and time", event -> {
+                    dateTimePicker.setValue(LocalDateTime.now());
+                });
         setCurrentTimeButton.setId("set-current-date-time");
 
-        NativeButton setSecondsPrecisionButton = new NativeButton("Set seconds precision", event -> {
-            dateTimePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
-        });
+        NativeButton setSecondsPrecisionButton = new NativeButton(
+                "Set seconds precision", event -> {
+                    dateTimePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
+                });
         setSecondsPrecisionButton.setId("set-seconds-precision");
 
-        NativeButton setMillisPrecisionButton = new NativeButton("Set millisecond precision", event -> {
-            dateTimePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
-        });
+        NativeButton setMillisPrecisionButton = new NativeButton(
+                "Set millisecond precision", event -> {
+                    dateTimePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
+                });
         setMillisPrecisionButton.setId("set-millis-precision");
 
         add(dateTimePicker);
-        add(new Div(setCurrentTimeButton, setSecondsPrecisionButton, setMillisPrecisionButton));
+        add(new Div(setCurrentTimeButton, setSecondsPrecisionButton,
+                setMillisPrecisionButton));
     }
 
     private void createChangeLog() {
@@ -67,11 +71,13 @@ public class DateTimePickerValueChangePage extends Div {
         add(changeLog);
     }
 
-    private void logValueChangedEvent(AbstractField.ComponentValueChangeEvent<DateTimePicker, LocalDateTime> event) {
+    private void logValueChangedEvent(
+            AbstractField.ComponentValueChangeEvent<DateTimePicker, LocalDateTime> event) {
         String source = event.isFromClient() ? "client" : "server";
         String value = event.getValue().format(DateTimeFormatter.ISO_DATE_TIME);
 
-        String logEntry = String.format("source: %s; value: %s%n", source, value);
+        String logEntry = String.format("source: %s; value: %s%n", source,
+                value);
 
         changeLog.setText(changeLog.getText() + logEntry);
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangeIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangeIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.datetimepicker.testbench.DateTimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.commands.TestBenchCommandExecutor;
+import com.vaadin.tests.AbstractComponentIT;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@TestPath("vaadin-date-time-picker/date-time-picker-value-change")
+public class DateTimePickerValueChangeIT extends AbstractComponentIT {
+
+    DateTimePickerElement picker;
+    TestBenchElement eventLog;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.tagName("vaadin-date-time-picker"));
+        eventLog = $("div").id("change-log");
+        picker = $(DateTimePickerElement.class).first();
+    }
+
+    @Test
+    public void setServerSideValueShouldTriggerSingleServerSideChangeEvent() {
+        TestBenchElement setCurrentDateTimeButton = $("button").id("set-current-date-time");
+
+        setCurrentDateTimeButton.click();
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+    }
+
+    @Test
+    public void setServerSideValueWithSecondsPrecisionShouldTriggerSingleServerSideChangeEvent() {
+        TestBenchElement setSecondsPrecisionButton = $("button").id("set-seconds-precision");
+        TestBenchElement setCurrentDateTimeButton = $("button").id("set-current-date-time");
+
+        setSecondsPrecisionButton.click();
+        setCurrentDateTimeButton.click();
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+    }
+
+    @Test
+    public void setServerSideValueWithMillisPrecisionShouldTriggerSingleServerSideChangeEvent() {
+        TestBenchElement setMillisPrecisionButton = $("button").id("set-millis-precision");
+        TestBenchElement setCurrentDateTimeButton = $("button").id("set-current-date-time");
+
+        setMillisPrecisionButton.click();
+        setCurrentDateTimeButton.click();
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+    }
+
+    @Test
+    public void setClientSideValueShouldTriggerSingleClientSideChangeEvent() {
+        picker.setDate(LocalDate.now());
+        picker.setTime(LocalTime.now());
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from client-side", entries[0].startsWith("source: client"));
+    }
+
+    private String[] getChangeLogEntries() {
+        return eventLog.getText().split("\n");
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangeIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerValueChangeIT.java
@@ -47,39 +47,47 @@ public class DateTimePickerValueChangeIT extends AbstractComponentIT {
 
     @Test
     public void setServerSideValueShouldTriggerSingleServerSideChangeEvent() {
-        TestBenchElement setCurrentDateTimeButton = $("button").id("set-current-date-time");
+        TestBenchElement setCurrentDateTimeButton = $("button")
+                .id("set-current-date-time");
 
         setCurrentDateTimeButton.click();
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+        Assert.assertTrue("Event should originate from server-side",
+                entries[0].startsWith("source: server"));
     }
 
     @Test
     public void setServerSideValueWithSecondsPrecisionShouldTriggerSingleServerSideChangeEvent() {
-        TestBenchElement setSecondsPrecisionButton = $("button").id("set-seconds-precision");
-        TestBenchElement setCurrentDateTimeButton = $("button").id("set-current-date-time");
+        TestBenchElement setSecondsPrecisionButton = $("button")
+                .id("set-seconds-precision");
+        TestBenchElement setCurrentDateTimeButton = $("button")
+                .id("set-current-date-time");
 
         setSecondsPrecisionButton.click();
         setCurrentDateTimeButton.click();
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+        Assert.assertTrue("Event should originate from server-side",
+                entries[0].startsWith("source: server"));
     }
 
     @Test
     public void setServerSideValueWithMillisPrecisionShouldTriggerSingleServerSideChangeEvent() {
-        TestBenchElement setMillisPrecisionButton = $("button").id("set-millis-precision");
-        TestBenchElement setCurrentDateTimeButton = $("button").id("set-current-date-time");
+        TestBenchElement setMillisPrecisionButton = $("button")
+                .id("set-millis-precision");
+        TestBenchElement setCurrentDateTimeButton = $("button")
+                .id("set-current-date-time");
 
         setMillisPrecisionButton.click();
         setCurrentDateTimeButton.click();
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+        Assert.assertTrue("Event should originate from server-side",
+                entries[0].startsWith("source: server"));
     }
 
     @Test
@@ -89,7 +97,8 @@ public class DateTimePickerValueChangeIT extends AbstractComponentIT {
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from client-side", entries[0].startsWith("source: client"));
+        Assert.assertTrue("Event should originate from client-side",
+                entries[0].startsWith("source: client"));
     }
 
     private String[] getChangeLogEntries() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -238,15 +238,6 @@ public class DateTimePicker extends AbstractField<DateTimePicker, LocalDateTime>
     @Override
     public void setValue(LocalDateTime value) {
         super.setValue(value);
-        // Get the value from client after possible adjustment.
-        // This is a workaround for infinite value change loop which can be
-        // triggered when the field is set as read-only.
-        // fixme(haprog) This workaround should probably be removed after this
-        // is fixed: https://github.com/vaadin/vaadin-time-picker-flow/issues/77
-        getElement().executeJs("return this.value;")
-                .then(jsonValue -> super.setValue(
-                        jsonValue.asString().isEmpty() ? null
-                                : LocalDateTime.parse(jsonValue.asString())));
     }
 
     @Override

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -69,6 +69,16 @@ public class DateTimePickerTest {
     }
 
     @Test
+    public void setValue_doesNotTruncateValue() {
+        // Value includes nanoseconds
+        LocalDateTime value = LocalDateTime.of(2018, 4, 25, 13, 45, 10, 123);
+        DateTimePicker picker = new DateTimePicker();
+        picker.setValue(value);
+
+        assertEquals(value, picker.getValue());
+    }
+
+    @Test
     public void setMinGetMin() {
         DateTimePicker picker = new DateTimePicker();
         picker.setMin(LocalDateTime.of(2018, 4, 25, 13, 45, 10));

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-demo/src/main/java/com/vaadin/flow/component/timepicker/demo/TimePickerView.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-demo/src/main/java/com/vaadin/flow/component/timepicker/demo/TimePickerView.java
@@ -291,6 +291,7 @@ public class TimePickerView extends DemoView {
 
         public void setStep(Duration step) {
             this.step = step;
+            updateValue();
         }
 
         private void updateValue() {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangePage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangePage.java
@@ -42,23 +42,27 @@ public class TimePickerValueChangePage extends Div {
         timePicker.setLabel("TimePicker");
         timePicker.addValueChangeListener(this::logValueChangedEvent);
 
-        NativeButton setCurrentTimeButton = new NativeButton("Set current time", event -> {
-           timePicker.setValue(LocalTime.now());
-        });
+        NativeButton setCurrentTimeButton = new NativeButton("Set current time",
+                event -> {
+                    timePicker.setValue(LocalTime.now());
+                });
         setCurrentTimeButton.setId("set-current-time");
 
-        NativeButton setSecondsPrecisionButton = new NativeButton("Set seconds precision", event -> {
-           timePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
-        });
+        NativeButton setSecondsPrecisionButton = new NativeButton(
+                "Set seconds precision", event -> {
+                    timePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
+                });
         setSecondsPrecisionButton.setId("set-seconds-precision");
 
-        NativeButton setMillisPrecisionButton = new NativeButton("Set millisecond precision", event -> {
-           timePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
-        });
+        NativeButton setMillisPrecisionButton = new NativeButton(
+                "Set millisecond precision", event -> {
+                    timePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
+                });
         setMillisPrecisionButton.setId("set-millis-precision");
 
         add(timePicker);
-        add(new Div(setCurrentTimeButton, setSecondsPrecisionButton, setMillisPrecisionButton));
+        add(new Div(setCurrentTimeButton, setSecondsPrecisionButton,
+                setMillisPrecisionButton));
     }
 
     private void createChangeLog() {
@@ -68,11 +72,13 @@ public class TimePickerValueChangePage extends Div {
         add(changeLog);
     }
 
-    private void logValueChangedEvent(AbstractField.ComponentValueChangeEvent<TimePicker, LocalTime> event) {
+    private void logValueChangedEvent(
+            AbstractField.ComponentValueChangeEvent<TimePicker, LocalTime> event) {
         String source = event.isFromClient() ? "client" : "server";
         String value = event.getValue().format(DateTimeFormatter.ISO_TIME);
 
-        String logEntry = String.format("source: %s; value: %s%n", source, value);
+        String logEntry = String.format("source: %s; value: %s%n", source,
+                value);
 
         changeLog.setText(changeLog.getText() + logEntry);
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangePage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangePage.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.router.Route;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+@Route("vaadin-time-picker/time-picker-value-change")
+public class TimePickerValueChangePage extends Div {
+
+    Div changeLog;
+
+    public TimePickerValueChangePage() {
+        createTimePicker();
+        createChangeLog();
+    }
+
+    private void createTimePicker() {
+        TimePicker timePicker = new TimePicker();
+        timePicker.setId("time-picker");
+        timePicker.setLabel("TimePicker");
+        timePicker.addValueChangeListener(this::logValueChangedEvent);
+
+        NativeButton setCurrentTimeButton = new NativeButton("Set current time", event -> {
+           timePicker.setValue(LocalTime.now());
+        });
+        setCurrentTimeButton.setId("set-current-time");
+
+        NativeButton setSecondsPrecisionButton = new NativeButton("Set seconds precision", event -> {
+           timePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
+        });
+        setSecondsPrecisionButton.setId("set-seconds-precision");
+
+        NativeButton setMillisPrecisionButton = new NativeButton("Set millisecond precision", event -> {
+           timePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
+        });
+        setMillisPrecisionButton.setId("set-millis-precision");
+
+        add(timePicker);
+        add(new Div(setCurrentTimeButton, setSecondsPrecisionButton, setMillisPrecisionButton));
+    }
+
+    private void createChangeLog() {
+        changeLog = new Div();
+        changeLog.setId("change-log");
+        changeLog.getStyle().set("whiteSpace", "pre");
+        add(changeLog);
+    }
+
+    private void logValueChangedEvent(AbstractField.ComponentValueChangeEvent<TimePicker, LocalTime> event) {
+        String source = event.isFromClient() ? "client" : "server";
+        String value = event.getValue().format(DateTimeFormatter.ISO_TIME);
+
+        String logEntry = String.format("source: %s; value: %s%n", source, value);
+
+        changeLog.setText(changeLog.getText() + logEntry);
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -156,13 +156,13 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
 
         errors.add(verifyFormat());
         errors.add(verifyValueProperty("17:22:33"));
-        errors.add(verifyServerValue("17:22:33.0"));
+        errors.add(verifyServerValue("17:22:33.123"));
 
         selectStep("1m");
 
         errors.add(verifyFormat());
         errors.add(verifyValueProperty("17:22"));
-        errors.add(verifyServerValue("17:22:0.0"));
+        errors.add(verifyServerValue("17:22:33.123"));
 
         selectStep("1h");
 
@@ -170,7 +170,7 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
         // when changing granularity from 1min -> 60min
         errors.add(verifyFormat());
         errors.add(verifyValueProperty("17:22"));
-        errors.add(verifyServerValue("17:22:0.0"));
+        errors.add(verifyServerValue("17:22:33.123"));
 
         errors.removeIf(item -> item == null);
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangeIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangeIT.java
@@ -39,39 +39,47 @@ public class TimePickerValueChangeIT extends AbstractComponentIT {
 
     @Test
     public void setServerSideValueShouldTriggerSingleServerSideChangeEvent() {
-        TestBenchElement setCurrentTimeButton = $("button").id("set-current-time");
+        TestBenchElement setCurrentTimeButton = $("button")
+                .id("set-current-time");
 
         setCurrentTimeButton.click();
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+        Assert.assertTrue("Event should originate from server-side",
+                entries[0].startsWith("source: server"));
     }
 
     @Test
     public void setServerSideValueWithSecondsPrecisionShouldTriggerSingleServerSideChangeEvent() {
-        TestBenchElement setSecondsPrecisionButton = $("button").id("set-seconds-precision");
-        TestBenchElement setCurrentTimeButton = $("button").id("set-current-time");
+        TestBenchElement setSecondsPrecisionButton = $("button")
+                .id("set-seconds-precision");
+        TestBenchElement setCurrentTimeButton = $("button")
+                .id("set-current-time");
 
         setSecondsPrecisionButton.click();
         setCurrentTimeButton.click();
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+        Assert.assertTrue("Event should originate from server-side",
+                entries[0].startsWith("source: server"));
     }
 
     @Test
     public void setServerSideValueWithMillisPrecisionShouldTriggerSingleServerSideChangeEvent() {
-        TestBenchElement setMillisPrecisionButton = $("button").id("set-millis-precision");
-        TestBenchElement setCurrentTimeButton = $("button").id("set-current-time");
+        TestBenchElement setMillisPrecisionButton = $("button")
+                .id("set-millis-precision");
+        TestBenchElement setCurrentTimeButton = $("button")
+                .id("set-current-time");
 
         setMillisPrecisionButton.click();
         setCurrentTimeButton.click();
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+        Assert.assertTrue("Event should originate from server-side",
+                entries[0].startsWith("source: server"));
     }
 
     @Test
@@ -80,7 +88,8 @@ public class TimePickerValueChangeIT extends AbstractComponentIT {
 
         String[] entries = getChangeLogEntries();
         Assert.assertEquals(1, entries.length);
-        Assert.assertTrue("Event should originate from client-side", entries[0].startsWith("source: client"));
+        Assert.assertTrue("Event should originate from client-side",
+                entries[0].startsWith("source: client"));
     }
 
     private String[] getChangeLogEntries() {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangeIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerValueChangeIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-time-picker/time-picker-value-change")
+public class TimePickerValueChangeIT extends AbstractComponentIT {
+
+    TimePickerElement picker;
+    TestBenchElement eventLog;
+
+    @Before
+    public void init() {
+        open();
+        $(TimePickerElement.class).waitForFirst();
+        eventLog = $("div").id("change-log");
+        picker = $(TimePickerElement.class).id("time-picker");
+    }
+
+    @Test
+    public void setServerSideValueShouldTriggerSingleServerSideChangeEvent() {
+        TestBenchElement setCurrentTimeButton = $("button").id("set-current-time");
+
+        setCurrentTimeButton.click();
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+    }
+
+    @Test
+    public void setServerSideValueWithSecondsPrecisionShouldTriggerSingleServerSideChangeEvent() {
+        TestBenchElement setSecondsPrecisionButton = $("button").id("set-seconds-precision");
+        TestBenchElement setCurrentTimeButton = $("button").id("set-current-time");
+
+        setSecondsPrecisionButton.click();
+        setCurrentTimeButton.click();
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+    }
+
+    @Test
+    public void setServerSideValueWithMillisPrecisionShouldTriggerSingleServerSideChangeEvent() {
+        TestBenchElement setMillisPrecisionButton = $("button").id("set-millis-precision");
+        TestBenchElement setCurrentTimeButton = $("button").id("set-current-time");
+
+        setMillisPrecisionButton.click();
+        setCurrentTimeButton.click();
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from server-side", entries[0].startsWith("source: server"));
+    }
+
+    @Test
+    public void setClientSideValueShouldTriggerSingleClientSideChangeEvent() {
+        picker.setValue("10:08");
+
+        String[] entries = getChangeLogEntries();
+        Assert.assertEquals(1, entries.length);
+        Assert.assertTrue("Event should originate from client-side", entries[0].startsWith("source: client"));
+    }
+
+    private String[] getChangeLogEntries() {
+        return eventLog.getText().split("\n");
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -938,7 +938,7 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
             SerializableBiFunction<R, T, P> modelToPresentation,
-                                         boolean isInitialValueOptional) {
+            boolean isInitialValueOptional) {
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
         if ((getElement().getProperty("value") == null

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -937,10 +937,12 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
     public <P> GeneratedVaadinTimePicker(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
-            SerializableBiFunction<R, T, P> modelToPresentation) {
+            SerializableBiFunction<R, T, P> modelToPresentation,
+                                         boolean isInitialValueOptional) {
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
-        if (initialValue != null) {
+        if ((getElement().getProperty("value") == null
+                || !isInitialValueOptional) && initialValue != null) {
             setPresentationValue(initialValue);
         }
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -121,9 +121,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      *            ignored and the initial value is set
      */
     private TimePicker(LocalTime time, boolean isInitialValueOptional) {
-        // TODO: restore isInitialValueOptional and add tests
         super(time, null, String.class, TimePicker::presentationToModel,
-                TimePicker::modelToPresentation);
+                TimePicker::modelToPresentation, isInitialValueOptional);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -50,6 +50,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         if (model == null)
             return "";
 
+        // Truncate value to the precision that the web component supports with
+        // its current step setting to prevent client-side value changed event
         LocalTime truncatedModelValue = timePicker.truncateToPrecision(model);
 
         return truncatedModelValue.toString();
@@ -61,7 +63,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
             return null;
 
         // If the value is still the same when respecting the precision, then
-        // keep current value to prevent additional value changed events
+        // keep current value to prevent additional value changed events from
+        // server-side
         LocalTime newValue = LocalTime.parse(presentation);
         LocalTime currentValue = timePicker.getValue();
         LocalTime truncatedCurrentValue = timePicker

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -82,8 +82,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
     private static final Duration MILLISECOND_PRECISION_THRESHOLD = Duration
             .of(1, ChronoUnit.SECONDS);
-    private static final Duration SECOND_PRECISION_THRESHOLD = Duration.of(60,
-            ChronoUnit.SECONDS);
+    private static final Duration SECOND_PRECISION_THRESHOLD = Duration.of(1,
+            ChronoUnit.MINUTES);
 
     private Locale locale;
     private transient DateTimeFormatter dateTimeFormatter;
@@ -338,7 +338,16 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         return Duration.ofNanos((long) (getStepDouble() * 1E9));
     }
 
-    // TODO: javadoc
+    /**
+     * Gets the precision of the time picker as ChronoUnit, based on the
+     * configured steps. This implementation mirrors the behaviour of the web
+     * component, where setting a step changes the precision of the string
+     * value. By default, the precision is ChronoUnit.MINUTES. Setting a step
+     * value lower than 1 minute results in a seconds precision. Setting a step
+     * value lower than 1 second results in a millisecond precision.
+     * 
+     * @return precision as ChronoUnit
+     */
     ChronoUnit getPrecision() {
         Duration step = getStep();
 
@@ -353,6 +362,15 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         return ChronoUnit.MINUTES;
     }
 
+    /**
+     * Truncates a LocalTime value to the precision that is currently configured
+     * in the time picker.
+     * 
+     * @see #getPrecision()
+     * @param value
+     *            the LocalTime value to truncate, can be null
+     * @return the LocalTime value truncated to the precision
+     */
     LocalTime truncateToPrecision(LocalTime value) {
         if (value == null)
             return null;

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2021 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -12,8 +12,9 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
-package com.vaadin.flow.component.timepicker.tests;
+package com.vaadin.flow.component.timepicker;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -278,5 +279,39 @@ public class TimePickerTest {
         assertTrue(timePicker.getElement().getProperty(PROP_AUTO_OPEN_DISABLED,
                 false));
         assertFalse(timePicker.isAutoOpen());
+    }
+
+    @Test
+    public void defaultPrecision() {
+        TimePicker timePicker = new TimePicker();
+        ChronoUnit precision = timePicker.getPrecision();
+
+        assertEquals(ChronoUnit.MINUTES, precision);
+    }
+
+    @Test
+    public void customStepPrecision() {
+        TimePicker timePicker = new TimePicker();
+
+        timePicker.setStep(Duration.of(1, ChronoUnit.HOURS));
+        assertEquals(ChronoUnit.MINUTES, timePicker.getPrecision());
+
+        timePicker.setStep(Duration.of(30, ChronoUnit.MINUTES));
+        assertEquals(ChronoUnit.MINUTES, timePicker.getPrecision());
+
+        timePicker.setStep(Duration.of(1, ChronoUnit.MINUTES));
+        assertEquals(ChronoUnit.MINUTES, timePicker.getPrecision());
+
+        timePicker.setStep(Duration.of(30, ChronoUnit.SECONDS));
+        assertEquals(ChronoUnit.SECONDS, timePicker.getPrecision());
+
+        timePicker.setStep(Duration.of(1, ChronoUnit.SECONDS));
+        assertEquals(ChronoUnit.SECONDS, timePicker.getPrecision());
+
+        timePicker.setStep(Duration.of(500, ChronoUnit.MILLIS));
+        assertEquals(ChronoUnit.MILLIS, timePicker.getPrecision());
+
+        timePicker.setStep(Duration.of(1, ChronoUnit.MILLIS));
+        assertEquals(ChronoUnit.MILLIS, timePicker.getPrecision());
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTest.java
@@ -76,6 +76,16 @@ public class TimePickerTest {
     }
 
     @Test
+    public void setValue_doesNotTruncateValue() {
+        // Value includes nanoseconds
+        LocalTime value = LocalTime.of(9, 32, 13, 123);
+        TimePicker picker = new TimePicker();
+        picker.setValue(value);
+
+        assertEquals(value, picker.getValue());
+    }
+
+    @Test
     public void timePickerWithLabel() {
         String label = "Time Picker Label";
         TimePicker picker = new TimePicker(label);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTest.java
@@ -16,10 +16,6 @@
  */
 package com.vaadin.flow.component.timepicker;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
@@ -30,17 +26,17 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.timepicker.GeneratedVaadinTimePicker;
-import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
+import static org.junit.Assert.*;
+
 public class TimePickerTest {
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 
-    private static LocalTime TEST_VALUE = LocalTime.now();
+    private static final LocalTime TEST_VALUE = LocalTime.now();
 
     private static class TestTimePicker
             extends GeneratedVaadinTimePicker<TestTimePicker, LocalTime> {
@@ -55,7 +51,7 @@ public class TimePickerTest {
     public void timePicker_basicCases() {
         TimePicker picker = new TimePicker();
 
-        assertEquals(null, picker.getValue());
+        assertNull(picker.getValue());
         assertFalse(picker.getElement().hasProperty("value"));
 
         picker.setValue(LocalTime.of(5, 30));
@@ -69,7 +65,7 @@ public class TimePickerTest {
     public void timePicker_nullValue() {
         TimePicker timePicker = new TimePicker();
         timePicker.setValue(null);
-        assertEquals(null, timePicker.getValue());
+        assertNull(timePicker.getValue());
     }
 
     @Test
@@ -81,14 +77,14 @@ public class TimePickerTest {
 
     @Test
     public void timePickerWithLabel() {
-        String label = new String("Time Picker Label");
+        String label = "Time Picker Label";
         TimePicker picker = new TimePicker(label);
         assertEquals(label, picker.getElement().getProperty("label"));
     }
 
     @Test
     public void timePickerWithPlaceholder() {
-        String placeholder = new String("This is a Time Picker");
+        String placeholder = "This is a Time Picker";
         TimePicker picker = new TimePicker();
         picker.setPlaceholder(placeholder);
 
@@ -186,19 +182,19 @@ public class TimePickerTest {
     @Test
     public void setMin_getMin_null() {
         TimePicker timePicker = new TimePicker();
-        assertEquals(null, timePicker.getMin());
+        assertNull(timePicker.getMin());
         timePicker.setMin(null);
         assertEquals("", timePicker.getMin());
-        assertEquals(null, timePicker.getMinTime());
+        assertNull(timePicker.getMinTime());
     }
 
     @Test
     public void setMinTime_getMin_null() {
         TimePicker timePicker = new TimePicker();
-        assertEquals(null, timePicker.getMinTime());
+        assertNull(timePicker.getMinTime());
         timePicker.setMinTime(null);
         assertEquals("", timePicker.getMin());
-        assertEquals(null, timePicker.getMinTime());
+        assertNull(timePicker.getMinTime());
     }
 
     @Test
@@ -214,19 +210,19 @@ public class TimePickerTest {
     @Test
     public void setMax_getMax_null() {
         TimePicker timePicker = new TimePicker();
-        assertEquals(null, timePicker.getMax());
+        assertNull(timePicker.getMax());
         timePicker.setMax(null);
         assertEquals("", timePicker.getMax());
-        assertEquals(null, timePicker.getMaxTime());
+        assertNull(timePicker.getMaxTime());
     }
 
     @Test
     public void setMaxTime_getMax_null() {
         TimePicker timePicker = new TimePicker();
-        assertEquals(null, timePicker.getMaxTime());
+        assertNull(timePicker.getMaxTime());
         timePicker.setMaxTime(null);
         assertEquals("", timePicker.getMax());
-        assertEquals(null, timePicker.getMaxTime());
+        assertNull(timePicker.getMaxTime());
     }
 
     @Test
@@ -313,5 +309,27 @@ public class TimePickerTest {
 
         timePicker.setStep(Duration.of(1, ChronoUnit.MILLIS));
         assertEquals(ChronoUnit.MILLIS, timePicker.getPrecision());
+    }
+
+    @Test
+    public void truncateToPrecision() {
+        TimePicker timePicker = new TimePicker();
+
+        LocalTime input = LocalTime.of(9, 30, 56);
+        // with default settings time should be truncated to minutes
+        LocalTime expected = LocalTime.of(9, 30);
+
+        LocalTime result = timePicker.truncateToPrecision(input);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void truncateToPrecision_handlesNull() {
+        TimePicker timePicker = new TimePicker();
+
+        LocalTime result = timePicker.truncateToPrecision(null);
+
+        assertNull(result);
     }
 }


### PR DESCRIPTION
## Description

Currently the DateTimePicker can trigger an additional value changed event, when the value is updated on the server side. There seem to be two different issues:

1. Using `TimePicker.setValue` with a time value that has sub-millisecond precision (e.g. `LocalTime.now()`), the value is truncated to millisecond precision, which means the TimePicker will store a different time as field value than the DateTimePicker. After setting the value in the web component, that will trigger a value changed event from the client. The DateTimePicker now reads back the values from the DatePicker and TimePicker, and calls `setModelValue` with the new values and an indicator that the value is from the client-side. This triggers the duplicate value changed event from the client, as the time values differ.
  This also results in a different issue that `TimePicker.getValue` might return a different value than what was set by the user.
2. The TimePicker web component truncates time values based on the `steps` setting, resulting in a lower precision value on the client-side. By default, the web component uses a minute precision, by changing the step setting the web component can also support second and millisecond precision values. However neither the TimePicker, nor the DateTimePicker Flow components mirror that logic. There is an [existing workaround](https://github.com/vaadin/flow-components/blob/master/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java#L241-L250) for a separate issue in the DateTimePicker which seems to deal with this inconsistency. The problem with the workaround is that it can lead to a duplicate value changed event from the server-side, as it's effectively a second server-side setValue call.

This change addresses these issues by:
- changing the behaviour of `TimePicker.setValue` to not truncate the value, but always keep the value that was passed in. This is a small behaviour change, but seems like a general improvement, as the TimePicker now keeps the value that was passed in as is.
- adding custom presentation<->model converters to the time picker, to deal with the fact that the server-side value might have a higher precision than the client-side value:
  - when converting to the presentation value, the Flow component now respects the steps setting, and produces a time value string that is truncated to that precision. I'm not sure if that is necessary for this fix, but it also can't hurt.
  - when converting to the model value, the Flow component checks if the new value is equal to the current value, if the current value would be truncated to the currently configured precision. If the values are equal, then it returns the old value (with potentially higher precision).
    - while this is not the intended purpose of the converter, I could not find an alternative way to prevent the Flow `AbstractField` from changing the internal value. I checked `valueEquals`, however that is not applicable is it isn't used to check if the incoming client-side value is different from the new value that was just set.
- removing the workaround mentioned in (2). This doesn't seem necessary anymore now that the TimePicker always keeps the value that was set, disregarding any changes if the changed value matches the old value when respecting the configured precision.

Fixes #1986
Fixes #1172

## Type of change

- [x] Bugfix
