### PR TITLE
fix: only use custom label when setting HTML

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/frontend/inject-checkbox.js
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/frontend/inject-checkbox.js
@@ -5,7 +5,7 @@ import '@vaadin/checkbox/vaadin-checkbox.js';
 class InjectChecbox extends PolymerElement {
     static get template() {
       return html`
-    <vaadin-checkbox id="accept">Accept</vaadin-checkbox>
+    <vaadin-checkbox id="accept" label="Accept"></vaadin-checkbox>
     <div id="div">A</div>
 `;
   }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/InjectedCheckboxIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/InjectedCheckboxIT.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.flow.testutil.TestPath;
 
 @TestPath("vaadin-checkbox/injected-checkbox")
@@ -28,8 +29,13 @@ public class InjectedCheckboxIT extends AbstractComponentIT {
     public void initialCheckboxValue() {
         open();
 
-        String isChecked = $("inject-checkbox").first().$("vaadin-checkbox")
-                .first().getAttribute("checked");
+        TestBenchElement checkbox = $("inject-checkbox").first()
+                .$("vaadin-checkbox").first();
+
+        String isChecked = checkbox.getAttribute("checked");
         Assert.assertEquals(Boolean.TRUE.toString(), isChecked);
+
+        Assert.assertEquals("Accept",
+                checkbox.getPropertyString("textContent").trim());
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -35,8 +35,6 @@ import com.vaadin.flow.dom.PropertyChangeListener;
 public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
         implements HasSize, HasLabel {
 
-    private final Label labelElement = appendLabelElement();
-
     private static final PropertyChangeListener NO_OP = event -> {
     };
 
@@ -138,7 +136,7 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
      */
     @Override
     public void setLabel(String label) {
-        labelElement.setText(label);
+        getElement().setProperty("label", label == null ? "" : label);
     }
 
     /**
@@ -153,7 +151,11 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
      *            the label html to set
      */
     public void setLabelAsHtml(String htmlContent) {
-        labelElement.getElement().setProperty("innerHTML", htmlContent);
+        // Create and add a new slotted label
+        Label label = new Label();
+        label.getElement().setAttribute("slot", "label");
+        label.getElement().setProperty("innerHTML", htmlContent);
+        getElement().appendChild(label.getElement());
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -120,14 +120,6 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
                 .get().getText();
     }
 
-    private Label appendLabelElement() {
-        // Create and add a new slotted label
-        Label label = new Label();
-        label.getElement().setAttribute("slot", "label");
-        getElement().appendChild(label.getElement());
-        return label;
-    }
-
     /**
      * Set the current label text of this checkbox.
      *

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -35,6 +35,8 @@ import com.vaadin.flow.dom.PropertyChangeListener;
 public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
         implements HasSize, HasLabel {
 
+    private final Label labelElement;
+
     private static final PropertyChangeListener NO_OP = event -> {
     };
 
@@ -50,6 +52,10 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
                 NO_OP);
         // https://github.com/vaadin/vaadin-checkbox/issues/25
         setIndeterminate(false);
+
+        // Initialize custom label
+        labelElement = new Label();
+        labelElement.getElement().setAttribute("slot", "label");
     }
 
     /**
@@ -141,11 +147,9 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
      *            the label html to set
      */
     public void setLabelAsHtml(String htmlContent) {
-        // Create and add a new slotted label
-        Label label = new Label();
-        label.getElement().setAttribute("slot", "label");
-        label.getElement().setProperty("innerHTML", htmlContent);
-        getElement().appendChild(label.getElement());
+        setLabel("");
+        labelElement.getElement().setProperty("innerHTML", htmlContent);
+        getElement().appendChild(labelElement.getElement());
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -115,9 +115,7 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
      */
     @Override
     public String getLabel() {
-        return getElement().getChildren()
-                .filter(child -> child.getTag().equals("label")).findFirst()
-                .get().getText();
+        return getElement().getProperty("label");
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -132,6 +132,9 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
      */
     @Override
     public void setLabel(String label) {
+        if (getElement().equals(labelElement.getElement().getParent())) {
+            getElement().removeChild(labelElement.getElement());
+        }
         getElement().setProperty("label", label == null ? "" : label);
     }
 


### PR DESCRIPTION
## Description

Currently, the custom `<label>` is always created even if there is one provided by the user via template.
This PR changes it to use `label` property instead, and only create `<label>` when using `.setLabelAsHtml()`.

Also, updated the IT for the checkbox in template to ensure the `label` attribute value is preserved.

Fixes #2551

## Type of change

- Bugfix