### PR TITLE
fix: make grid connector request content update on missing data (CP2)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -224,6 +224,9 @@
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
+                        <configuration>
+                            <scanIntervalSeconds>1</scanIntervalSeconds>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreMultiSortedPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreMultiSortedPage.java
@@ -37,7 +37,8 @@ public class PreMultiSortedPage extends Div {
         grid.setMultiSort(true);
         grid.setColumns("firstName", "lastName");
 
-        List<GridSortOrder<Person>> sorting = new GridSortOrderBuilder<Person>().thenAsc(grid.getColumns().get(0))
+        List<GridSortOrder<Person>> sorting = new GridSortOrderBuilder<Person>()
+                .thenAsc(grid.getColumns().get(0))
                 .thenAsc(grid.getColumns().get(1)).build();
         grid.sort(sorting);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreMultiSortedPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/PreMultiSortedPage.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridSortOrder;
+import com.vaadin.flow.component.grid.GridSortOrderBuilder;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/pre-multisorted")
+public class PreMultiSortedPage extends Div {
+
+    public PreMultiSortedPage() {
+        Grid<Person> grid = new Grid<>(Person.class, true);
+
+        setSizeFull();
+        add(grid);
+        grid.setPageSize(5);
+        grid.setMultiSort(true);
+        grid.setColumns("firstName", "lastName");
+
+        List<GridSortOrder<Person>> sorting = new GridSortOrderBuilder<Person>().thenAsc(grid.getColumns().get(0))
+                .thenAsc(grid.getColumns().get(1)).build();
+        grid.sort(sorting);
+
+        List<Person> items = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            Person person = new Person();
+            person.setFirstName("First " + i);
+            person.setLastName("Last " + i);
+            items.add(person);
+        }
+
+        grid.setItems(items);
+        grid.setHeightFull();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreMultiSortedIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreMultiSortedIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-grid/pre-multisorted")
+public class PreMultiSortedIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void rowsRendered() {
+        GridElement grid = $(GridElement.class).first();
+        Assert.assertEquals("First 13", grid.getCell(5, 0).getText());
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -890,7 +890,17 @@
           const callback = rootPageCallbacks[page];
           if ((cache[root] && cache[root][page]) || page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
             delete rootPageCallbacks[page];
-            callback(cache[root][page] || new Array(grid.pageSize));
+            
+            if (cache[root][page]) {
+              // Cached data is available, resolve the callback
+              callback(cache[root][page]);
+            } else {
+              // No cached data, resolve the callback with an empty array
+              callback(new Array(grid.pageSize));
+              // Request grid for content update
+              grid._assignModels();
+            }
+
             // Makes sure to push all new rows before this stack execution is done so any timeout expiration called after will be applied on a fully updated grid
             //Resolves https://github.com/vaadin/vaadin-grid-flow/issues/511
             if(grid._debounceIncreasePool){


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/2069

This PR effectively backports the fix from https://github.com/vaadin/flow-components/pull/2392 with a valid test case obtained from https://github.com/vaadin/flow-components/issues/2069

Earlier, we [backported the test case only](https://github.com/vaadin/flow-components/pull/2395) because the [original issue only reproduced in V22](https://github.com/vaadin/flow-components/pull/2392#issuecomment-984370764).