### PR TITLE
fix: prevent duplicate feature click events for overlapping markers

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
@@ -41,9 +41,10 @@ public class FeatureEventsPage extends Div {
         secondMarkerFeature.setId("second-marker-feature");
         secondFeatureLayer.addFeature(secondMarkerFeature);
 
-        // Setup several overlapping markers to verify that we receive only one event when clicking that location
+        // Setup several overlapping markers to verify that we receive only one
+        // event when clicking that location
         int numOverlappingMarkers = 3;
-        for(int i = 0; i < numOverlappingMarkers; i++) {
+        for (int i = 0; i < numOverlappingMarkers; i++) {
             MarkerFeature overlappingMarker = new MarkerFeature(
                     new Coordinate(4000000, 0));
             overlappingMarker.setId("overlapping-marker-feature-" + (i + 1));

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
@@ -41,6 +41,15 @@ public class FeatureEventsPage extends Div {
         secondMarkerFeature.setId("second-marker-feature");
         secondFeatureLayer.addFeature(secondMarkerFeature);
 
+        // Setup several overlapping markers to verify that we receive only one event when clicking that location
+        int numOverlappingMarkers = 3;
+        for(int i = 0; i < numOverlappingMarkers; i++) {
+            MarkerFeature overlappingMarker = new MarkerFeature(
+                    new Coordinate(4000000, 0));
+            overlappingMarker.setId("overlapping-marker-feature-" + (i + 1));
+            firstFeatureLayer.addFeature(overlappingMarker);
+        }
+
         Div eventLog = new Div();
         eventLog.setId("event-log");
         eventLog.getElement().getStyle().set("white-space", "pre");

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
@@ -69,6 +69,22 @@ public class FeatureEventsIT extends AbstractComponentIT {
                 "click: feature=first-marker-feature | layer=first-feature-layer | source=first-source");
     }
 
+    @Test
+    public void overlappingFeatures_singleEventFromTopLevelFeature() {
+        addFirstLayerFeatureClickListener.click();
+
+        // Click on overlapping markers
+        map.clickAtCoordinates(4000000, 0);
+        // Click events are delayed by around 250ms, wait for event
+        waitSeconds(1);
+
+        // Should have only one event, from the marker that was last added
+        assertEventLogHasNumberOfEvents(1);
+        assertEventLogContainsEvent(
+                "click: feature=overlapping-marker-feature-3 | layer=first-feature-layer | source=first-source");
+    }
+
+
     private void assertEventLogHasNumberOfEvents(int expectedEvents) {
         String[] eventLines = eventLog.getText().split(System.lineSeparator());
         Assert.assertEquals(expectedEvents, eventLines.length);

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
@@ -84,7 +84,6 @@ public class FeatureEventsIT extends AbstractComponentIT {
                 "click: feature=overlapping-marker-feature-3 | layer=first-feature-layer | source=first-source");
     }
 
-
     private void assertEventLogHasNumberOfEvents(int expectedEvents) {
         String[] eventLines = eventLog.getText().split(System.lineSeparator());
         Assert.assertEquals(expectedEvents, eventLines.length);

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/util.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/util.js
@@ -2,16 +2,38 @@ import VectorSource from "ol/source/Vector";
 
 /**
  * Searches an OpenLayers map instance for the layer whose source contains a specific feature
- * @param map an OpenLayers map instance
+ * @param layers the array of layers configured in the map
  * @param feature the feature that should be contained in the layers source
  * @returns {*} the layer that contains the feature, or undefined
  */
-export function getLayerForFeature(map, feature) {
-  const layers = map.getLayers().getArray();
+export function getLayerForFeature(layers, feature) {
   return layers.find((layer) => {
     const source = layer.getSource && layer.getSource();
     const isVectorSource = source && source instanceof VectorSource;
 
     return isVectorSource && source.getFeatures().includes(feature);
   });
+}
+
+/**
+ * Takes an array of features, and returns an array of { feature, layer } tuples,
+ * where each tuple contains the first feature that occurred for a specific
+ * layer in the given array of features.
+ * @param layers the array of layers configured in the map
+ * @param features the array of features for which to find the first feature per layer
+ * @returns {{layer, feature}[]}
+ */
+export function findFirstFeaturePerLayer(layers, features) {
+  const layerToFeaturesMap = {};
+
+  features.forEach((feature) => {
+    // First lookup the layer that the feature is in
+    const layer = getLayerForFeature(layers, feature);
+    // Skip if we already had a feature for that layer
+    if (layerToFeaturesMap[layer.id]) return;
+    // Otherwise, register that feature as the first one for that layer
+    layerToFeaturesMap[layer.id] = { feature, layer };
+  });
+
+  return Object.values(layerToFeaturesMap);
 }


### PR DESCRIPTION
## Description

Currently clicking on a location that contains overlapping features, results in one click event per feature. This fixes it by sending only a single event per layer that contains clicked features, for the top-most feature in that layer at that position. This is possible because OpenLayers actually returns the features for a clicked position sorted by their display order (either the order in which they are added, or using their z-index), so the first returned feature is the one that is displayed on top.

Theoretically we could also only send a single event for all layers, but I'm not sure if there would be use-cases where the clickable feature would be below another one in a higher layer. Besides the Flow component already supports registering feature clicks for specific layers only.

## Type of change

- [x] Bugfix
