### PR TITLE
fix: check sub cache queue of a grid instance in connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
@@ -43,11 +43,13 @@ public class TreeGridDetachAttachPage extends Div {
         });
         toggleAttached.setId("toggle-attached");
         add(toggleAttached);
-        
-        NativeButton useAutoWidthColumn = new NativeButton("use auto-width column", e -> {
-            grid.removeAllColumns();
-            grid.addHierarchyColumn(HierarchicalTestBean::toString).setAutoWidth(true).setFlexGrow(0);
-        });
+
+        NativeButton useAutoWidthColumn = new NativeButton(
+                "use auto-width column", e -> {
+                    grid.removeAllColumns();
+                    grid.addHierarchyColumn(HierarchicalTestBean::toString)
+                            .setAutoWidth(true).setFlexGrow(0);
+                });
         useAutoWidthColumn.setId("use-auto-width-column");
         add(useAutoWidthColumn);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
@@ -43,5 +43,12 @@ public class TreeGridDetachAttachPage extends Div {
         });
         toggleAttached.setId("toggle-attached");
         add(toggleAttached);
+        
+        NativeButton useAutoWidthColumn = new NativeButton("use auto-width column", e -> {
+            grid.removeAllColumns();
+            grid.addHierarchyColumn(HierarchicalTestBean::toString).setAutoWidth(true).setFlexGrow(0);
+        });
+        useAutoWidthColumn.setId("use-auto-width-column");
+        add(useAutoWidthColumn);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
@@ -29,12 +29,14 @@ public class TreeGridDetachAttachIT extends AbstractComponentIT {
 
     private TreeGridElement grid;
     private TestBenchElement toggleAttachedButton;
+    private TestBenchElement useAutoWidthColumnButton;
 
     @Before
     public void before() {
         open();
         grid = $(TreeGridElement.class).first();
         toggleAttachedButton = $("button").id("toggle-attached");
+        useAutoWidthColumnButton = $("button").id("use-auto-width-column");
     }
 
     @Test
@@ -71,5 +73,19 @@ public class TreeGridDetachAttachIT extends AbstractComponentIT {
 
         grid = $(TreeGridElement.class).first();
         Assert.assertTrue(grid.isRowExpanded(2, 0));
+    }
+
+    @Test
+    public void useAutoWidthColumn_detach_attach_shouldHaveProperColumnWidth() {
+        grid.expandWithClick(0);
+        useAutoWidthColumnButton.click();
+
+        Integer columnOffsetWidth = grid.getCell(0, 0).getPropertyInteger("offsetWidth");
+
+        toggleAttachedButton.click();
+        toggleAttachedButton.click();
+
+        grid = $(TreeGridElement.class).first();
+        Assert.assertEquals(columnOffsetWidth, grid.getCell(0, 0).getPropertyInteger("offsetWidth"));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
@@ -80,12 +80,14 @@ public class TreeGridDetachAttachIT extends AbstractComponentIT {
         grid.expandWithClick(0);
         useAutoWidthColumnButton.click();
 
-        Integer columnOffsetWidth = grid.getCell(0, 0).getPropertyInteger("offsetWidth");
+        Integer columnOffsetWidth = grid.getCell(0, 0)
+                .getPropertyInteger("offsetWidth");
 
         toggleAttachedButton.click();
         toggleAttachedButton.click();
 
         grid = $(TreeGridElement.class).first();
-        Assert.assertEquals(columnOffsetWidth, grid.getCell(0, 0).getPropertyInteger("offsetWidth"));
+        Assert.assertEquals(columnOffsetWidth,
+                grid.getCell(0, 0).getPropertyInteger("offsetWidth"));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -37,7 +37,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         });
 
         ItemCache.prototype.isLoading = tryCatchWrapper(function() {
-          return Boolean(ensureSubCacheQueue.length || Object.keys(this.pendingRequests).length || Object.keys(this.itemCaches).filter(index => {
+          return Boolean(this.grid.$connector.hasEnsureSubCacheQueue() || Object.keys(this.pendingRequests).length || Object.keys(this.itemCaches).filter(index => {
             return this.itemCaches[index].isLoading();
           })[0]);
         });


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/3292

The `gridConnector` patches certain functions from the `<vaadin-grid>`'s `ItemCache` type. The patched functions can reference the grid instance they're associated with using `this.grid`, and the related connector using `this.grid.$connector`. 

The patched `isLoading()` function was erroneously [referencing](https://github.com/vaadin/flow-components/blob/f94d5700368a850fee544392b78cd3150d8fb61d/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L40) the `ensureSubCacheQueue` array directly inside the connector, bypassing the related grid instance reference. Meaning that the `IsLoading()` check of each grid would use the `ensureSubCacheQueue` state of the first grid added on the page.