### PR TITLE
test: custom value set event should not fire when readonly

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxReadOnlyBlurPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxReadOnlyBlurPage.java
@@ -1,0 +1,47 @@
+   
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-combo-box/readonly-blur")
+public class ComboBoxReadOnlyBlurPage extends VerticalLayout {
+
+    public ComboBoxReadOnlyBlurPage() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setAllowCustomValue(true);
+        comboBox.setRequired(true);
+        comboBox.setReadOnly(true);
+        comboBox.addCustomValueSetListener(ev -> {
+            Span span = new Span();
+            span.setText("Triggered");
+            span.setId("triggered");
+            add(span);
+        });
+        comboBox.setItems("A", "B", "C");
+        comboBox.setValue("C");
+        comboBox.focus();
+        Button button = new Button("Click");
+        button.setId("blur-combo");
+        add(comboBox, button);
+    }
+
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxReadOnlyBlurIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxReadOnlyBlurIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.NoSuchElementException;
+
+import com.vaadin.flow.testutil.TestPath;
+
+import static org.junit.Assert.assertTrue;
+
+@TestPath("vaadin-combo-box/readonly-blur")
+public class ComboBoxReadOnlyBlurIT extends AbstractComboBoxIT {
+
+    @Test(expected = NoSuchElementException.class)
+    public void comboBoxReadOnlyBlur() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+        findElement(By.id("blur-combo")).click();
+        WebElement span = findElement(By.id("triggered"));
+        assertTrue(span == null);
+    }
+}


### PR DESCRIPTION
Integration test to test: https://github.com/vaadin/web-components/pull/2721