### PR TITLE
feat: configurable attributions

### DIFF
--- a/vaadin-map-flow-parent/pom.xml
+++ b/vaadin-map-flow-parent/pom.xml
@@ -18,7 +18,6 @@
     <modules>
         <module>vaadin-map-flow</module>
         <module>vaadin-map-testbench</module>
-        <module>vaadin-map-flow-integration-tests</module>
     </modules>
     <profiles>
         <profile>

--- a/vaadin-map-flow-parent/pom.xml
+++ b/vaadin-map-flow-parent/pom.xml
@@ -18,6 +18,7 @@
     <modules>
         <module>vaadin-map-flow</module>
         <module>vaadin-map-testbench</module>
+        <module>vaadin-map-flow-integration-tests</module>
     </modules>
     <profiles>
         <profile>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
@@ -4,6 +4,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.map.configuration.layer.TileLayer;
 import com.vaadin.flow.component.map.configuration.source.OSMSource;
+import com.vaadin.flow.component.map.configuration.source.XYZSource;
 import com.vaadin.flow.router.Route;
 
 import java.util.ArrayList;
@@ -11,6 +12,11 @@ import java.util.List;
 
 @Route("vaadin-map/attributions")
 public class AttributionsPage extends Div {
+
+    List<String> testAttributions = List.of(
+            "© <a href=\"https://map-service-1.com\">Map service 1</a>",
+            "© <a href=\"https://map-service-2.com\">Map service 2</a>");
+
     public AttributionsPage() {
         Map map = new Map();
         map.setWidthFull();
@@ -19,33 +25,45 @@ public class AttributionsPage extends Div {
         NativeButton setupCustomAttributions = new NativeButton(
                 "Setup custom attributions", e -> {
                     OSMSource source = new OSMSource();
-                    List<String> attributions = List.of(
-                            "© <a href=\"https://map-service-1.com\">Map service 1</a>",
-                            "© <a href=\"https://map-service-2.com\">Map service 2</a>");
-                    source.setAttributions(attributions);
+                    source.setAttributions(testAttributions);
                     ((TileLayer) map.getBackgroundLayer()).setSource(source);
                 });
         setupCustomAttributions.setId("setup-custom-attributions");
 
         NativeButton changeAttributions = new NativeButton(
                 "Change attributions", e -> {
-                    List<String> attributions = List.of(
-                            "© <a href=\"https://map-service-1.com\">Map service 1</a>",
-                            "© <a href=\"https://map-service-2.com\">Map service 2</a>");
                     ((TileLayer) map.getBackgroundLayer()).getSource()
-                            .setAttributions(attributions);
+                            .setAttributions(testAttributions);
                 });
         changeAttributions.setId("change-attributions");
 
         NativeButton clearAttributions = new NativeButton("Clear attributions",
                 e -> {
-                    List<String> attributions = new ArrayList<>();
+                    List<String> emptyAttributions = new ArrayList<>();
                     ((TileLayer) map.getBackgroundLayer()).getSource()
-                            .setAttributions(attributions);
+                            .setAttributions(emptyAttributions);
                 });
         clearAttributions.setId("clear-attributions");
 
+        NativeButton setupCollapsibleEnabled = new NativeButton("Setup collapsible enabled",
+                e -> {
+                    // Default OSMSource does not allow changing collapsible settings, so use something else
+                    XYZSource source = new XYZSource(new XYZSource.Options().setAttributionsCollapsible(true));
+                    source.setAttributions(testAttributions);
+                    ((TileLayer) map.getBackgroundLayer()).setSource(source);
+                });
+        setupCollapsibleEnabled.setId("setup-collapsible-enabled");
+
+        NativeButton setupCollapsibleDisabled = new NativeButton("Setup collapsible disabled",
+                e -> {
+                    // Default OSMSource does not allow changing collapsible settings, so use something else
+                    XYZSource source = new XYZSource(new XYZSource.Options().setAttributionsCollapsible(false));
+                    source.setAttributions(testAttributions);
+                    ((TileLayer) map.getBackgroundLayer()).setSource(source);
+                });
+        setupCollapsibleDisabled.setId("setup-collapsible-disabled");
+
         add(map, new Div(setupCustomAttributions, changeAttributions,
-                clearAttributions));
+                clearAttributions, setupCollapsibleEnabled,  setupCollapsibleDisabled));
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
@@ -1,0 +1,51 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.layer.TileLayer;
+import com.vaadin.flow.component.map.configuration.source.OSMSource;
+import com.vaadin.flow.router.Route;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Route("vaadin-map/attributions")
+public class AttributionsPage extends Div {
+    public AttributionsPage() {
+        Map map = new Map();
+        map.setWidthFull();
+        map.setHeight("400px");
+
+        NativeButton setupCustomAttributions = new NativeButton(
+                "Setup custom attributions", e -> {
+                    OSMSource source = new OSMSource();
+                    List<String> attributions = List.of(
+                            "© <a href=\"https://map-service-1.com\">Map service 1</a>",
+                            "© <a href=\"https://map-service-2.com\">Map service 2</a>");
+                    source.setAttributions(attributions);
+                    ((TileLayer) map.getBackgroundLayer()).setSource(source);
+                });
+        setupCustomAttributions.setId("setup-custom-attributions");
+
+        NativeButton changeAttributions = new NativeButton(
+                "Change attributions", e -> {
+                    List<String> attributions = List.of(
+                            "© <a href=\"https://map-service-1.com\">Map service 1</a>",
+                            "© <a href=\"https://map-service-2.com\">Map service 2</a>");
+                    ((TileLayer) map.getBackgroundLayer()).getSource()
+                            .setAttributions(attributions);
+                });
+        changeAttributions.setId("change-attributions");
+
+        NativeButton clearAttributions = new NativeButton("Clear attributions",
+                e -> {
+                    List<String> attributions = new ArrayList<>();
+                    ((TileLayer) map.getBackgroundLayer()).getSource()
+                            .setAttributions(attributions);
+                });
+        clearAttributions.setId("clear-attributions");
+
+        add(map, new Div(setupCustomAttributions, changeAttributions,
+                clearAttributions));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
@@ -7,7 +7,6 @@ import com.vaadin.flow.component.map.configuration.source.OSMSource;
 import com.vaadin.flow.component.map.configuration.source.XYZSource;
 import com.vaadin.flow.router.Route;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Route("vaadin-map/attributions")
@@ -22,26 +21,31 @@ public class AttributionsPage extends Div {
         map.setWidthFull();
         map.setHeight("400px");
 
-        NativeButton setupCustomAttributions = new NativeButton(
-                "Setup custom attributions", e -> {
-                    OSMSource source = new OSMSource();
-                    source.setAttributions(testAttributions);
-                    ((TileLayer) map.getBackgroundLayer()).setSource(source);
+        NativeButton setupOSMSource = new NativeButton("Setup OSM source",
+                e -> {
+                    ((TileLayer) map.getBackgroundLayer())
+                            .setSource(new OSMSource());
                 });
-        setupCustomAttributions.setId("setup-custom-attributions");
+        setupOSMSource.setId("setup-osm-source");
 
-        NativeButton changeAttributions = new NativeButton(
-                "Change attributions", e -> {
+        NativeButton setupXYZSource = new NativeButton("Setup XYZ source",
+                e -> {
+                    ((TileLayer) map.getBackgroundLayer())
+                            .setSource(new XYZSource());
+                });
+        setupXYZSource.setId("setup-xyz-source");
+
+        NativeButton setCustomAttributions = new NativeButton(
+                "Set custom attributions", e -> {
                     ((TileLayer) map.getBackgroundLayer()).getSource()
                             .setAttributions(testAttributions);
                 });
-        changeAttributions.setId("change-attributions");
+        setCustomAttributions.setId("set-custom-attributions");
 
         NativeButton clearAttributions = new NativeButton("Clear attributions",
                 e -> {
-                    List<String> emptyAttributions = new ArrayList<>();
                     ((TileLayer) map.getBackgroundLayer()).getSource()
-                            .setAttributions(emptyAttributions);
+                            .setAttributions(null);
                 });
         clearAttributions.setId("clear-attributions");
 
@@ -67,7 +71,7 @@ public class AttributionsPage extends Div {
                 });
         setupCollapsibleDisabled.setId("setup-collapsible-disabled");
 
-        add(map, new Div(setupCustomAttributions, changeAttributions,
+        add(map, new Div(setupOSMSource, setupXYZSource, setCustomAttributions,
                 clearAttributions, setupCollapsibleEnabled,
                 setupCollapsibleDisabled));
     }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/AttributionsPage.java
@@ -45,25 +45,30 @@ public class AttributionsPage extends Div {
                 });
         clearAttributions.setId("clear-attributions");
 
-        NativeButton setupCollapsibleEnabled = new NativeButton("Setup collapsible enabled",
-                e -> {
-                    // Default OSMSource does not allow changing collapsible settings, so use something else
-                    XYZSource source = new XYZSource(new XYZSource.Options().setAttributionsCollapsible(true));
+        NativeButton setupCollapsibleEnabled = new NativeButton(
+                "Setup collapsible enabled", e -> {
+                    // Default OSMSource does not allow changing collapsible
+                    // settings, so use something else
+                    XYZSource source = new XYZSource(new XYZSource.Options()
+                            .setAttributionsCollapsible(true));
                     source.setAttributions(testAttributions);
                     ((TileLayer) map.getBackgroundLayer()).setSource(source);
                 });
         setupCollapsibleEnabled.setId("setup-collapsible-enabled");
 
-        NativeButton setupCollapsibleDisabled = new NativeButton("Setup collapsible disabled",
-                e -> {
-                    // Default OSMSource does not allow changing collapsible settings, so use something else
-                    XYZSource source = new XYZSource(new XYZSource.Options().setAttributionsCollapsible(false));
+        NativeButton setupCollapsibleDisabled = new NativeButton(
+                "Setup collapsible disabled", e -> {
+                    // Default OSMSource does not allow changing collapsible
+                    // settings, so use something else
+                    XYZSource source = new XYZSource(new XYZSource.Options()
+                            .setAttributionsCollapsible(false));
                     source.setAttributions(testAttributions);
                     ((TileLayer) map.getBackgroundLayer()).setSource(source);
                 });
         setupCollapsibleDisabled.setId("setup-collapsible-disabled");
 
         add(map, new Div(setupCustomAttributions, changeAttributions,
-                clearAttributions, setupCollapsibleEnabled,  setupCollapsibleDisabled));
+                clearAttributions, setupCollapsibleEnabled,
+                setupCollapsibleDisabled));
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
@@ -16,6 +16,8 @@ public class AttributionsIT extends AbstractComponentIT {
     private TestBenchElement setupCustomAttributions;
     private TestBenchElement changeAttributions;
     private TestBenchElement clearAttributions;
+    private TestBenchElement setupCollapsibleEnabled;
+    private TestBenchElement setupCollapsibleDisabled;
 
     @Before
     public void init() {
@@ -24,6 +26,8 @@ public class AttributionsIT extends AbstractComponentIT {
         setupCustomAttributions = $("button").id("setup-custom-attributions");
         changeAttributions = $("button").id("change-attributions");
         clearAttributions = $("button").id("clear-attributions");
+        setupCollapsibleEnabled = $("button").id("setup-collapsible-enabled");
+        setupCollapsibleDisabled = $("button").id("setup-collapsible-disabled");
     }
 
     @Test
@@ -78,6 +82,38 @@ public class AttributionsIT extends AbstractComponentIT {
         // Updating attributions might be async in OpenLayers, wait until we
         // have the correct number
         waitUntilNumberOfAttributions(0);
+    }
+
+    @Test
+    public void collapsibleEnabled() {
+        setupCollapsibleEnabled.click();
+
+        // Updating attributions might be async in OpenLayers, wait until we
+        // have the correct number
+        waitUntilNumberOfAttributions(2);
+
+        // Collapsed by default
+        TestBenchElement attributionContainer = map.getAttributionContainer();
+        Assert.assertTrue("Attributions should have collapsed state", attributionContainer.getClassNames().contains("ol-collapsed"));
+        // Has collapse button to toggle collapsed state (no need to test button clicks, that is OpenLayers internal)
+        TestBenchElement collapseButton = attributionContainer.$("button").first();
+        Assert.assertTrue("Collapse button should be displayed", collapseButton.isDisplayed());
+    }
+
+    @Test
+    public void collapsibleDisabled() {
+        setupCollapsibleDisabled.click();
+
+        // Updating attributions might be async in OpenLayers, wait until we
+        // have the correct number
+        waitUntilNumberOfAttributions(2);
+
+        // Not collapsed
+        TestBenchElement attributionContainer = map.getAttributionContainer();
+        Assert.assertFalse("Attributions should not have collapsed state", attributionContainer.getClassNames().contains("ol-collapsed"));
+        // No collapse button to toggle collapsed state
+        TestBenchElement collapseButton = attributionContainer.$("button").first();
+        Assert.assertFalse("Collapse button should not be displayed", collapseButton.isDisplayed());
     }
 
     public void waitUntilNumberOfAttributions(int expectedNumber) {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
@@ -23,7 +23,7 @@ public class AttributionsIT extends AbstractComponentIT {
     @Before
     public void init() {
         open();
-        map = $(MapElement.class).first();
+        map = $(MapElement.class).waitForFirst();
         setupOSMSource = $("button").id("setup-osm-source");
         setupXYZSource = $("button").id("setup-xyz-source");
         setCustomAttributions = $("button").id("set-custom-attributions");

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
@@ -94,10 +94,14 @@ public class AttributionsIT extends AbstractComponentIT {
 
         // Collapsed by default
         TestBenchElement attributionContainer = map.getAttributionContainer();
-        Assert.assertTrue("Attributions should have collapsed state", attributionContainer.getClassNames().contains("ol-collapsed"));
-        // Has collapse button to toggle collapsed state (no need to test button clicks, that is OpenLayers internal)
-        TestBenchElement collapseButton = attributionContainer.$("button").first();
-        Assert.assertTrue("Collapse button should be displayed", collapseButton.isDisplayed());
+        Assert.assertTrue("Attributions should have collapsed state",
+                attributionContainer.getClassNames().contains("ol-collapsed"));
+        // Has collapse button to toggle collapsed state (no need to test button
+        // clicks, that is OpenLayers internal)
+        TestBenchElement collapseButton = attributionContainer.$("button")
+                .first();
+        Assert.assertTrue("Collapse button should be displayed",
+                collapseButton.isDisplayed());
     }
 
     @Test
@@ -110,10 +114,13 @@ public class AttributionsIT extends AbstractComponentIT {
 
         // Not collapsed
         TestBenchElement attributionContainer = map.getAttributionContainer();
-        Assert.assertFalse("Attributions should not have collapsed state", attributionContainer.getClassNames().contains("ol-collapsed"));
+        Assert.assertFalse("Attributions should not have collapsed state",
+                attributionContainer.getClassNames().contains("ol-collapsed"));
         // No collapse button to toggle collapsed state
-        TestBenchElement collapseButton = attributionContainer.$("button").first();
-        Assert.assertFalse("Collapse button should not be displayed", collapseButton.isDisplayed());
+        TestBenchElement collapseButton = attributionContainer.$("button")
+                .first();
+        Assert.assertFalse("Collapse button should not be displayed",
+                collapseButton.isDisplayed());
     }
 
     public void waitUntilNumberOfAttributions(int expectedNumber) {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/AttributionsIT.java
@@ -1,0 +1,89 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+@TestPath("vaadin-map/attributions")
+public class AttributionsIT extends AbstractComponentIT {
+    private MapElement map;
+    private TestBenchElement setupCustomAttributions;
+    private TestBenchElement changeAttributions;
+    private TestBenchElement clearAttributions;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).first();
+        setupCustomAttributions = $("button").id("setup-custom-attributions");
+        changeAttributions = $("button").id("change-attributions");
+        clearAttributions = $("button").id("clear-attributions");
+    }
+
+    @Test
+    public void defaultAttributions() {
+        List<TestBenchElement> attributionItems = map.getAttributionItems();
+
+        Assert.assertEquals(1, attributionItems.size());
+        Assert.assertEquals(
+                "© <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors.",
+                attributionItems.get(0).getPropertyString("innerHTML"));
+    }
+
+    @Test
+    public void setupCustomAttributions() {
+        setupCustomAttributions.click();
+
+        // Updating attributions might be async in OpenLayers, wait until we
+        // have the correct number
+        waitUntilNumberOfAttributions(2);
+        List<TestBenchElement> attributionItems = map.getAttributionItems();
+
+        Assert.assertEquals(
+                "© <a href=\"https://map-service-1.com\">Map service 1</a>",
+                attributionItems.get(0).getPropertyString("innerHTML"));
+        Assert.assertEquals(
+                "© <a href=\"https://map-service-2.com\">Map service 2</a>",
+                attributionItems.get(1).getPropertyString("innerHTML"));
+    }
+
+    @Test
+    public void changeAttributions() {
+        changeAttributions.click();
+
+        // Updating attributions might be async in OpenLayers, wait until we
+        // have the correct number
+        waitUntilNumberOfAttributions(2);
+        List<TestBenchElement> attributionItems = map.getAttributionItems();
+
+        Assert.assertEquals(2, attributionItems.size());
+        Assert.assertEquals(
+                "© <a href=\"https://map-service-1.com\">Map service 1</a>",
+                attributionItems.get(0).getPropertyString("innerHTML"));
+        Assert.assertEquals(
+                "© <a href=\"https://map-service-2.com\">Map service 2</a>",
+                attributionItems.get(1).getPropertyString("innerHTML"));
+    }
+
+    @Test
+    public void clearAttributions() {
+        clearAttributions.click();
+
+        // Updating attributions might be async in OpenLayers, wait until we
+        // have the correct number
+        waitUntilNumberOfAttributions(0);
+    }
+
+    public void waitUntilNumberOfAttributions(int expectedNumber) {
+        waitUntil(driver -> {
+            List<TestBenchElement> attributionItems = map.getAttributionItems();
+            return attributionItems.size() == expectedNumber;
+        });
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/OSMSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/OSMSource.java
@@ -39,9 +39,9 @@ public class OSMSource extends XYZSource {
     }
 
     /**
-     * Determines whether attributions are collapsible on smaller screen sizes.
-     * For {@link OSMSource} the default is {@code false}, and this value can
-     * not be changed in the options.
+     * Determines whether attributions are collapsible. For {@link OSMSource}
+     * the default is {@code false}, and this value can not be changed in the
+     * options.
      *
      * @return whether attributions are collapsible
      */

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/OSMSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/OSMSource.java
@@ -38,9 +38,32 @@ public class OSMSource extends XYZSource {
         return Constants.OL_SOURCE_OSM;
     }
 
+    /**
+     * Determines whether attributions are collapsible on smaller screen sizes.
+     * For {@link OSMSource} the default is {@code false}, and this value can
+     * not be changed in the options.
+     *
+     * @return whether attributions are collapsible
+     */
+    @Override
+    public boolean isAttributionsCollapsible() {
+        return super.isAttributionsCollapsible();
+    }
+
     public static class Options extends XYZSource.BaseOptions<Options> {
         public Options() {
             setUrl("https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png");
+            setAttributionsCollapsible(false);
+        }
+
+        @Override
+        public Options setAttributionsCollapsible(
+                boolean attributionsCollapsible) {
+            if (attributionsCollapsible) {
+                throw new IllegalArgumentException(
+                        "OSMSource does not allow to collapse attributions");
+            }
+            return getThis();
         }
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
@@ -58,6 +58,10 @@ public abstract class Source extends AbstractConfigurationObject {
 
     /**
      * Sets the attributions to display for the source.
+     * <p>
+     * Setting this to {@code null} displays the default attributions, if the
+     * specific type of source has any. This should only be the case for
+     * {@link OSMSource}. Otherwise, the attributions will be cleared.
      *
      * @param attributions
      *            the new attributions

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
@@ -38,16 +38,26 @@ public abstract class Source extends AbstractConfigurationObject {
     }
 
     /**
-     * @return list of attributions to display for this source
+     * The attributions to display for the source. Attributions can be
+     * copyrights and other information that needs to be displayed in order to
+     * use map data from a service.
+     * <p>
+     * This property uses a list to allow displaying a number of contributions.
+     * Multiple attributions will be displayed next to each other in the
+     * attribution container.
+     * <p>
+     * By default, the value is {@code null}, which means that default
+     * attributions will be displayed, if the specific type of source has any.
+     * This should only be the case for {@link OSMSource}.
+     *
+     * @return the list of current attributions
      */
     public List<String> getAttributions() {
         return attributions;
     }
 
     /**
-     * Sets the attributions to display for the source. Attributions can be
-     * copyrights and other information that needs to be displayed in order to
-     * use map data from a service.
+     * Sets the attributions to display for the source.
      *
      * @param attributions
      *            the new attributions
@@ -96,7 +106,7 @@ public abstract class Source extends AbstractConfigurationObject {
         }
 
         /**
-         * @see Source#setAttributions(List)
+         * @see Source#getAttributions()
          */
         public T setAttributions(List<String> attributions) {
             this.attributions = attributions;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
@@ -68,7 +68,11 @@ public abstract class Source extends AbstractConfigurationObject {
     }
 
     /**
-     * Determines whether attributions are collapsible. Default is {@code true}.
+     * Determines whether attributions are collapsible on smaller screen sizes.
+     * Default is {@code true}.
+     * <p>
+     * <b>NOTE:</b> Specific types of sources, such as {@link OSMSource}, might
+     * not allow collapsing the attributions.
      * <p>
      * This value can not be changed after constructing an instance, it can only
      * be set initially by passing an options object to the constructor.

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
@@ -42,7 +42,7 @@ public abstract class Source extends AbstractConfigurationObject {
      * copyrights and other information that needs to be displayed in order to
      * use map data from a service.
      * <p>
-     * This property uses a list to allow displaying a number of contributions.
+     * This property uses a list to allow displaying a number of attributions.
      * Multiple attributions will be displayed next to each other in the
      * attribution container.
      * <p>

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/Source.java
@@ -68,8 +68,7 @@ public abstract class Source extends AbstractConfigurationObject {
     }
 
     /**
-     * Determines whether attributions are collapsible on smaller screen sizes.
-     * Default is {@code true}.
+     * Determines whether attributions are collapsible. Default is {@code true}.
      * <p>
      * <b>NOTE:</b> Specific types of sources, such as {@link OSMSource}, might
      * not allow collapsing the attributions.

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
@@ -37,5 +37,6 @@ public class XYZSource extends TileImageSource {
             extends TileImageSource.BaseOptions<T> {
     }
 
-    public static class Options extends BaseOptions<Options> {}
+    public static class Options extends BaseOptions<Options> {
+    }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
@@ -19,8 +19,8 @@ package com.vaadin.flow.component.map.configuration.source;
 import com.vaadin.flow.component.map.configuration.Constants;
 
 /**
- * Abstract base class for map sources loading tiled images from a map service
- * using the XYZ URL format
+ * Map source for loading tiled images from a map service using the XYZ URL
+ * format
  */
 public class XYZSource extends TileImageSource {
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
@@ -24,6 +24,10 @@ import com.vaadin.flow.component.map.configuration.Constants;
  */
 public class XYZSource extends TileImageSource {
 
+    public XYZSource() {
+        this(new Options());
+    }
+
     public XYZSource(BaseOptions<?> options) {
         super(options);
     }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
@@ -33,7 +33,7 @@ public class XYZSource extends TileImageSource {
         return Constants.OL_SOURCE_XYZ;
     }
 
-    public static class BaseOptions<T extends BaseOptions<T>>
+    public static abstract class BaseOptions<T extends BaseOptions<T>>
             extends TileImageSource.BaseOptions<T> {
     }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/XYZSource.java
@@ -22,9 +22,9 @@ import com.vaadin.flow.component.map.configuration.Constants;
  * Abstract base class for map sources loading tiled images from a map service
  * using the XYZ URL format
  */
-public abstract class XYZSource extends TileImageSource {
+public class XYZSource extends TileImageSource {
 
-    protected XYZSource(BaseOptions<?> options) {
+    public XYZSource(BaseOptions<?> options) {
         super(options);
     }
 
@@ -33,7 +33,9 @@ public abstract class XYZSource extends TileImageSource {
         return Constants.OL_SOURCE_XYZ;
     }
 
-    protected static class BaseOptions<T extends BaseOptions<T>>
+    public static class BaseOptions<T extends BaseOptions<T>>
             extends TileImageSource.BaseOptions<T> {
     }
+
+    public static class Options extends BaseOptions<Options> {}
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
@@ -14,7 +14,7 @@ function synchronizeSource(target, source, _context) {
     throw new Error("Can not instantiate base class: ol/source/Source");
   }
   // Keep default attributions if there is no custom value
-  if(source.attributions) {
+  if (source.attributions) {
     target.setAttributions(source.attributions);
   }
 
@@ -35,8 +35,9 @@ function synchronizeUrlTileSource(target, source, context) {
     throw new Error("Can not instantiate base class: ol/source/UrlTile");
   }
   synchronizeTileSource(target, source, context);
-
-  if(source.url) {
+  // Setting null URL is not supported. While not an actual use-case, it is useful to prevent errors here in order
+  // to keep the URL empty in integration tests
+  if (source.url) {
     target.setUrl(source.url);
   }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
@@ -13,7 +13,10 @@ function synchronizeSource(target, source, _context) {
   if (!target) {
     throw new Error("Can not instantiate base class: ol/source/Source");
   }
-  target.setAttributions(source.attributions);
+  // Keep default attributions if there is no custom value
+  if(source.attributions) {
+    target.setAttributions(source.attributions);
+  }
 
   return target;
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
@@ -14,9 +14,7 @@ function synchronizeSource(target, source, _context) {
     throw new Error("Can not instantiate base class: ol/source/Source");
   }
 
-  // Using undefined causes OL to reset to default attributions
-  const attributions = source.attributions || undefined;
-  target.setAttributions(attributions);
+  target.setAttributions(source.attributions);
 
   return target;
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
@@ -35,7 +35,10 @@ function synchronizeUrlTileSource(target, source, context) {
     throw new Error("Can not instantiate base class: ol/source/UrlTile");
   }
   synchronizeTileSource(target, source, context);
-  target.setUrl(source.url || target.getUrl());
+
+  if(source.url) {
+    target.setUrl(source.url);
+  }
 
   return target;
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/sources.js
@@ -4,7 +4,7 @@
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import Collection from "ol/Collection";
-import OSM from "ol/source/OSM";
+import OSM, { ATTRIBUTION as OSM_ATTRIBUTION } from "ol/source/OSM";
 import VectorSource from "ol/source/Vector";
 import XYZ from "ol/source/XYZ";
 import { createOptions, synchronizeCollection } from "./util.js";
@@ -13,10 +13,10 @@ function synchronizeSource(target, source, _context) {
   if (!target) {
     throw new Error("Can not instantiate base class: ol/source/Source");
   }
-  // Keep default attributions if there is no custom value
-  if (source.attributions) {
-    target.setAttributions(source.attributions);
-  }
+
+  // Using undefined causes OL to reset to default attributions
+  const attributions = source.attributions || undefined;
+  target.setAttributions(attributions);
 
   return target;
 }
@@ -65,6 +65,11 @@ export function synchronizeXYZSource(target, source, context) {
 export function synchronizeOSMSource(target, source, context) {
   if (!target) {
     target = new OSM(createOptions(source));
+  }
+
+  // For OSM source use default attributions as fallback
+  if (!source.attributions) {
+    source.attributions = OSM_ATTRIBUTION;
   }
   synchronizeXYZSource(target, source, context);
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/OSMSourceTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/OSMSourceTest.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.map.configuration.source;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OSMSourceTest {
+    @Test
+    public void setAttributionsCollapsible_mayNotBeEnabled() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            new OSMSource.Options().setAttributionsCollapsible(true);
+        });
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -64,14 +64,22 @@ public class MapElement extends TestBenchElement {
     }
 
     /**
-     * Gets the list of attributions list items in the attributions container
+     * Gets the attribution container div
+     *
+     * @return attribution container div
+     */
+    public TestBenchElement getAttributionContainer() {
+        return $("div")
+                .attributeContains("class", "ol-attribution").first();
+    }
+
+    /**
+     * Gets the list of attributions list items in the attribution container
      * div
      *
      * @return list of list items
      */
     public List<TestBenchElement> getAttributionItems() {
-        TestBenchElement attributions = $("div")
-                .attributeContains("class", "ol-attribution").first();
-        return attributions.$("li").all();
+        return getAttributionContainer().$("li").all();
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -3,6 +3,8 @@ package com.vaadin.flow.component.map.testbench;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
+import java.util.List;
+
 @Element("vaadin-map")
 public class MapElement extends TestBenchElement {
     /**
@@ -59,5 +61,17 @@ public class MapElement extends TestBenchElement {
     public String getFeatureCollectionExpression() {
         return getFeatureLayerExpression()
                 + ".getSource().getFeaturesCollection()";
+    }
+
+    /**
+     * Gets the list of attributions list items in the attributions container
+     * div
+     *
+     * @return list of list items
+     */
+    public List<TestBenchElement> getAttributionItems() {
+        TestBenchElement attributions = $("div")
+                .attributeContains("class", "ol-attribution").first();
+        return attributions.$("li").all();
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -69,13 +69,11 @@ public class MapElement extends TestBenchElement {
      * @return attribution container div
      */
     public TestBenchElement getAttributionContainer() {
-        return $("div")
-                .attributeContains("class", "ol-attribution").first();
+        return $("div").attributeContains("class", "ol-attribution").first();
     }
 
     /**
-     * Gets the list of attributions list items in the attribution container
-     * div
+     * Gets the list of attributions list items in the attribution container div
      *
      * @return list of list items
      */


### PR DESCRIPTION
## Description

Adds support for configuring attributions.
- Keeping the default null value will display default attributions of the source (only applies to OSM source to my knowledge)
- Setting empty list clears attributions
- Setting list of attributions displays them in the attributions container
- Attributions collapsible flag is correctly applied

Fixes #2503 