### PR TITLE
feat: allow setting global options #2335

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ChartOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ChartOptions.java
@@ -8,6 +8,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.charts.model.AbstractConfigurationObject;
+import com.vaadin.flow.component.charts.model.Global;
 import com.vaadin.flow.component.charts.model.Lang;
 import com.vaadin.flow.component.charts.model.style.Theme;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
@@ -27,6 +28,7 @@ public class ChartOptions extends AbstractConfigurationObject {
     @JsonUnwrapped
     private Theme theme;
     private Lang lang;
+    private Global global;
     private transient JreJsonFactory jsonFactory;
 
     protected ChartOptions() {
@@ -95,6 +97,30 @@ public class ChartOptions extends AbstractConfigurationObject {
         this.theme = theme;
         updateOptions();
     }
+
+    /**
+     * Returns the {@link Global} in use or {@code null} if no global configuration
+     * has been set.
+     *
+     * @return the {@link Global} in use or {@code null}.
+     */
+    public Global getGlobal() {
+        return global;
+    }
+
+    /**
+     * Changes the Global params of all charts.
+     * <p/>
+     * Note that if the view is already drawn, all existing {@link Chart}s will
+     * be redrawn.
+     *
+     * @param global
+     */
+    public void setGlobal(Global global) {
+        this.global = global;
+        updateOptions();
+    }
+
 
     /**
      * Returns a ChartOptions instance for the given UI. If a ChartOptions

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ChartOptionsJSONSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ChartOptionsJSONSerializationTest.java
@@ -14,6 +14,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.charts.model.Global;
 import com.vaadin.flow.component.charts.model.Lang;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
 
@@ -83,5 +84,35 @@ public class ChartOptionsJSONSerializationTest {
         ChartOptions chartOptions = om.readValue(json, ChartOptions.class);
 
         Assert.assertArrayEquals(fiDays, chartOptions.getLang().getWeekdays());
+    }
+
+    @Test
+    public void toJSON_GlobalWithoutUTC()
+            throws IOException {
+        final Global noUTC = new Global();
+        noUTC.setUseUTC(false);
+
+        options.setGlobal(noUTC);
+        String json = toJSON(options);
+
+        ObjectMapper om = ChartSerialization.createObjectMapper();
+        ChartOptions chartOptions = om.readValue(json, ChartOptions.class);
+
+        Assert.assertFalse(chartOptions.getGlobal().getUseUTC());
+    }
+
+    @Test
+    public void toJSON_GlobalWithUTC()
+            throws IOException {
+        final Global withUTC = new Global();
+        withUTC.setUseUTC(true);
+
+        options.setGlobal(withUTC);
+        String json = toJSON(options);
+
+        ObjectMapper om = ChartSerialization.createObjectMapper();
+        ChartOptions chartOptions = om.readValue(json, ChartOptions.class);
+
+        Assert.assertTrue(chartOptions.getGlobal().getUseUTC());
     }
 }


### PR DESCRIPTION
## Description

The `Global` object is already present in the API, but there was no way to actually set it yet. This PR adds the necessary API.

Fixes #2335

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
