### PR TITLE
fix: prevent HasItem.getItem throwing ClassCastException

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/DrilldownEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/DrilldownEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -30,7 +30,8 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
     private final Double x;
     private final Double y;
     private final int pointIndex;
-    private int seriesIndex;
+    private final String pointId;
+    private final int seriesIndex;
 
     /**
      * Construct a ChartDrilldownEvent
@@ -43,6 +44,7 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
             @EventData("event.detail.originalEvent.point.x") Double x,
             @EventData("event.detail.originalEvent.point.y") Double y,
             @EventData("event.detail.originalEvent.point.index") int pointIndex,
+            @EventData("event.detail.originalEvent.point.id") String pointId,
             @EventData("event.detail.originalEvent.point.series.index") int seriesIndex) {
         super(source, fromClient);
 
@@ -51,6 +53,7 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
         this.x = x;
         this.y = y;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
         this.seriesIndex = seriesIndex;
     }
 
@@ -84,5 +87,10 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -14,8 +14,12 @@ package com.vaadin.flow.component.charts.events;
  */
 
 import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.charts.model.AbstractSeriesItem;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.NodeSeries;
+import com.vaadin.flow.component.charts.model.NodeSeriesItem;
 import com.vaadin.flow.component.charts.model.Series;
 
 /**
@@ -28,20 +32,63 @@ public interface HasItem extends HasSeries {
     String getCategory();
 
     /**
-     * Returns the index of {@link #getItem()} in {@link #getSeries()}.
-     *
-     * @return
+     * Returns the index of the series item, that is associated with this event, in {@link #getSeries()}.
+     * Can be used to identify the item within the series.
+     * <p>
+     * Example for {@link ListSeries}:
+     * <pre>
+     * {@code
+     * int itemIndex = event.getItemIndex();
+     * ListSeries series = (ListSeries) event.getSeries();
+     * Number datum = series.getData()[itemIndex];
+     * }
+     * </pre>
+     * @return the index of the item in the series
+     * @see #getItem()
+     * @see #getItemId()
      */
     int getItemIndex();
 
     /**
+     * The ID of the series item that is associated with the event.
+     * Can be used to identify the item within the series.
+     * <p>
+     * Example for {@link NodeSeries}:
+     * <pre>
+     * {@code
+     * String id = event.getItemId();
+     * NodeSeries series = (NodeSeries) event.getSeries();
+     * Optional<NodeSeriesItem> seriesItem = series.getData()
+     *     .stream()
+     *     .filter(item -> item.getId() != null && item.getId().equals(id))
+     *     .findFirst();
+     * }
+     * </pre>
+     * <p>
+     * Only {@link AbstractSeriesItem} and {@link NodeSeriesItem} support setting an ID.
+     * For other types of series items this property will always return null.
+     * For {@link AbstractSeriesItem} the ID is optional.
+     * Unless the developer has explicitly set an ID for the item associated with the event, this property will be null.
+     * See {@link #getItem()} or {@link #getItemIndex()} for alternatives.
+     *
+     * @return the ID of the series item associated with the event, or null if the series item has no ID
+     * @see #getItem()
+     * @see #getItemIndex()
+     */
+    String getItemId();
+
+    /**
      * Returns the data series item that this event is associated with.
+     * <p>
+     * <b>NOTE:</b> This method only works with series of type {@link DataSeries}.
+     * For other series an {@link UnsupportedOperationException} will be thrown.
+     * See {@link #getItemIndex()} or {@link #getItemId()} for alternatives.
      *
-     * This method only works with series of type DataSeries. For other series an UnsupportedOperationException will be thrown.
-     *
-     * @return the DataSeriesItem that is associated with this event
+     * @return the {@link DataSeriesItem} that is associated with this event
      * @throws UnsupportedOperationException
      *             when using this method with a series that is not a DataSeries
+     * @see #getItemIndex()
+     * @see #getItemId()
      */
     default DataSeriesItem getItem() {
         Series series = getSeries();

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -18,8 +18,8 @@ import com.vaadin.flow.component.charts.model.AbstractSeriesItem;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
 import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.Node;
 import com.vaadin.flow.component.charts.model.NodeSeries;
-import com.vaadin.flow.component.charts.model.NodeSeriesItem;
 import com.vaadin.flow.component.charts.model.Series;
 
 /**
@@ -56,16 +56,14 @@ public interface HasItem extends HasSeries {
      * Example for {@link NodeSeries}:
      * <pre>
      * {@code
-     * String id = event.getItemId();
-     * NodeSeries series = (NodeSeries) event.getSeries();
-     * Optional<NodeSeriesItem> seriesItem = series.getData()
-     *     .stream()
-     *     .filter(item -> item.getId() != null && item.getId().equals(id))
-     *     .findFirst();
-     * }
+     * String id = this.getItemId();
+     * NodeSeries series = (NodeSeries) this.getSeries();
+     * Optional<Node> nodeForId = series.getNodes().stream()
+     *   .filter(node -> node.getId().equals(id))
+     *   .findFirst();
      * </pre>
      * <p>
-     * Only {@link AbstractSeriesItem} and {@link NodeSeriesItem} support setting an ID.
+     * Only {@link AbstractSeriesItem} and {@link Node} support setting an ID.
      * For other types of series items this property will always return null.
      * For {@link AbstractSeriesItem} the ID is optional.
      * Unless the developer has explicitly set an ID for the item associated with the event, this property will be null.

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -16,6 +16,7 @@ package com.vaadin.flow.component.charts.events;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.Series;
 
 /**
  * Indicates that an event has an associated item
@@ -34,11 +35,20 @@ public interface HasItem extends HasSeries {
     int getItemIndex();
 
     /**
-     * Returns the item that was clicked
+     * Returns the data series item that this event is associated with.
      *
-     * @return
+     * This method only works with series of type DataSeries. For other series an UnsupportedOperationException will be thrown.
+     *
+     * @return the DataSeriesItem that is associated with this event
+     * @throws UnsupportedOperationException
+     *             when using this method with a series that is not a DataSeries
      */
     default DataSeriesItem getItem() {
-        return ((DataSeries) getSeries()).get(getItemIndex());
+        Series series = getSeries();
+        if(!(series instanceof DataSeries)) {
+            String seriesClassName = series.getClass().getSimpleName();
+            throw new UnsupportedOperationException(String.format("HasItem.getItem does not support series of type: %s. Only series of type com.vaadin.flow.component.charts.model.DataSeries are supported. Please check the API docs for further information.", seriesClassName));
+        }
+        return ((DataSeries) series).get(getItemIndex());
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -32,17 +32,18 @@ public interface HasItem extends HasSeries {
     String getCategory();
 
     /**
-     * Returns the index of the series item, that is associated with this event, in {@link #getSeries()}.
-     * Can be used to identify the item within the series.
+     * Returns the index of the series item, that is associated with this event,
+     * in {@link #getSeries()}. Can be used to identify the item within the
+     * series.
      * <p>
      * Example for {@link ListSeries}:
+     *
      * <pre>
-     * {@code
      * int itemIndex = event.getItemIndex();
      * ListSeries series = (ListSeries) event.getSeries();
      * Number datum = series.getData()[itemIndex];
-     * }
      * </pre>
+     *
      * @return the index of the item in the series
      * @see #getItem()
      * @see #getItemId()
@@ -50,26 +51,29 @@ public interface HasItem extends HasSeries {
     int getItemIndex();
 
     /**
-     * The ID of the series item that is associated with the event.
-     * Can be used to identify the item within the series.
+     * The ID of the series item that is associated with the event. Can be used
+     * to identify the item within the series.
      * <p>
      * Example for {@link NodeSeries}:
+     *
      * <pre>
-     * {@code
      * String id = this.getItemId();
      * NodeSeries series = (NodeSeries) this.getSeries();
-     * Optional<Node> nodeForId = series.getNodes().stream()
+     * Optional&lt;Node&gt; nodeForId = series.getNodes().stream()
      *   .filter(node -> node.getId().equals(id))
      *   .findFirst();
      * </pre>
      * <p>
      * Only {@link AbstractSeriesItem} and {@link Node} support setting an ID.
      * For other types of series items this property will always return null.
-     * For {@link AbstractSeriesItem} the ID is optional.
-     * Unless the developer has explicitly set an ID for the item associated with the event, this property will be null.
-     * See {@link #getItem()} or {@link #getItemIndex()} for alternatives.
+     * For {@link AbstractSeriesItem} the ID is optional. Unless the developer
+     * has explicitly set an ID for the item associated with the event, this
+     * property will be null. See {@link #getItem()} or {@link #getItemIndex()}
+     * for alternatives.
      *
-     * @return the ID of the series item associated with the event, or null if the series item has no ID
+     * @return the ID of the series item associated with the event, or null if
+     *         the series item has no ID
+     *
      * @see #getItem()
      * @see #getItemIndex()
      */
@@ -78,9 +82,10 @@ public interface HasItem extends HasSeries {
     /**
      * Returns the data series item that this event is associated with.
      * <p>
-     * <b>NOTE:</b> This method only works with series of type {@link DataSeries}.
-     * For other series an {@link UnsupportedOperationException} will be thrown.
-     * See {@link #getItemIndex()} or {@link #getItemId()} for alternatives.
+     * <b>NOTE:</b> This method only works with series of type
+     * {@link DataSeries}. For other series an
+     * {@link UnsupportedOperationException} will be thrown. See
+     * {@link #getItemIndex()} or {@link #getItemId()} for alternatives.
      *
      * @return the {@link DataSeriesItem} that is associated with this event
      * @throws UnsupportedOperationException
@@ -90,9 +95,11 @@ public interface HasItem extends HasSeries {
      */
     default DataSeriesItem getItem() {
         Series series = getSeries();
-        if(!(series instanceof DataSeries)) {
+        if (!(series instanceof DataSeries)) {
             String seriesClassName = series.getClass().getSimpleName();
-            throw new UnsupportedOperationException(String.format("HasItem.getItem does not support series of type: %s. Only series of type com.vaadin.flow.component.charts.model.DataSeries are supported. Please check the API docs for further information.", seriesClassName));
+            throw new UnsupportedOperationException(String.format(
+                    "HasItem.getItem does not support series of type: %s. Only series of type com.vaadin.flow.component.charts.model.DataSeries are supported. Please check the API docs for further information.",
+                    seriesClassName));
         }
         return ((DataSeries) series).get(getItemIndex());
     }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointClickEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -29,6 +29,7 @@ public class PointClickEvent extends ComponentEvent<Chart>
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
     private final MouseEventDetails details;
 
     /**
@@ -46,6 +47,7 @@ public class PointClickEvent extends ComponentEvent<Chart>
      * @param seriesIndex
      * @param category
      * @param pointIndex
+     * @param pointId
      */
     public PointClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.pageX") int pageX,
@@ -59,11 +61,13 @@ public class PointClickEvent extends ComponentEvent<Chart>
             @EventData("event.detail.originalEvent.point.y") double y,
             @EventData("event.detail.originalEvent.point.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.point.category") String category,
-            @EventData("event.detail.originalEvent.point.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.point.index") int pointIndex,
+            @EventData("event.detail.originalEvent.point.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
 
         details = new MouseEventDetails();
         details.setxValue(x);
@@ -95,5 +99,10 @@ public class PointClickEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -29,11 +29,12 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
     private final MouseEventDetails details;
 
     /**
      * Constructs a SeriesLegendItemClickEvent
-     * 
+     *
      * @param source
      * @param fromClient
      */
@@ -47,11 +48,13 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
             @EventData("event.detail.originalEvent.button") int button,
             @EventData("event.detail.point.series.index") int seriesIndex,
             @EventData("event.detail.point.category") String category,
-            @EventData("event.detail.point.index") int pointIndex) {
+            @EventData("event.detail.point.index") int pointIndex,
+            @EventData("event.detail.point.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
 
         details = new MouseEventDetails();
         details.setAbsoluteX(pageX);
@@ -76,6 +79,11 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 
     @Override

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOutEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOutEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -28,14 +28,17 @@ public class PointMouseOutEvent extends ComponentEvent<Chart>
     private final String category;
     private final int seriesIndex;
     private final int pointIndex;
+    private final String pointId;
 
     public PointMouseOutEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId,
             @EventData("event.detail.originalEvent.target.category") String category) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
         this.category = category;
     }
 
@@ -47,6 +50,11 @@ public class PointMouseOutEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 
     @Override

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOverEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOverEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -28,14 +28,17 @@ public class PointMouseOverEvent extends ComponentEvent<Chart>
     private final String category;
     private final int seriesIndex;
     private final int pointIndex;
+    private final String pointId;
 
     public PointMouseOverEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId,
             @EventData("event.detail.originalEvent.target.category") String category) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
         this.category = category;
     }
 
@@ -47,6 +50,11 @@ public class PointMouseOverEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 
     @Override

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointRemoveEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointRemoveEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -30,19 +30,22 @@ public class PointRemoveEvent extends ComponentEvent<Chart> implements HasItem {
     private final double x;
     private final double y;
     private final int pointIndex;
+    private final String pointId;
 
     public PointRemoveEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
             @EventData("event.detail.originalEvent.target.x") double x,
             @EventData("event.detail.originalEvent.target.y") double y,
-            @EventData("event.detail.originalEvent.target.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.x = x;
         this.y = y;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -66,5 +69,10 @@ public class PointRemoveEvent extends ComponentEvent<Chart> implements HasItem {
 
     public double getyValue() {
         return y;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointSelectEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointSelectEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -28,15 +28,18 @@ public class PointSelectEvent extends ComponentEvent<Chart> implements HasItem {
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
 
     public PointSelectEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
-            @EventData("event.detail.originalEvent.target.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -52,5 +55,10 @@ public class PointSelectEvent extends ComponentEvent<Chart> implements HasItem {
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUnselectEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUnselectEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -29,15 +29,18 @@ public class PointUnselectEvent extends ComponentEvent<Chart>
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
 
     public PointUnselectEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
-            @EventData("event.detail.originalEvent.target.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -53,5 +56,10 @@ public class PointUnselectEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUpdateEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUpdateEvent.java
@@ -8,7 +8,7 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
- * 
+ *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%
  */
@@ -32,11 +32,13 @@ public class PointUpdateEvent extends ComponentEvent<Chart> implements HasItem {
     private final Double newXValue;
     private final Double newYValue;
     private final int pointIndex;
+    private final String pointId;
 
     public PointUpdateEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
             @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId,
             @EventData("event.detail.originalEvent.target.x") Double oldXValue,
             @EventData("event.detail.originalEvent.target.y") Double oldYValue,
             @EventData("event.detail.originalEvent.options.x") Double newXValue,
@@ -49,6 +51,7 @@ public class PointUpdateEvent extends ComponentEvent<Chart> implements HasItem {
         this.newXValue = newXValue;
         this.newYValue = newYValue;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     public Double getOldXValue() {
@@ -80,5 +83,10 @@ public class PointUpdateEvent extends ComponentEvent<Chart> implements HasItem {
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
@@ -96,11 +96,8 @@ public class HasItemTest {
         private final int itemIndex;
         private final int seriesItemIndex;
 
-        public HasItemTestImpl(
-                Chart chart,
-                int itemIndex,
-                int seriesItemIndex
-        ) {
+        public HasItemTestImpl(Chart chart, int itemIndex,
+                int seriesItemIndex) {
             this.chart = chart;
             this.itemIndex = itemIndex;
             this.seriesItemIndex = seriesItemIndex;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.charts;
+
+import com.vaadin.flow.component.charts.events.HasItem;
+import com.vaadin.flow.component.charts.model.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HasItemTest {
+    @Test
+    public void getSeries() {
+        Chart chart = new Chart();
+        DataSeries series = new DataSeries();
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        Series result = hasItem.getSeries();
+
+        Assert.assertEquals(series, result);
+    }
+
+    @Test
+    public void getItemWithDataSeries() {
+        Chart chart = new Chart();
+        DataSeriesItem item = new DataSeriesItem(5, 10);
+        DataSeries series = new DataSeries(item);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        DataSeriesItem result = hasItem.getItem();
+
+        Assert.assertEquals(item, result);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItemWithNodeSeriesThrowsUnsupportedOperationException() {
+        Chart chart = new Chart();
+        Node node1 = new Node("Node1");
+        Node node2 = new Node("Node2");
+        NodeSeries series = new NodeSeries();
+        series.add(node1, node2);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        hasItem.getItem();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItemWithListSeriesThrowsUnsupportedOperationException() {
+        Chart chart = new Chart();
+        ListSeries series = new ListSeries(1, 2, 3);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        hasItem.getItem();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItemWithTreeSeriesThrowsUnsupportedOperationException() {
+        Chart chart = new Chart();
+        TreeSeriesItem item = new TreeSeriesItem("1", "1");
+        TreeSeries series = new TreeSeries();
+        series.add(item);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        hasItem.getItem();
+    }
+
+    private static class HasItemTestImpl implements HasItem {
+
+        private final Chart chart;
+        private final int itemIndex;
+        private final int seriesItemIndex;
+
+        public HasItemTestImpl(
+                Chart chart,
+                int itemIndex,
+                int seriesItemIndex
+        ) {
+            this.chart = chart;
+            this.itemIndex = itemIndex;
+            this.seriesItemIndex = seriesItemIndex;
+        }
+
+        @Override
+        public Chart getSource() {
+            return this.chart;
+        }
+
+        @Override
+        public String getCategory() {
+            return null;
+        }
+
+        @Override
+        public int getItemIndex() {
+            return this.itemIndex;
+        }
+
+        @Override
+        public int getSeriesItemIndex() {
+            return this.seriesItemIndex;
+        }
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
@@ -18,7 +18,14 @@
 package com.vaadin.flow.component.charts;
 
 import com.vaadin.flow.component.charts.events.HasItem;
-import com.vaadin.flow.component.charts.model.*;
+import com.vaadin.flow.component.charts.model.DataSeries;
+import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.Node;
+import com.vaadin.flow.component.charts.model.NodeSeries;
+import com.vaadin.flow.component.charts.model.Series;
+import com.vaadin.flow.component.charts.model.TreeSeries;
+import com.vaadin.flow.component.charts.model.TreeSeriesItem;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -112,6 +119,11 @@ public class HasItemTest {
         @Override
         public int getItemIndex() {
             return this.itemIndex;
+        }
+
+        @Override
+        public String getItemId() {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
## Description

Context: Charts

Currently using `HasItem.getItem` (for example through `PointClickEvent.getItem`) with any series other than `DataSeries` results in a `ClassCastException`. The issue is that the method assumes that all series will be a `DataSeries`, and it can only return a `DataSeriesItem` as well. Additionally there are no obvious solutions for how to get the item from an event for other series, like `NodeSeries` or `ListSeries`.

As this is a common API we can not modify its signature or name to reflect that it only works with DataSeries. We also can not introduce major new APIs to handle other series types. Instead this change contains:
- throw a more appropriate `UnsupportedOperationException` with a relevant message that indicates that this method only works for `DataSeries`
- update the `HasItem.getItem` JavaDoc to note about the fact
- in order to support retrieving items from series other than `DataSeries`:
  - add a `HasItem.getItemId` method that returns the ID of the item, and implement it in all event classes implementing `HasItem`. The item ID be used to manually identify the item in the series data, given that the series items support setting an ID.
  - add JavaDoc to the method to note about its usage as an alternative to `HasItem.getItem` and add example code for `NodeSeries`
  - add JavaDoc to `HasItem.getItemIndex` to note about its usage as an alternative to `HasItem.getItem` and add example code for `ListSeries`

I did manual testing to verify that the item / point ID is provided by all events that implement `HasItem`.

Fixes #1040 

## Type of change

- [X] Bugfix
