### PR TITLE
fix: issue with ComboBox initial value when used in LitTemplate

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/frontend/src/combobox-template-initial-value-serverside.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/frontend/src/combobox-template-initial-value-serverside.ts
@@ -1,0 +1,25 @@
+import {customElement, html, TemplateResult, LitElement} from "lit-element";
+
+@customElement("combobox-initial-value")
+export class TestForm extends LitElement {
+
+    protected render(): TemplateResult {
+        return html`
+            <div>
+                <vaadin-combo-box id="combo" style="width: 100%;"></vaadin-combo-box>
+            </div>
+        `;
+    }
+
+    constructor() {
+        super();
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/template/ComboBoxTemplateInitialValue.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/template/ComboBoxTemplateInitialValue.java
@@ -1,0 +1,73 @@
+package com.vaadin.flow.component.combobox.test.template;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.template.Id;
+import com.vaadin.flow.data.binder.Binder;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsModule("./src/combobox-template-initial-value-serverside.ts")
+@Tag("combobox-initial-value")
+public class ComboBoxTemplateInitialValue extends LitTemplate {
+
+    @Id("combo")
+    private ComboBox<Bean> comboBox;
+
+
+    List<Bean> beans = new ArrayList<>();
+
+    private Binder<BeanHolder> binder = new Binder<>();
+
+    public ComboBoxTemplateInitialValue() {
+        for (int i = 0; i < 4; i++) {
+            beans.add(new Bean("" + i));
+        }
+        setupForm();
+        // you can also set the value through Binder with readBean
+        comboBox.setValue(beans.get(1));
+    }
+
+    private void setupForm() {
+        comboBox.setReadOnly(false);
+        comboBox.setClearButtonVisible(true);
+        comboBox.setPlaceholder("Placeholder");
+        comboBox.setItems(beans);
+        comboBox.setItemLabelGenerator(Bean::getBeanid);
+        comboBox.setAllowCustomValue(true);
+        binder.forField(comboBox)
+                .asRequired("Not blank");
+    }
+
+    public static class Bean implements Serializable {
+        private String beanid;
+
+        public Bean(String beanid) {
+            this.beanid = beanid;
+        }
+
+        public String getBeanid() {
+            return beanid;
+        }
+
+        public void setBeanid(String beanid) {
+            this.beanid = beanid;
+        }
+    }
+
+    public static class BeanHolder {
+        private Bean bean;
+
+        public void setBean(Bean study) {
+            this.bean = study;
+        }
+
+        public Bean getBean() {
+            return bean;
+        }
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/template/ComboBoxTemplateInitialValuePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/template/ComboBoxTemplateInitialValuePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.combobox.test.template;
+
+import com.vaadin.flow.component.orderedlayout.FlexLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-combo-box/combo-box-in-template-initial-value")
+public class ComboBoxTemplateInitialValuePage extends FlexLayout {
+
+    public ComboBoxTemplateInitialValuePage() {
+        setWidthFull();
+        add(new ComboBoxTemplateInitialValue());
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxInTemplateInitValueServersideIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxInTemplateInitValueServersideIT.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-combo-box/combo-box-in-template-initial-value")
+public class ComboBoxInTemplateInitValueServersideIT extends AbstractComboBoxIT {
+
+    private ComboBoxElement comboBox;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $("combobox-initial-value").first().$(ComboBoxElement.class).id("combo");
+    }
+
+    @Test
+    public void comboBoxInitialValue_litTemplate_ShouldBeSetWithSetValue() {
+        String labelValue = "1";
+
+        Assert.assertEquals(labelValue, comboBox.getProperty("_inputElementValue"));
+    }
+
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -403,6 +403,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         dataGenerator.generateData(value, json);
         setSelectedItem(json);
         getElement().setProperty(PROP_VALUE, keyMapper.key(value));
+        getElement().setProperty(PROP_INPUT_ELEMENT_VALUE, generateLabel(value));
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fixes the issue with ComboBox when used with LitTemplate. The original issue raised when some specific order of methods were called on ComboBox element (`setReadonly`, `setPlaceholder` ...). After analysing it we realised that some calls to `getElement().setProperty(PROP_INPUT_ELEMENT_VALUE, value)` are out of sync; Which change the component `_inputElementValue` from 1 to `""`.

We fix this issue by setting `_inputElementValue` explicitly when the `value` of input is set to mitigate this randomized behaviour.  

Fixes # (issue)

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
