### PR TITLE
feat: add missing ItemLabelGenerator to the radiobuttongroup

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-demo/src/main/java/com/vaadin/flow/component/radiobutton/demo/RadioButtonGroupView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-demo/src/main/java/com/vaadin/flow/component/radiobutton/demo/RadioButtonGroupView.java
@@ -37,7 +37,6 @@ import com.vaadin.flow.component.radiobutton.demo.data.DepartmentData;
 import com.vaadin.flow.component.radiobutton.demo.entity.Department;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
-import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
 
@@ -106,7 +105,7 @@ public class RadioButtonGroupView extends DemoView {
         radioGroup.setLabel("Department");
         List<Department> departmentList = getDepartments();
         radioGroup.setItems(departmentList);
-        radioGroup.setRenderer(new TextRenderer<>(Department::getName));
+        radioGroup.setItemLabelGenerator(Department::getName);
         radioGroup.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
         // end-source-example
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDemoPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDemoPage.java
@@ -195,7 +195,7 @@ public class RadioButtonGroupDemoPage extends DemoView {
         RadioButtonGroup<Person> group = new RadioButtonGroup<>();
         group.setItems(new Person("Joe"), new Person("John"),
                 new Person("Bill"));
-        group.setRenderer(new TextRenderer<>(Person::getName));
+        group.setItemLabelGenerator(Person::getName);
         group.addValueChangeListener(event -> message.setText(String.format(
                 "Radio button group value changed from '%s' to '%s'",
                 getName(event.getOldValue()), getName(event.getValue()))));

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -254,6 +254,7 @@ public class RadioButtonGroup<T>
         Objects.requireNonNull(itemLabelGenerator,
                 "The item label generator can not be null");
         this.itemLabelGenerator = itemLabelGenerator;
+        refreshButtons();
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
+import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupDataView;
@@ -49,6 +50,7 @@ import com.vaadin.flow.data.provider.KeyMapper;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.selection.SingleSelect;
 import com.vaadin.flow.dom.PropertyChangeEvent;
@@ -85,7 +87,10 @@ public class RadioButtonGroup<T>
 
     private SerializablePredicate<T> itemEnabledProvider = item -> isEnabled();
 
-    private ComponentRenderer<? extends Component, T> itemRenderer = new TextRenderer<>();
+    private ItemLabelGenerator<T> itemLabelGenerator = String::valueOf;
+
+    private ComponentRenderer<? extends Component, T> itemRenderer = new TextRenderer<>(
+            itemLabelGenerator);
 
     private final PropertyChangeListener validationListener = this::validateSelectionEnabledState;
     private Registration validationRegistration;
@@ -233,6 +238,32 @@ public class RadioButtonGroup<T>
                         reset();
                     }
                 });
+    }
+
+    /**
+     * Sets the item label generator that is used to produce the strings shown
+     * in the radio button group for each item. By default,
+     * {@link String#valueOf(Object)} is used.
+     * <p>
+     * 
+     * @param itemLabelGenerator
+     *            the item label provider to use, not null
+     */
+    public void setItemLabelGenerator(
+            ItemLabelGenerator<T> itemLabelGenerator) {
+        Objects.requireNonNull(itemLabelGenerator,
+                "The item label generator can not be null");
+        this.itemLabelGenerator = itemLabelGenerator;
+    }
+
+    /**
+     * Gets the item label generator that is used to produce the strings shown
+     * in the radio button group for each item.
+     *
+     * @return the item label generator used, not null
+     */
+    public ItemLabelGenerator<T> getItemLabelGenerator() {
+        return itemLabelGenerator;
     }
 
     @Override

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -254,7 +254,7 @@ public class RadioButtonGroup<T>
         Objects.requireNonNull(itemLabelGenerator,
                 "The item label generator can not be null");
         this.itemLabelGenerator = itemLabelGenerator;
-        refreshButtons();
+        setRenderer(new TextRenderer<>(itemLabelGenerator));
     }
 
     /**


### PR DESCRIPTION
## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes https://github.com/vaadin/flow-components/issues/1681

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.

I have updated the current test that is using a setRenderer(new TextRenderer()) since this is doing the same and setRenderer is already tested in the other tests with a Component renderer.
