### PR TITLE
fix: prevent HasItem.getItem throwing ClassCastException (#2390) (CP: 14.8)

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/DrilldownEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/DrilldownEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -34,7 +34,8 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
     private final Double x;
     private final Double y;
     private final int pointIndex;
-    private int seriesIndex;
+    private final String pointId;
+    private final int seriesIndex;
 
     /**
      * Construct a ChartDrilldownEvent
@@ -47,6 +48,7 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
             @EventData("event.detail.originalEvent.point.x") Double x,
             @EventData("event.detail.originalEvent.point.y") Double y,
             @EventData("event.detail.originalEvent.point.index") int pointIndex,
+            @EventData("event.detail.originalEvent.point.id") String pointId,
             @EventData("event.detail.originalEvent.point.series.index") int seriesIndex) {
         super(source, fromClient);
 
@@ -55,6 +57,7 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
         this.x = x;
         this.y = y;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
         this.seriesIndex = seriesIndex;
     }
 
@@ -88,5 +91,10 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -8,18 +8,23 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
  */
 
 import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.charts.model.AbstractSeriesItem;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.Node;
+import com.vaadin.flow.component.charts.model.NodeSeries;
+import com.vaadin.flow.component.charts.model.Series;
 
 /**
  * Indicates that an event has an associated item
@@ -31,18 +36,75 @@ public interface HasItem extends HasSeries {
     String getCategory();
 
     /**
-     * Returns the index of {@link #getItem()} in {@link #getSeries()}.
+     * Returns the index of the series item, that is associated with this event,
+     * in {@link #getSeries()}. Can be used to identify the item within the
+     * series.
+     * <p>
+     * Example for {@link ListSeries}:
      *
-     * @return
+     * <pre>
+     * int itemIndex = event.getItemIndex();
+     * ListSeries series = (ListSeries) event.getSeries();
+     * Number datum = series.getData()[itemIndex];
+     * </pre>
+     *
+     * @return the index of the item in the series
+     * @see #getItem()
+     * @see #getItemId()
      */
     int getItemIndex();
 
     /**
-     * Returns the item that was clicked
+     * The ID of the series item that is associated with the event. Can be used
+     * to identify the item within the series.
+     * <p>
+     * Example for {@link NodeSeries}:
      *
-     * @return
+     * <pre>
+     * String id = this.getItemId();
+     * NodeSeries series = (NodeSeries) this.getSeries();
+     * Optional&lt;Node&gt; nodeForId = series.getNodes().stream()
+     *   .filter(node -> node.getId().equals(id))
+     *   .findFirst();
+     * </pre>
+     * <p>
+     * Only {@link AbstractSeriesItem} and {@link Node} support setting an ID.
+     * For other types of series items this property will always return null.
+     * For {@link AbstractSeriesItem} the ID is optional. Unless the developer
+     * has explicitly set an ID for the item associated with the event, this
+     * property will be null. See {@link #getItem()} or {@link #getItemIndex()}
+     * for alternatives.
+     *
+     * @return the ID of the series item associated with the event, or null if
+     *         the series item has no ID
+     *
+     * @see #getItem()
+     * @see #getItemIndex()
+     */
+    String getItemId();
+
+    /**
+     * Returns the data series item that this event is associated with.
+     * <p>
+     * <b>NOTE:</b> This method only works with series of type
+     * {@link DataSeries}. For other series an
+     * {@link UnsupportedOperationException} will be thrown. See
+     * {@link #getItemIndex()} or {@link #getItemId()} for alternatives.
+     *
+     * @return the {@link DataSeriesItem} that is associated with this event
+     * @throws UnsupportedOperationException
+     *             when using this method with a series that is not a DataSeries
+     * @see #getItemIndex()
+     * @see #getItemId()
      */
     default DataSeriesItem getItem() {
-        return ((DataSeries) getSeries()).get(getItemIndex());
+        Series series = getSeries();
+        if (!(series instanceof DataSeries)) {
+            String seriesClassName = series.getClass().getSimpleName();
+            throw new UnsupportedOperationException(String.format(
+                    "HasItem.getItem does not support series of type: %s. Only series of type com.vaadin.flow.component.charts.model.DataSeries are supported. Please check the API docs for further information.",
+                    seriesClassName));
+        }
+        return ((DataSeries) series).get(getItemIndex());
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -22,9 +22,8 @@ import com.vaadin.flow.component.charts.model.AbstractSeriesItem;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
 import com.vaadin.flow.component.charts.model.ListSeries;
-import com.vaadin.flow.component.charts.model.Node;
-import com.vaadin.flow.component.charts.model.NodeSeries;
 import com.vaadin.flow.component.charts.model.Series;
+import com.vaadin.flow.component.charts.model.TreeSeries;
 
 /**
  * Indicates that an event has an associated item
@@ -58,17 +57,17 @@ public interface HasItem extends HasSeries {
      * The ID of the series item that is associated with the event. Can be used
      * to identify the item within the series.
      * <p>
-     * Example for {@link NodeSeries}:
+     * Example for {@link TreeSeries}:
      *
      * <pre>
      * String id = this.getItemId();
-     * NodeSeries series = (NodeSeries) this.getSeries();
-     * Optional&lt;Node&gt; nodeForId = series.getNodes().stream()
-     *   .filter(node -> node.getId().equals(id))
+     * TreeSeries series = (TreeSeries) this.getSeries();
+     * Optional&lt;TreeSeriesItem&gt; treeItem = series.getData().stream()
+     *   .filter(item -> item.getId().equals(id))
      *   .findFirst();
      * </pre>
      * <p>
-     * Only {@link AbstractSeriesItem} and {@link Node} support setting an ID.
+     * Only {@link AbstractSeriesItem} supports setting an ID.
      * For other types of series items this property will always return null.
      * For {@link AbstractSeriesItem} the ID is optional. Unless the developer
      * has explicitly set an ID for the item associated with the event, this

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasItem.java
@@ -67,10 +67,10 @@ public interface HasItem extends HasSeries {
      *   .findFirst();
      * </pre>
      * <p>
-     * Only {@link AbstractSeriesItem} supports setting an ID.
-     * For other types of series items this property will always return null.
-     * For {@link AbstractSeriesItem} the ID is optional. Unless the developer
-     * has explicitly set an ID for the item associated with the event, this
+     * Only {@link AbstractSeriesItem} supports setting an ID. For other types
+     * of series items this property will always return null. For
+     * {@link AbstractSeriesItem} the ID is optional. Unless the developer has
+     * explicitly set an ID for the item associated with the event, this
      * property will be null. See {@link #getItem()} or {@link #getItemIndex()}
      * for alternatives.
      *

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointClickEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -33,6 +33,7 @@ public class PointClickEvent extends ComponentEvent<Chart>
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
     private final MouseEventDetails details;
 
     /**
@@ -50,6 +51,7 @@ public class PointClickEvent extends ComponentEvent<Chart>
      * @param seriesIndex
      * @param category
      * @param pointIndex
+     * @param pointId
      */
     public PointClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.pageX") int pageX,
@@ -63,11 +65,13 @@ public class PointClickEvent extends ComponentEvent<Chart>
             @EventData("event.detail.originalEvent.point.y") double y,
             @EventData("event.detail.originalEvent.point.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.point.category") String category,
-            @EventData("event.detail.originalEvent.point.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.point.index") int pointIndex,
+            @EventData("event.detail.originalEvent.point.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
 
         details = new MouseEventDetails();
         details.setxValue(x);
@@ -99,5 +103,10 @@ public class PointClickEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -33,21 +33,24 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
 
     /**
      * Constructs a SeriesLegendItemClickEvent
-     * 
+     *
      * @param source
      * @param fromClient
      */
     public PointLegendItemClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.point.series.index") int seriesIndex,
             @EventData("event.detail.point.category") String category,
-            @EventData("event.detail.point.index") int pointIndex) {
+            @EventData("event.detail.point.index") int pointIndex,
+            @EventData("event.detail.point.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -63,5 +66,10 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOutEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOutEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -32,14 +32,17 @@ public class PointMouseOutEvent extends ComponentEvent<Chart>
     private final String category;
     private final int seriesIndex;
     private final int pointIndex;
+    private final String pointId;
 
     public PointMouseOutEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId,
             @EventData("event.detail.originalEvent.target.category") String category) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
         this.category = category;
     }
 
@@ -51,6 +54,11 @@ public class PointMouseOutEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 
     @Override

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOverEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointMouseOverEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -32,14 +32,17 @@ public class PointMouseOverEvent extends ComponentEvent<Chart>
     private final String category;
     private final int seriesIndex;
     private final int pointIndex;
+    private final String pointId;
 
     public PointMouseOverEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId,
             @EventData("event.detail.originalEvent.target.category") String category) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
         this.category = category;
     }
 
@@ -51,6 +54,11 @@ public class PointMouseOverEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 
     @Override

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointRemoveEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointRemoveEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -34,19 +34,22 @@ public class PointRemoveEvent extends ComponentEvent<Chart> implements HasItem {
     private final double x;
     private final double y;
     private final int pointIndex;
+    private final String pointId;
 
     public PointRemoveEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
             @EventData("event.detail.originalEvent.target.x") double x,
             @EventData("event.detail.originalEvent.target.y") double y,
-            @EventData("event.detail.originalEvent.target.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.x = x;
         this.y = y;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -70,5 +73,10 @@ public class PointRemoveEvent extends ComponentEvent<Chart> implements HasItem {
 
     public double getyValue() {
         return y;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointSelectEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointSelectEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -32,15 +32,18 @@ public class PointSelectEvent extends ComponentEvent<Chart> implements HasItem {
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
 
     public PointSelectEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
-            @EventData("event.detail.originalEvent.target.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -56,5 +59,10 @@ public class PointSelectEvent extends ComponentEvent<Chart> implements HasItem {
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUnselectEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUnselectEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -33,15 +33,18 @@ public class PointUnselectEvent extends ComponentEvent<Chart>
     private final int seriesIndex;
     private final String category;
     private final int pointIndex;
+    private final String pointId;
 
     public PointUnselectEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
-            @EventData("event.detail.originalEvent.target.index") int pointIndex) {
+            @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;
         this.category = category;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     @Override
@@ -57,5 +60,10 @@ public class PointUnselectEvent extends ComponentEvent<Chart>
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUpdateEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointUpdateEvent.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.charts.events;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file licensing.txt distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <https://vaadin.com/license/cval-3>.
  * #L%
@@ -36,11 +36,13 @@ public class PointUpdateEvent extends ComponentEvent<Chart> implements HasItem {
     private final Double newXValue;
     private final Double newYValue;
     private final int pointIndex;
+    private final String pointId;
 
     public PointUpdateEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.target.series.index") int seriesIndex,
             @EventData("event.detail.originalEvent.target.category") String category,
             @EventData("event.detail.originalEvent.target.index") int pointIndex,
+            @EventData("event.detail.originalEvent.target.id") String pointId,
             @EventData("event.detail.originalEvent.target.x") Double oldXValue,
             @EventData("event.detail.originalEvent.target.y") Double oldYValue,
             @EventData("event.detail.originalEvent.options.x") Double newXValue,
@@ -53,6 +55,7 @@ public class PointUpdateEvent extends ComponentEvent<Chart> implements HasItem {
         this.newXValue = newXValue;
         this.newYValue = newYValue;
         this.pointIndex = pointIndex;
+        this.pointId = pointId;
     }
 
     public Double getOldXValue() {
@@ -84,5 +87,10 @@ public class PointUpdateEvent extends ComponentEvent<Chart> implements HasItem {
     @Override
     public int getItemIndex() {
         return pointIndex;
+    }
+
+    @Override
+    public String getItemId() {
+        return pointId;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.charts;
+
+import com.vaadin.flow.component.charts.events.HasItem;
+import com.vaadin.flow.component.charts.model.DataSeries;
+import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.Node;
+import com.vaadin.flow.component.charts.model.NodeSeries;
+import com.vaadin.flow.component.charts.model.Series;
+import com.vaadin.flow.component.charts.model.TreeSeries;
+import com.vaadin.flow.component.charts.model.TreeSeriesItem;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HasItemTest {
+    @Test
+    public void getSeries() {
+        Chart chart = new Chart();
+        DataSeries series = new DataSeries();
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        Series result = hasItem.getSeries();
+
+        Assert.assertEquals(series, result);
+    }
+
+    @Test
+    public void getItemWithDataSeries() {
+        Chart chart = new Chart();
+        DataSeriesItem item = new DataSeriesItem(5, 10);
+        DataSeries series = new DataSeries(item);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        DataSeriesItem result = hasItem.getItem();
+
+        Assert.assertEquals(item, result);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItemWithNodeSeriesThrowsUnsupportedOperationException() {
+        Chart chart = new Chart();
+        Node node1 = new Node("Node1");
+        Node node2 = new Node("Node2");
+        NodeSeries series = new NodeSeries();
+        series.add(node1, node2);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        hasItem.getItem();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItemWithListSeriesThrowsUnsupportedOperationException() {
+        Chart chart = new Chart();
+        ListSeries series = new ListSeries(1, 2, 3);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        hasItem.getItem();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItemWithTreeSeriesThrowsUnsupportedOperationException() {
+        Chart chart = new Chart();
+        TreeSeriesItem item = new TreeSeriesItem("1", "1");
+        TreeSeries series = new TreeSeries();
+        series.add(item);
+        chart.getConfiguration().addSeries(series);
+
+        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
+        hasItem.getItem();
+    }
+
+    private static class HasItemTestImpl implements HasItem {
+
+        private final Chart chart;
+        private final int itemIndex;
+        private final int seriesItemIndex;
+
+        public HasItemTestImpl(Chart chart, int itemIndex,
+                int seriesItemIndex) {
+            this.chart = chart;
+            this.itemIndex = itemIndex;
+            this.seriesItemIndex = seriesItemIndex;
+        }
+
+        @Override
+        public Chart getSource() {
+            return this.chart;
+        }
+
+        @Override
+        public String getCategory() {
+            return null;
+        }
+
+        @Override
+        public int getItemIndex() {
+            return this.itemIndex;
+        }
+
+        @Override
+        public String getItemId() {
+            return null;
+        }
+
+        @Override
+        public int getSeriesItemIndex() {
+            return this.seriesItemIndex;
+        }
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/HasItemTest.java
@@ -21,8 +21,6 @@ import com.vaadin.flow.component.charts.events.HasItem;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
 import com.vaadin.flow.component.charts.model.ListSeries;
-import com.vaadin.flow.component.charts.model.Node;
-import com.vaadin.flow.component.charts.model.NodeSeries;
 import com.vaadin.flow.component.charts.model.Series;
 import com.vaadin.flow.component.charts.model.TreeSeries;
 import com.vaadin.flow.component.charts.model.TreeSeriesItem;
@@ -53,19 +51,6 @@ public class HasItemTest {
         DataSeriesItem result = hasItem.getItem();
 
         Assert.assertEquals(item, result);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void getItemWithNodeSeriesThrowsUnsupportedOperationException() {
-        Chart chart = new Chart();
-        Node node1 = new Node("Node1");
-        Node node2 = new Node("Node2");
-        NodeSeries series = new NodeSeries();
-        series.add(node1, node2);
-        chart.getConfiguration().addSeries(series);
-
-        HasItem hasItem = new HasItemTestImpl(chart, 0, 0);
-        hasItem.getItem();
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Cherry-pick of: #2390 
Fixes: #1040 

Changes:
- removed `HasItemTest.getItemWithNodeSeriesThrowsUnsupportedOperationException` - NodeSeries does not exist in 14
- updated JavaDoc for `HasItem.getItemId` - removed references to NodeSeries, updated example to use TreeSeries

(cherry picked from commit 5b6ba0608c1e728843c53f6331d0dee8b85508bd)