### PR TITLE
fix: clear input element value when clearing custom value in ComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 
 @TestPath("vaadin-combo-box/clear-value")
 public class ClearValueIT extends AbstractComponentIT {
@@ -69,18 +70,60 @@ public class ClearValueIT extends AbstractComponentIT {
     }
 
     @Test
-    public void valueIsCorrectlyCleared_allowCustomValue() {
+    public void allowCustomValue_setInitialValue_valueIsCorrectlyCleared() {
         checkEmptyValue(ClearValuePage.COMBO_BOX_WITH_ALLOW_CUSTOM_VALUE_ID,
                 ClearValuePage.BUTTON_CUSTOM_VALUE_CLEAR_ID, true);
     }
 
     @Test
-    public void valueIsCorrectlySetToNull_allowCustomValue() {
+    public void allowCustomValue_setInitialValue_valueIsCorrectlySetToNull() {
         Assert.assertNull(
                 "Combobox empty value is not null, add clear tests also",
                 new ComboBox<>().getEmptyValue());
         checkEmptyValue(ClearValuePage.COMBO_BOX_WITH_ALLOW_CUSTOM_VALUE_ID,
                 ClearValuePage.BUTTON_CUSTOM_VALUE_SET_NULL_ID, true);
+    }
+
+    @Test
+    public void allowCustomValue_enterCustomValue_clearValue_inputElementValueIsCleared() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id(ClearValuePage.COMBO_BOX_WITH_ALLOW_CUSTOM_VALUE_ID);
+        TestBenchElement clearButton = $("button")
+                .id(ClearValuePage.BUTTON_CUSTOM_VALUE_CLEAR_ID);
+
+        // Clear initial value to set the state of the input element value
+        // property to an empty value
+        clearButton.click();
+        Assert.assertEquals("", comboBox.getInputElementValue());
+
+        // Enter custom value
+        comboBox.sendKeys("foo", Keys.ENTER);
+        Assert.assertEquals("foo", comboBox.getInputElementValue());
+
+        // Clear value
+        clearButton.click();
+        Assert.assertEquals("", comboBox.getInputElementValue());
+    }
+
+    @Test
+    public void allowCustomValue_enterCustomValue_setNullValue_inputElementValueIsCleared() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id(ClearValuePage.COMBO_BOX_WITH_ALLOW_CUSTOM_VALUE_ID);
+        TestBenchElement setNullButton = $("button")
+                .id(ClearValuePage.BUTTON_CUSTOM_VALUE_SET_NULL_ID);
+
+        // Set null value to set the state of the input element value property
+        // to an empty value
+        setNullButton.click();
+        Assert.assertEquals("", comboBox.getInputElementValue());
+
+        // Enter custom value
+        comboBox.sendKeys("foo", Keys.ENTER);
+        Assert.assertEquals("foo", comboBox.getInputElementValue());
+
+        // Set null value
+        setNullButton.click();
+        Assert.assertEquals("", comboBox.getInputElementValue());
     }
 
     private void checkEmptyValue(String comboBoxId, String buttonId,

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -298,6 +298,16 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         setItems(new DataCommunicator.EmptyDataProvider<>());
 
         getElement().setAttribute("suppress-template-warning", true);
+
+        // Synchronize input element value property state when setting a custom
+        // value. This is necessary to allow clearing the input value in
+        // `ComboBox.refreshValue`. If the input element value is not
+        // synchronized here, then setting the property to an empty value would
+        // not trigger a client update. Need to use `super` here, in order to
+        // avoid enabling custom values, which is a side effect of
+        // `ComboBox.addCustomValueSetListener`.
+        super.addCustomValueSetListener(e -> this.getElement()
+                .setProperty(PROP_INPUT_ELEMENT_VALUE, e.getDetail()));
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
@@ -93,6 +93,10 @@ public class ComboBoxElement extends TestBenchElement
                 + "  return selectedItem.label;", this);
     }
 
+    public String getInputElementValue() {
+        return this.getPropertyString("_inputElementValue");
+    }
+
     /**
      * Opens the popup with options, if it is not already open.
      */


### PR DESCRIPTION
## Description

Currently clearing the ComboBox using `ComboBox.clear()`, or using `ComboBox.setValue(null)`, does not clear the internal input element's value after entering a custom value. One cause here is that the [connector](https://github.com/vaadin/flow-components/blob/master/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js#L337) prevents propagating the value change event, probably because Flow uses item keys as values, and setting a custom value could interfere with that. That also means that the state of the value property is never updated on the server-side, which means setting the value to null/empty does not trigger a client-side update, since the values are the same.

To fix this I used a different property `_inputElementValue`, which is already being used by the [`refreshValue`](https://github.com/vaadin/flow-components/blob/master/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java#L398) method to clear the value of the internal input element. There is a similar issue here, in that the property is not observable, so Flow never gets notified about changes to it from the client-side. To fix this, I added an event listener for the `custom-value-set` event, and synchronize the `_inputElementValue` property there manually. That means that when clearing the value / setting it to null, the code linked above will trigger a client update, because now there is an actual value change.

Fixes #1090 

## Type of change

- [x] Bugfix
