### PR TITLE
fix: handle unfinalized grid in the connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridVirtualChildPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridVirtualChildPage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-grid/virtual-child")
+public class GridVirtualChildPage extends Div {
+
+    public GridVirtualChildPage() {
+        Grid<String> grid = new Grid<>();
+        grid.addColumn(s -> s).setHeader("Test");
+        grid.setItems("1", "2", "3");
+        getElement().appendVirtualChild(grid.getElement());
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridVirtualChildIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridVirtualChildIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Test;
+
+@TestPath("vaadin-grid/virtual-child")
+public class GridVirtualChildIT extends AbstractComponentIT {
+
+    @Test
+    public void shouldNotHaveErrors() {
+        open();
+        checkLogsForErrors();
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/2555

There were a couple of places in the connector where the `<vaadin-grid>` instance was assumed to have been fully finalized (access to `grid.$....`)