### PR TITLE
chore: remove grid.notifyResize() calls

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -55,7 +55,6 @@ public class SortingPage extends Div {
         NativeButton showGridBtn = new NativeButton("Show grid", e -> {
             grid.getStyle().set("display", "block");
             grid.getStyle().remove("max-height");
-            grid.getElement().executeJs("$0.notifyResize();");
         });
         showGridBtn.setId("show-hidden-grid");
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -927,10 +927,6 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
       grid.$connector.setVerticalScrollingEnabled = tryCatchWrapper(function(enabled) {
         // There are two scollable containers in grid so apply the changes for both
         setVerticalScrollingEnabled(grid.$.table, enabled);
-
-        // Since the scrollbars were toggled, there might have been some changes to layout
-        // size. Notify grid of the resize to ensure everything is in place.
-        grid.notifyResize();
       });
 
       const setVerticalScrollingEnabled = function(scrollable, enabled) {


### PR DESCRIPTION
Since [grid.notifyResize() is currently a no-op](https://github.com/vaadin/web-components/blob/2a05a00e6a92a247af8a4d845eed7d44b51973c4/packages/vaadin-grid/src/vaadin-grid.js#L993) all internal invocations to the function can be removed.

Removing the calls in `flow-components` enables us to add a deprecation warning message to the function in `<vaadin-grid>`