### PR TITLE
fix: don't raise item-click when focusable header is clicked after item keys are changed.

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -1,23 +1,22 @@
 package com.vaadin.flow.component.grid.it;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
+import org.apache.commons.lang3.StringUtils;
 
 @Route("vaadin-grid/grid-filtering")
 public class GridFilteringPage extends Div {
@@ -50,6 +49,7 @@ public class GridFilteringPage extends Div {
         add(field, grid);
 
         createLazyLoadingAndFilterableGrid();
+        createCheckBoxFilterGrid();
     }
 
     private void createLazyLoadingAndFilterableGrid() {
@@ -75,6 +75,32 @@ public class GridFilteringPage extends Div {
         grid.setId(LAZY_FILTERABLE_GRID_ID);
 
         add(filterField, grid);
+    }
+
+    private void createCheckBoxFilterGrid() {
+
+        Span message = new Span();
+        message.setId("notification-message");
+
+        Grid<String> grid = new Grid<>();
+        grid.setDataProvider(new ListDataProvider<>(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")));
+        grid.addColumn(x -> x).setHeader("Header");
+        ComboBox<String> filter = new ComboBox<>();
+        filter.addValueChangeListener(evt -> {
+            ListDataProvider<String> dataProvider = (ListDataProvider<String>) grid.getDataProvider();
+            dataProvider.clearFilters();
+            if (filter.getValue() != null) {
+                dataProvider
+                        .addFilter(item -> StringUtils.containsIgnoreCase(item,
+                                filter.getValue())
+                        );
+            }
+        });
+        filter.setClearButtonVisible(true);
+        filter.setItems(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"));
+        grid.prependHeaderRow().getCells().get(0).setComponent(filter);
+        grid.addItemClickListener(ev -> message.setText("column=" + ev.getColumn() + " item=" + ev.getItem()));
+        add(grid, message);
     }
 
     private Collection<String> findAnyMatching(Optional<String> filter) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -5,18 +5,14 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import org.apache.commons.lang3.StringUtils;
 
 @Route("vaadin-grid/grid-filtering")
 public class GridFilteringPage extends Div {
@@ -49,7 +45,6 @@ public class GridFilteringPage extends Div {
         add(field, grid);
 
         createLazyLoadingAndFilterableGrid();
-        createCheckBoxFilterGrid();
     }
 
     private void createLazyLoadingAndFilterableGrid() {
@@ -75,34 +70,6 @@ public class GridFilteringPage extends Div {
         grid.setId(LAZY_FILTERABLE_GRID_ID);
 
         add(filterField, grid);
-    }
-
-    private void createCheckBoxFilterGrid() {
-
-        Span message = new Span();
-        message.setId("notification-message");
-
-        Grid<String> grid = new Grid<>();
-        grid.setDataProvider(new ListDataProvider<>(Arrays.asList("a", "b", "c",
-                "d", "e", "f", "g", "h", "i", "j", "k")));
-        grid.addColumn(x -> x).setHeader("Header");
-        ComboBox<String> filter = new ComboBox<>();
-        filter.addValueChangeListener(evt -> {
-            ListDataProvider<String> dataProvider = (ListDataProvider<String>) grid
-                    .getDataProvider();
-            dataProvider.clearFilters();
-            if (filter.getValue() != null) {
-                dataProvider.addFilter(item -> StringUtils
-                        .containsIgnoreCase(item, filter.getValue()));
-            }
-        });
-        filter.setClearButtonVisible(true);
-        filter.setItems(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h",
-                "i", "j", "k"));
-        grid.prependHeaderRow().getCells().get(0).setComponent(filter);
-        grid.addItemClickListener(ev -> message
-                .setText("column=" + ev.getColumn() + " item=" + ev.getItem()));
-        add(grid, message);
     }
 
     private Collection<String> findAnyMatching(Optional<String> filter) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -83,23 +83,25 @@ public class GridFilteringPage extends Div {
         message.setId("notification-message");
 
         Grid<String> grid = new Grid<>();
-        grid.setDataProvider(new ListDataProvider<>(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")));
+        grid.setDataProvider(new ListDataProvider<>(Arrays.asList("a", "b", "c",
+                "d", "e", "f", "g", "h", "i", "j", "k")));
         grid.addColumn(x -> x).setHeader("Header");
         ComboBox<String> filter = new ComboBox<>();
         filter.addValueChangeListener(evt -> {
-            ListDataProvider<String> dataProvider = (ListDataProvider<String>) grid.getDataProvider();
+            ListDataProvider<String> dataProvider = (ListDataProvider<String>) grid
+                    .getDataProvider();
             dataProvider.clearFilters();
             if (filter.getValue() != null) {
-                dataProvider
-                        .addFilter(item -> StringUtils.containsIgnoreCase(item,
-                                filter.getValue())
-                        );
+                dataProvider.addFilter(item -> StringUtils
+                        .containsIgnoreCase(item, filter.getValue()));
             }
         });
         filter.setClearButtonVisible(true);
-        filter.setItems(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"));
+        filter.setItems(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h",
+                "i", "j", "k"));
         grid.prependHeaderRow().getCells().get(0).setComponent(filter);
-        grid.addItemClickListener(ev -> message.setText("column=" + ev.getColumn() + " item=" + ev.getItem()));
+        grid.addItemClickListener(ev -> message
+                .setText("column=" + ev.getColumn() + " item=" + ev.getItem()));
         add(grid, message);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -1,6 +1,11 @@
 package com.vaadin.flow.component.grid.it;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -15,16 +15,23 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.router.Route;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
 
 @Route("vaadin-grid/item-click-listener")
 public class ItemClickListenerPage extends Div {
+    static final String GRID_FILTER_FOCUSABLE_HEADER = "grid-filter-focusable-header";
 
     public ItemClickListenerPage() {
         Div clickMsg = new Div();
@@ -62,6 +69,8 @@ public class ItemClickListenerPage extends Div {
         grid.setDetailsVisible("bar", true);
 
         add(grid, clickMsg, dblClickMsg, columnClickMsg, columnDblClickMsg);
+
+        createGridWithChangingKeysOfItemsAndFocusableHeader();
     }
 
     private static Span getDetailsComponent(String s) {
@@ -70,4 +79,39 @@ public class ItemClickListenerPage extends Div {
         return result;
     }
 
+    private void createGridWithChangingKeysOfItemsAndFocusableHeader() {
+        Span message = new Span();
+        message.setId("item-click-event-log");
+
+        ListDataProvider<String> dataProvider = new ListDataProvider<>(
+                Arrays.asList("a", "b", "c"));
+        Grid<String> grid = new Grid<>();
+        grid.setItems(dataProvider);
+        grid.addColumn(x -> x).setHeader("Header");
+        grid.addItemClickListener(ev -> message.setText("ItemClicked"));
+        grid.setId(GRID_FILTER_FOCUSABLE_HEADER);
+
+        Button filterButton = new Button("Filter");
+        filterButton.setId("filterButton");
+        Button clearFilterButton = new Button("Clear filter");
+        clearFilterButton.setId("clearFilterButton");
+
+        filterButton.addClickListener(event -> filterGrid(dataProvider, "b"));
+        clearFilterButton
+                .addClickListener(event -> filterGrid(dataProvider, null));
+
+        TextField focusableHeader = new TextField();
+        focusableHeader.setId("focusableHeader");
+        grid.prependHeaderRow().getCells().get(0).setComponent(focusableHeader);
+        add(grid, filterButton, clearFilterButton, message);
+    }
+
+    private void filterGrid(ListDataProvider<String> dataProvider,
+            String filterValue) {
+        dataProvider.clearFilters();
+        if (filterValue != null) {
+            dataProvider.addFilter(
+                    item -> StringUtils.containsIgnoreCase(item, filterValue));
+        }
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.tests.AbstractComponentIT;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -28,6 +29,8 @@ import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import org.openqa.selenium.WebElement;
+
+import static com.vaadin.flow.component.grid.it.ItemClickListenerPage.GRID_FILTER_FOCUSABLE_HEADER;
 
 @TestPath("vaadin-grid/item-click-listener")
 public class ItemClickListenerIT extends AbstractComponentIT {
@@ -117,6 +120,37 @@ public class ItemClickListenerIT extends AbstractComponentIT {
         Assert.assertEquals("", getColumnDoubleClickMessage());
         Assert.assertEquals("", getDoubleClickMessage());
         Assert.assertEquals("", getClickMessage());
+    }
+
+    // Regression test for this issue:
+    // https://github.com/vaadin/flow-components/issues/2247
+    @Test
+    public void gridItemKeysChanged_whenFocusableHeaderElementClicked_shouldNotRaiseItemClickEvent() {
+        open();
+
+        // wait for grid to be loaded
+        waitUntil(driver -> $(GridElement.class)
+                .id(GRID_FILTER_FOCUSABLE_HEADER).getRowCount() > 0);
+
+        GridElement gridElement = $(GridElement.class)
+                .id(GRID_FILTER_FOCUSABLE_HEADER);
+
+        // Select an item with specific key
+        gridElement.select(0);
+
+        // Trigger key change on grid items by filtering
+        ButtonElement filterButton = $(ButtonElement.class).id("filterButton");
+        ButtonElement clearFilterButton = $(ButtonElement.class)
+                .id("clearFilterButton");
+        filterButton.click();
+        clearFilterButton.click();
+
+        WebElement focusableHeader = gridElement
+                .findElement(By.id("focusableHeader"));
+        focusableHeader.click();
+
+        TestBenchElement span = $("span").id("item-click-event-log");
+        Assert.assertEquals("", span.getText());
     }
 
     private String getColumnDoubleClickMessage() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -628,7 +628,7 @@ import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
           cache[pkey][page] = slice;
 
           grid.$connector.doSelection(slice.filter(
-            item => item.selected && !isSelectedOnGrid(item)));
+            item => item.selected && !isSelectedOnGrid(item)), true);
           grid.$connector.doDeselection(slice.filter(
             item => !item.selected  && (selectedKeys[item.key] || isSelectedOnGrid(item))));
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1015,21 +1015,21 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         }));
       }));
 
-    function _fireClickEvent(event, eventName) {
-      const target = event.target;
-      const eventContext = grid.getEventContext(event);
-      const section = eventContext.section;
+      function _fireClickEvent(event, eventName) {
+        const target = event.target;
+        const eventContext = grid.getEventContext(event);
+        const section = eventContext.section;
 
-      if (eventContext.item && !isFocusable(target) && section !== 'details') {
-        event.itemKey = eventContext.item.key;
-        // if you have a details-renderer, getEventContext().column is undefined
-        if (eventContext.column) {
-          event.internalColumnId = eventContext.column._flowId;
+        if (eventContext.item && !isFocusable(target) && section !== 'details') {
+          event.itemKey = eventContext.item.key;
+          // if you have a details-renderer, getEventContext().column is undefined
+          if (eventContext.column) {
+            event.internalColumnId = eventContext.column._flowId;
+          }
+          grid.dispatchEvent(new CustomEvent(eventName,
+            { detail: event }));
         }
-        grid.dispatchEvent(new CustomEvent(eventName,
-          { detail: event }));
       }
-    }
 
       grid.cellClassNameGenerator = tryCatchWrapper(function(column, rowData) {
           const style = rowData.item.style;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -168,11 +168,11 @@ import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
               grid.$server.select(item.key);
             }
           }
-          const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
-          if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
-            grid.activeItem = item;
-            grid.$connector.activeItem = item;
-          }
+//          const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
+//          if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
+//            grid.activeItem = item;
+//            grid.$connector.activeItem = item;
+//          }
         });
       });
 
@@ -628,7 +628,7 @@ import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
           cache[pkey][page] = slice;
 
           grid.$connector.doSelection(slice.filter(
-            item => item.selected && !isSelectedOnGrid(item)), true);
+            item => item.selected && !isSelectedOnGrid(item)));
           grid.$connector.doDeselection(slice.filter(
             item => !item.selected  && (selectedKeys[item.key] || isSelectedOnGrid(item))));
 


### PR DESCRIPTION
## Description
This PR fixes the issue when a focusable element is used in header (prepended), and clicking on this element causes `item-click` event to be raised (with a pre condition that grid item's `key` values are changed by something like filtering and clearing the filter after a grid row is clicked). It fixes it by using `getEventContext` and do more checking in order not to fire click event.
It also removed usage of `$connector.activeItem` which was introduced as a workaround [before](https://github.com/vaadin/vaadin-grid-flow/commit/74b944acb2da62bc7fffe106a7d8e93f8173ba4f).

Fixes [#2247](https://github.com/vaadin/flow-components/issues/2247)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
