### PR TITLE
feat: add "no-padding" theme variants to dialog (CP: #589)

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -642,8 +642,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      */
     public void addThemeVariants(DialogVariant... variants) {
         getThemeNames()
-                .addAll(Stream.of(variants)
-                        .map(DialogVariant::getVariantName)
+                .addAll(Stream.of(variants).map(DialogVariant::getVariantName)
                         .collect(Collectors.toList()));
     }
 
@@ -654,9 +653,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      *            theme variants to remove
      */
     public void removeThemeVariants(DialogVariant... variants) {
-        getThemeNames()
-                .removeAll(Stream.of(variants)
-                        .map(DialogVariant::getVariantName)
+        getThemeNames().removeAll(
+                Stream.of(variants).map(DialogVariant::getVariantName)
                         .collect(Collectors.toList()));
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/DialogVariant.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/DialogVariant.java
@@ -19,8 +19,7 @@ package com.vaadin.flow.component.dialog;
  * Set of theme variants applicable for {@code vaadin-dialog} component.
  */
 public enum DialogVariant {
-    LUMO_NO_PADDING("no-padding"),
-    MATERIAL_NO_PADDING("no-padding");
+    LUMO_NO_PADDING("no-padding"), MATERIAL_NO_PADDING("no-padding");
 
     private final String variant;
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogThemeVariantTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogThemeVariantTest.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.dialog;
 
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
## Description

Adds `no-padding` theme variant to the `Dialog` component.

Fixes #2161

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.