### PR TITLE
chore: fix formatter config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,16 +425,9 @@
                 <artifactId>formatter-maven-plugin</artifactId>
                 <version>2.11.0</version>
                 <configuration>
-                    <configFile>eclipse/VaadinJavaConventions.xml</configFile>
+                    <configFile>https://raw.githubusercontent.com/vaadin/flow/master/eclipse/VaadinJavaConventions.xml</configFile>
                     <skipHtmlFormatting>true</skipHtmlFormatting>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>${project.groupId}</groupId>
-                        <artifactId>flow-buildtools</artifactId>
-                        <version>${flow.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Description

Fix the code formatter config to remove the invalid buildtools dependency, and load the config from Github instead. Based on the changes from: https://github.com/vaadin/flow/pull/12430
