### PR TITLE
test: eliminate a bad constant in a grid test

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
@@ -80,7 +80,8 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
 
         grid.scrollToRow(500);
 
-        int viewportItemCapacity = grid.getLastVisibleRowIndex() - grid.getFirstVisibleRowIndex();
+        int viewportItemCapacity = grid.getLastVisibleRowIndex()
+                - grid.getFirstVisibleRowIndex();
         int expectedLastItem = 500 + viewportItemCapacity;
         Assert.assertEquals(
                 "Grid should be able to scroll after changing to defined size",


### PR DESCRIPTION
Eliminate a fixed constant `int VIEWPORT_ITEM_CAPACITY = 16;` in a grid test in favor of dynamically computing the value.