### PR TITLE
fix: enforce checkbox web component disabled state

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemPage.java
@@ -32,6 +32,10 @@ public class CheckboxGroupDisabledItemPage extends VerticalLayout {
                 });
         toggleBarButton.setId("toggle-bar-button");
 
-        add(group, new Div(toggleBarButton));
+        NativeButton toggleEnabledButton = new NativeButton("Toggle enabled",
+                event -> group.setEnabled(!group.isEnabled()));
+        toggleEnabledButton.setId("toggle-enabled-button");
+
+        add(group, new Div(toggleBarButton, toggleEnabledButton));
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemIT.java
@@ -78,4 +78,24 @@ public class CheckboxGroupDisabledItemIT extends AbstractComponentIT {
         firstCheckbox.click();
         Assert.assertNull(firstCheckbox.getAttribute("checked"));
     }
+
+    @Test
+    public void enablingTheGroupDoesnNotEnableItemDisabledWithItemEnabledProvider() {
+        open();
+        TestBenchElement group = $(TestBenchElement.class)
+                .id("checkbox-group-disabled-item");
+        List<TestBenchElement> checkboxes = group.$("vaadin-checkbox").all();
+        TestBenchElement toggleEnabledButton = $("button").id("toggle-enabled-button");
+
+        // Disable group
+        toggleEnabledButton.click();
+
+        // Re-enable group
+        toggleEnabledButton.click();
+
+        Assert.assertEquals("Second checkbox should be disabled",
+                Boolean.TRUE.toString(), checkboxes.get(1).getAttribute("disabled"));
+    }
+
+
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemIT.java
@@ -85,7 +85,8 @@ public class CheckboxGroupDisabledItemIT extends AbstractComponentIT {
         TestBenchElement group = $(TestBenchElement.class)
                 .id("checkbox-group-disabled-item");
         List<TestBenchElement> checkboxes = group.$("vaadin-checkbox").all();
-        TestBenchElement toggleEnabledButton = $("button").id("toggle-enabled-button");
+        TestBenchElement toggleEnabledButton = $("button")
+                .id("toggle-enabled-button");
 
         // Disable group
         toggleEnabledButton.click();
@@ -94,8 +95,8 @@ public class CheckboxGroupDisabledItemIT extends AbstractComponentIT {
         toggleEnabledButton.click();
 
         Assert.assertEquals("Second checkbox should be disabled",
-                Boolean.TRUE.toString(), checkboxes.get(1).getAttribute("disabled"));
+                Boolean.TRUE.toString(),
+                checkboxes.get(1).getAttribute("disabled"));
     }
-
 
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -527,17 +527,12 @@ public class CheckboxGroup<T>
     private void updateEnabled(CheckBoxItem<T> checkbox) {
         boolean disabled = isDisabledBoolean()
                 || !getItemEnabledProvider().test(checkbox.getItem());
-        Serializable rawValue = checkbox.getElement()
-                .getPropertyRaw("disabled");
-        if (rawValue instanceof Boolean) {
-            // convert the boolean value to a String to force update the
-            // property value. Otherwise since the provided value is the same as
-            // the current one the update don't do anything.
-            checkbox.getElement().setProperty("disabled",
-                    disabled ? Boolean.TRUE.toString() : null);
-        } else {
-            checkbox.setDisabled(disabled);
-        }
+        checkbox.setDisabled(disabled);
+        // When enabling a disabled checkbox group, individual checkbox Web
+        // Components that should remain disabled (due to itemEnabledProvider),
+        // may end up rendering as enabled.
+        // Enforce the Web Component state using JS.
+        checkbox.getElement().executeJs("this.disabled = $0", disabled);
     }
 
     private void validateSelectionEnabledState(PropertyChangeEvent event) {


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/2577

Same as https://github.com/vaadin/flow-components/pull/2563 but for CheckboxGroup