### PR TITLE
Trim the text before selecting to be more compatible with templates

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
@@ -91,8 +91,10 @@ public class SelectElement extends TestBenchElement
 
     @Override
     public void selectByText(String text) {
-        getItemsStream().filter(item -> text.equals(item.getText())).findFirst()
-                .get().click();
+        getItemsStream()
+                .filter(item -> text
+                        .equals(item.getPropertyString("textContent").trim()))
+                .findFirst().get().click();
     }
 
     @Override


### PR DESCRIPTION
## Description

Uses textContent instead of getText so it does not fail if the popup is off screen
