### PR TITLE
fix: don't raise item-click when focusable header is clicked after item keys are changed. (#2327) (CP: 21.0)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -15,16 +15,23 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.router.Route;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
 
 @Route("vaadin-grid/item-click-listener")
 public class ItemClickListenerPage extends Div {
+    static final String GRID_FILTER_FOCUSABLE_HEADER = "grid-filter-focusable-header";
 
     public ItemClickListenerPage() {
         Div clickMsg = new Div();
@@ -62,6 +69,8 @@ public class ItemClickListenerPage extends Div {
         grid.setDetailsVisible("bar", true);
 
         add(grid, clickMsg, dblClickMsg, columnClickMsg, columnDblClickMsg);
+
+        createGridWithChangingKeysOfItemsAndFocusableHeader();
     }
 
     private static Span getDetailsComponent(String s) {
@@ -70,4 +79,39 @@ public class ItemClickListenerPage extends Div {
         return result;
     }
 
+    private void createGridWithChangingKeysOfItemsAndFocusableHeader() {
+        Span message = new Span();
+        message.setId("item-click-event-log");
+
+        ListDataProvider<String> dataProvider = new ListDataProvider<>(
+                Arrays.asList("a", "b", "c"));
+        Grid<String> grid = new Grid<>();
+        grid.setItems(dataProvider);
+        grid.addColumn(x -> x).setHeader("Header");
+        grid.addItemClickListener(ev -> message.setText("ItemClicked"));
+        grid.setId(GRID_FILTER_FOCUSABLE_HEADER);
+
+        Button filterButton = new Button("Filter");
+        filterButton.setId("filterButton");
+        Button clearFilterButton = new Button("Clear filter");
+        clearFilterButton.setId("clearFilterButton");
+
+        filterButton.addClickListener(event -> filterGrid(dataProvider, "b"));
+        clearFilterButton
+                .addClickListener(event -> filterGrid(dataProvider, null));
+
+        TextField focusableHeader = new TextField();
+        focusableHeader.setId("focusableHeader");
+        grid.prependHeaderRow().getCells().get(0).setComponent(focusableHeader);
+        add(grid, filterButton, clearFilterButton, message);
+    }
+
+    private void filterGrid(ListDataProvider<String> dataProvider,
+            String filterValue) {
+        dataProvider.clearFilters();
+        if (filterValue != null) {
+            dataProvider.addFilter(
+                    item -> StringUtils.containsIgnoreCase(item, filterValue));
+        }
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.tests.AbstractComponentIT;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -28,6 +29,8 @@ import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import org.openqa.selenium.WebElement;
+
+import static com.vaadin.flow.component.grid.it.ItemClickListenerPage.GRID_FILTER_FOCUSABLE_HEADER;
 
 @TestPath("vaadin-grid/item-click-listener")
 public class ItemClickListenerIT extends AbstractComponentIT {
@@ -117,6 +120,37 @@ public class ItemClickListenerIT extends AbstractComponentIT {
         Assert.assertEquals("", getColumnDoubleClickMessage());
         Assert.assertEquals("", getDoubleClickMessage());
         Assert.assertEquals("", getClickMessage());
+    }
+
+    // Regression test for this issue:
+    // https://github.com/vaadin/flow-components/issues/2247
+    @Test
+    public void gridItemKeysChanged_whenFocusableHeaderElementClicked_shouldNotRaiseItemClickEvent() {
+        open();
+
+        // wait for grid to be loaded
+        waitUntil(driver -> $(GridElement.class)
+                .id(GRID_FILTER_FOCUSABLE_HEADER).getRowCount() > 0);
+
+        GridElement gridElement = $(GridElement.class)
+                .id(GRID_FILTER_FOCUSABLE_HEADER);
+
+        // Select an item with specific key
+        gridElement.select(0);
+
+        // Trigger key change on grid items by filtering
+        ButtonElement filterButton = $(ButtonElement.class).id("filterButton");
+        ButtonElement clearFilterButton = $(ButtonElement.class)
+                .id("clearFilterButton");
+        filterButton.click();
+        clearFilterButton.click();
+
+        WebElement focusableHeader = gridElement
+                .findElement(By.id("focusableHeader"));
+        focusableHeader.click();
+
+        TestBenchElement span = $("span").id("item-click-event-log");
+        Assert.assertEquals("", span.getText());
     }
 
     private String getColumnDoubleClickMessage() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -3,7 +3,6 @@ import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
-import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
 (function () {
   const tryCatchWrapper = function (callback) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1,8 +1,8 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
-import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
-import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
-import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
+import { GridElement } from '@vaadin/vaadin-grid/src/vaadin-grid.js';
+import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mixin.js';
+import { isFocusable } from '@vaadin/vaadin-grid/src/vaadin-grid-active-item-mixin.js';
 
 (function () {
   const tryCatchWrapper = function (callback) {


### PR DESCRIPTION
cherry-pick of this PR to version 21.0.

notable changes: change in imported names in `gridConnector.js`