### PR TITLE
fix: delete selected key when input is cleared

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
@@ -126,6 +126,28 @@ public class ClearValueIT extends AbstractComponentIT {
         Assert.assertEquals("", comboBox.getInputElementValue());
     }
 
+    @Test
+    public void allowCustomValue_openPopup_clearButton_selectedItemIsReset() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id(ClearValuePage.COMBO_BOX_WITH_ALLOW_CUSTOM_VALUE_ID);
+
+        comboBox.openPopup();
+        comboBox.closePopup();
+
+        comboBox.$("[part~='clear-button']").get(0).click();
+
+        comboBox.openPopup();
+
+        TestBenchElement overlay = $("vaadin-combo-box-overlay").first();
+        ElementQuery<TestBenchElement> items = overlay
+                .$("vaadin-combo-box-item");
+
+        items.all()
+                .forEach(item -> Assert.assertFalse(
+                        "Item is not selected after clear button click",
+                        item.hasAttribute("selected")));
+    }
+
     private void checkEmptyValue(String comboBoxId, String buttonId,
             boolean allowCustomValue) {
         ComboBoxElement comboBox = $(ComboBoxElement.class).id(comboBoxId);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
@@ -62,6 +62,28 @@ public class ClearValueIT extends AbstractComponentIT {
     }
 
     @Test
+    public void openPopup_clearButton_selectedItemIsReset() {
+        String comboBoxId = ClearValuePage.COMBO_BOX_WITH_CLEAR_BUTTON_ID;
+        ComboBoxElement comboBox = $(ComboBoxElement.class).id(comboBoxId);
+
+        comboBox.openPopup();
+        comboBox.closePopup();
+
+        comboBox.$("[part~='clear-button']").get(0).click();
+
+        comboBox.openPopup();
+
+        TestBenchElement overlay = $("vaadin-combo-box-overlay").first();
+        ElementQuery<TestBenchElement> items = overlay
+                .$("vaadin-combo-box-item");
+
+        items.all()
+                .forEach(item -> Assert.assertFalse(
+                        "Item is not selected after clear button click",
+                        item.hasAttribute("selected")));
+    }
+
+    @Test
     public void valueIsCorrectlySetToNull() {
         Assert.assertNull(
                 "Combobox empty value is not null, add clear tests also",
@@ -125,28 +147,6 @@ public class ClearValueIT extends AbstractComponentIT {
         // Set null value
         setNullButton.click();
         Assert.assertEquals("", comboBox.getInputElementValue());
-    }
-
-    @Test
-    public void allowCustomValue_openPopup_clearButton_selectedItemIsReset() {
-        ComboBoxElement comboBox = $(ComboBoxElement.class)
-                .id(ClearValuePage.COMBO_BOX_WITH_ALLOW_CUSTOM_VALUE_ID);
-
-        comboBox.openPopup();
-        comboBox.closePopup();
-
-        comboBox.$("[part~='clear-button']").get(0).click();
-
-        comboBox.openPopup();
-
-        TestBenchElement overlay = $("vaadin-combo-box-overlay").first();
-        ElementQuery<TestBenchElement> items = overlay
-                .$("vaadin-combo-box-item");
-
-        items.all()
-                .forEach(item -> Assert.assertFalse(
-                        "Item is not selected after clear button click",
-                        item.hasAttribute("selected")));
     }
 
     private void checkEmptyValue(String comboBoxId, String buttonId,

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -260,6 +260,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
                 }
             }), { once: true });
 
+            comboBox.addEventListener('value-changed', tryCatchWrapper((event) => {
+                if (comboBox._selectedKey && !event.detail.value) {
+                    delete comboBox._selectedKey;
+                }
+            }));
 
             comboBox.$connector.enableClientValidation = tryCatchWrapper(function( enable ){
                 if ( comboBox.$ ){


### PR DESCRIPTION
## Description

The internal `_selectedKey` state is not maintained on the server so should be enough to clear it in the connector.

Fixes #2222

## Type of change

- Bugfix