### PR TITLE
fix: make DateTimePicker apply initial steps

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerStepPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerStepPage.java
@@ -16,7 +16,7 @@
 package com.vaadin.flow.component.datetimepicker;
 
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
@@ -29,8 +29,24 @@ import java.util.Locale;
 public class DateTimePickerStepPage extends Div {
 
     public DateTimePickerStepPage() {
+        setupInitialSteps();
+        setupChangeSteps();
+    }
+
+    private void setupInitialSteps() {
         DateTimePicker picker = new DateTimePicker();
-        picker.setId("date-time-picker");
+        picker.setId("initial-steps-date-time-picker");
+        picker.setStep(Duration.ofMillis(500));
+        picker.setValue(LocalDateTime.of(2021, 9, 13, 15, 20, 30)
+                .plus(Duration.ofMillis(123)));
+
+        add(new H1("Initial steps"));
+        add(picker);
+    }
+
+    private void setupChangeSteps() {
+        DateTimePicker picker = new DateTimePicker();
+        picker.setId("change-steps-date-time-picker");
 
         NativeButton valueButton = new NativeButton("Set value");
         valueButton.addClickListener(e -> picker.setValue(LocalDateTime
@@ -49,6 +65,7 @@ public class DateTimePickerStepPage extends Div {
                 .addClickListener(e -> picker.setStep(Duration.ofMillis(500)));
         millisecondPrecisionButton.setId("set-millisecond-precision");
 
+        add(new H1("Change steps"));
         add(picker);
         add(new Div(valueButton, secondPrecisionButton,
                 millisecondPrecisionButton));

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerStepIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerStepIT.java
@@ -24,19 +24,26 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-
 @TestPath("vaadin-date-time-picker/date-time-picker-step")
 public class DateTimePickerStepIT extends AbstractComponentIT {
 
-    DateTimePickerElement picker;
+    DateTimePickerElement initialStepsPicker;
+    DateTimePickerElement changeStepsPicker;
 
     @Before
     public void init() {
         open();
         waitForElementPresent(By.tagName("vaadin-date-time-picker"));
-        picker = $(DateTimePickerElement.class).first();
+        initialStepsPicker = $(DateTimePickerElement.class)
+                .id("initial-steps-date-time-picker");
+        changeStepsPicker = $(DateTimePickerElement.class)
+                .id("change-steps-date-time-picker");
+    }
+
+    @Test
+    public void setInitialStepsToMillisecondPrecisionShouldFormatWithMillisecondPrecision() {
+        Assert.assertEquals("3:20:30.123 PM",
+                initialStepsPicker.getTimePresentation());
     }
 
     @Test
@@ -45,7 +52,7 @@ public class DateTimePickerStepIT extends AbstractComponentIT {
 
         setValue.click();
 
-        Assert.assertEquals("3:20 PM", picker.getTimePresentation());
+        Assert.assertEquals("3:20 PM", changeStepsPicker.getTimePresentation());
     }
 
     @Test
@@ -57,7 +64,8 @@ public class DateTimePickerStepIT extends AbstractComponentIT {
         setSecondPrecision.click();
         setValue.click();
 
-        Assert.assertEquals("3:20:30 PM", picker.getTimePresentation());
+        Assert.assertEquals("3:20:30 PM",
+                changeStepsPicker.getTimePresentation());
     }
 
     @Test
@@ -69,6 +77,7 @@ public class DateTimePickerStepIT extends AbstractComponentIT {
         setMillisecondPrecision.click();
         setValue.click();
 
-        Assert.assertEquals("3:20:30.123 PM", picker.getTimePresentation());
+        Assert.assertEquals("3:20:30.123 PM",
+                changeStepsPicker.getTimePresentation());
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -389,6 +389,7 @@ public class DateTimePicker
 
         getElement().setProperty("step",
                 StepsUtil.convertDurationToStepsValue(step));
+        timePicker.setStep(step);
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes the DateTimePicker to apply steps if they were set before attaching the component. The issue is that the web component synchronizes the steps property from the TimePicker to the DateTimePicker, when using a slotted TimePicker. To solve this, I changed `setSteps` to additionally set the value on the TimePicker. I could not observe any issues with the solutions, it works when setting the steps before and after attaching the component.

Fixes #2164

## Type of change

- [x] Bugfix
