### PR TITLE
fix: make context menu clicks cover the whole cell

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
@@ -19,16 +19,19 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
+import org.openqa.selenium.interactions.Actions;
 
 @TestPath("vaadin-grid/context-menu-grid")
 public class ContextMenuGridIT extends AbstractComponentIT {
@@ -47,6 +50,23 @@ public class ContextMenuGridIT extends AbstractComponentIT {
     @Test
     public void contextClickOnRow_itemClickGetsTargetItem() {
         grid.getCell(56, 1).contextClick();
+        $("vaadin-context-menu-item").first().click();
+        assertMessage("Person 56");
+        verifyClosed();
+    }
+
+    @Test
+    public void contextClickOnEdgeOfCell_itemClickGetsTargetItem() {
+        GridTHTDElement cell = grid.getCell(56, 0);
+        // Move cursor to upper edge of the cell
+        // moveToElement moves to center, so we subtract half of the height to
+        // approximately get to the cells edge
+        Rectangle cellRectangle = cell.getWrappedElement().getRect();
+        int offsetToCellStart = (int) Math
+                .ceil((float) cellRectangle.height / 2);
+        (new Actions(this.getDriver()))
+                .moveToElement(cell, 0, -offsetToCellStart).contextClick()
+                .build().perform();
         $("vaadin-context-menu-item").first().click();
         assertMessage("Person 56");
         verifyClosed();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,8 @@ import org.openqa.selenium.By;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.interactions.Actions;
 
 @TestPath("vaadin-grid/dynamic-context-menu-grid")
 public class DynamicContextMenuGridIT extends AbstractComponentIT {
@@ -54,6 +57,24 @@ public class DynamicContextMenuGridIT extends AbstractComponentIT {
 
         $("body").first().click();
         verifyClosed();
+    }
+
+    @Test
+    public void shouldOpenContextMenuWhenClickingOnTheEdgeOfCell() {
+        GridTHTDElement cell = grid.getCell(40, 0);
+        // Move cursor to upper edge of the cell
+        // moveToElement moves to center, so we subtract half of the height to
+        // approximately get to the cells edge
+        Rectangle cellRectangle = cell.getWrappedElement().getRect();
+        int offsetToCellStart = (int) Math
+                .ceil((float) cellRectangle.height / 2);
+        (new Actions(this.getDriver()))
+                .moveToElement(cell, 0, -offsetToCellStart).contextClick()
+                .build().perform();
+
+        verifyOpened();
+        Assert.assertEquals("Person 40",
+                $(OVERLAY_TAG).first().getAttribute("innerText"));
     }
 
     private void verifyOpened() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -959,7 +959,10 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
       };
 
       const contextMenuListener = function(e) {
-        const eventContext = grid.getEventContext(e);
+        // For `contextmenu` events, we need to access the source event,
+        // when using open on click we just use the click event itself
+        const sourceEvent = e.detail.sourceEvent || e;
+        const eventContext = grid.getEventContext(sourceEvent);
         const key = eventContext.item && eventContext.item.key;
         const colId = eventContext.column && eventContext.column.id;
         grid.$server.updateContextMenuTargetItem(key, colId);
@@ -970,7 +973,10 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
       }));
 
       grid.getContextMenuBeforeOpenDetail = tryCatchWrapper(function(event) {
-        const eventContext = grid.getEventContext(event);
+        // For `contextmenu` events, we need to access the source event,
+        // when using open on click we just use the click event itself
+        const sourceEvent = event.detail.sourceEvent || event;
+        const eventContext = grid.getEventContext(sourceEvent);
         return {
           key: (eventContext.item && eventContext.item.key) || ""
         };


### PR DESCRIPTION
## Description

Fixes the grid context menu to always provide the correct item information in the open event, as well as the dynamic content handler. Previously in both cases the item could be missing if the context click was not directly on the grid cell content element, but on the table cell element itself. The approach of using the `sourceEvent` to get the event context is taken from the Typescript example in the docs: https://vaadin.com/docs/latest/ds/components/grid/#context-menu

Fixes #2444 

## Type of change

- [x] Bugfix
- [ ] Feature
