### PR TITLE
fix: patch _isItemSelected once combobox is finalized

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/InitiallyEmptyPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/InitiallyEmptyPage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-combo-box/initially-empty")
+public class InitiallyEmptyPage extends Div {
+
+    public InitiallyEmptyPage() {
+        NativeButton addInsideDetachedContainerButton = new NativeButton(
+                "add inside a detached container", e -> {
+                    Div container = new Div();
+                    add(container);
+                    // Detach the container element with JS
+                    container.getElement().executeJs(
+                            "this.__parent = this.parentElement; this.remove();")
+                            .then((res) -> {
+                                // Add a combo box to the detached container
+                                ComboBox<String> comboBox = new ComboBox<>();
+                                comboBox.setItems("foo", "bar");
+                                container.add(comboBox);
+
+                                // Re-attach the container element with JS
+                                container.getElement().executeJs("")
+                                        .then((res2) -> {
+                                            container.getElement().executeJs(
+                                                    "this.__parent.appendChild(this);");
+                                        });
+
+                            });
+                });
+        addInsideDetachedContainerButton
+                .setId("add-inside-detached-container-button");
+
+        // This page must not add a ComboBox on the page initially so that the
+        // "<vaadin-cmobo-box>" Web Component doesn't get prematurely finalized.
+        // This ensures the related tests remain valid.
+        add(addInsideDetachedContainerButton);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/InitiallyEmptyPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/InitiallyEmptyPageIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-combo-box/initially-empty")
+public class InitiallyEmptyPageIT extends AbstractComboBoxIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void shouldAddAComboBoxInsideADetachedContainer() {
+        clickButton("add-inside-detached-container-button");
+        checkLogsForErrors();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -239,7 +239,10 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
                 comboBox.$server.confirmUpdate(id);
             });
 
-            customElements.whenDefined('vaadin-combo-box').then(tryCatchWrapper(() => {
+            comboBox.addEventListener('opened-changed', () => {
+                // Patch once the instance is ready and vaadin-combo-box has
+                // been finalized (i.e. opened-changed is emitted)
+
                 const isItemSelected = comboBox.$.dropdown._scroller.__isItemSelected;
                 // Override comboBox's _isItemSelected logic to handle remapped items
                 comboBox.$.dropdown._scroller.__isItemSelected = (item, selectedItem, itemIdPath) => {
@@ -255,7 +258,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
                     return selected;
                 }
-            }));
+            }, { once: true });
 
 
             comboBox.$connector.enableClientValidation = tryCatchWrapper(function( enable ){


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/1086

The `comboBoxConnector` needs to patch the `<vaadin-combo-box-scroller>`'s `__isItemSelected` function in order to add custom logic to it.

Previously, the [patching took place](https://github.com/vaadin/flow-components/blob/d4d675d6730c64fbd58586ed59b5c4ba16f08d2b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js#L245) once `customElements.whenDefined('vaadin-combo-box')` had resolved. The timing is problematic since the Polymer-based `<vaadin-combo-box>` may have not been yet finalized even if the Custom Element type was defined. In order for a Polymer element type to get fully finalized, at least one instance of it must have been attached to the DOM.

This PR changes the timing so that the function gets patched not until the `<vaadin-combo-box>` element emits an "opened-changed" event, which indicates that the Custom Element type has been defined AND finalized.