### PR TITLE
feat: Make CellEditStartedEvent#getPath public

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -514,7 +514,7 @@ public class GridPro<E> extends Grid<E> {
          *
          * @return the key of the column
          */
-        private String getPath() {
+        public String getPath() {
             return path;
         }
     }


### PR DESCRIPTION
Based on JavaDoc it looks like it was the original intention and it has been private just by accident