### PR TITLE
fix: sync scrollbar state with client.

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-demo/src/main/java/com/vaadin/flow/component/charts/demo/examples/bar/SimpleBarChartWithScroll.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-demo/src/main/java/com/vaadin/flow/component/charts/demo/examples/bar/SimpleBarChartWithScroll.java
@@ -1,0 +1,29 @@
+package com.vaadin.flow.component.charts.demo.examples.bar;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.charts.demo.AbstractChartExample;
+import com.vaadin.flow.component.charts.model.ChartType;
+import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.ListSeries;
+
+public class SimpleBarChartWithScroll extends AbstractChartExample {
+    private boolean enabled = false;
+
+    @Override
+    public void initDemo() {
+        Chart chart = new Chart(ChartType.COLUMN);
+        Configuration conf = chart.getConfiguration();
+
+        ListSeries series = new ListSeries(10, 10, 10);
+        conf.addSeries(series);
+
+
+        Button toggle = new Button("Toggle scrollbar", event -> {
+            enabled = !enabled;
+            conf.getScrollbar().setEnabled(enabled);
+        });
+
+        add(chart, toggle);
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-demo/src/main/java/com/vaadin/flow/component/charts/demo/examples/bar/SimpleBarChartWithScroll.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-demo/src/main/java/com/vaadin/flow/component/charts/demo/examples/bar/SimpleBarChartWithScroll.java
@@ -18,7 +18,6 @@ public class SimpleBarChartWithScroll extends AbstractChartExample {
         ListSeries series = new ListSeries(10, 10, 10);
         conf.addSeries(series);
 
-
         Button toggle = new Button("Toggle scrollbar", event -> {
             enabled = !enabled;
             conf.getScrollbar().setEnabled(enabled);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/SimpleBarChartWithScrollIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/SimpleBarChartWithScrollIT.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component.charts.tests;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.charts.demo.AbstractChartExample;
+import com.vaadin.flow.component.charts.demo.examples.bar.SimpleBarChartWithScroll;
+import com.vaadin.flow.component.charts.testbench.ChartElement;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SimpleBarChartWithScrollIT extends AbstractTBTest{
+    @Override
+    protected Class<? extends AbstractChartExample> getView() {
+        return SimpleBarChartWithScroll.class;
+    }
+
+    @Test
+    public void Chart_ScrollStateIsVisible() {
+        ChartElement chart = getChartElement();
+
+        ButtonElement toggle = $(ButtonElement.class).first();
+
+        toggle.click();
+        // todo: check scrollbar is shown
+        assertTrue(false);
+    }
+
+    @Test
+    public void Chart_ScrollStateIsNotVisible() {
+        ChartElement chart = getChartElement();
+
+        ButtonElement toggle = $(ButtonElement.class).first();
+
+        toggle.click();
+        toggle.click();
+
+        // todo: check scrollbar is not shown
+        assertTrue(false);
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/SimpleBarChartWithScrollIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/SimpleBarChartWithScrollIT.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
-public class SimpleBarChartWithScrollIT extends AbstractTBTest{
+public class SimpleBarChartWithScrollIT extends AbstractTBTest {
     @Override
     protected Class<? extends AbstractChartExample> getView() {
         return SimpleBarChartWithScroll.class;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ProxyChangeForwarder.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ProxyChangeForwarder.java
@@ -13,16 +13,7 @@ package com.vaadin.flow.component.charts;
  * #L%
  */
 
-import com.vaadin.flow.component.charts.events.internal.AbstractSeriesEvent;
-import com.vaadin.flow.component.charts.events.internal.AxisRescaledEvent;
-import com.vaadin.flow.component.charts.events.internal.ConfigurationChangeListener;
-import com.vaadin.flow.component.charts.events.internal.DataAddedEvent;
-import com.vaadin.flow.component.charts.events.internal.DataRemovedEvent;
-import com.vaadin.flow.component.charts.events.internal.DataUpdatedEvent;
-import com.vaadin.flow.component.charts.events.internal.ItemSlicedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesAddedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesChangedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesStateEvent;
+import com.vaadin.flow.component.charts.events.internal.*;
 import com.vaadin.flow.component.charts.model.AbstractConfigurationObject;
 import com.vaadin.flow.component.charts.model.AxisDimension;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
@@ -122,6 +113,12 @@ class ProxyChangeForwarder implements ConfigurationChangeListener {
                     "setExtremes", AxisDimension.Y_AXIS.getIndex(), i, null,
                     null, redraw, animate);
         }
+    }
+
+    @Override
+    public void scrollStateChanged(ScrollbarVisibilityChanged event) {
+        chart.getElement().executeJs(String.format("$0.configuration.update({\"scrollbar\":{\"enabled\":%s}})",
+                event.getVisibility()));
     }
 
     private int getSeriesIndex(AbstractSeriesEvent event) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ProxyChangeForwarder.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ProxyChangeForwarder.java
@@ -117,7 +117,8 @@ class ProxyChangeForwarder implements ConfigurationChangeListener {
 
     @Override
     public void scrollStateChanged(ScrollbarVisibilityChanged event) {
-        chart.getElement().executeJs(String.format("$0.configuration.update({\"scrollbar\":{\"enabled\":%s}})",
+        chart.getElement().executeJs(String.format(
+                "$0.configuration.update({\"scrollbar\":{\"enabled\":%s}})",
                 event.getVisibility()));
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ConfigurationChangeListener.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ConfigurationChangeListener.java
@@ -96,6 +96,7 @@ public interface ConfigurationChangeListener extends Serializable {
 
     /**
      * Toggles visibility of chart's scrollbar
+     * 
      * @param event
      */
     void scrollStateChanged(ScrollbarVisibilityChanged event);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ConfigurationChangeListener.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ConfigurationChangeListener.java
@@ -93,4 +93,10 @@ public interface ConfigurationChangeListener extends Serializable {
      * @param animate
      */
     void resetZoom(boolean redraw, boolean animate);
+
+    /**
+     * Toggles visibility of chart's scrollbar
+     * @param event
+     */
+    void scrollStateChanged(ScrollbarVisibilityChanged event);
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ScrollbarVisibilityChanged.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ScrollbarVisibilityChanged.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.component.charts.events.internal;
+
+import java.io.Serializable;
+
+public class ScrollbarVisibilityChanged implements Serializable {
+    private boolean visibility;
+
+    public boolean getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(boolean visibility) {
+        this.visibility = visibility;
+    }
+
+    public ScrollbarVisibilityChanged(boolean value) {
+        this.visibility = value;
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ChartConfiguration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ChartConfiguration.java
@@ -19,4 +19,6 @@ public interface ChartConfiguration extends Serializable {
 
     void fireAxesRescaled(Axis axis, Number minimum, Number maximum,
             boolean redraw, boolean animate);
+
+    void fireScrollbarVisibilityChanged(boolean visible);
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -1162,7 +1162,8 @@ public class Configuration extends AbstractConfigurationObject
     }
 
     public void fireScrollbarVisibilityChanged(boolean visible) {
-        ScrollbarVisibilityChanged event = new ScrollbarVisibilityChanged(visible);
+        ScrollbarVisibilityChanged event = new ScrollbarVisibilityChanged(
+                visible);
         for (ConfigurationChangeListener listener : changeListeners) {
             listener.scrollStateChanged(event);
         }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -15,15 +15,7 @@ package com.vaadin.flow.component.charts.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vaadin.flow.component.charts.Chart;
-import com.vaadin.flow.component.charts.events.internal.AxisRescaledEvent;
-import com.vaadin.flow.component.charts.events.internal.ConfigurationChangeListener;
-import com.vaadin.flow.component.charts.events.internal.DataAddedEvent;
-import com.vaadin.flow.component.charts.events.internal.DataRemovedEvent;
-import com.vaadin.flow.component.charts.events.internal.DataUpdatedEvent;
-import com.vaadin.flow.component.charts.events.internal.ItemSlicedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesAddedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesChangedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesStateEvent;
+import com.vaadin.flow.component.charts.events.internal.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -736,6 +728,7 @@ public class Configuration extends AbstractConfigurationObject
     public Scrollbar getScrollbar() {
         if (scrollbar == null) {
             scrollbar = new Scrollbar();
+            scrollbar.setConfiguration(this);
         }
         return scrollbar;
     }
@@ -1166,6 +1159,13 @@ public class Configuration extends AbstractConfigurationObject
             axis.setConfiguration(this);
         }
         colorAxis.addAxis(axis);
+    }
+
+    public void fireScrollbarVisibilityChanged(boolean visible) {
+        ScrollbarVisibilityChanged event = new ScrollbarVisibilityChanged(visible);
+        for (ConfigurationChangeListener listener : changeListeners) {
+            listener.scrollStateChanged(event);
+        }
     }
 
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Scrollbar.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Scrollbar.java
@@ -13,6 +13,7 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -55,9 +56,33 @@ public class Scrollbar extends AbstractConfigurationObject {
     private Number trackBorderRadius;
     private Number zIndex;
     private Number height;
+    @JsonIgnore
+    private ChartConfiguration configuration;
+
 
     public Scrollbar() {
     }
+
+    /**
+     * Returns the configuration that this scrollbar is bound to
+     *
+     * @return The configuration.
+     */
+    public ChartConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    /**
+     * Sets the configuration this scrollbar is bound to. This method is
+     * automatically called by configuration, when the scrollbar is created.
+     *
+     * @param configuration
+     *            Configuration this object is linked to.
+     */
+    public void setConfiguration(ChartConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
 
     /**
      * @see #setBarBackgroundColor(Color)
@@ -221,6 +246,7 @@ public class Scrollbar extends AbstractConfigurationObject {
      */
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+        this.getConfiguration().fireScrollbarVisibilityChanged(enabled);
     }
 
     /**

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Scrollbar.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Scrollbar.java
@@ -59,7 +59,6 @@ public class Scrollbar extends AbstractConfigurationObject {
     @JsonIgnore
     private ChartConfiguration configuration;
 
-
     public Scrollbar() {
     }
 
@@ -82,7 +81,6 @@ public class Scrollbar extends AbstractConfigurationObject {
     public void setConfiguration(ChartConfiguration configuration) {
         this.configuration = configuration;
     }
-
 
     /**
      * @see #setBarBackgroundColor(Color)

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
@@ -3,17 +3,9 @@ package com.vaadin.flow.component.charts;
 import static com.vaadin.flow.component.charts.util.ChartSerialization.toJSON;
 import static org.junit.Assert.assertEquals;
 
+import com.vaadin.flow.component.charts.events.internal.*;
 import org.junit.Test;
 
-import com.vaadin.flow.component.charts.events.internal.AxisRescaledEvent;
-import com.vaadin.flow.component.charts.events.internal.ConfigurationChangeListener;
-import com.vaadin.flow.component.charts.events.internal.DataAddedEvent;
-import com.vaadin.flow.component.charts.events.internal.DataRemovedEvent;
-import com.vaadin.flow.component.charts.events.internal.DataUpdatedEvent;
-import com.vaadin.flow.component.charts.events.internal.ItemSlicedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesAddedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesChangedEvent;
-import com.vaadin.flow.component.charts.events.internal.SeriesStateEvent;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.Inactive;
 import com.vaadin.flow.component.charts.model.ListSeries;
@@ -84,6 +76,11 @@ public class ConfigurationJSONSerializationTest {
             @Override
             public void resetZoom(boolean redraw, boolean animate) {
                 // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void scrollStateChanged(ScrollbarVisibilityChanged event) {
 
             }
         });


### PR DESCRIPTION
This PR fixes one of the issues listed in the issue below, it simply tries to sync client with what's happening on the server related to scrollbar state (enable, disable). This PR still lacks proper testing and IMO it needs more discussion, but this is the solution that I came up with based on workaround by @alvarezguille .

Fixes #1025

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
