### PR TITLE
refactor: change internal components of vaadin-select to vaadin-select-list-box and vaadin-select-item

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/SelectListDataViewIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/SelectListDataViewIT.java
@@ -112,12 +112,12 @@ public class SelectListDataViewIT extends AbstractComponentIT {
         findElement(By.id(SelectListDataViewPage.SORT_BUTTON)).click();
 
         Assert.assertEquals("Unexpected sort order", "John,Mike,Paul",
-                select.$("vaadin-item").all().stream()
+                select.$("vaadin-select-item").all().stream()
                         .map(TestBenchElement::getText)
                         .collect(Collectors.joining(",")));
 
         Assert.assertEquals("Unexpected sort order", "John,Paul,Mike",
-                otherSelect.$("vaadin-item").all().stream()
+                otherSelect.$("vaadin-select-item").all().stream()
                         .map(TestBenchElement::getText)
                         .collect(Collectors.joining(",")));
     }
@@ -127,15 +127,15 @@ public class SelectListDataViewIT extends AbstractComponentIT {
         findElement(By.id(SelectListDataViewPage.FILTER_BUTTON)).click();
 
         Assert.assertEquals("Unexpected filtered items count", 1,
-                select.$("vaadin-item").all().size());
+                select.$("vaadin-select-item").all().size());
         Assert.assertEquals("Unexpected filtered item", "Paul",
-                select.$("vaadin-item").all().get(0).getText());
+                select.$("vaadin-select-item").all().get(0).getText());
 
         Assert.assertEquals("No filter expected", 3,
-                otherSelect.$("vaadin-item").all().size());
+                otherSelect.$("vaadin-select-item").all().size());
         Assert.assertArrayEquals("No filter expected",
                 new String[] { "John", "Paul", "Mike" },
-                otherSelect.$("vaadin-item").all().stream()
+                otherSelect.$("vaadin-select-item").all().stream()
                         .map(TestBenchElement::getText).toArray());
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -185,10 +185,10 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
      * are not the correct ones, e.g. the list box is the only child of select,
      * even though that is not visible from the component level.
      */
-    @Tag("vaadin-list-box")
+    @Tag("vaadin-select-list-box")
     @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.0-alpha1")
     @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-    private class InternalListBox<T> extends Component
+    private class InternalListBox extends Component
             implements HasItemComponents<T> {
 
         @Override

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -169,7 +169,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
 
     /*
      * Internal version of list box that is just used to delegate the child
-     * components to. vaadin-select.html imports vaadin-list-box.html.
+     * components to.
      *
      * Using this internally allows all events and updates to the children
      * (items, possible child components) to work even though the list box

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
  * @param <T>
  *            the type of the bean
  */
-@Tag("vaadin-item")
+@Tag("vaadin-select-item")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.0-alpha1")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 class VaadinItem<T> extends Component implements

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
@@ -25,8 +25,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.data.binder.HasItemComponents;
 
 /**
- * Internal representation of {@code <vaadin-item>}. vaadin-select.html imports
- * vaadin-item.html.
+ * Internal representation of {@code <vaadin-select-item>}.
  *
  * @param <T>
  *            the type of the bean

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
@@ -8,7 +8,7 @@
             const _findListBoxElement = tryCatchWrapper(function () {
                 for (let i = 0; i < select.childElementCount; i++) {
                     const child = select.children[i];
-                    if ("VAADIN-LIST-BOX" === child.tagName.toUpperCase()) {
+                    if ("VAADIN-SELECT-LIST-BOX" === child.tagName.toUpperCase()) {
                         return child;
                     }
                 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -256,13 +256,13 @@ public class SelectTest {
         select.setTextRenderer(bean -> "!" + bean.getProperty());
 
         Assert.assertEquals(
-                "<vaadin-item value=\"1\">\n <span>!foo</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"1\">\n <span>!foo</span>\n</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-item value=\"2\">\n <span>!bar</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"2\">\n <span>!bar</span>\n</vaadin-select-item>",
                 getListBoxChild(1).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-item value=\"3\">\n <span>!baz</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"3\">\n <span>!baz</span>\n</vaadin-select-item>",
                 getListBoxChild(2).getOuterHTML());
     }
 
@@ -273,21 +273,21 @@ public class SelectTest {
                 (SerializableFunction<String, Span>) Span::new));
 
         Assert.assertEquals(
-                "<vaadin-item value=\"1\">\n <span>foo</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"1\">\n <span>foo</span>\n</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-item value=\"2\">\n <span>bar</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"2\">\n <span>bar</span>\n</vaadin-select-item>",
                 getListBoxChild(1).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-item value=\"3\">\n <span>baz</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"3\">\n <span>baz</span>\n</vaadin-select-item>",
                 getListBoxChild(2).getOuterHTML());
 
         select.setItems("1", "2");
         Assert.assertEquals(
-                "<vaadin-item value=\"4\">\n <span>1</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"4\">\n <span>1</span>\n</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-item value=\"5\">\n <span>2</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"5\">\n <span>2</span>\n</vaadin-select-item>",
                 getListBoxChild(1).getOuterHTML());
     }
 
@@ -298,7 +298,7 @@ public class SelectTest {
                 (SerializableFunction<String, Span>) Span::new));
         select.setItemLabelGenerator(item -> "bar");
         Assert.assertEquals(
-                "<vaadin-item value=\"1\" label=\"bar\">\n <span>foo</span>\n</vaadin-item>",
+                "<vaadin-select-item value=\"1\" label=\"bar\">\n <span>foo</span>\n</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
     }
 
@@ -312,7 +312,7 @@ public class SelectTest {
 
         // getOuterHTML jsoup interprets the property value with "" as value as
         // a boolean
-        Assert.assertEquals("<vaadin-item value></vaadin-item>",
+        Assert.assertEquals("<vaadin-select-item value></vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
 
         validateItem(0, "", null, true);
@@ -327,7 +327,7 @@ public class SelectTest {
         select.setEmptySelectionAllowed(true);
         select.setEmptySelectionCaption("EMPTY");
 
-        Assert.assertEquals("<vaadin-item value>\n EMPTY\n</vaadin-item>",
+        Assert.assertEquals("<vaadin-select-item value>\n EMPTY\n</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
 
         validateItem(0, "EMPTY", null, true);

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -327,7 +327,8 @@ public class SelectTest {
         select.setEmptySelectionAllowed(true);
         select.setEmptySelectionCaption("EMPTY");
 
-        Assert.assertEquals("<vaadin-select-item value>\n EMPTY\n</vaadin-select-item>",
+        Assert.assertEquals(
+                "<vaadin-select-item value>\n EMPTY\n</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
 
         validateItem(0, "EMPTY", null, true);

--- a/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.WebElement;
 public class SelectElement extends TestBenchElement
         implements HasSelectByText, HasLabel, HasPlaceholder, HasHelper {
 
-    @Element("vaadin-item")
+    @Element("vaadin-select-item")
     public static class ItemElement extends TestBenchElement {
         public ItemElement() {
             // needed for creating instances inside TB
@@ -46,19 +46,6 @@ public class SelectElement extends TestBenchElement
 
         // used to convert in streams
         ItemElement(WebElement item, TestBenchCommandExecutor commandExecutor) {
-            super(item, commandExecutor);
-        }
-    }
-
-    @Element("vaadin-select-item")
-    public static class SelectItemElement extends ItemElement {
-        public SelectItemElement() {
-            // needed for creating instances inside TB
-        }
-
-        // used to convert in streams
-        SelectItemElement(WebElement item,
-                TestBenchCommandExecutor commandExecutor) {
             super(item, commandExecutor);
         }
     }
@@ -89,8 +76,8 @@ public class SelectElement extends TestBenchElement
     public Stream<ItemElement> getItemsStream() {
         openPopup();
         List<WebElement> elements = getPropertyElement("_overlayElement")
-                .findElement(By.tagName("vaadin-list-box"))
-                .findElements(By.tagName("vaadin-item"));
+                .findElement(By.tagName("vaadin-select-list-box"))
+                .findElements(By.tagName("vaadin-select-item"));
         if (elements.size() == 0) {
             return Stream.<ItemElement> builder().build();
         }
@@ -124,17 +111,6 @@ public class SelectElement extends TestBenchElement
 
     public ItemElement getSelectedItem() {
         TestBenchElement valueElement = $("vaadin-select-value-button").first();
-
-        // TODO: Remove after aligning flow-components with changes from
-        // https://github.com/vaadin/web-components/pull/2990
-        ElementQuery<SelectItemElement> selectItemElementQuery = valueElement
-                .$(SelectItemElement.class);
-
-        // Check for vaadin-select-item first
-        if (selectItemElementQuery.exists())
-            return selectItemElementQuery.first();
-
-        // Alternatively look for vaadin-item
         return valueElement.$(ItemElement.class).first();
     }
 }


### PR DESCRIPTION
## Description

To align the Flow component to it's web-component counterpart with the changes introduced in https://github.com/vaadin/web-components/pull/2990, the `vaadin-select` component will now use `vaadin-select-list-box` and `vaadin-select-item` internally.

Fixes #2369

## Type of change

- Refactor
