### PR TITLE
fix: clear selected key when item selected

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
@@ -62,6 +62,7 @@ public class ComboBoxPage extends Div {
         createWithUpdateProvider();
         createWithValueChangeListener();
         createWithUpdatableValue();
+        createWithUpdateOnValueChange();
         createWithPresetValue();
         createWithButtonRenderer();
         setLabelGeneratorAfterValue();
@@ -197,6 +198,20 @@ public class ComboBoxPage extends Div {
         message.setId("updatable-combo-message");
         button.setId("updatable-combo-button");
         add(combo, message, button);
+    }
+
+    private void createWithUpdateOnValueChange() {
+        ComboBox<String> combo = new ComboBox<>();
+        combo.setItems("1", "2", "3");
+        combo.setValue("2");
+
+        combo.addValueChangeListener(e -> {
+            String value = e.getValue();
+            combo.setValue(value);
+        });
+
+        combo.setId("update-on-change-combo");
+        add(combo);
     }
 
     private void setLabelGeneratorAfterValue() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -212,7 +212,7 @@ public class ComboBoxPageIT extends AbstractComboBoxIT {
         Assert.assertFalse(item1.hasAttribute("selected"));
         Assert.assertTrue(item2.hasAttribute("selected"));
 
-        item2.click();
+        item1.click();
 
         combo.openPopup();
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -25,6 +25,8 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
 
 import static org.junit.Assert.assertFalse;
 
@@ -192,6 +194,30 @@ public class ComboBoxPageIT extends AbstractComboBoxIT {
         Assert.assertEquals("Item 2", getSelectedItemLabel(combo));
         Assert.assertEquals("Value: Item 2 isFromClient: false",
                 message.getText());
+    }
+
+    @Test
+    public void changeValue_oldSelectedItemKeyIsReset() {
+        ComboBoxElement combo = $(ComboBoxElement.class)
+                .id("update-on-change-combo");
+        combo.openPopup();
+
+        TestBenchElement overlay = $("vaadin-combo-box-overlay").first();
+        ElementQuery<TestBenchElement> items = overlay
+                .$("vaadin-combo-box-item");
+
+        TestBenchElement item1 = items.get(0);
+        TestBenchElement item2 = items.get(1);
+
+        Assert.assertFalse(item1.hasAttribute("selected"));
+        Assert.assertTrue(item2.hasAttribute("selected"));
+
+        item2.click();
+
+        combo.openPopup();
+
+        Assert.assertTrue(item1.hasAttribute("selected"));
+        Assert.assertFalse(item2.hasAttribute("selected"));
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -309,6 +309,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         // `ComboBox.addCustomValueSetListener`.
         super.addCustomValueSetListener(e -> this.getElement()
                 .setProperty(PROP_INPUT_ELEMENT_VALUE, e.getDetail()));
+
+        super.addValueChangeListener(e -> updateSelectedKey());
     }
 
     /**
@@ -1658,6 +1660,12 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         reset();
     }
 
+    private void updateSelectedKey() {
+        // Send (possibly updated) key for the selected value
+        getElement().executeJs("this._selectedKey=$0",
+                getValue() != null ? getKeyMapper().key(getValue()) : "");
+    }
+
     @ClientCallable
     private void confirmUpdate(int id) {
         dataCommunicator.confirmUpdate(id);
@@ -1667,9 +1675,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     private void setRequestedRange(int start, int length, String filter) {
         dataCommunicator.setRequestedRange(start, length);
         filterSlot.accept(filter);
-        // Send (possibly updated) key for the selected value
-        getElement().executeJs("this._selectedKey=$0",
-                getValue() != null ? getKeyMapper().key(getValue()) : "");
+        updateSelectedKey();
     }
 
     @ClientCallable

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -260,15 +260,6 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
                 }
             }), { once: true });
 
-            comboBox.addEventListener('selected-item-changed', tryCatchWrapper((event) => {
-                const itemIdPath = comboBox.itemIdPath;
-                const selectedItem = event.detail.value;
-
-                if (comboBox._selectedKey && (!selectedItem || selectedItem[itemIdPath] !== comboBox._selectedKey)) {
-                    delete comboBox._selectedKey;
-                }
-            }));
-
             comboBox.$connector.enableClientValidation = tryCatchWrapper(function( enable ){
                 if ( comboBox.$ ){
                     if ( enable){

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -260,8 +260,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
                 }
             }), { once: true });
 
-            comboBox.addEventListener('value-changed', tryCatchWrapper((event) => {
-                if (comboBox._selectedKey && !event.detail.value) {
+            comboBox.addEventListener('selected-item-changed', tryCatchWrapper((event) => {
+                const itemIdPath = comboBox.itemIdPath;
+                const selectedItem = event.detail.value;
+
+                if (comboBox._selectedKey && (!selectedItem || selectedItem[itemIdPath] !== comboBox._selectedKey)) {
                     delete comboBox._selectedKey;
                 }
             }));


### PR DESCRIPTION
## Description

Updated to use `selected-item-changed` event for checking if `_selectedKey` is outdated.

Fixes #2615

## Type of change

- Bugfix