### PR TITLE
chore: fix build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,9 +31,15 @@ args="$args -B $quiet"
 ## compute modules that were modified in this PR
 if [ -z "$modules" -a -n "$PR" ]
 then
+  ## need to check whether changes in the root or not 
+  modifiedAll=`curl -s https://api.github.com/repos/vaadin/flow-components/pulls/$PR/files \
+    | jq -r '.[] | .filename' | sort -u | tr -d '[:space:]'`
+  modifiedComponent=`curl -s https://api.github.com/repos/vaadin/flow-components/pulls/$PR/files \
+    | jq -r '.[] | .filename' | grep 'vaadin.*parent' | sort -u | tr -d '[:space:]'`
   modified=`curl -s https://api.github.com/repos/vaadin/flow-components/pulls/$PR/files \
     | jq -r '.[] | .filename' | grep 'vaadin.*parent' | perl -pe 's,^vaadin-(.*)-flow-parent.*,$1,g' | sort -u`
-  if [ `echo "$modified" | wc -w` -lt 5 ]
+  
+  if [ `echo "$modified" | wc -w` -lt 5 ] && [ `echo ${#modifiedAll}` = `echo ${#modifiedComponent}` ]
   then
     for i in $modified
     do


### PR DESCRIPTION
fixed the script, when there are changes in the root (e.g. pom.xml) and individual component modules
the build will run validation for the whole project

the current setting will run the validation on the individual component only. 