### PR TITLE
fix: fallback to super.getLocale() if no custom locale is set (#2416) (CP: 14.8)

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -71,7 +71,6 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     };
 
     private Locale locale;
-    private String languageTag;
 
     private LocalDate max;
     private LocalDate min;
@@ -283,20 +282,6 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     public void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale must not be null.");
         this.locale = locale;
-        // For ill-formed locales, Locale.toLanguageTag() will append subtag
-        // "lvariant" to it, which will cause the client side
-        // Date().toLocaleDateString()
-        // fallback to the system default locale silently.
-        // This has been caught by DatePickerValidationPage::invalidLocale test
-        // when running on
-        // Chrome(73+)/FireFox(66)/Edge(42.17134).
-        if (!locale.toLanguageTag().contains("lvariant")) {
-            languageTag = locale.toLanguageTag();
-        } else if (locale.getCountry().isEmpty()) {
-            languageTag = locale.getLanguage();
-        } else {
-            languageTag = locale.getLanguage() + "-" + locale.getCountry();
-        }
         requestI18nUpdate();
     }
 
@@ -307,21 +292,18 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
      */
     @Override
     public Locale getLocale() {
-        return locale;
+        if (locale != null) {
+            return locale;
+        } else {
+            return super.getLocale();
+        }
     }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
-        if (locale == null) {
-            getUI().ifPresent(ui -> setLocale(ui.getLocale()));
-        } else if (languageTag != null) {
-            requestI18nUpdate();
-        }
-        if (i18n != null) {
-            requestI18nUpdate();
-        }
+        requestI18nUpdate();
         FieldValidationUtil.disableClientValidation(this);
     }
 
@@ -384,6 +366,24 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         // component
         if (i18nObject != null) {
             removeNullValuesFromJsonObject(i18nObject);
+        }
+
+        // For ill-formed locales, Locale.toLanguageTag() will append subtag
+        // "lvariant" to it, which will cause the client side
+        // Date().toLocaleDateString()
+        // fallback to the system default locale silently.
+        // This has been caught by DatePickerValidationPage::invalidLocale test
+        // when running on
+        // Chrome(73+)/FireFox(66)/Edge(42.17134).
+        Locale appliedLocale = getLocale();
+        String languageTag;
+        if (!appliedLocale.toLanguageTag().contains("lvariant")) {
+            languageTag = appliedLocale.toLanguageTag();
+        } else if (appliedLocale.getCountry().isEmpty()) {
+            languageTag = appliedLocale.getLanguage();
+        } else {
+            languageTag = appliedLocale.getLanguage() + "-"
+                    + appliedLocale.getCountry();
         }
 
         // Call update function in connector with locale and I18N settings

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleTest.java
@@ -1,0 +1,50 @@
+package com.vaadin.flow.component.datepicker;
+
+import java.time.LocalDate;
+import java.util.Locale;
+
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+
+@NotThreadSafe
+public class DatePickerLocaleTest {
+
+    private UI ui;
+
+    @Before
+    public void setUp() {
+        ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test
+    public void newDatePicker_returnsUiLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        ui.setLocale(finnishLocale);
+        DatePicker datePicker = new DatePicker();
+        Assert.assertEquals(finnishLocale, datePicker.getLocale());
+    }
+
+    @Test
+    public void newDatePickerWithCustomLocale_returnsCustomLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        Locale usLocale = new Locale("en-US");
+        ui.setLocale(finnishLocale);
+        DatePicker datePicker = new DatePicker(LocalDate.now(), usLocale);
+        Assert.assertEquals(usLocale, datePicker.getLocale());
+    }
+
+    @Test
+    public void setCustomLocale_returnsCustomLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        Locale usLocale = new Locale("en-US");
+        ui.setLocale(finnishLocale);
+        DatePicker datePicker = new DatePicker();
+        datePicker.setLocale(usLocale);
+        Assert.assertEquals(usLocale, datePicker.getLocale());
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -143,8 +143,6 @@ public class DateTimePicker
         addToSlot(datePicker, "date-picker");
         addToSlot(timePicker, "time-picker");
 
-        setLocale(UI.getCurrent().getLocale());
-
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
 
@@ -459,7 +457,11 @@ public class DateTimePicker
      */
     @Override
     public Locale getLocale() {
-        return locale;
+        if (locale != null) {
+            return locale;
+        } else {
+            return super.getLocale();
+        }
     }
 
     /**

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
@@ -1,0 +1,50 @@
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.UI;
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+@NotThreadSafe
+public class DateTimePickerLocaleTest {
+
+    private UI ui;
+
+    @Before
+    public void setUp() {
+        ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test
+    public void newDateTimePicker_returnsUiLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        ui.setLocale(finnishLocale);
+        DateTimePicker dateTimePicker = new DateTimePicker();
+        Assert.assertEquals(finnishLocale, dateTimePicker.getLocale());
+    }
+
+    @Test
+    public void newDateTimePickerWithCustomLocale_returnsCustomLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        Locale usLocale = new Locale("en-US");
+        ui.setLocale(finnishLocale);
+        DateTimePicker dateTimePicker = new DateTimePicker(LocalDateTime.now(),
+                usLocale);
+        Assert.assertEquals(usLocale, dateTimePicker.getLocale());
+    }
+
+    @Test
+    public void setCustomLocale_returnsCustomLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        Locale usLocale = new Locale("en-US");
+        ui.setLocale(finnishLocale);
+        DateTimePicker dateTimePicker = new DateTimePicker();
+        dateTimePicker.setLocale(usLocale);
+        Assert.assertEquals(usLocale, dateTimePicker.getLocale());
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerDetachAttachPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerDetachAttachPage.java
@@ -20,6 +20,9 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.router.Route;
 
+import java.time.LocalTime;
+import java.util.Locale;
+
 /**
  * Test view for attaching / detaching {@link TimePicker}.
  */
@@ -44,5 +47,18 @@ public class TimePickerDetachAttachPage extends Div {
         });
         toggleAttached.setId("toggle-attached");
         add(toggleAttached);
+
+        NativeButton setValue = new NativeButton("set value", e -> {
+            timePicker.setValue(LocalTime.of(2, 0));
+        });
+        setValue.setId("set-value");
+        add(setValue);
+
+        NativeButton setCaliforniaLocale = new NativeButton(
+                "set California locale", e -> {
+                    timePicker.setLocale(new Locale("en-CA"));
+                });
+        setCaliforniaLocale.setId("set-california-locale");
+        add(setCaliforniaLocale);
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerDetachAttachPageIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerDetachAttachPageIT.java
@@ -15,13 +15,14 @@
  */
 package com.vaadin.flow.component.timepicker.tests;
 
+import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
+import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 
 /**
  * Integration tests for attaching / detaching time picker.
@@ -29,22 +30,46 @@ import org.openqa.selenium.WebElement;
 @TestPath("vaadin-time-picker/time-picker-detach-attach")
 public class TimePickerDetachAttachPageIT extends AbstractComponentIT {
 
+    TestBenchElement toggleAttach;
+    TestBenchElement setValue;
+    TestBenchElement setLocale;
+
+    @Before
+    public void init() {
+        open();
+        toggleAttach = $("button").id("toggle-attached");
+        setValue = $("button").id("set-value");
+        setLocale = $("button").id("set-california-locale");
+    }
+
     @Test
     public void clientSideValidationIsOverriddenOnAttach() {
-        open();
-
         assertTimePickerIsValidOnTab();
 
         // Detaching and attaching time picker
-        WebElement toggleAttach = findElement(By.id("toggle-attached"));
         toggleAttach.click();
         toggleAttach.click();
 
         assertTimePickerIsValidOnTab();
     }
 
+    @Test
+    public void formatShouldRespectLocaleAfterDetachAndReattach() {
+        setValue.click();
+        setLocale.click();
+        TimePickerElement timePicker = $(TimePickerElement.class)
+                .id("time-picker");
+        Assert.assertEquals("2:00 a.m.", timePicker.getSelectedText());
+
+        toggleAttach.click();
+        toggleAttach.click();
+        timePicker = $(TimePickerElement.class).id("time-picker");
+        Assert.assertEquals("2:00 a.m.", timePicker.getSelectedText());
+    }
+
     private void assertTimePickerIsValidOnTab() {
-        WebElement timePicker = findElement(By.id("time-picker"));
+        TimePickerElement timePicker = $(TimePickerElement.class)
+                .id("time-picker");
         timePicker.sendKeys(Keys.TAB);
         Assert.assertFalse("Time picker should be valid after Tab",
                 Boolean.parseBoolean(timePicker.getAttribute("invalid")));

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
@@ -152,6 +152,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins/>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocaleTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocaleTest.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.timepicker.TimePicker;
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+
+@NotThreadSafe
+public class TimePickerLocaleTest {
+
+    private UI ui;
+
+    @Before
+    public void setUp() {
+        ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test
+    public void newTimePicker_returnsUiLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        ui.setLocale(finnishLocale);
+        TimePicker timePicker = new TimePicker();
+        Assert.assertEquals(finnishLocale, timePicker.getLocale());
+    }
+
+    @Test
+    public void setCustomLocale_returnsCustomLocale() {
+        Locale finnishLocale = new Locale("fi-FI");
+        Locale usLocale = new Locale("en-US");
+        ui.setLocale(finnishLocale);
+        TimePicker timePicker = new TimePicker();
+        timePicker.setLocale(usLocale);
+        Assert.assertEquals(usLocale, timePicker.getLocale());
+    }
+}


### PR DESCRIPTION
Cherry-pick of: https://github.com/vaadin/flow-components/pull/2416
Fixes: https://github.com/vaadin/flow-components/issues/2379

Co-authored-by: Tatu Lund <tatu@vaadin.com>

(cherry picked from commit 1a2e3a8a9bc56a8a146505a13f38874626a01591)
