### PR TITLE
feat: deprecate cancel key in UploadI18N

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -556,6 +556,7 @@ public class UploadI18N implements Serializable {
      * @deprecated since Vaadin 22, {@link #getCancel()} is deprecated as the
      *             `cancel` translation is not used anywhere.
      */
+    @Deprecated
     public String getCancel() {
         return cancel;
     }
@@ -570,6 +571,7 @@ public class UploadI18N implements Serializable {
      * @deprecated since Vaadin 22, {@link #setCancel(String)} is deprecated as
      *             the `cancel` translation is not used anywhere.
      */
+    @Deprecated
     public UploadI18N setCancel(String cancel) {
         this.cancel = cancel;
         return this;


### PR DESCRIPTION
## Description

The PR deprecates the `setCancel` and `getCancel` methods in UploadI18N as the related `cancel` i18n key has been removed from the web component in https://github.com/vaadin/web-components/issues/2337. The methods are planned to be completely dropped in the next Vaadin version.

Part of #2179

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
