### PR TITLE
fix: fix selecting an item in a single select grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModel.java
@@ -60,7 +60,7 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
 
     @Override
     public void selectFromClient(T item) {
-        if (Objects.equals(item, selectedItem)) {
+        if (Objects.equals(getItemId(item), getItemId(selectedItem))) {
             return;
         }
         doSelect(item, true);
@@ -68,7 +68,7 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
 
     @Override
     public void select(T item) {
-        if (Objects.equals(item, selectedItem)) {
+        if (Objects.equals(getItemId(item), getItemId(selectedItem))) {
             return;
         }
         T oldItem = selectedItem;
@@ -193,5 +193,10 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
         selectedItem = item;
         fireSelectionEvent(new SingleSelectionEvent<>(getGrid(),
                 getGrid().asSingleSelect(), oldValue, userOriginated));
+    }
+
+    private Object getItemId(T item) {
+        return item == null ? null
+                : getGrid().getDataCommunicator().getDataProvider().getId(item);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModelTest.java
@@ -1,0 +1,77 @@
+package com.vaadin.flow.component.grid;
+
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.data.provider.CallbackDataProvider;
+
+public class AbstractGridSingleSelectionModelTest {
+
+    private static final Person PERSON_C = new Person("c", 3);
+    private static final Person PERSON_B = new Person("b", 2);
+    private static final Person PERSON_A = new Person("a", 1);
+
+    private Grid<Person> grid;
+    private AbstractGridSingleSelectionModel<Person> selectionModel;
+    private CallbackDataProvider<Person, Void> spy;
+
+    @Before
+    public void init() {
+        grid = new Grid<>();
+        selectionModel = (AbstractGridSingleSelectionModel<Person>) grid
+                .getSelectionModel();
+        final CallbackDataProvider<Person, Void> dataProvider = new CallbackDataProvider<>(
+                query -> Stream.of(PERSON_A, PERSON_B, PERSON_C), query -> 3,
+                Person::getName);
+        spy = Mockito.spy(dataProvider);
+        grid.setItems(spy);
+    }
+
+    @Test // #2354
+    public void selectItem_dataProviderWithIdentifierProvider_identityUsedForEqualsComparison() {
+        grid.select(PERSON_A);
+
+        // called 3 times - once by selection model and twice by KeyMapper
+        Mockito.verify(spy, Mockito.times(3)).getId(PERSON_A);
+        Mockito.verify(spy, Mockito.never()).getId(PERSON_B);
+
+        Mockito.reset(spy);
+        grid.select(PERSON_B);
+
+        // called 3 times - once by selection model and twice by KeyMapper
+        Mockito.verify(spy, Mockito.times(3)).getId(PERSON_B);
+        // called 2 times - once by selection model and once by KeyMapper
+        Mockito.verify(spy, Mockito.times(2)).getId(PERSON_A);
+
+        Mockito.reset(spy);
+        grid.select(null);
+
+        // called 2 times - once by selection model and once by KeyMapper
+        Mockito.verify(spy, Mockito.times(2)).getId(PERSON_B);
+        Mockito.verify(spy, Mockito.never()).getId(null);
+    }
+
+    @Test // #2354
+    public void selectFromClient_dataProviderWithIdentifierProvider_identityUsedForEqualsComparison() {
+        selectionModel.selectFromClient(PERSON_A);
+
+        Mockito.verify(spy, Mockito.times(1)).getId(PERSON_A);
+        Mockito.verify(spy, Mockito.never()).getId(PERSON_B);
+
+        Mockito.reset(spy);
+        selectionModel.selectFromClient(PERSON_B);
+
+        Mockito.verify(spy, Mockito.times(1)).getId(PERSON_B);
+        Mockito.verify(spy, Mockito.times(1)).getId(PERSON_A);
+
+        Mockito.reset(spy);
+        selectionModel.selectFromClient(null);
+
+        // called 2 times - once by selection model and once by KeyMapper
+        Mockito.verify(spy, Mockito.times(1)).getId(PERSON_B);
+        Mockito.verify(spy, Mockito.never()).getId(null);
+    }
+}


### PR DESCRIPTION
Fixes selecting an item when an identifier provider is used through the
data provider or the data view API.

Fixes #2354

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.