### PR TITLE
chore: fix npm update script after the new wc package [skip ci]

### DIFF
--- a/scripts/updateNpmVer.js
+++ b/scripts/updateNpmVer.js
@@ -57,7 +57,7 @@ function excludeComponents() {
       }
   }
   exclude=components.split(',');
-  packageBase='@vaadin/vaadin-';
+  packageBase='@vaadin/';
   for(j = 0; j < exclude.length; j++){
 	  exclude[j] = packageBase.concat(exclude[j]);
   }


### PR DESCRIPTION
now the script will catch all packages in an annotation starts with `@vaadin/`
![image](https://user-images.githubusercontent.com/31067185/136575094-21fbbd01-d39c-4034-840f-d4b78c34750a.png)
