### PR TITLE
chore: ensure the correct overlay is used when multiple selects are open

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
@@ -74,8 +74,7 @@ public class SelectElement extends TestBenchElement
 
     public Stream<ItemElement> getItemsStream() {
         openPopup();
-        List<WebElement> elements = getDriver()
-                .findElement(By.tagName("vaadin-select-overlay"))
+        List<WebElement> elements = getPropertyElement("_overlayElement")
                 .findElement(By.tagName("vaadin-list-box"))
                 .findElements(By.tagName("vaadin-item"));
         if (elements.size() == 0) {


### PR DESCRIPTION
## Description
Fixes #1061
