### PR TITLE
chore: correct the expression in test and fix chart tests

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
@@ -18,31 +18,22 @@ package com.vaadin.flow.component.charts.tests;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.flow.component.charts.AbstractChartExample;
 import com.vaadin.flow.component.charts.testbench.ChartElement;
+import com.vaadin.flow.component.charts.ui.MainView;
+import com.vaadin.tests.AbstractParallelTest;
 
-import com.vaadin.testbench.parallel.Browser;
-import com.vaadin.testbench.parallel.BrowserUtil;
-import com.vaadin.testbench.parallel.DefaultBrowserFactory;
-import com.vaadin.tests.ParallelTest;
-import com.vaadin.testbench.parallel.TestBenchBrowserFactory;
-
-public abstract class AbstractTBTest extends ParallelTest {
-
-    private static final String PROPERTY_TEST_ALL_BROWSERS = "test.allBrowsers";
+public abstract class AbstractTBTest extends AbstractParallelTest {
 
     @Override
     public void setup() throws Exception {
         super.setup();
-        openTestURL();
+        driver.get(getTestUrl(getView()));
     }
 
     protected ChartElement getChartElement() {
@@ -69,63 +60,16 @@ public abstract class AbstractTBTest extends ParallelTest {
                 "Could not find required element in the shadowRoot");
     }
 
-    public List<DesiredCapabilities> getBrowserConfiguration() {
-        if (System.getProperty(PROPERTY_TEST_ALL_BROWSERS) == null) {
-            return Arrays.asList(BrowserUtil.chrome());
-        }
-
-        TestBenchBrowserFactory browserFactory = new DefaultBrowserFactory();
-        return Arrays.asList(BrowserUtil.chrome()
-
-        );
-    }
-
-    protected void openTestURL() {
-        String url = getTestUrl();
-        driver.get(url);
-    }
-
     /**
-     * Returns the full URL to be used for the test
-     *
-     * @return the full URL for the test
+     * Overriding the way how test path is calculated. In Charts we prepend a
+     * fragment like `/vaadin-charts/area/`
      */
-    protected String getTestUrl() {
-        String baseUrl = getBaseURL();
-        if (baseUrl.endsWith("/")) {
-            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
-        }
-
-        return baseUrl + getDeploymentPath();
+    @Override
+    protected String getDeploymentPath(Class<?> viewClass) {
+        return "/" + viewClass.getCanonicalName()
+                .replace(MainView.EXAMPLE_BASE_PACKAGE, "vaadin-charts/")
+                .replace(".", "/");
     }
 
-    /**
-     * Returns the path that should be used for the test. The path contains the
-     * full path (appended to hostname+port) and must start with a slash.
-     *
-     * @return The URL path to the UI class to test
-     */
-    protected String getDeploymentPath() {
-        return "/" + "vaadin-charts/" + getTestView().getCanonicalName();
-    }
-
-    /**
-     * Used to determine what URL to initially open for the test
-     *
-     * @return The base URL for the test. Does not include a trailing slash.
-     */
-    protected String getBaseURL() {
-        return "http://" + getDeploymentHostname() + ":" + getDeploymentPort();
-    }
-
-    protected String getDeploymentHostname() {
-        return "localhost";
-    }
-
-    protected int getDeploymentPort() {
-        return 8080;
-    }
-
-    protected abstract Class<? extends AbstractChartExample> getTestView();
-
+    protected abstract Class<? extends AbstractChartExample> getView();
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 public class BasicChartIT extends AbstractTBTest {
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return AreaChart.class;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ChartSizeIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ChartSizeIT.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.charts.testbench.ChartElement;
 public class ChartSizeIT extends AbstractTBTest {
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return PieWithSize.class;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ChartStyleIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ChartStyleIT.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.charts.testbench.ChartElement;
 public class ChartStyleIT extends AbstractTBTest {
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return PieWithClassName.class;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 public class DynamicChangesIT extends AbstractTBTest {
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return DynamicChanges.class;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 public class DynamicExtremesIT extends AbstractTBTest {
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return DynamicExtremes.class;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithoutAccessibilityIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithoutAccessibilityIT.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.charts.testbench.ChartElement;
 public class PieWithoutAccessibilityIT extends AbstractTBTest {
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return PieWithoutAccessibility.class;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -47,7 +47,7 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     @Override
-    protected Class<? extends AbstractChartExample> getTestView() {
+    protected Class<? extends AbstractChartExample> getView() {
         return ServerSideEvents.class;
     }
 

--- a/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/AbstractParallelTest.java
+++ b/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/AbstractParallelTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractParallelTest extends ParallelTest {
 
     /**
      * Copied from com.vaadin.flow.testutil.AbstractTestBenchTest
-     * 
+     *
      * @return current host address if running in a hub or localhost otherwise
      */
     protected String getCurrentHostAddress() {

--- a/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/AbstractParallelTest.java
+++ b/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/AbstractParallelTest.java
@@ -105,7 +105,7 @@ public abstract class AbstractParallelTest extends ParallelTest {
      */
     protected String getCurrentHostAddress() {
         if (getRunOnHub(getClass()) == null
-                || Parameters.getHubHostname() == null) {
+                && Parameters.getHubHostname() == null) {
             return "localhost";
         }
         try {

--- a/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/ComponentDemoTest.java
+++ b/vaadin-flow-components-shared/src/main/java/com/vaadin/tests/ComponentDemoTest.java
@@ -27,6 +27,7 @@ public abstract class ComponentDemoTest
         return browser.getGridBrowsers().orElse(super.getHubBrowsersToTest());
     }
 
+    @Override
     protected int getDeploymentPort() {
         return 8080;
     }


### PR DESCRIPTION
while at the current situation, `getRunOnHub`  returns a null, though we have set a `hubhostname`, it still returns **localhost** , while there is no local installed hub after the seleniod update, the test failed with 404 .