### PR TITLE
chore: Update Flow snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <version>2.0.2</version>
     </parent>
     <properties>
-        <flow.version>10.0-SNAPSHOT</flow.version>
+        <flow.version>23.0-SNAPSHOT</flow.version>
         <testbench.version>8.0.0.beta2</testbench.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
Flow 23.0 (previously 10.0) is the version for V23 (master is 23.1)
