### PR TITLE
chore: fix shadowroot usage in component TB classes (#2447) (CP:14.8)

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -40,19 +42,15 @@ public abstract class AbstractTBTest extends AbstractParallelTest {
         return $(ChartElement.class).waitForFirst();
     }
 
-    protected WebElement getElementFromShadowRoot(WebElement shadowRootOwner,
-            By by) {
-        return getElementFromShadowRoot(shadowRootOwner, by, 0);
+    protected TestBenchElement getElementFromShadowRoot(
+            TestBenchElement shadowRootOwner, String selector) {
+        return shadowRootOwner.$(selector).first();
     }
 
-    protected WebElement getElementFromShadowRoot(WebElement shadowRootOwner,
-            By by, int index) {
-        WebElement shadowRoot = (WebElement) executeScript(
-                "return arguments[0].shadowRoot", shadowRootOwner);
-        assertNotNull("Could not locate shadowRoot in the element", shadowRoot);
-
-        List<WebElement> elements = shadowRoot.findElements(by);
-        if (elements.size() > index) {
+    protected TestBenchElement getElementFromShadowRoot(
+            TestBenchElement shadowRootOwner, String selector, int index) {
+        ElementQuery<TestBenchElement> elements = shadowRootOwner.$(selector);
+        if (elements.all().size() > index) {
             return elements.get(index);
         }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.charts.tests;
 
 import com.vaadin.flow.component.charts.AbstractChartExample;
 import com.vaadin.flow.component.charts.examples.area.AreaChart;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -33,34 +34,34 @@ public class BasicChartIT extends AbstractTBTest {
 
     @Test
     public void Chart_TitleDisplayed() {
-        final WebElement chart = getChartElement();
-        final WebElement title = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        final TestBenchElement chart = getChartElement();
+        final WebElement title = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         assertTrue(title.getText().contains("First Chart for Flow"));
     }
 
     @Test
     @org.junit.Ignore("Unstable test when migrated to mono-repo")
     public void Chart_TitleCanBeChanged() {
-        final WebElement chart = getChartElement();
-        final WebElement title = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        final TestBenchElement chart = getChartElement();
+        final WebElement title = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         assertTrue(title.getText().contains("First Chart for Flow"));
 
         final WebElement changeTitleButton = findElement(By.id("change_title"));
         changeTitleButton.click();
 
-        final WebElement titleChanged = getElementFromShadowRoot(chart,
-                By.className("highcharts-title"));
+        final WebElement titleChanged = chart.$("*")
+                .attributeContains("class", "highcharts-title").first();
         assertTrue(titleChanged.getText()
                 .contains("First Chart for Flow - title changed"));
     }
 
     @Test
     public void Chart_SeriesNameIsSet() {
-        final WebElement chart = getChartElement();
-        final WebElement series = getElementFromShadowRoot(chart,
-                By.className("highcharts-legend-item"));
+        final TestBenchElement chart = getChartElement();
+        final WebElement series = chart.$("*")
+                .attributeContains("class", "highcharts-legend-item").first();
         assertTrue(series.getText().contains("Tokyo"));
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangesIT.java
@@ -36,7 +36,8 @@ public class DynamicChangesIT extends AbstractTBTest {
         ChartElement chart = getChartElement();
         int initialPointsCount = chart.getPoints().size();
         findElement(By.id("addPointButton")).click();
-        assertEquals(initialPointsCount + 1, chart.getPoints().size());
+        assertEquals(initialPointsCount + 1,
+                chart.$(".highcharts-point").all().size());
     }
 
     @Test

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -176,7 +176,7 @@ public class ServerSideEventsIT extends AbstractTBTest {
     @Test
     public void select_occured_eventIsFired() {
         ChartElement chart = getChartElement();
-        List<WebElement> points = chart.getPoints();
+        List<TestBenchElement> points = chart.$(".highcharts-point").all();
         points.get(1).click();
 
         assertHasEventOfType(PointSelectEvent.class);
@@ -243,12 +243,12 @@ public class ServerSideEventsIT extends AbstractTBTest {
 
     private WebElement findLastDataPointOfTheFirstSeries() {
         return getElementFromShadowRoot(getChartElement(),
-                By.cssSelector(".highcharts-markers > path"));
+                ".highcharts-markers > path");
     }
 
     private WebElement findLegendItem() {
-        return getElementFromShadowRoot(getChartElement(),
-                By.className("highcharts-legend-item"));
+        return getChartElement().$("*")
+                .attributeContains("class", "highcharts-legend-item").first();
     }
 
     private WebElement findCheckBox() {
@@ -260,8 +260,8 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findCheckBox(int index) {
-        return getElementFromShadowRoot(getChartElement(),
-                By.cssSelector("input[type=\"checkbox\"]"), index);
+        return getChartElement().$("input")
+                .attributeContains("type", "checkbox").get(index);
     }
 
     private WebElement findDisableVisibityToggle() {

--- a/vaadin-charts-flow-parent/vaadin-charts-testbench/src/main/java/com/vaadin/flow/component/charts/testbench/ChartElement.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-testbench/src/main/java/com/vaadin/flow/component/charts/testbench/ChartElement.java
@@ -12,13 +12,12 @@ import static org.junit.Assert.assertNotNull;
 @Element("vaadin-chart")
 public class ChartElement extends TestBenchElement {
 
-    public List<WebElement> getPoints() {
-        return getElementsFromShadowRootBySelector(".highcharts-point");
+    public List<TestBenchElement> getPoints() {
+        return $(".highcharts-point").all();
     }
 
-    public List<WebElement> getVisiblePoints() {
-        return getElementsFromShadowRootBySelector(
-                ":not([visibility=hidden]).highcharts-point");
+    public List<TestBenchElement> getVisiblePoints() {
+        return $(":not([visibility=hidden]).highcharts-point").all();
     }
 
     private List<WebElement> getElementsFromShadowRootBySelector(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingIT.java
@@ -26,8 +26,7 @@ public class EditorVerticalScrollingIT extends AbstractComponentIT {
 
     @Test
     public void editRow_scrollingIsDisabled_closeEditor_scrollingIsRestored() {
-        String overflow = grid.findInShadowRoot(By.id("table")).get(0)
-                .getCssValue("overflow-y");
+        String overflow = grid.$("*").id("table").getCssValue("overflow-y");
         Assert.assertEquals("auto", overflow);
 
         TestBenchElement editButton = grid.findElement(By.id("edit-1"));
@@ -35,8 +34,7 @@ public class EditorVerticalScrollingIT extends AbstractComponentIT {
 
         waitForElementPresent(By.id("cancel-1"));
 
-        overflow = grid.findInShadowRoot(By.id("table")).get(0)
-                .getCssValue("overflow-y");
+        overflow = grid.$("*").id("table").getCssValue("overflow-y");
         Assert.assertEquals("hidden", overflow);
 
         TestBenchElement cancelButton = grid.findElement(By.id("cancel-1"));
@@ -44,8 +42,7 @@ public class EditorVerticalScrollingIT extends AbstractComponentIT {
 
         waitForElementPresent(By.id("edit-1"));
 
-        overflow = grid.findInShadowRoot(By.id("table")).get(0)
-                .getCssValue("overflow-y");
+        overflow = grid.$("*").id("table").getCssValue("overflow-y");
         Assert.assertEquals("auto", overflow);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -290,7 +290,7 @@ public class GridElement extends TestBenchElement {
      */
     public TestBenchElement getHeaderCellContent(int rowIndex,
             int columnIndex) {
-        WebElement thead = findInShadowRoot(By.id("header")).get(0);
+        WebElement thead = $("*").id("header");
         List<WebElement> headerRows = thead.findElements(By.tagName("tr"));
         List<WebElement> headerCells = headerRows.get(rowIndex)
                 .findElements(By.tagName("th"));
@@ -303,11 +303,14 @@ public class GridElement extends TestBenchElement {
 
     /**
      * Find all {@link WebElement}s using the given {@link By} selector.
-     *
+     * 
+     * @deprecated this method will not working for Chrome 96+, because of the
+     *             breaking changes in ChromeDriver.
      * @param by
      *            the selector used to find elements
      * @return a list of found elements
      */
+    @Deprecated
     public List<WebElement> findInShadowRoot(By by) {
         return getShadowRoot().findElements(by);
     }


### PR DESCRIPTION
* chore: fix shadowroot usage in component TB classes

charts and grid

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
