### PR TITLE
fix: avoid temporarily clearing the component renderer

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightPage.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.router.Route;
 @Route(value = "vaadin-grid/component-column-height")
 public class ComponentColumnWithHeightPage extends Div {
     private List<Person> persons = new ArrayList<>();
-    
+
     public ComponentColumnWithHeightPage() {
         Grid<Person> grid = new Grid<>();
         grid.addComponentColumn(person -> {
@@ -38,15 +38,15 @@ public class ComponentColumnWithHeightPage extends Div {
         });
 
         for (int i = 0; i < 50; i++) {
-			persons.add(new Person("Name", -1));
-		}
+            persons.add(new Person("Name", -1));
+        }
         grid.setItems(persons);
-    	
+
         NativeButton add = new NativeButton("Add person");
         add.addClickListener(e -> {
-			persons.add(new Person("Name", -1));
+            persons.add(new Person("Name", -1));
             grid.setItems(persons);
-		});
+        });
 
         add(grid, add);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightPage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-grid/component-column-height")
+public class ComponentColumnWithHeightPage extends Div {
+    private List<Person> persons = new ArrayList<>();
+    
+    public ComponentColumnWithHeightPage() {
+        Grid<Person> grid = new Grid<>();
+        grid.addComponentColumn(person -> {
+            Div div = new Div();
+            div.setText(person.getFirstName());
+            div.setHeight("50px");
+            return div;
+        });
+
+        for (int i = 0; i < 50; i++) {
+			persons.add(new Person("Name", -1));
+		}
+        grid.setItems(persons);
+    	
+        NativeButton add = new NativeButton("Add person");
+        add.addClickListener(e -> {
+			persons.add(new Person("Name", -1));
+            grid.setItems(persons);
+		});
+
+        add(grid, add);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.grid.it;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.provider.ListDataProvider;
@@ -30,7 +31,7 @@ public class GridDetailsRowPage extends Div {
 
         ListDataProvider<Person> ldp = new ListDataProvider<>(items);
         grid.setDataProvider(ldp);
-
+        grid.setSelectionMode(SelectionMode.NONE);
         grid.addColumn(Person::getFirstName).setHeader("name");
         grid.setItemDetailsRenderer(new ComponentRenderer<>(
                 item -> new Button(item.getFirstName())));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Tests for dynamically adding new columns with different renderers after the
+ * Grid has already been attached and rendered.
+ */
+@TestPath("vaadin-grid/component-column-height")
+public class ComponentColumnWithHeightIT extends AbstractComponentIT {
+
+    private GridElement grid;
+    private WebElement add;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridElement.class).first();
+        add = $("button").first();
+    }
+
+    @Test
+    public void shouldPositionItemsCorrectlyAfterUpdatingComponentRenderers() {
+        add.click();
+        // Expect the y position of the second row to equal the y position + the height of the first row
+        Assert.assertEquals(grid.getRow(0).getLocation().y + grid.getRow(0).getSize().height, grid.getRow(1).getLocation().y);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ComponentColumnWithHeightIT.java
@@ -43,7 +43,11 @@ public class ComponentColumnWithHeightIT extends AbstractComponentIT {
     @Test
     public void shouldPositionItemsCorrectlyAfterUpdatingComponentRenderers() {
         add.click();
-        // Expect the y position of the second row to equal the y position + the height of the first row
-        Assert.assertEquals(grid.getRow(0).getLocation().y + grid.getRow(0).getSize().height, grid.getRow(1).getLocation().y);
+        // Expect the y position of the second row to equal the y position + the
+        // height of the first row
+        Assert.assertEquals(
+                grid.getRow(0).getLocation().y
+                        + grid.getRow(0).getSize().height,
+                grid.getRow(1).getLocation().y);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
@@ -25,7 +25,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
-import java.util.Locale;
 
 @TestPath("vaadin-grid/grid-details-row")
 public class GridDetailsRowIT extends AbstractComponentIT {
@@ -69,10 +68,10 @@ public class GridDetailsRowIT extends AbstractComponentIT {
                 .findElements(By.tagName("flow-component-renderer"));
         Assert.assertEquals(3, detailsElement.size());
 
-        // detail on row 0 is empty
-        assertElementHasNoButton(detailsElement.get(0));
-        // detail on row 1 is empty
-        assertElementHasNoButton(detailsElement.get(1));
+        // detail on row 0 is not displayed
+        assertElementNotDisplayed(detailsElement.get(0));
+        // detail on row 1 is not displayed
+        assertElementNotDisplayed(detailsElement.get(1));
         // detail on row 3 contains a button
         assertElementHasButton(detailsElement.get(2), "Person 4");
     }
@@ -96,10 +95,10 @@ public class GridDetailsRowIT extends AbstractComponentIT {
         List<WebElement> detailsElement = grid
                 .findElements(By.tagName("flow-component-renderer"));
         Assert.assertEquals(3, detailsElement.size());
-        // detail on row 0 is empty
-        assertElementHasNoButton(detailsElement.get(0));
-        // detail on row 1 is empty
-        assertElementHasNoButton(detailsElement.get(1));
+        // detail on row 0 is not displayed
+        assertElementNotDisplayed(detailsElement.get(0));
+        // detail on row 1 is not displayed
+        assertElementNotDisplayed(detailsElement.get(1));
         // detail on row 3 contains a button
         assertElementHasButton(detailsElement.get(2), "Person 3");
 
@@ -115,10 +114,10 @@ public class GridDetailsRowIT extends AbstractComponentIT {
 
         Assert.assertEquals(3, detailsElement.size());
 
-        // detail on row 0 is empty
-        assertElementHasNoButton(detailsElement.get(0));
-        // detail on row 1 is empty
-        assertElementHasNoButton(detailsElement.get(1));
+        // detail on row 0 is not displayed
+        assertElementNotDisplayed(detailsElement.get(0));
+        // detail on row 1 is not displayed
+        assertElementNotDisplayed(detailsElement.get(1));
         // detail on row 3 contains a button
         assertElementHasButton(detailsElement.get(2), "Person 3 - updates 1");
 
@@ -146,11 +145,8 @@ public class GridDetailsRowIT extends AbstractComponentIT {
         Assert.assertEquals(content, children.get(0).getText());
     }
 
-    private void assertElementHasNoButton(WebElement componentRenderer) {
-
-        List<WebElement> children = componentRenderer
-                .findElements(By.tagName("vaadin-button"));
-        Assert.assertEquals(0, children.size());
+    private void assertElementNotDisplayed(WebElement componentRenderer) {
+        Assert.assertFalse(componentRenderer.isDisplayed());
 
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -63,7 +63,6 @@ class FlowComponentRenderer extends PolymerElement {
     const renderedComponent = this._getRenderedComponent();
     if (this.firstChild) {
       if (!renderedComponent) {
-        this._clear();
         this._asyncAttachRenderedComponentIfAble();
       } else if (this.firstChild !== renderedComponent) {
         this.replaceChild(renderedComponent, this.firstChild);
@@ -96,12 +95,6 @@ class FlowComponentRenderer extends PolymerElement {
       console.error(error);
     }
     return null;
-  }
-
-  _clear() {
-    while (this.firstChild) {
-      this.removeChild(this.firstChild);
-    }
   }
 
   onComponentRendered() {


### PR DESCRIPTION
Fixes #2363

The `Virtualizer` (also used by `<vaadin-grid>`) [uses](https://github.com/vaadin/web-components/blob/87bbb0e333cd037c006c6cf279f574aa28cedd01/packages/component-base/src/virtualizer-iron-list-adapter.js#L34) a native `ResizeObserver` internally to detect and react to item height changes; in the case of `Grid`, it observes height changes on the body row (`<tr>`) elements. Typically it catches row height changes just fine and updates the row positions accordingly.

In this specific case, a `<flow-component-renderer>` on each row gets assigned a new element reference due to a dynamic data update, resulting in the [old element getting removed](https://github.com/vaadin/flow-components/blob/8dc595c13137613db970412956a38757272a7989/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js#L66) and the [new element getting added _asynchronously_](https://github.com/vaadin/flow-components/blob/8dc595c13137613db970412956a38757272a7989/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js#L67).

Between these events, (after clearing the content and before the new element gets asynchronously added), the `Grid` [requests](https://github.com/vaadin/web-components/blob/87bbb0e333cd037c006c6cf279f574aa28cedd01/packages/grid/src/vaadin-grid.js#L494) the `Virtualizer` to flush, resulting in the [row positions getting recalculated ](https://github.com/vaadin/web-components/blob/87bbb0e333cd037c006c6cf279f574aa28cedd01/packages/component-base/src/virtualizer-iron-list-adapter.js#L118)with _empty_ `<flow-component-renderer>`s in place (meaning, with reduced row height)

After that, the new content is added and the row height increases back to what it was before. One could assume that the `ResizeObserver` would catch this change in height and fix the row positions. But while all this happens asynchronously, the height actually gets restored exactly to what it was and the delay is fast enough so that the `ResizeObserver` simply ignores the temporary size change. As a result, the rows end up not getting re-measured and re-positioned with the proper content in place.

This PR changes `flow-component-renderer` so that it doesn't clear its content while waiting for the new element, but always [uses](https://github.com/vaadin/flow-components/blob/8dc595c13137613db970412956a38757272a7989/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js#L69) `replaceChild` if it includes a discarded child element beforehand.