### PR TITLE
fix: discard radios/checkboxes right before adding new ones

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/RefreshOnValueChangePage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/RefreshOnValueChangePage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupListDataView;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-checkbox/refresh-on-value-change")
+public class RefreshOnValueChangePage extends Div {
+
+    public RefreshOnValueChangePage() {
+        CheckboxGroup<String> group = new CheckboxGroup<>();
+        group.setLabel("Label");
+
+        List<String> items = new LinkedList<>(Arrays.asList("foo", "bar"));
+        CheckboxGroupListDataView<String> dataView = group.setItems(items);
+
+        group.addValueChangeListener(e -> dataView.refreshAll());
+
+        add(group);
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/RefreshOnValueChangeIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/RefreshOnValueChangeIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-checkbox/refresh-on-value-change")
+public class RefreshOnValueChangeIT extends AbstractComponentIT {
+
+    @Test
+    public void subsequentValueChangesDontAffectElementCount() {
+        open();
+        Assert.assertEquals(2, $("vaadin-checkbox").all().size());
+
+        $("vaadin-checkbox").first().click();
+
+        Assert.assertEquals(2, $("vaadin-checkbox").all().size());
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -464,19 +464,20 @@ public class CheckboxGroup<T>
 
     @SuppressWarnings("unchecked")
     private void reset() {
-        // Cache helper component before removal
-        Component helperComponent = getHelperComponent();
         keyMapper.removeAll();
         clear();
 
-        // reinsert helper component
-        // see https://github.com/vaadin/vaadin-checkbox/issues/191
-        setHelperComponent(helperComponent);
-
         synchronized (dataProvider) {
+            // Cache helper component before removal
+            Component helperComponent = getHelperComponent();
+
             // Remove all known children (doesn't remove client-side-only
             // children such as the label)
             getChildren().forEach(this::remove);
+            
+            // reinsert helper component
+            // see https://github.com/vaadin/vaadin-checkbox/issues/191
+            setHelperComponent(helperComponent);
 
             final AtomicInteger itemCounter = new AtomicInteger(0);
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -474,7 +474,7 @@ public class CheckboxGroup<T>
             // Remove all known children (doesn't remove client-side-only
             // children such as the label)
             getChildren().forEach(this::remove);
-            
+
             // reinsert helper component
             // see https://github.com/vaadin/vaadin-checkbox/issues/191
             setHelperComponent(helperComponent);

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -474,10 +474,10 @@ public class CheckboxGroup<T>
         setHelperComponent(helperComponent);
 
         synchronized (dataProvider) {
-            // Remove all known children (doesn't remove client-side-only children
-            // such as the label)
+            // Remove all known children (doesn't remove client-side-only
+            // children such as the label)
             getChildren().forEach(this::remove);
-            
+
             final AtomicInteger itemCounter = new AtomicInteger(0);
 
             getDataProvider().fetch(DataViewUtils.getQuery(this))

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -467,9 +467,6 @@ public class CheckboxGroup<T>
         // Cache helper component before removal
         Component helperComponent = getHelperComponent();
         keyMapper.removeAll();
-        // Remove all known children (doesn't remove client-side-only children
-        // such as the label)
-        getChildren().forEach(this::remove);
         clear();
 
         // reinsert helper component
@@ -477,6 +474,10 @@ public class CheckboxGroup<T>
         setHelperComponent(helperComponent);
 
         synchronized (dataProvider) {
+            // Remove all known children (doesn't remove client-side-only children
+            // such as the label)
+            getChildren().forEach(this::remove);
+            
             final AtomicInteger itemCounter = new AtomicInteger(0);
 
             getDataProvider().fetch(DataViewUtils.getQuery(this))

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RefreshOnValueChangePage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RefreshOnValueChangePage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.tests;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-radio-button/refresh-on-value-change")
+public class RefreshOnValueChangePage extends Div {
+
+    public RefreshOnValueChangePage() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setLabel("Label");
+
+        List<String> items = new LinkedList<>(Arrays.asList("foo", "bar"));
+        RadioButtonGroupListDataView<String> dataView = group.setItems(items);
+
+        group.addValueChangeListener(e -> dataView.refreshAll());
+
+        add(group);
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RefreshOnValueChangeIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RefreshOnValueChangeIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-radio-button/refresh-on-value-change")
+public class RefreshOnValueChangeIT extends AbstractComponentIT {
+
+    @Test
+    public void subsequentValueChangesDontAffectElementCount() {
+        open();
+        Assert.assertEquals(2, $("vaadin-radio-button").all().size());
+
+        $("vaadin-radio-button").first().click();
+
+        Assert.assertEquals(2, $("vaadin-radio-button").all().size());
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -450,18 +450,19 @@ public class RadioButtonGroup<T>
 
     @SuppressWarnings("unchecked")
     private void reset() {
-        // Cache helper component before removal
-        Component helperComponent = getHelperComponent();
         keyMapper.removeAll();
         clear();
 
-        // reinsert helper component
-        setHelperComponent(helperComponent);
-
         synchronized (dataProvider) {
+            // Cache helper component before removal
+            Component helperComponent = getHelperComponent();
+            
             // Remove all known children (doesn't remove client-side-only
             // children such as the label)
             getChildren().forEach(this::remove);
+
+            // reinsert helper component
+            setHelperComponent(helperComponent);
 
             final AtomicInteger itemCounter = new AtomicInteger(0);
             getDataProvider().fetch(DataViewUtils.getQuery(this))

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -459,8 +459,8 @@ public class RadioButtonGroup<T>
         setHelperComponent(helperComponent);
 
         synchronized (dataProvider) {
-            // Remove all known children (doesn't remove client-side-only children
-            // such as the label)
+            // Remove all known children (doesn't remove client-side-only
+            // children such as the label)
             getChildren().forEach(this::remove);
 
             final AtomicInteger itemCounter = new AtomicInteger(0);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -456,7 +456,7 @@ public class RadioButtonGroup<T>
         synchronized (dataProvider) {
             // Cache helper component before removal
             Component helperComponent = getHelperComponent();
-            
+
             // Remove all known children (doesn't remove client-side-only
             // children such as the label)
             getChildren().forEach(this::remove);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -453,15 +453,16 @@ public class RadioButtonGroup<T>
         // Cache helper component before removal
         Component helperComponent = getHelperComponent();
         keyMapper.removeAll();
-        // Remove all known children (doesn't remove client-side-only children
-        // such as the label)
-        getChildren().forEach(this::remove);
         clear();
 
         // reinsert helper component
         setHelperComponent(helperComponent);
 
         synchronized (dataProvider) {
+            // Remove all known children (doesn't remove client-side-only children
+            // such as the label)
+            getChildren().forEach(this::remove);
+
             final AtomicInteger itemCounter = new AtomicInteger(0);
             getDataProvider().fetch(DataViewUtils.getQuery(this))
                     .map(item -> createRadioButton((T) item))


### PR DESCRIPTION
A `CheckBoxGroup`/`RadioButtonGroup` with a value change listener that invokes `reset()` (via some public API) can result in excess radios/checkboxes getting created. This is due to the current order in which the old radios/checkboxes are removed and the component's value is cleared inside the `reset()` method.

The issue is fixed by having the discarded child components removed right before new ones are created/added (inside the same synchronized block).

Fixes #2525 

Note that checking a radio/checkbox in the IT page's group still ends up with the group having no value. This is because the group uses a value change listener that calls `dataView.refreshAll()` which in turn [clears the group's value](https://github.com/vaadin/vaadin-radio-button-flow/pull/53).