### PR TITLE
chore: Add dummy integration module [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 bin
 target
-integration-tests
 pom.xml.bak
 
 # Eclipse

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin
 target
+integration-tests
 pom.xml.bak
 
 # Eclipse

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <version>23.0-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-flow-components-integration-tests</artifactId>
-  <packaging>war</packaging>
+  <packaging>pom</packaging>
   <name>component Integration Tests (dummy)</name>
   <description>this is a dummy module pom to make it work with dependabot</description>
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.vaadin</groupId>
+    <artifactId>vaadin-flow-components</artifactId>
+    <version>23.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>vaadin-flow-components-integration-tests</artifactId>
+  <packaging>war</packaging>
+  <name>component Integration Tests (dummy)</name>
+  <description>this is a dummy module pom to make it work with dependabot</description>
+</project>


### PR DESCRIPTION
dependabot runs **all profiles** in the project, but this wont work with our own generated modules, for example, integration-tests.

so that this error can be seen from the build log ([under Insights tab](https://github.com/vaadin/flow-components/network/updates/277991666) )
```
Dependabot requires a pom.xml to evaluate your Java dependencies. It had expected to find one at the path: /integration-tests/pom.xml.
```

currently the bot doesn't allow us to configure to ignore modules. so we add this dummy integration-tests/pom.xml to the project 