### PR TITLE
fix: fix duplicate inputs when using DateTimePicker in a Lit template

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/frontend/src/date-time-picker-lit-template.ts
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/frontend/src/date-time-picker-lit-template.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import { LitElement, html, customElement } from 'lit-element';
+import '@vaadin/date-time-picker';
+
+@customElement('date-time-picker-lit-template')
+export class DateTimePickerLitTemplate extends LitElement {
+    render() {
+        return html`
+        <vaadin-date-time-picker id="date-time-picker" label="Date and Time"></vaadin-date-time-picker>
+    `;
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLitTemplatePage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLitTemplatePage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.template.Id;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-date-time-picker/lit-template")
+public class DateTimePickerLitTemplatePage extends Div {
+
+    public DateTimePickerLitTemplatePage() {
+        DateTimePickerLitTemplate dateTimePickerLitTemplate = new DateTimePickerLitTemplate();
+        add(dateTimePickerLitTemplate);
+    }
+
+    @Tag("date-time-picker-lit-template")
+    @JsModule("./src/date-time-picker-lit-template.ts")
+    public static class DateTimePickerLitTemplate extends LitTemplate {
+        @Id("date-time-picker")
+        private DateTimePicker picker;
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLitTemplateIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLitTemplateIT.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.datetimepicker.testbench.DateTimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for the {@link DateTimePickerLitTemplatePage}.
+ */
+@TestPath("vaadin-date-time-picker/lit-template")
+public class DateTimePickerLitTemplateIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    // Regression test for: https://github.com/vaadin/web-components/issues/3149
+    public void testUsingLitTemplatesShouldCorrectlyReplaceSlotContents() {
+        TestBenchElement wrapper = $("date-time-picker-lit-template").first();
+        DateTimePickerElement dateTimePickerElement = wrapper
+                .$(DateTimePickerElement.class).first();
+
+        // should have correctly removed the web component's default slotted
+        // children, and added custom slotted children, resulting in one date
+        // picker and one time picker
+        int numDatePickers = dateTimePickerElement
+                .$("vaadin-date-time-picker-date-picker").all().size();
+        int numTimePickers = dateTimePickerElement
+                .$("vaadin-date-time-picker-time-picker").all().size();
+
+        Assert.assertEquals(1, numDatePickers);
+        Assert.assertEquals(1, numTimePickers);
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -145,8 +145,8 @@ public class DateTimePicker
             synchronizeChildComponentValues(initialDateTime);
         }
 
-        addToSlot(datePicker, "date-picker");
-        addToSlot(timePicker, "time-picker");
+        replaceDefaultSlotContent("date-picker", datePicker);
+        replaceDefaultSlotContent("time-picker", timePicker);
 
         setLocale(UI.getCurrent().getLocale());
 
@@ -292,11 +292,21 @@ public class DateTimePicker
     }
 
     /**
-     * Adds the given Component to the specified slot of this component.
+     * Removes the web components default slot contents, and adds the given
+     * component to it.
      */
-    private void addToSlot(Component component, String slot) {
+    private void replaceDefaultSlotContent(String slot, Component component) {
         Objects.requireNonNull(component, "Component to add cannot be null");
         component.getElement().setAttribute("slot", slot);
+        component.getElement().setAttribute("is-flow-slotted-child", "");
+
+        // executeJs call to remove the default slot contents. executeJs
+        // actually runs after appendChild, so the removal logic would also
+        // remove the replacement component we add below. To fix that we check
+        // for a custom attribute and only remove children that do not have it.
+        getElement().executeJs(
+                "this.querySelectorAll(`[slot=\"${$0}\"]`).forEach(child => !child.hasAttribute('is-flow-slotted-child') && child.remove());",
+                slot);
         getElement().appendChild(component.getElement());
     }
 


### PR DESCRIPTION
## Description

When using a DateTimePicker in a Lit template, the Flow component seems to add it's custom date and time pickers at a later stage, at which the web component has already created its own slotted children. This results in duplicates.

This change modifies the initialization logic of the Flow component to first remove the default contents of the slots before adding its custom content.

Fixes https://github.com/vaadin/web-components/issues/3149

## Type of change

- [x] Bugfix
