### PR TITLE
test: scope grid benchmark styles

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/frontend/benchmark.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/frontend/benchmark.js
@@ -16,7 +16,7 @@ style.appendChild(
     }
   }
 
-  vaadin-grid-tree-toggle[leaf] {
+  [benchmark] vaadin-grid-tree-toggle[leaf] {
     transition: opacity 1s;
     opacity: 0.9;
   }
@@ -27,7 +27,7 @@ document.head.appendChild(style);
 registerStyles(
   'vaadin-grid',
   css`
-    [part~='body-cell'] {
+    :host([benchmark]) [part~='body-cell'] {
       height: 50px;
     }
 
@@ -37,15 +37,15 @@ registerStyles(
       }
     }
 
-    [part~='cell'] {
+    :host([benchmark]) [part~='cell'] {
       animation: content-ready 1s;
     }
 
-    :host {
+    :host([benchmark]) {
       transition: opacity 1s;
     }
 
-    :host[loading] {
+    :host([benchmark][loading]) {
       opacity: 0.9;
     }
   `
@@ -60,7 +60,7 @@ registerStyles(
       }
     }
 
-    :host {
+    :host([benchmark]) {
       animation: content-ready 1s;
     }
   `

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridBenchmark.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridBenchmark.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.router.Route;
 
 import org.slf4j.LoggerFactory;
 
+// Example: http://localhost:8080/vaadin-grid/benchmark?variant=simple&metric=rendertime
 @Route("vaadin-grid/benchmark")
 @JsModule("./benchmark.js")
 public class GridBenchmark extends Div implements HasUrlParameter<String> {
@@ -173,12 +174,14 @@ public class GridBenchmark extends Div implements HasUrlParameter<String> {
     private Grid<String> getGrid() {
         Grid<String> result = new Grid<>();
         result.setItems(items);
+        result.getElement().setAttribute("benchmark", true);
         return result;
     }
 
     private TreeGrid<String> getTreeGrid() {
         TreeGrid<String> result = new TreeGrid<>();
         result.setTreeData(treeData);
+        result.getElement().setAttribute("benchmark", true);
         return result;
     }
 


### PR DESCRIPTION
The `benchmark.js` file includes style registrations that are intended for `<vaadin-grid>` in benchmark tests. The styles aren't scoped so they currently leak to all Grid integration tests. This PR scopes the styles to only affect `<vaadin-grid benchmark>`