### PR TITLE
chore: fix shadowroot usage in component TB classes

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
@@ -38,11 +38,13 @@ public abstract class AbstractTBTest extends AbstractParallelTest {
         return $(ChartElement.class).waitForFirst();
     }
 
-    protected TestBenchElement getElementFromShadowRoot(TestBenchElement shadowRootOwner, String selector){
+    protected TestBenchElement getElementFromShadowRoot(
+            TestBenchElement shadowRootOwner, String selector) {
         return shadowRootOwner.$(selector).first();
     }
 
-    protected TestBenchElement getElementFromShadowRoot(TestBenchElement shadowRootOwner, String selector, int index){
+    protected TestBenchElement getElementFromShadowRoot(
+            TestBenchElement shadowRootOwner, String selector, int index) {
         ElementQuery<TestBenchElement> elements = shadowRootOwner.$(selector);
         if (elements.all().size() > index) {
             return elements.get(index);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -36,19 +38,13 @@ public abstract class AbstractTBTest extends AbstractParallelTest {
         return $(ChartElement.class).waitForFirst();
     }
 
-    protected WebElement getElementFromShadowRoot(WebElement shadowRootOwner,
-            By by) {
-        return getElementFromShadowRoot(shadowRootOwner, by, 0);
+    protected TestBenchElement getElementFromShadowRoot(TestBenchElement shadowRootOwner, String selector){
+        return shadowRootOwner.$(selector).first();
     }
 
-    protected WebElement getElementFromShadowRoot(WebElement shadowRootOwner,
-            By by, int index) {
-        WebElement shadowRoot = (WebElement) executeScript(
-                "return arguments[0].shadowRoot", shadowRootOwner);
-        assertNotNull("Could not locate shadowRoot in the element", shadowRoot);
-
-        List<WebElement> elements = shadowRoot.findElements(by);
-        if (elements.size() > index) {
+    protected TestBenchElement getElementFromShadowRoot(TestBenchElement shadowRootOwner, String selector, int index){
+        ElementQuery<TestBenchElement> elements = shadowRootOwner.$(selector);
+        if (elements.all().size() > index) {
             return elements.get(index);
         }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
@@ -32,7 +32,8 @@ public class BasicChartIT extends AbstractTBTest {
     @Test
     public void Chart_TitleDisplayed() {
         final TestBenchElement chart = getChartElement();
-        final WebElement title = chart.$("*").attributeContains("class", "highcharts-title").first();
+        final WebElement title = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         assertTrue(title.getText().contains("First Chart for Flow"));
     }
 
@@ -40,13 +41,15 @@ public class BasicChartIT extends AbstractTBTest {
 
     public void Chart_TitleCanBeChanged() {
         final TestBenchElement chart = getChartElement();
-        final WebElement title = chart.$("*").attributeContains("class", "highcharts-title").first();
+        final WebElement title = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         assertTrue(title.getText().contains("First Chart for Flow"));
 
         final WebElement changeTitleButton = findElement(By.id("change_title"));
         changeTitleButton.click();
 
-        final WebElement titleChanged = chart.$("*").attributeContains("class", "highcharts-title").first();
+        final WebElement titleChanged = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         assertTrue(titleChanged.getText()
                 .contains("First Chart for Flow - title changed"));
     }
@@ -54,7 +57,8 @@ public class BasicChartIT extends AbstractTBTest {
     @Test
     public void Chart_SeriesNameIsSet() {
         final TestBenchElement chart = getChartElement();
-        final WebElement series = chart.$("*").attributeContains("class", "highcharts-legend-item").first();
+        final WebElement series = chart.$("*")
+                .attributeContains("class", "highcharts-legend-item").first();
         assertTrue(series.getText().contains("Tokyo"));
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
@@ -32,7 +32,7 @@ public class BasicChartIT extends AbstractTBTest {
     @Test
     public void Chart_TitleDisplayed() {
         final TestBenchElement chart = getChartElement();
-        final WebElement title = getElementFromShadowRoot(chart, "highcharts-title");
+        final WebElement title = chart.$("*").attributeContains("class", "highcharts-title").first();
         assertTrue(title.getText().contains("First Chart for Flow"));
     }
 
@@ -40,13 +40,13 @@ public class BasicChartIT extends AbstractTBTest {
 
     public void Chart_TitleCanBeChanged() {
         final TestBenchElement chart = getChartElement();
-        final WebElement title = getElementFromShadowRoot(chart, "highcharts-title");
+        final WebElement title = chart.$("*").attributeContains("class", "highcharts-title").first();
         assertTrue(title.getText().contains("First Chart for Flow"));
 
         final WebElement changeTitleButton = findElement(By.id("change_title"));
         changeTitleButton.click();
 
-        final WebElement titleChanged = getElementFromShadowRoot(chart, "highcharts-title");
+        final WebElement titleChanged = chart.$("*").attributeContains("class", "highcharts-title").first();
         assertTrue(titleChanged.getText()
                 .contains("First Chart for Flow - title changed"));
     }
@@ -54,7 +54,7 @@ public class BasicChartIT extends AbstractTBTest {
     @Test
     public void Chart_SeriesNameIsSet() {
         final TestBenchElement chart = getChartElement();
-        final WebElement series = getElementFromShadowRoot(chart, "highcharts-legend-item");
+        final WebElement series = chart.$("*").attributeContains("class", "highcharts-legend-item").first();
         assertTrue(series.getText().contains("Tokyo"));
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
@@ -12,6 +12,7 @@
  */
 package com.vaadin.flow.component.charts.tests;
 
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -30,34 +31,30 @@ public class BasicChartIT extends AbstractTBTest {
 
     @Test
     public void Chart_TitleDisplayed() {
-        final WebElement chart = getChartElement();
-        final WebElement title = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        final TestBenchElement chart = getChartElement();
+        final WebElement title = getElementFromShadowRoot(chart, "highcharts-title");
         assertTrue(title.getText().contains("First Chart for Flow"));
     }
 
     @Test
 
     public void Chart_TitleCanBeChanged() {
-        final WebElement chart = getChartElement();
-        final WebElement title = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        final TestBenchElement chart = getChartElement();
+        final WebElement title = getElementFromShadowRoot(chart, "highcharts-title");
         assertTrue(title.getText().contains("First Chart for Flow"));
 
         final WebElement changeTitleButton = findElement(By.id("change_title"));
         changeTitleButton.click();
 
-        final WebElement titleChanged = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        final WebElement titleChanged = getElementFromShadowRoot(chart, "highcharts-title");
         assertTrue(titleChanged.getText()
                 .contains("First Chart for Flow - title changed"));
     }
 
     @Test
     public void Chart_SeriesNameIsSet() {
-        final WebElement chart = getChartElement();
-        final WebElement series = getElementFromShadowRoot(chart,
-                By.className("highcharts-legend-item"));
+        final TestBenchElement chart = getChartElement();
+        final WebElement series = getElementFromShadowRoot(chart, "highcharts-legend-item");
         assertTrue(series.getText().contains("Tokyo"));
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
@@ -24,7 +24,8 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
     @Test
     public void test() throws AssertionError {
         ChartElement chart = $(ChartElement.class).first();
-        waitUntil(e -> getElementFromShadowRoot(chart, ".highcharts-drilldown-point") != null);
+        waitUntil(e -> getElementFromShadowRoot(chart,
+                ".highcharts-drilldown-point") != null);
         clickDrilldownPoint(chart, 0);
         // Can't drilldown with null callback
         assertEquals(0, getLogMessages().size());
@@ -64,7 +65,8 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
     }
 
     private void clickDrilldownPoint(ChartElement chart, int index) {
-        getElementFromShadowRoot(chart, ".highcharts-drilldown-point", index).click();
+        getElementFromShadowRoot(chart, ".highcharts-drilldown-point", index)
+                .click();
     }
 
     private WebElement getDrillUpButtonByTopItemName(ChartElement chart,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
@@ -24,8 +24,7 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
     @Test
     public void test() throws AssertionError {
         ChartElement chart = $(ChartElement.class).first();
-        waitUntil(e -> getElementFromShadowRoot(chart,
-                By.cssSelector(".highcharts-drilldown-point")) != null);
+        waitUntil(e -> getElementFromShadowRoot(chart, ".highcharts-drilldown-point") != null);
         clickDrilldownPoint(chart, 0);
         // Can't drilldown with null callback
         assertEquals(0, getLogMessages().size());
@@ -65,8 +64,7 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
     }
 
     private void clickDrilldownPoint(ChartElement chart, int index) {
-        getElementFromShadowRoot(chart,
-                By.cssSelector(".highcharts-drilldown-point"), index).click();
+        getElementFromShadowRoot(chart, ".highcharts-drilldown-point", index).click();
     }
 
     private WebElement getDrillUpButtonByTopItemName(ChartElement chart,
@@ -77,7 +75,7 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
     private WebElement getDrillUpButton(ChartElement chart, String label) {
         final String selector = String.format("button[aria-label=\"◁ %s\"",
                 label);
-        return getElementFromShadowRoot(chart, By.cssSelector(selector));
+        return getElementFromShadowRoot(chart, selector);
     }
 
     private void assertLastLogText(String text) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownIT.java
@@ -33,12 +33,11 @@ public class ColumnWithLazyMultiLevelDrilldownIT extends AbstractTBTest {
     }
 
     private WebElement getFirstDrilldownPoint(ChartElement chart) {
-        return getElementFromShadowRoot(chart,
-                By.cssSelector(".highcharts-drilldown-point"));
+        return getElementFromShadowRoot(chart, ".highcharts-drilldown-point");
     }
 
     private WebElement getDrillUpButton(ChartElement chart) {
-        return getElementFromShadowRoot(chart, By.cssSelector("button"));
+        return getElementFromShadowRoot(chart,"button");
     }
 
     private void assertLogText(String text) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownIT.java
@@ -37,7 +37,7 @@ public class ColumnWithLazyMultiLevelDrilldownIT extends AbstractTBTest {
     }
 
     private WebElement getDrillUpButton(ChartElement chart) {
-        return getElementFromShadowRoot(chart,"button");
+        return getElementFromShadowRoot(chart, "button");
     }
 
     private void assertLogText(String text) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
@@ -30,7 +30,7 @@ public class DynamicChangesIT extends AbstractTBTest {
     @Test
     public void seriesFunction_addPoint_pointCreated() {
         ChartElement chart = getChartElement();
-        int initialPointsCount = chart.getPoints().size();
+        int initialPointsCount = chart.$(".highcharts-point").all().size();
         findElement(By.id("addPointButton")).click();
         assertEquals(initialPointsCount + 1, chart.getPoints().size());
     }
@@ -38,7 +38,7 @@ public class DynamicChangesIT extends AbstractTBTest {
     @Test
     public void pointFunction_removePoint_pointDeleted() {
         ChartElement chart = getChartElement();
-        int initialPointsCount = chart.getPoints().size();
+        int initialPointsCount = chart.$(".highcharts-point").all().size();
         findElement(By.id("removePointButton")).click();
         assertEquals(initialPointsCount - 1, chart.getPoints().size());
     }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
@@ -30,7 +30,7 @@ public class DynamicChangesIT extends AbstractTBTest {
     @Test
     public void seriesFunction_addPoint_pointCreated() {
         ChartElement chart = getChartElement();
-        int initialPointsCount = chart.$(".highcharts-point").all().size();
+        int initialPointsCount = chart.getPoints().size();
         findElement(By.id("addPointButton")).click();
         assertEquals(initialPointsCount + 1,
                 chart.$(".highcharts-point").all().size());
@@ -39,10 +39,9 @@ public class DynamicChangesIT extends AbstractTBTest {
     @Test
     public void pointFunction_removePoint_pointDeleted() {
         ChartElement chart = getChartElement();
-        int initialPointsCount = chart.$(".highcharts-point").all().size();
+        int initialPointsCount = chart.getPoints().size();
         findElement(By.id("removePointButton")).click();
-        assertEquals(initialPointsCount - 1,
-                chart.$(".highcharts-point").all().size());
+        assertEquals(initialPointsCount - 1, chart.getPoints().size());
     }
 
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
@@ -32,7 +32,8 @@ public class DynamicChangesIT extends AbstractTBTest {
         ChartElement chart = getChartElement();
         int initialPointsCount = chart.$(".highcharts-point").all().size();
         findElement(By.id("addPointButton")).click();
-        assertEquals(initialPointsCount + 1, chart.getPoints().size());
+        assertEquals(initialPointsCount + 1,
+                chart.$(".highcharts-point").all().size());
     }
 
     @Test
@@ -40,7 +41,8 @@ public class DynamicChangesIT extends AbstractTBTest {
         ChartElement chart = getChartElement();
         int initialPointsCount = chart.$(".highcharts-point").all().size();
         findElement(By.id("removePointButton")).click();
-        assertEquals(initialPointsCount - 1, chart.getPoints().size());
+        assertEquals(initialPointsCount - 1,
+                chart.$(".highcharts-point").all().size());
     }
 
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
@@ -27,8 +27,7 @@ public class DynamicChangingChartIT extends AbstractTBTest {
     }
 
     private void assertTitle(ChartElement chart, String expectedTitle) {
-        WebElement title = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        WebElement title = getElementFromShadowRoot(chart, "highcharts-title");
         waitUntil(e -> expectedTitle.equals(title.getText()), 2);
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
@@ -27,7 +27,7 @@ public class DynamicChangingChartIT extends AbstractTBTest {
     }
 
     private void assertTitle(ChartElement chart, String expectedTitle) {
-        WebElement title = getElementFromShadowRoot(chart, "highcharts-title");
+        WebElement title = chart.$("*").attributeContains("class", "highcharts-title").first();
         waitUntil(e -> expectedTitle.equals(title.getText()), 2);
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
@@ -27,7 +27,8 @@ public class DynamicChangingChartIT extends AbstractTBTest {
     }
 
     private void assertTitle(ChartElement chart, String expectedTitle) {
-        WebElement title = chart.$("*").attributeContains("class", "highcharts-title").first();
+        WebElement title = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         waitUntil(e -> expectedTitle.equals(title.getText()), 2);
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
@@ -36,10 +36,10 @@ public class DynamicExtremesIT extends AbstractTBTest {
                 By.id("toggleExtremesButton"));
         int initialVisiblePointsCount = chart.getVisiblePoints().size();
         toggleExtremesButton.click();
-        assertNotEquals(initialVisiblePointsCount, chart
-                .$(":not([visibility=hidden]).highcharts-point").all().size());
+        assertNotEquals(initialVisiblePointsCount,
+                chart.getVisiblePoints().size());
         toggleExtremesButton.click();
-        assertEquals(initialVisiblePointsCount, chart
-                .$(":not([visibility=hidden]).highcharts-point").all().size());
+        assertEquals(initialVisiblePointsCount,
+                chart.getVisiblePoints().size());
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicExtremesIT.java
@@ -36,10 +36,10 @@ public class DynamicExtremesIT extends AbstractTBTest {
                 By.id("toggleExtremesButton"));
         int initialVisiblePointsCount = chart.getVisiblePoints().size();
         toggleExtremesButton.click();
-        assertNotEquals(initialVisiblePointsCount,
-                chart.getVisiblePoints().size());
+        assertNotEquals(initialVisiblePointsCount, chart
+                .$(":not([visibility=hidden]).highcharts-point").all().size());
         toggleExtremesButton.click();
-        assertEquals(initialVisiblePointsCount,
-                chart.getVisiblePoints().size());
+        assertEquals(initialVisiblePointsCount, chart
+                .$(":not([visibility=hidden]).highcharts-point").all().size());
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
@@ -63,6 +63,6 @@ public class PieWithLegendEventsIT extends AbstractTBTest {
     }
 
     private WebElement getLegendElement() {
-        return getElementFromShadowRoot(getChartElement(), "highcharts-legend-item");
+        return getChartElement().$("*").attributeContains("class", "highcharts-legend-item").first();
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
@@ -63,6 +63,7 @@ public class PieWithLegendEventsIT extends AbstractTBTest {
     }
 
     private WebElement getLegendElement() {
-        return getChartElement().$("*").attributeContains("class", "highcharts-legend-item").first();
+        return getChartElement().$("*")
+                .attributeContains("class", "highcharts-legend-item").first();
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
@@ -63,7 +63,6 @@ public class PieWithLegendEventsIT extends AbstractTBTest {
     }
 
     private WebElement getLegendElement() {
-        return getElementFromShadowRoot(getChartElement(),
-                By.className("highcharts-legend-item"));
+        return getElementFromShadowRoot(getChartElement(), "highcharts-legend-item");
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -190,7 +190,7 @@ public class ServerSideEventsIT extends AbstractTBTest {
     @Test
     public void select_occured_eventIsFired() {
         ChartElement chart = getChartElement();
-        List<WebElement> points = chart.getPoints();
+        List<TestBenchElement> points = chart.$(".highcharts-point").all();
         points.get(1).click();
 
         assertHasEventOfType(PointSelectEvent.class);
@@ -272,7 +272,7 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findCheckBox(int index) {
-        return getElementFromShadowRoot(getChartElement(), "input[type=\"checkbox\"]", index);
+        return getChartElement().$("input").attributeContains("type", "checkbox").get(index);
     }
 
     private WebElement findDisableVisibityToggle() {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -256,11 +256,13 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findLastDataPointOfTheFirstSeries() {
-        return getElementFromShadowRoot(getChartElement(), ".highcharts-markers > path");
+        return getElementFromShadowRoot(getChartElement(),
+                ".highcharts-markers > path");
     }
 
     private WebElement findLegendItem() {
-        return getChartElement().$("*").attributeContains("class", "highcharts-legend-item").first();
+        return getChartElement().$("*")
+                .attributeContains("class", "highcharts-legend-item").first();
     }
 
     private WebElement findCheckBox() {
@@ -272,7 +274,8 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findCheckBox(int index) {
-        return getChartElement().$("input").attributeContains("type", "checkbox").get(index);
+        return getChartElement().$("input")
+                .attributeContains("type", "checkbox").get(index);
     }
 
     private WebElement findDisableVisibityToggle() {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -256,13 +256,11 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findLastDataPointOfTheFirstSeries() {
-        return getElementFromShadowRoot(getChartElement(),
-                By.cssSelector(".highcharts-markers > path"));
+        return getElementFromShadowRoot(getChartElement(), ".highcharts-markers > path");
     }
 
     private WebElement findLegendItem() {
-        return getElementFromShadowRoot(getChartElement(),
-                By.className("highcharts-legend-item"));
+        return getElementFromShadowRoot(getChartElement(), "highcharts-legend-item");
     }
 
     private WebElement findCheckBox() {
@@ -274,8 +272,7 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findCheckBox(int index) {
-        return getElementFromShadowRoot(getChartElement(),
-                By.cssSelector("input[type=\"checkbox\"]"), index);
+        return getElementFromShadowRoot(getChartElement(), "input[type=\"checkbox\"]", index);
     }
 
     private WebElement findDisableVisibityToggle() {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -260,7 +260,7 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findLegendItem() {
-        return getElementFromShadowRoot(getChartElement(), "highcharts-legend-item");
+        return getChartElement().$("*").attributeContains("class", "highcharts-legend-item").first();
     }
 
     private WebElement findCheckBox() {

--- a/vaadin-charts-flow-parent/vaadin-charts-testbench/src/main/java/com/vaadin/flow/component/charts/testbench/ChartElement.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-testbench/src/main/java/com/vaadin/flow/component/charts/testbench/ChartElement.java
@@ -12,13 +12,12 @@ import static org.junit.Assert.assertNotNull;
 @Element("vaadin-chart")
 public class ChartElement extends TestBenchElement {
 
-    public List<WebElement> getPoints() {
-        return getElementsFromShadowRootBySelector(".highcharts-point");
+    public List<TestBenchElement> getPoints() {
+        return $(".highcharts-point").all();
     }
 
-    public List<WebElement> getVisiblePoints() {
-        return getElementsFromShadowRootBySelector(
-                ":not([visibility=hidden]).highcharts-point");
+    public List<TestBenchElement> getVisiblePoints() {
+        return $(":not([visibility=hidden]).highcharts-point").all();
     }
 
     private List<WebElement> getElementsFromShadowRootBySelector(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingIT.java
@@ -26,8 +26,7 @@ public class EditorVerticalScrollingIT extends AbstractComponentIT {
 
     @Test
     public void editRow_scrollingIsDisabled_closeEditor_scrollingIsRestored() {
-        String overflow = grid.findInShadowRoot(By.id("table")).get(0)
-                .getCssValue("overflow-y");
+        String overflow = grid.$("*").id("table").getCssValue("overflow-y");
         Assert.assertEquals("auto", overflow);
 
         TestBenchElement editButton = grid.findElement(By.id("edit-1"));
@@ -35,8 +34,7 @@ public class EditorVerticalScrollingIT extends AbstractComponentIT {
 
         waitForElementPresent(By.id("cancel-1"));
 
-        overflow = grid.findInShadowRoot(By.id("table")).get(0)
-                .getCssValue("overflow-y");
+        overflow = grid.$("*").id("table").getCssValue("overflow-y");
         Assert.assertEquals("hidden", overflow);
 
         TestBenchElement cancelButton = grid.findElement(By.id("cancel-1"));
@@ -44,8 +42,7 @@ public class EditorVerticalScrollingIT extends AbstractComponentIT {
 
         waitForElementPresent(By.id("edit-1"));
 
-        overflow = grid.findInShadowRoot(By.id("table")).get(0)
-                .getCssValue("overflow-y");
+        overflow = grid.$("*").id("table").getCssValue("overflow-y");
         Assert.assertEquals("auto", overflow);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -301,7 +301,7 @@ public class GridElement extends TestBenchElement {
 
     /**
      * Find all {@link WebElement}s using the given {@link By} selector.
-     * @Deprecated this method will not working for Chrome 96+, because of
+     * @deprecated this method will not working for Chrome 96+, because of
      * the breaking changes in ChromeDriver.
      * @param by
      *            the selector used to find elements

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -301,8 +301,9 @@ public class GridElement extends TestBenchElement {
 
     /**
      * Find all {@link WebElement}s using the given {@link By} selector.
-     * @deprecated this method will not working for Chrome 96+, because of
-     * the breaking changes in ChromeDriver.
+     * 
+     * @deprecated this method will not working for Chrome 96+, because of the
+     *             breaking changes in ChromeDriver.
      * @param by
      *            the selector used to find elements
      * @return a list of found elements

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -288,7 +288,7 @@ public class GridElement extends TestBenchElement {
      */
     public TestBenchElement getHeaderCellContent(int rowIndex,
             int columnIndex) {
-        WebElement thead = findInShadowRoot(By.id("header")).get(0);
+        WebElement thead = $("*").id("header");
         List<WebElement> headerRows = thead.findElements(By.tagName("tr"));
         List<WebElement> headerCells = headerRows.get(rowIndex)
                 .findElements(By.tagName("th"));
@@ -301,11 +301,13 @@ public class GridElement extends TestBenchElement {
 
     /**
      * Find all {@link WebElement}s using the given {@link By} selector.
-     *
+     * @Deprecated this method will not working for Chrome 96+, because of
+     * the breaking changes in ChromeDriver.
      * @param by
      *            the selector used to find elements
      * @return a list of found elements
      */
+    @Deprecated
     public List<WebElement> findInShadowRoot(By by) {
         return getShadowRoot().findElements(by);
     }


### PR DESCRIPTION
Since the breaking changes in chrome driver 96, we need to replace the shadowroot usage 