### PR TITLE
fix: Use getDataProvider().getId(item) instead of item.hashCode() (#2411)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/LazyHierarchicalDataProvider.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/LazyHierarchicalDataProvider.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.treegrid.it;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -80,5 +81,11 @@ public class LazyHierarchicalDataProvider extends
                     i + query.getOffset()));
         }
         return list.stream();
+    }
+
+    @Override
+    public Object getId(HierarchicalTestBean item) {
+        Objects.requireNonNull(item, "Cannot provide an id for a null item.");
+        return item.getId();
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesPage.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.treegrid.it;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -108,9 +109,9 @@ public class TreeGridBasicFeaturesPage extends Div {
             });
         });
 
-        inMemoryDataProvider = new TreeDataProvider<>(data);
+        inMemoryDataProvider = new CustomTreeDataProvider(data);
         lazyDataProvider = new LazyHierarchicalDataProvider(3, 2);
-        loggingDataProvider = new TreeDataProvider<HierarchicalTestBean>(data) {
+        loggingDataProvider = new CustomTreeDataProvider(data) {
 
             @Override
             public Stream<HierarchicalTestBean> fetchChildren(
@@ -246,5 +247,19 @@ public class TreeGridBasicFeaturesPage extends Div {
     private NativeButton setIdByText(NativeButton button) {
         button.setId(button.getText().replace(" ", ""));
         return button;
+    }
+
+    public class CustomTreeDataProvider
+            extends TreeDataProvider<HierarchicalTestBean> {
+        public CustomTreeDataProvider(TreeData<HierarchicalTestBean> treeData) {
+            super(treeData);
+        }
+
+        @Override
+        public Object getId(HierarchicalTestBean item) {
+            Objects.requireNonNull(item,
+                    "Cannot provide an id for a null item.");
+            return item.getId();
+        }
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHashCollisionPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHashCollisionPage.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-grid/treegrid-hash-collision")
+public class TreeGridHashCollisionPage extends VerticalLayout {
+    private final TreeGrid<String> treeGrid = new TreeGrid<>();
+
+    public TreeGridHashCollisionPage() {
+        TreeData<String> stringTreeData = new TreeData<>();
+        // "Aa".hashCode() == "BB".hashCode()
+        // Thus if TreeGrid identity provider is based on hash, collision will
+        // happen and TreeGrid will fail to render correctly
+        stringTreeData.addItem(null, "Aa");
+        stringTreeData.addItem("Aa", "BB");
+        treeGrid.setDataProvider(new TreeDataProvider<>(stringTreeData));
+        treeGrid.addHierarchyColumn(s -> s);
+        treeGrid.expand("Aa");
+        add(treeGrid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHashCollisionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHashCollisionIT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License. 
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-grid/treegrid-hash-collision")
+public class TreeGridHashCollisionIT extends AbstractTreeGridIT {
+
+    @Before
+    public void before() {
+        open();
+        setupTreeGrid();
+    }
+
+    @Test
+    public void treegrid_opens_correctly() {
+        // Test that child has opened
+        Assert.assertEquals("BB", getTreeGrid().getCell(1, 0).getText());
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -138,8 +138,8 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
-    private final ValueProvider<T, String> defaultUniqueKeyProvider = item -> String
-            .valueOf(item.hashCode());
+    private final ValueProvider<T, String> defaultUniqueKeyProvider = item -> getDataProvider()
+            .getId(item).toString();
 
     private Registration dataProviderRegistration;
 


### PR DESCRIPTION
Backport of #2411 to Vaadin 14.