### PR TITLE
feat: finalize background layer

### DIFF
--- a/vaadin-map-flow-parent/pom.xml
+++ b/vaadin-map-flow-parent/pom.xml
@@ -18,6 +18,7 @@
     <modules>
         <module>vaadin-map-flow</module>
         <module>vaadin-map-flow-integration-tests</module>
+        <module>vaadin-map-testbench</module>
     </modules>
     <profiles>
         <profile>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -69,6 +69,12 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-map-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-flow-components-shared</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/BackgroundLayerPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/BackgroundLayerPage.java
@@ -8,10 +8,12 @@ import com.vaadin.flow.component.map.configuration.source.OSMSource;
 import com.vaadin.flow.component.map.configuration.source.VectorSource;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-map/map-defaults")
+@Route("vaadin-map/background-layer")
 public class BackgroundLayerPage extends Div {
     public BackgroundLayerPage() {
         Map map = new Map();
+        map.setWidthFull();
+        map.setHeight("400px");
 
         NativeButton setCustomOsmSource = new NativeButton(
                 "Set custom OSM source", e -> {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/BackgroundLayerPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/BackgroundLayerPage.java
@@ -1,0 +1,38 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.layer.TileLayer;
+import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
+import com.vaadin.flow.component.map.configuration.source.OSMSource;
+import com.vaadin.flow.component.map.configuration.source.VectorSource;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/map-defaults")
+public class BackgroundLayerPage extends Div {
+    public BackgroundLayerPage() {
+        Map map = new Map();
+
+        NativeButton setCustomOsmSource = new NativeButton(
+                "Set custom OSM source", e -> {
+                    TileLayer backgroundLayer = (TileLayer) map
+                            .getBackgroundLayer();
+                    backgroundLayer
+                            .setSource(new OSMSource(new OSMSource.Options()
+                                    .setUrl("https://example.com")));
+                });
+        setCustomOsmSource.setId("set-custom-osm-source");
+
+        NativeButton replaceBackgroundLayer = new NativeButton(
+                "Replace background layer", e -> {
+                    VectorSource vectorSource = new VectorSource();
+                    VectorLayer vectorLayer = new VectorLayer();
+                    vectorLayer.setSource(vectorSource);
+                    map.setBackgroundLayer(vectorLayer);
+                });
+        replaceBackgroundLayer.setId("replace-background-layer");
+
+        add(map);
+        add(new Div(setCustomOsmSource, replaceBackgroundLayer));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapView.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapView.java
@@ -65,8 +65,7 @@ public class MapView extends Div {
                 e -> {
                     OSMSource seaMapSource = new OSMSource(
                             new OSMSource.Options().setUrl(
-                                    "https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png")
-                                    .setOpaque(false));
+                                    "https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"));
                     TileLayer seaMapLayer = new TileLayer();
                     seaMapLayer.setSource(seaMapSource);
                     map.addLayer(seaMapLayer);

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapView.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapView.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.map.configuration.layer.TileLayer;
 import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
 import com.vaadin.flow.component.map.configuration.feature.CircleFeature;
 import com.vaadin.flow.component.map.configuration.source.OSMSource;
+import com.vaadin.flow.component.map.configuration.source.UrlTileSource;
 import com.vaadin.flow.component.map.configuration.source.VectorSource;
 import com.vaadin.flow.component.map.configuration.style.CircleStyle;
 import com.vaadin.flow.component.map.configuration.style.Fill;
@@ -56,7 +57,7 @@ public class MapView extends Div {
         NativeButton useOpenStreetMap = new NativeButton("Use OpenStreetMap",
                 e -> {
                     TileLayer layer = (TileLayer) map.getBackgroundLayer();
-                    layer.getSource().setUrl(
+                    ((UrlTileSource) layer.getSource()).setUrl(
                             "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png");
                 });
 

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/BackgroundLayerIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/BackgroundLayerIT.java
@@ -8,7 +8,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-@TestPath("vaadin-map/map-defaults")
+@TestPath("vaadin-map/background-layer")
 public class BackgroundLayerIT extends AbstractComponentIT {
     @Before
     public void init() {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/BackgroundLayerIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/BackgroundLayerIT.java
@@ -1,0 +1,83 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-map/map-defaults")
+public class BackgroundLayerIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void defaults() {
+        MapElement map = $(MapElement.class).first();
+
+        // Initialized with one layer by default
+        long numLayers = (long) map
+                .evaluateOLExpression("map.getLayers().getLength()");
+        Assert.assertEquals(1, numLayers);
+
+        // Layer should be a tile layer
+        String layerTypeName = (String) map.evaluateOLExpression(
+                map.getOLTypeNameExpression("map.getLayers().item(0)"));
+        Assert.assertEquals("TileLayer", layerTypeName);
+
+        // Layer's source should be an OpenStreetMap source
+        String sourceTypeName = (String) map
+                .evaluateOLExpression(map.getOLTypeNameExpression(
+                        "map.getLayers().item(0).getSource()"));
+        Assert.assertEquals("OSM", sourceTypeName);
+    }
+
+    @Test
+    public void customOsmSource() {
+        MapElement map = $(MapElement.class).first();
+        TestBenchElement setCustomOsmSource = $("button")
+                .id("set-custom-osm-source");
+
+        setCustomOsmSource.click();
+
+        // Layer's source should be an OpenStreetMap source
+        String sourceTypeName = (String) map
+                .evaluateOLExpression(map.getOLTypeNameExpression(
+                        "map.getLayers().item(0).getSource()"));
+        Assert.assertEquals("OSM", sourceTypeName);
+
+        // Layer's source should use custom URL
+        String sourceUrl = (String) map.evaluateOLExpression(
+                "map.getLayers().item(0).getSource().getUrls()[0]");
+        Assert.assertEquals("https://example.com", sourceUrl);
+    }
+
+    @Test
+    public void replaceLayer() {
+        MapElement map = $(MapElement.class).first();
+        TestBenchElement replaceBackgroundLayer = $("button")
+                .id("replace-background-layer");
+
+        replaceBackgroundLayer.click();
+
+        // Should still have a layer
+        long numLayers = (long) map
+                .evaluateOLExpression("map.getLayers().getLength()");
+        Assert.assertEquals(1, numLayers);
+
+        // Layer should be a vector layer
+        String layerTypeName = (String) map.evaluateOLExpression(
+                map.getOLTypeNameExpression("map.getLayers().item(0)"));
+        Assert.assertEquals("VectorLayer", layerTypeName);
+
+        // Layer's source should be a vector source
+        String sourceTypeName = (String) map
+                .evaluateOLExpression(map.getOLTypeNameExpression(
+                        "map.getLayers().item(0).getSource()"));
+        Assert.assertEquals("VectorSource", sourceTypeName);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -23,6 +23,8 @@ import com.vaadin.flow.component.map.configuration.layer.Layer;
 import com.vaadin.flow.component.map.configuration.layer.TileLayer;
 import com.vaadin.flow.component.map.configuration.source.OSMSource;
 
+import java.util.Objects;
+
 @Tag("vaadin-map")
 // TODO: Enable once released
 // @NpmPackage(value = "@vaadin/map", version = "23.0.0-alpha4")
@@ -45,11 +47,31 @@ public class Map extends MapBase {
         return getConfiguration();
     }
 
+    /**
+     * Background layer of the map. Every new instance of a {@link Map} is
+     * initialized with a background layer. By default, the background layer
+     * will be a {@link TileLayer} using an {@link OSMSource}, which means it
+     * will display tiled map data from the official OpenStreetMap server.
+     * 
+     * @return the background layer of the map
+     */
     public Layer getBackgroundLayer() {
         return backgroundLayer;
     }
 
+    /**
+     * Sets the background layer of the map. The layer will be prepended before
+     * all other layers, which means it will be rendered in the background by
+     * default. The background layer is not intended to be removed, and thus can
+     * not be set to null. For use-cases where you want to use a dynamic set of
+     * layers, consider setting the first layer as background layer, and then
+     * adding the remaining layers using {@link #addLayer(Layer)}.
+     * 
+     * @param backgroundLayer
+     *            the new background layer, not null
+     */
     public void setBackgroundLayer(Layer backgroundLayer) {
+        Objects.requireNonNull(backgroundLayer);
         if (this.backgroundLayer != null) {
             getConfiguration().removeLayer(this.backgroundLayer);
         }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Constants.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Constants.java
@@ -21,7 +21,7 @@ public class Constants {
     public static final String OL_LAYER_TILE = "ol/layer/Tile";
     public static final String OL_LAYER_VECTOR = "ol/layer/Vector";
     // Sources
-    public static final String OL_SOURCE_URL_TILE = "ol/source/UrlTile";
+    public static final String OL_SOURCE_XYZ = "ol/source/XYZ";
     public static final String OL_SOURCE_OSM = "ol/source/OSM";
     public static final String OL_SOURCE_VECTOR = "ol/source/Vector";
     // Geometry

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/Layer.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/Layer.java
@@ -18,25 +18,131 @@ package com.vaadin.flow.component.map.configuration.layer;
 
 import com.vaadin.flow.component.map.configuration.AbstractConfigurationObject;
 
+/**
+ * Abstract base class for all map layers
+ */
 public abstract class Layer extends AbstractConfigurationObject {
     private float opacity = 1;
     private boolean visible = true;
+    private Integer zIndex;
+    private Float minZoom;
+    private Float maxZoom;
+    private String background;
 
+    /**
+     * @return opacity of the layer
+     */
     public float getOpacity() {
         return opacity;
     }
 
-    public void setOpacity(float opacity, boolean markDirty) {
+    /**
+     * Sets the opacity of the layer. The value must lie between {@code 0} and
+     * {@code 1}. Default value is {@code 1}.
+     *
+     * @param opacity
+     *            new opacity of the layer
+     */
+    public void setOpacity(float opacity) {
         this.opacity = opacity;
         notifyChange();
     }
 
+    /**
+     * @return whether the layer is visible or not
+     */
     public boolean isVisible() {
         return visible;
     }
 
+    /**
+     * Sets the visibility of the layer. Default value is {@code true}.
+     *
+     * @param visible
+     *            new visibility of the layer
+     */
     public void setVisible(boolean visible) {
         this.visible = visible;
+        notifyChange();
+    }
+
+    /**
+     * @return the z-index of the layer, or null if not defined
+     */
+    public Integer getzIndex() {
+        return zIndex;
+    }
+
+    /**
+     * Sets the z-index of the layer. This allows to control in which order
+     * layers are rendered. Layers with higher z-indexes are rendered above
+     * layers with lower z-indexes. This value is {@code null} by default, which
+     * means the order of the layers in the map determines the rendering order.
+     *
+     * @param zIndex
+     *            the new z-index, or null to remove the z-index
+     */
+    public void setzIndex(Integer zIndex) {
+        this.zIndex = zIndex;
+        notifyChange();
+    }
+
+    /**
+     * @return the minimum zoom level at which this layer will be visible, or
+     *         null if not defined
+     */
+    public Float getMinZoom() {
+        return minZoom;
+    }
+
+    /**
+     * Sets the minimum zoom level at which this layer will be visible.
+     *
+     * @param minZoom
+     *            the new minimum zoom level, or null to remove it
+     */
+    public void setMinZoom(Float minZoom) {
+        this.minZoom = minZoom;
+        notifyChange();
+    }
+
+    /**
+     * @return the maximum zoom level at which this layer will be visible, or
+     *         null if not defined
+     */
+    public Float getMaxZoom() {
+        return maxZoom;
+    }
+
+    /**
+     * Sets the maximum zoom level at which this layer will be visible.
+     *
+     * @param maxZoom
+     *            the new maximum zoom level, or null to remove it
+     */
+    public void setMaxZoom(Float maxZoom) {
+        this.maxZoom = maxZoom;
+        notifyChange();
+    }
+
+    /**
+     * @return the background color of the layer as CSS color string, or null if
+     *         not defined
+     */
+    public String getBackground() {
+        return background;
+    }
+
+    /**
+     * Sets the background color of the layer as CSS color string. All valid CSS
+     * colors are supported, for example {@code "black"} or
+     * {@code "rgb(0,0,0)"}.
+     *
+     * @param background
+     *            the new background color of the layer, or null to remove it
+     */
+    public void setBackground(String background) {
+        this.background = background;
         notifyChange();
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/TileLayer.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/TileLayer.java
@@ -17,22 +17,36 @@ package com.vaadin.flow.component.map.configuration.layer;
  */
 
 import com.vaadin.flow.component.map.configuration.Constants;
+import com.vaadin.flow.component.map.configuration.source.TileSource;
 import com.vaadin.flow.component.map.configuration.source.UrlTileSource;
 
 import java.util.Objects;
 
+/**
+ * Layer for displayed tiled map data
+ */
 public class TileLayer extends Layer {
-    private UrlTileSource source;
+    private TileSource source;
 
     @Override
     public String getType() {
         return Constants.OL_LAYER_TILE;
     }
 
-    public UrlTileSource getSource() {
+    /**
+     * @return source for this layer, null by default
+     */
+    public TileSource getSource() {
         return source;
     }
 
+    /**
+     * Sets the source for this layer. The source must be a subclass of
+     * {@link TileSource}, which means that it must provide tiled map data.
+     *
+     * @param source
+     *            the new source for the layer, not null
+     */
     public void setSource(UrlTileSource source) {
         Objects.requireNonNull(source);
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/TileLayer.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/TileLayer.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.map.configuration.source.UrlTileSource;
 import java.util.Objects;
 
 /**
- * Layer for displayed tiled map data
+ * Layer for displaying tiled map data
  */
 public class TileLayer extends Layer {
     private TileSource source;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/OSMSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/OSMSource.java
@@ -18,7 +18,12 @@ package com.vaadin.flow.component.map.configuration.source;
 
 import com.vaadin.flow.component.map.configuration.Constants;
 
-public class OSMSource extends UrlTileSource {
+/**
+ * Map source for loading tiled images from an OpenStreetMap service. The source
+ * will use the official OpenStreetMap service by default. A custom URL can be
+ * configured to load data from a different service.
+ */
+public class OSMSource extends XYZSource {
 
     public OSMSource() {
         this(new Options());
@@ -33,7 +38,7 @@ public class OSMSource extends UrlTileSource {
         return Constants.OL_SOURCE_OSM;
     }
 
-    public static class Options extends UrlTileSource.BaseOptions<Options> {
+    public static class Options extends XYZSource.BaseOptions<Options> {
         public Options() {
             setUrl("https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png");
         }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
@@ -18,5 +18,105 @@ package com.vaadin.flow.component.map.configuration.source;
 
 import com.vaadin.flow.component.map.configuration.AbstractConfigurationObject;
 
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Abstract base class for all map sources
+ */
 public abstract class Source extends AbstractConfigurationObject {
+
+    private List<String> attributions;
+    private final boolean attributionsCollapsible;
+    private final String projection;
+
+    protected Source(BaseOptions<?> options) {
+        Objects.requireNonNull(options);
+        this.attributions = options.attributions;
+        this.attributionsCollapsible = options.attributionsCollapsible;
+        this.projection = options.projection;
+    }
+
+    /**
+     * @return list of attributions to display for this source
+     */
+    public List<String> getAttributions() {
+        return attributions;
+    }
+
+    /**
+     * Sets the attributions to display for the source. Attributions can be
+     * copyrights and other information that needs to be displayed in order to
+     * use map data from a service.
+     *
+     * @param attributions
+     *            the new attributions
+     */
+    public void setAttributions(List<String> attributions) {
+        this.attributions = attributions;
+        notifyChange();
+    }
+
+    /**
+     * Determines whether attributions are collapsible. Default is {@code true}.
+     * <p>
+     * This value can not be changed after constructing an instance, it can only
+     * be set initially by passing an options object to the constructor.
+     *
+     * @return whether attributions are collapsible
+     */
+    public boolean isAttributionsCollapsible() {
+        return attributionsCollapsible;
+    }
+
+    /**
+     * The type of coordinate projection to use for this source. For example
+     * {@code "EPSG:4326"} or {@code "EPSG:3857"}. Default is null, which uses
+     * the projection from the view.
+     * <p>
+     * This value can not be changed after constructing an instance, it can only
+     * be set initially by passing an options object to the constructor.
+     *
+     * @return the custom projection to use, or null
+     */
+    public String getProjection() {
+        return projection;
+    }
+
+    protected static class BaseOptions<T extends BaseOptions<T>> {
+        private List<String> attributions;
+        private boolean attributionsCollapsible = true;
+        private String projection;
+
+        /**
+         * Extracted to avoid littering unchecked type-casts in all setters
+         */
+        protected T getThis() {
+            return (T) this;
+        }
+
+        /**
+         * @see Source#setAttributions(List)
+         */
+        public T setAttributions(List<String> attributions) {
+            this.attributions = attributions;
+            return getThis();
+        }
+
+        /**
+         * @see Source#isAttributionsCollapsible()
+         */
+        public T setAttributionsCollapsible(boolean attributionsCollapsible) {
+            this.attributionsCollapsible = attributionsCollapsible;
+            return getThis();
+        }
+
+        /**
+         * @see Source#getProjection()
+         */
+        public T setProjection(String projection) {
+            this.projection = projection;
+            return getThis();
+        }
+    }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/TileImageSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/TileImageSource.java
@@ -1,0 +1,55 @@
+package com.vaadin.flow.component.map.configuration.source;
+
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
+/**
+ * Abstract base class for map sources providing tiled images from a URL
+ */
+public abstract class TileImageSource extends UrlTileSource {
+
+    private final String crossOrigin;
+
+    protected TileImageSource(BaseOptions<?> options) {
+        super(options);
+        this.crossOrigin = options.crossOrigin;
+    }
+
+    /**
+     * The {@code crossOrigin} attribute for loaded images.
+     * <p>
+     * This value can not be changed after constructing an instance, it can only
+     * be set initially by passing an options object to the constructor.
+     *
+     * @return the crossOrigin attribute used for loaded images
+     */
+    public String getCrossOrigin() {
+        return crossOrigin;
+    }
+
+    protected static class BaseOptions<T extends BaseOptions<T>>
+            extends UrlTileSource.BaseOptions<T> {
+        private String crossOrigin;
+
+        /**
+         * @see TileImageSource#getCrossOrigin()
+         */
+        public T setCrossOrigin(String crossOrigin) {
+            this.crossOrigin = crossOrigin;
+            return getThis();
+        }
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/TileSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/TileSource.java
@@ -1,0 +1,56 @@
+package com.vaadin.flow.component.map.configuration.source;
+
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
+/**
+ * Abstract base class for map sources providing tiled map data
+ */
+public abstract class TileSource extends Source {
+
+    private final boolean opaque;
+
+    protected TileSource(BaseOptions<?> options) {
+        super(options);
+        this.opaque = options.opaque;
+    }
+
+    /**
+     * Whether the source has an opaque background or not. A non-opaque source
+     * has a transparent background, which is useful for overlay layers.
+     * <p>
+     * This value can not be changed after constructing an instance, it can only
+     * be set initially by passing an options object to the constructor.
+     *
+     * @return whether the source has an opaque background
+     */
+    public boolean isOpaque() {
+        return opaque;
+    }
+
+    protected static class BaseOptions<T extends BaseOptions<T>>
+            extends Source.BaseOptions<T> {
+        private boolean opaque;
+
+        /**
+         * @see TileSource#isOpaque()
+         */
+        public T setOpaque(boolean opaque) {
+            this.opaque = opaque;
+            return getThis();
+        }
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/TileSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/TileSource.java
@@ -30,7 +30,8 @@ public abstract class TileSource extends Source {
 
     /**
      * Whether the source has an opaque background or not. A non-opaque source
-     * has a transparent background, which is useful for overlay layers.
+     * has a transparent background, which is useful for overlay layers. Default
+     * value is {@code false}.
      * <p>
      * This value can not be changed after constructing an instance, it can only
      * be set initially by passing an options object to the constructor.
@@ -43,7 +44,7 @@ public abstract class TileSource extends Source {
 
     protected static class BaseOptions<T extends BaseOptions<T>>
             extends Source.BaseOptions<T> {
-        private boolean opaque;
+        private boolean opaque = false;
 
         /**
          * @see TileSource#isOpaque()

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/UrlTileSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/UrlTileSource.java
@@ -16,56 +16,46 @@ package com.vaadin.flow.component.map.configuration.source;
  * #L%
  */
 
-import com.vaadin.flow.component.map.configuration.Constants;
-
-import java.util.Objects;
-
-public abstract class UrlTileSource extends Source {
+/**
+ * Abstract base class for map sources providing tiled map data from a URL
+ */
+public abstract class UrlTileSource extends TileSource {
 
     private String url;
 
-    private final boolean opaque;
-
-    protected UrlTileSource(BaseOptions options) {
-        Objects.requireNonNull(options);
-
+    protected UrlTileSource(BaseOptions<?> options) {
+        super(options);
         this.url = options.url;
-        this.opaque = options.opaque;
     }
 
-    @Override
-    public String getType() {
-        return Constants.OL_SOURCE_URL_TILE;
-    }
-
+    /**
+     * @return the URL to load tile data from
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * Sets the URL from which to load tile data.
+     *
+     * @param url
+     *            the new URL
+     */
     public void setUrl(String url) {
         this.url = url;
         notifyChange();
     }
 
-    public boolean isOpaque() {
-        return opaque;
-    }
-
-    protected static class BaseOptions<T extends BaseOptions<T>> {
+    protected static class BaseOptions<T extends BaseOptions<T>>
+            extends TileSource.BaseOptions<T> {
         private String url;
-        private boolean opaque = true;
 
+        /**
+         * @see UrlTileSource#setUrl(String)
+         */
         public T setUrl(String url) {
             this.url = url;
-            return (T) this;
+            return getThis();
         }
-
-        public T setOpaque(boolean opaque) {
-            this.opaque = opaque;
-            return (T) this;
-        }
-    }
-
-    public static class Options extends BaseOptions<Options> {
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/VectorSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/VectorSource.java
@@ -27,6 +27,14 @@ import java.util.Objects;
 public class VectorSource extends Source {
     private final List<Feature> features = new ArrayList<>();
 
+    public VectorSource() {
+        this(new Options());
+    }
+
+    public VectorSource(BaseOptions options) {
+        super(options);
+    }
+
     @Override
     public String getType() {
         return Constants.OL_SOURCE_VECTOR;
@@ -52,5 +60,12 @@ public class VectorSource extends Source {
 
         features.remove(feature);
         notifyChange();
+    }
+
+    protected static class BaseOptions<T extends BaseOptions<T>>
+            extends Source.BaseOptions<T> {
+    }
+
+    public static class Options extends BaseOptions<Options> {
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
@@ -1,0 +1,39 @@
+package com.vaadin.flow.component.map.configuration.source;
+
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
+import com.vaadin.flow.component.map.configuration.Constants;
+
+/**
+ * Abstract base class for map sources loading tiled images from a map service
+ * using the XYZ URL format
+ */
+public abstract class XYZSource extends TileImageSource {
+
+    protected XYZSource(BaseOptions<?> options) {
+        super(options);
+    }
+
+    @Override
+    public String getType() {
+        return Constants.OL_SOURCE_XYZ;
+    }
+
+    protected static class BaseOptions<T extends BaseOptions<T>>
+            extends TileImageSource.BaseOptions<T> {
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapTest.java
@@ -1,0 +1,55 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.map.configuration.layer.TileLayer;
+import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
+import com.vaadin.flow.component.map.configuration.source.OSMSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MapTest {
+    @Test
+    public void defaultLayer() {
+        Map map = new Map();
+
+        Assert.assertEquals(1, map.getConfiguration().getLayers().size());
+        Assert.assertTrue(
+                map.getConfiguration().getLayers().get(0) instanceof TileLayer);
+        Assert.assertTrue(
+                ((TileLayer) map.getConfiguration().getLayers().get(0))
+                        .getSource() instanceof OSMSource);
+    }
+
+    @Test
+    public void setBackgroundLayer_replacesDefaultLayer() {
+        Map map = new Map();
+        TileLayer newBackgroundLayer = new TileLayer();
+        map.setBackgroundLayer(newBackgroundLayer);
+
+        Assert.assertEquals(1, map.getConfiguration().getLayers().size());
+        Assert.assertTrue(map.getConfiguration().getLayers()
+                .contains(newBackgroundLayer));
+    }
+
+    @Test
+    public void setBackgroundLayer_prependsLayer() {
+        Map map = new Map();
+        VectorLayer overlayLayer = new VectorLayer();
+        map.addLayer(overlayLayer);
+        TileLayer newBackgroundLayer = new TileLayer();
+        map.setBackgroundLayer(newBackgroundLayer);
+
+        Assert.assertEquals(2, map.getConfiguration().getLayers().size());
+        Assert.assertEquals(0,
+                map.getConfiguration().getLayers().indexOf(newBackgroundLayer));
+        Assert.assertEquals(1,
+                map.getConfiguration().getLayers().indexOf(overlayLayer));
+    }
+
+    @Test
+    public void setBackgroundLayer_doesNotAcceptNull() {
+        Map map = new Map();
+
+        Assert.assertThrows(NullPointerException.class,
+                () -> map.setBackgroundLayer(null));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-testbench/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>vaadin-map-flow-parent</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>23.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>vaadin-map-testbench</artifactId>
+    <packaging>jar</packaging>
+    <name>Vaadin Map Testbench API</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-core</artifactId>
+            <version>${testbench.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>attach-docs</id>
+            <activation>
+                <property>
+                    <name>with-docs</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -1,0 +1,35 @@
+package com.vaadin.flow.component.map.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-map")
+public class MapElement extends TestBenchElement {
+    /**
+     * Evaluates a Javascript expression against a vaadin-map's internal
+     * OpenLayers map instance, and returns the result. The OpenLayers map
+     * instance will be provided as the {@code map} variable to the expression.
+     *
+     * @param expression
+     *            the Javascript expression to execute
+     * @return result of the Javascript evaluation
+     */
+    public Object evaluateOLExpression(String expression) {
+        return executeScript(
+                "const map = arguments[0].configuration; return " + expression,
+                getWrappedElement());
+    }
+
+    /**
+     * Helper for building a Javascript expression that returns the type name of
+     * an OpenLayers class instance
+     *
+     * @param jsExpression
+     *            a Javascript expression that returns an OpenLayers class
+     *            instance
+     * @return the Javascript expression that evaluates the type name
+     */
+    public String getOLTypeNameExpression(String jsExpression) {
+        return jsExpression + ".constructor.name";
+    }
+}


### PR DESCRIPTION
## Description

Finalizes the background layer and default OSM source features. This includes having a default background layer using an OSM source, being able to set a custom OSM URL, and being able to completely replace the default background layer.

Changes:
- Adds several OpenLayers classes that were missing from the layer and source class hierarchy
- Adds several properties / options to layers and sources that were easy to support
- Adds API docs for at least the classes that were relevant for the feature
- Adds integration test that verify that the map defaults, and configuration changes are synced correctly to OpenLayers
- Adds a testbench module and element class for the map, and some methods to support getting information from OpenLayers

Skipping CI because the required web component has no release and thus can not be resolved in the CI setup.

Fixes #2496 
Fixes #2497 

## Type of change

- [x] Feature