### PR TITLE
fix: notify flag thread local initial value

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
@@ -25,14 +25,13 @@ import java.util.UUID;
 public abstract class AbstractConfigurationObject implements Serializable {
 
     private String id;
-    private final ThreadLocal<Boolean> notifyChanges = new ThreadLocal<>();
+    private final ThreadLocal<Boolean> notifyChanges = ThreadLocal.withInitial(() -> true);
 
     protected final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(
             this);
 
     public AbstractConfigurationObject() {
         this.id = UUID.randomUUID().toString();
-        notifyChanges.set(true);
     }
 
     public String getId() {

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
@@ -25,7 +25,8 @@ import java.util.UUID;
 public abstract class AbstractConfigurationObject implements Serializable {
 
     private String id;
-    private final ThreadLocal<Boolean> notifyChanges = ThreadLocal.withInitial(() -> true);
+    private final ThreadLocal<Boolean> notifyChanges = ThreadLocal
+            .withInitial(() -> true);
 
     protected final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(
             this);


### PR DESCRIPTION
## Description

Fixes the thread local initialization for configuration classes. Updates running from a different thread than the one that initialized the thread local could end up with an initial value of false.

## Type of change

- [x] Bugfix
