### PR TITLE
feat: map feature click events

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
@@ -1,0 +1,83 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.Feature;
+import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
+import com.vaadin.flow.component.map.configuration.layer.FeatureLayer;
+import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
+import com.vaadin.flow.component.map.configuration.source.VectorSource;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/feature-events")
+public class FeatureEventsPage extends Div {
+    public FeatureEventsPage() {
+        Map map = new Map();
+        map.setWidthFull();
+        map.setHeight("400px");
+        map.getView().setCenter(new Coordinate(0, 0));
+        map.getView().setZoom(3);
+
+        // Setup first feature layer with one marker
+        FeatureLayer firstFeatureLayer = new FeatureLayer();
+        firstFeatureLayer.setId("first-feature-layer");
+        firstFeatureLayer.getSource().setId("first-source");
+        map.addLayer(firstFeatureLayer);
+
+        MarkerFeature firstMarkerFeature = new MarkerFeature(
+                new Coordinate(0, 0));
+        firstMarkerFeature.setId("first-marker-feature");
+        firstFeatureLayer.addFeature(firstMarkerFeature);
+
+        // Setup second feature layer with one marker
+        FeatureLayer secondFeatureLayer = new FeatureLayer();
+        secondFeatureLayer.setId("second-feature-layer");
+        secondFeatureLayer.getSource().setId("second-source");
+        map.addLayer(secondFeatureLayer);
+
+        MarkerFeature secondMarkerFeature = new MarkerFeature(
+                new Coordinate(2000000, 0));
+        secondMarkerFeature.setId("second-marker-feature");
+        secondFeatureLayer.addFeature(secondMarkerFeature);
+
+        Div eventLog = new Div();
+        eventLog.setId("event-log");
+        eventLog.getElement().getStyle().set("white-space", "pre");
+
+        NativeButton addGlobalFeatureClickListener = new NativeButton(
+                "Add global feature click listener", e -> {
+                    map.addFeatureClickListener(event -> {
+                        Feature feature = event.getFeature();
+                        VectorLayer layer = event.getLayer();
+                        VectorSource source = event.getVectorSource();
+                        String eventInfoText = String.format(
+                                "click: feature=%s | layer=%s | source=%s%n",
+                                feature.getId(), layer.getId(), source.getId());
+
+                        eventLog.setText(eventLog.getText() + eventInfoText);
+                    });
+                });
+        addGlobalFeatureClickListener
+                .setId("add-global-feature-click-listener");
+
+        NativeButton addFirstLayerFeatureClickListener = new NativeButton(
+                "Add feature click listener for first layer only", e -> {
+                    map.addFeatureClickListener(firstFeatureLayer, event -> {
+                        Feature feature = event.getFeature();
+                        VectorLayer layer = event.getLayer();
+                        VectorSource source = event.getVectorSource();
+                        String eventInfoText = String.format(
+                                "click: feature=%s | layer=%s | source=%s%n",
+                                feature.getId(), layer.getId(), source.getId());
+
+                        eventLog.setText(eventLog.getText() + eventInfoText);
+                    });
+                });
+        addFirstLayerFeatureClickListener
+                .setId("add-first-layer-feature-click-listener");
+
+        add(map, new Div(addGlobalFeatureClickListener,
+                addFirstLayerFeatureClickListener), eventLog);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapEventsPage.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.component.map;
 
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.map.configuration.View;
 import com.vaadin.flow.router.Route;
 
@@ -18,29 +19,38 @@ public class MapEventsPage extends Div {
         map.setWidth("400px");
         map.getView().setZoom(3);
 
-        map.addViewMoveEndEventListener(event -> {
-            View mapView = map.getView();
-            String stateText = mapView.getCenter().getX() + ";"
-                    + mapView.getCenter().getY() + ";";
-            stateText += mapView.getRotation() + ";";
-            stateText += mapView.getZoom();
+        NativeButton addMoveEndListener = new NativeButton(
+                "Add move end listener", e -> {
+                    map.addViewMoveEndEventListener(event -> {
+                        View mapView = map.getView();
+                        String stateText = mapView.getCenter().getX() + ";"
+                                + mapView.getCenter().getY() + ";";
+                        stateText += mapView.getRotation() + ";";
+                        stateText += mapView.getZoom();
 
-            viewState.setText(stateText);
+                        viewState.setText(stateText);
 
-            String eventDataText = event.getCenter().getX() + ";"
-                    + event.getCenter().getY() + ";" + event.getRotation() + ";"
-                    + event.getZoom();
+                        String eventDataText = event.getCenter().getX() + ";"
+                                + event.getCenter().getY() + ";"
+                                + event.getRotation() + ";" + event.getZoom();
 
-            eventData.setText(eventDataText);
-        });
+                        eventData.setText(eventDataText);
+                    });
+                });
+        addMoveEndListener.setId("add-move-end-listener");
 
-        map.addClickEventListener(event -> {
-            eventData.setText(event.getCoordinate().getX() + ";"
-                    + event.getCoordinate().getY() + ";"
-                    + event.getMouseDetails().getAbsoluteX() + ";"
-                    + event.getMouseDetails().getAbsoluteY());
-        });
+        NativeButton addClickListener = new NativeButton("Add click listener",
+                e -> {
+                    map.addClickEventListener(event -> {
+                        eventData.setText(event.getCoordinate().getX() + ";"
+                                + event.getCoordinate().getY() + ";"
+                                + event.getMouseDetails().getAbsoluteX() + ";"
+                                + event.getMouseDetails().getAbsoluteY());
+                    });
+                });
+        addClickListener.setId("add-click-listener");
 
-        add(map, viewState, eventData);
+        add(map, viewState, eventData,
+                new Div(addMoveEndListener, addClickListener));
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapView.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapView.java
@@ -28,6 +28,12 @@ public class MapView extends Div {
                 new Coordinate(1233058.1696443919, 6351912.406929109));
         map.getFeatureLayer().addFeature(nurembergMarker);
 
+        map.addFeatureClickListener(e -> {
+            System.out.println(
+                    "Feature click: featureId=" + e.getFeature().getId()
+                            + ", layerId=" + e.getLayer().getId());
+        });
+
         NativeButton toggleLayerVisible = new NativeButton("Toggle Layer",
                 e -> {
                     Layer layer = map.getBackgroundLayer();

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
@@ -4,6 +4,7 @@ import com.vaadin.flow.component.map.testbench.MapElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,8 +35,12 @@ public class FeatureEventsIT extends AbstractComponentIT {
 
         // Click on first marker
         map.clickAtCoordinates(0, 0);
+        // To prevent double-clicking, wait before we trigger the next event
+        waitSeconds(1);
         // Click on second marker
         map.clickAtCoordinates(2000000, 0);
+        // Click events are delayed by around 250ms, wait for last event
+        waitSeconds(1);
 
         // Should have two events, one from each marker
         assertEventLogHasNumberOfEvents(2);
@@ -51,8 +56,12 @@ public class FeatureEventsIT extends AbstractComponentIT {
 
         // Click on first marker
         map.clickAtCoordinates(0, 0);
+        // To prevent double-clicking, wait before we trigger the next event
+        waitSeconds(1);
         // Click on second marker
         map.clickAtCoordinates(2000000, 0);
+        // Click events are delayed by around 250ms, wait for last event
+        waitSeconds(1);
 
         // Should have only one event, from the first marker
         assertEventLogHasNumberOfEvents(1);
@@ -61,18 +70,22 @@ public class FeatureEventsIT extends AbstractComponentIT {
     }
 
     private void assertEventLogHasNumberOfEvents(int expectedEvents) {
-        waitUntil(driver -> {
-            String[] eventLines = eventLog.getText()
-                    .split(System.lineSeparator());
-            return expectedEvents == eventLines.length;
-        });
+        String[] eventLines = eventLog.getText().split(System.lineSeparator());
+        Assert.assertEquals(expectedEvents, eventLines.length);
     }
 
     private void assertEventLogContainsEvent(String expectedEvent) {
+        String[] eventLines = eventLog.getText().split(System.lineSeparator());
+        Assert.assertTrue("Event was not triggered: " + expectedEvent,
+                Arrays.asList(eventLines).contains(expectedEvent));
+    }
+
+    private void waitSeconds(int seconds) {
+        long start = System.currentTimeMillis();
         waitUntil(driver -> {
-            String[] eventLines = eventLog.getText()
-                    .split(System.lineSeparator());
-            return Arrays.asList(eventLines).contains(expectedEvent);
+            long now = System.currentTimeMillis();
+            double delta = Math.floor((now - start) / 1000f);
+            return delta > seconds;
         });
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
@@ -1,0 +1,78 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+@TestPath("vaadin-map/feature-events")
+public class FeatureEventsIT extends AbstractComponentIT {
+    private MapElement map;
+    private TestBenchElement addGlobalFeatureClickListener;
+    private TestBenchElement addFirstLayerFeatureClickListener;
+    private TestBenchElement eventLog;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+        map.disableInteractions();
+        addGlobalFeatureClickListener = $("button")
+                .id("add-global-feature-click-listener");
+        addFirstLayerFeatureClickListener = $("button")
+                .id("add-first-layer-feature-click-listener");
+        eventLog = $("div").id("event-log");
+    }
+
+    @Test
+    public void globalClickListener_capturesEventsFromAllLayers() {
+        addGlobalFeatureClickListener.click();
+
+        // Click on first marker
+        map.clickAtCoordinates(0, 0);
+        // Click on second marker
+        map.clickAtCoordinates(2000000, 0);
+
+        // Should have two events, one from each marker
+        assertEventLogHasNumberOfEvents(2);
+        assertEventLogContainsEvent(
+                "click: feature=first-marker-feature | layer=first-feature-layer | source=first-source");
+        assertEventLogContainsEvent(
+                "click: feature=second-marker-feature | layer=second-feature-layer | source=second-source");
+    }
+
+    @Test
+    public void layerClickListener_capturesEventsFromSingleLayer() {
+        addFirstLayerFeatureClickListener.click();
+
+        // Click on first marker
+        map.clickAtCoordinates(0, 0);
+        // Click on second marker
+        map.clickAtCoordinates(2000000, 0);
+
+        // Should have only one event, from the first marker
+        assertEventLogHasNumberOfEvents(1);
+        assertEventLogContainsEvent(
+                "click: feature=first-marker-feature | layer=first-feature-layer | source=first-source");
+    }
+
+    private void assertEventLogHasNumberOfEvents(int expectedEvents) {
+        waitUntil(driver -> {
+            String[] eventLines = eventLog.getText()
+                    .split(System.lineSeparator());
+            return expectedEvents == eventLines.length;
+        });
+    }
+
+    private void assertEventLogContainsEvent(String expectedEvent) {
+        waitUntil(driver -> {
+            String[] eventLines = eventLog.getText()
+                    .split(System.lineSeparator());
+            return Arrays.asList(eventLines).contains(expectedEvent);
+        });
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/MapEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/MapEventsIT.java
@@ -10,23 +10,32 @@ import org.junit.Test;
 
 @TestPath("vaadin-map/map-events")
 public class MapEventsIT extends AbstractComponentIT {
+    private MapElement map;
+    private TestBenchElement viewStateDiv;
+    private TestBenchElement eventDataDiv;
+    private TestBenchElement addMoveEndListener;
+    private TestBenchElement addClickListener;
+
     @Before
     public void init() {
         open();
+        map = $(MapElement.class).waitForFirst();
+        viewStateDiv = $("div").id("view-state");
+        eventDataDiv = $("div").id("event-data");
+        addMoveEndListener = $("button").id("add-move-end-listener");
+        addClickListener = $("button").id("add-click-listener");
     }
 
     @Test
     public void changeViewPort_viewStateUpdated() {
-        MapElement map = $(MapElement.class).first();
-        TestBenchElement stateTextDiv = $("div").id("view-state");
-
+        addMoveEndListener.click();
         // We are simulating user changing the view port of the map
         map.evaluateOLExpression(
                 "map.getView().setCenter([4849385.650796606, 5487570.011434158]);");
         map.evaluateOLExpression("map.getView().setRotation(5);");
         map.evaluateOLExpression("map.getView().setZoom(6)");
 
-        String[] parts = stateTextDiv.getText().split(";");
+        String[] parts = viewStateDiv.getText().split(";");
         double centerX = Double.parseDouble(parts[0]);
         double centerY = Double.parseDouble(parts[1]);
         float rotation = Float.parseFloat(parts[2]);
@@ -40,9 +49,7 @@ public class MapEventsIT extends AbstractComponentIT {
 
     @Test
     public void changeViewPort_correctEventDataReceived() {
-        MapElement map = $(MapElement.class).first();
-        TestBenchElement eventDataDiv = $("div").id("event-data");
-
+        addMoveEndListener.click();
         // We are simulating user changing the view port of the map
         map.evaluateOLExpression(
                 "map.getView().setCenter([4849385.650796606, 5487570.011434158]);");
@@ -63,10 +70,12 @@ public class MapEventsIT extends AbstractComponentIT {
 
     @Test
     public void mapClick_correctEventDataReceived() {
-        MapElement map = $(MapElement.class).waitForFirst();
-        TestBenchElement eventDataDiv = $("div").id("event-data");
+        addClickListener.click();
 
         map.clickAtCoordinates(-1956787.9241005122, 1956787.9241005122);
+
+        // Click events are delayed, so wait until event data shows up
+        waitUntilHasText(eventDataDiv);
 
         String[] parts = eventDataDiv.getText().split(";");
 
@@ -81,4 +90,8 @@ public class MapEventsIT extends AbstractComponentIT {
         Assert.assertEquals(1956787.9241005122, yCoordinate, 0.00000001);
     }
 
+    private void waitUntilHasText(TestBenchElement element) {
+        waitUntil(driver -> element.getText() != null
+                && !element.getText().isEmpty());
+    }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
@@ -175,7 +175,7 @@ public abstract class MapBase extends Component implements HasSize {
      * @see com.vaadin.flow.component.map.configuration.Feature
      */
     public Registration addFeatureClickListener(VectorLayer layer,
-                                                ComponentEventListener<MapFeatureClickEvent> listener) {
+            ComponentEventListener<MapFeatureClickEvent> listener) {
         return addListener(MapFeatureClickEvent.class, event -> {
             // Filter events for specified layer
             if (!Objects.equals(layer, event.getLayer()))

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
@@ -25,6 +25,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.map.configuration.Configuration;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.View;
+import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
+import com.vaadin.flow.component.map.events.MapFeatureClickEvent;
 import com.vaadin.flow.component.map.configuration.Extent;
 import com.vaadin.flow.component.map.events.MapClickEvent;
 import com.vaadin.flow.component.map.events.MapViewMoveEndEvent;
@@ -34,6 +36,7 @@ import com.vaadin.flow.shared.Registration;
 import elemental.json.JsonValue;
 
 import java.beans.PropertyChangeEvent;
+import java.util.Objects;
 
 public abstract class MapBase extends Component implements HasSize {
     private final Configuration configuration;
@@ -158,6 +161,45 @@ public abstract class MapBase extends Component implements HasSize {
     public Registration addClickEventListener(
             ComponentEventListener<MapClickEvent> listener) {
         return addListener(MapClickEvent.class, listener);
+    }
+
+    /**
+     * Adds a click listener for geographical features. The listener will be
+     * invoked for a click on any feature in the specified layer. For clicks on
+     * overlapping features, the listener will be invoked individually for each
+     * feature at the clicked position.
+     *
+     * @param listener
+     *            the listener to trigger
+     * @return registration for the listener
+     * @see com.vaadin.flow.component.map.configuration.Feature
+     */
+    public Registration addFeatureClickListener(VectorLayer layer,
+                                                ComponentEventListener<MapFeatureClickEvent> listener) {
+        return addListener(MapFeatureClickEvent.class, event -> {
+            // Filter events for specified layer
+            if (!Objects.equals(layer, event.getLayer()))
+                return;
+            listener.onComponentEvent(event);
+        });
+    }
+
+    /**
+     * Adds a click listener for geographical features. The listener will be
+     * invoked for a click on any feature, in any layer. To listen for feature
+     * clicks in a specific layer, see
+     * {@link #addFeatureClickListener(VectorLayer, ComponentEventListener)}.
+     * For clicks on overlapping features, the listener will be invoked
+     * individually for each feature at the clicked position.
+     *
+     * @param listener
+     *            the listener to trigger
+     * @return registration for the listener
+     * @see com.vaadin.flow.component.map.configuration.Feature
+     */
+    public Registration addFeatureClickListener(
+            ComponentEventListener<MapFeatureClickEvent> listener) {
+        return addListener(MapFeatureClickEvent.class, listener);
     }
 
     /**

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapFeatureClickEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapFeatureClickEvent.java
@@ -23,15 +23,15 @@ public class MapFeatureClickEvent extends ComponentEvent<Map> {
     private final MouseEventDetails details;
 
     public MapFeatureClickEvent(Map source, boolean fromClient,
-                                @EventData("event.detail.feature.id") String featureId,
-                                @EventData("event.detail.layer.id") String layerId,
-                                @EventData("event.detail.originalEvent.pageX") int pageX,
-                                @EventData("event.detail.originalEvent.pageY") int pageY,
-                                @EventData("event.detail.originalEvent.altKey") boolean altKey,
-                                @EventData("event.detail.originalEvent.ctrlKey") boolean ctrlKey,
-                                @EventData("event.detail.originalEvent.metaKey") boolean metaKey,
-                                @EventData("event.detail.originalEvent.shiftKey") boolean shiftKey,
-                                @EventData("event.detail.originalEvent.button") int button) {
+            @EventData("event.detail.feature.id") String featureId,
+            @EventData("event.detail.layer.id") String layerId,
+            @EventData("event.detail.originalEvent.pageX") int pageX,
+            @EventData("event.detail.originalEvent.pageY") int pageY,
+            @EventData("event.detail.originalEvent.altKey") boolean altKey,
+            @EventData("event.detail.originalEvent.ctrlKey") boolean ctrlKey,
+            @EventData("event.detail.originalEvent.metaKey") boolean metaKey,
+            @EventData("event.detail.originalEvent.shiftKey") boolean shiftKey,
+            @EventData("event.detail.originalEvent.button") int button) {
         super(source, fromClient);
 
         Optional<VectorLayer> maybeLayer = source.getRawConfiguration()

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapFeatureClickEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapFeatureClickEvent.java
@@ -1,0 +1,92 @@
+package com.vaadin.flow.component.map.events;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.map.Map;
+import com.vaadin.flow.component.map.configuration.Feature;
+import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
+import com.vaadin.flow.component.map.configuration.source.VectorSource;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Provides data for click events on geographic features
+ */
+@DomEvent("map-feature-click")
+public class MapFeatureClickEvent extends ComponentEvent<Map> {
+
+    private final Feature feature;
+    private final VectorLayer layer;
+    private final VectorSource vectorSource;
+    private final MouseEventDetails details;
+
+    public MapFeatureClickEvent(Map source, boolean fromClient,
+                                @EventData("event.detail.feature.id") String featureId,
+                                @EventData("event.detail.layer.id") String layerId,
+                                @EventData("event.detail.originalEvent.pageX") int pageX,
+                                @EventData("event.detail.originalEvent.pageY") int pageY,
+                                @EventData("event.detail.originalEvent.altKey") boolean altKey,
+                                @EventData("event.detail.originalEvent.ctrlKey") boolean ctrlKey,
+                                @EventData("event.detail.originalEvent.metaKey") boolean metaKey,
+                                @EventData("event.detail.originalEvent.shiftKey") boolean shiftKey,
+                                @EventData("event.detail.originalEvent.button") int button) {
+        super(source, fromClient);
+
+        Optional<VectorLayer> maybeLayer = source.getRawConfiguration()
+                .getLayers().stream()
+                .filter(layer -> layer instanceof VectorLayer
+                        && Objects.equals(layer.getId(), layerId))
+                .findFirst().map(layer -> (VectorLayer) layer);
+        Optional<VectorSource> maybeVectorSource = maybeLayer
+                .map(layer -> (VectorSource) layer.getSource());
+        Optional<Feature> maybeFeature = maybeVectorSource.flatMap(
+                vectorSource -> vectorSource.getFeatures().stream().filter(
+                        feature -> Objects.equals(feature.getId(), featureId))
+                        .findFirst());
+
+        this.layer = maybeLayer.orElse(null);
+        this.vectorSource = maybeVectorSource.orElse(null);
+        this.feature = maybeFeature.orElse(null);
+
+        details = new MouseEventDetails();
+        details.setAbsoluteX(pageX);
+        details.setAbsoluteY(pageY);
+        details.setButton(MouseEventDetails.MouseButton.of(button));
+        details.setAltKey(altKey);
+        details.setCtrlKey(ctrlKey);
+        details.setMetaKey(metaKey);
+        details.setShiftKey(shiftKey);
+    }
+
+    /**
+     * The feature that was clicked
+     */
+    public Feature getFeature() {
+        return feature;
+    }
+
+    /**
+     * The layer that contains the feature
+     */
+    public VectorLayer getLayer() {
+        return layer;
+    }
+
+    /**
+     * The source that contains the feature
+     */
+    public VectorSource getVectorSource() {
+        return vectorSource;
+    }
+
+    /**
+     * Gets the click's mouse event details.
+     *
+     * @return mouse event details
+     */
+    public MouseEventDetails getMouseDetails() {
+        return details;
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -60,7 +60,7 @@ import { getLayerForFeature } from "./util";
       mapElement.dispatchEvent(customEvent);
     });
 
-    mapElement.configuration.on("click", (event) => {
+    mapElement.configuration.on("singleclick", (event) => {
       const coordinate = event.coordinate;
 
       // Map click event

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -1,4 +1,5 @@
 import { synchronize } from "./synchronization";
+import { getLayerForFeature } from "./util";
 
 (function () {
   function init(mapElement) {
@@ -37,7 +38,7 @@ import { synchronize } from "./synchronization";
         synchronize(target, configuration, context);
         // TODO: layers don't render on initialization in some cases, needs investigation
         mapElement.configuration.updateSize();
-      }
+      },
     };
 
     mapElement.configuration.on("moveend", (_event) => {
@@ -62,6 +63,7 @@ import { synchronize } from "./synchronization";
     mapElement.configuration.on("click", (event) => {
       const coordinate = event.coordinate;
 
+      // Map click event
       const customEvent = new CustomEvent("map-click", {
         detail: {
           coordinate,
@@ -70,6 +72,24 @@ import { synchronize } from "./synchronization";
       });
 
       mapElement.dispatchEvent(customEvent);
+
+      // Feature click events
+      const pixelCoordinate = event.pixel;
+      const featuresAtPixel =
+        mapElement.configuration.getFeaturesAtPixel(pixelCoordinate);
+
+      featuresAtPixel.forEach((feature) => {
+        const layer = getLayerForFeature(mapElement.configuration, feature);
+        const customEvent = new CustomEvent("map-feature-click", {
+          detail: {
+            feature,
+            layer,
+            originalEvent: event.originalEvent,
+          },
+        });
+
+        mapElement.dispatchEvent(customEvent);
+      });
     });
   }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/util.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/util.js
@@ -4,7 +4,7 @@ import VectorSource from "ol/source/Vector";
  * Searches an OpenLayers map instance for the layer whose source contains a specific feature
  * @param map an OpenLayers map instance
  * @param feature the feature that should be contained in the layers source
- * @returns {*} the layer that contains the feature, or null
+ * @returns {*} the layer that contains the feature, or undefined
  */
 export function getLayerForFeature(map, feature) {
   const layers = map.getLayers().getArray();

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/util.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/util.js
@@ -1,0 +1,17 @@
+import VectorSource from "ol/source/Vector";
+
+/**
+ * Searches an OpenLayers map instance for the layer whose source contains a specific feature
+ * @param map an OpenLayers map instance
+ * @param feature the feature that should be contained in the layers source
+ * @returns {*} the layer that contains the feature, or null
+ */
+export function getLayerForFeature(map, feature) {
+  const layers = map.getLayers().getArray();
+  return layers.find((layer) => {
+    const source = layer.getSource && layer.getSource();
+    const isVectorSource = source && source instanceof VectorSource;
+
+    return isVectorSource && source.getFeatures().includes(feature);
+  });
+}

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -52,7 +52,6 @@ public class MapElement extends TestBenchElement {
         int startLeft = -mapRectangle.width / 2;
         int startTop = -mapRectangle.height / 2;
 
-        // todo: use executeJS parameters instead of string concatenation
         List<Number> pixelCoordinates = (List<Number>) executeScript(
                 "return arguments[0].configuration.getPixelFromCoordinate([arguments[1], arguments[2]])",
                 this, x, y);
@@ -104,5 +103,15 @@ public class MapElement extends TestBenchElement {
      */
     public List<TestBenchElement> getAttributionItems() {
         return getAttributionContainer().$("li").all();
+    }
+
+    /**
+     * Disables all interactions that could interfere with a test, such as
+     * double-click to zoom.
+     */
+    public void disableInteractions() {
+        String script = "const interactions = arguments[0].configuration.getInteractions();"
+                + "interactions.forEach(interaction => interaction.setActive && interaction.setActive(false));";
+        executeScript(script, this);
     }
 }


### PR DESCRIPTION
## Description

Allows to get notified about clicks on features. The click events contain the clicked feature, as well as the layer and the source that contain the feature. Optionally a filter layer can be specified for the click listener, so that the listener is only triggered when features in a specific layer are clicked.

Also changes the OL event used for map clicks and feature clicks to `singleclick` in order to ignore double-clicks and drags.

Fixes #2513 
