### PR TITLE
chore: map javadoc improvements

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Assets.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Assets.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.map;
 
 import com.vaadin.flow.server.StreamResource;
 
+/**
+ * Defines the default assets that the Map component provides
+ */
 public class Assets {
     public static final ImageAsset PIN = new ImageAsset("pin.png",
             "/META-INF/resources/frontend/vaadin-map/assets/pin.png", 80, 104);

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/ExperimentalFeatureException.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/ExperimentalFeatureException.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 public class ExperimentalFeatureException extends RuntimeException {
     public ExperimentalFeatureException() {
         super("The map component is currently an experimental feature and needs to be explicitly enabled. The component can be enabled using the Vaadin dev-mode Gizmo, in the experimental features tab, or by adding a `src/main/resources/vaadin-featureflags.properties` file with the following content: `com.vaadin.experimental.mapComponent=true`");

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -22,13 +22,45 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.map.configuration.Configuration;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.View;
+import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
 import com.vaadin.flow.component.map.configuration.layer.FeatureLayer;
+import com.vaadin.flow.component.map.configuration.layer.ImageLayer;
 import com.vaadin.flow.component.map.configuration.layer.Layer;
 import com.vaadin.flow.component.map.configuration.layer.TileLayer;
+import com.vaadin.flow.component.map.configuration.layer.VectorLayer;
 import com.vaadin.flow.component.map.configuration.source.OSMSource;
+import com.vaadin.flow.component.map.configuration.source.Source;
+import com.vaadin.flow.component.map.configuration.source.VectorSource;
+import com.vaadin.flow.component.map.configuration.source.XYZSource;
 
 import java.util.Objects;
 
+/**
+ * Map is a component for displaying geographic maps from various sources. It
+ * supports multiple layers, tiled and full image sources, adding markers, and
+ * interaction through events.
+ * <p>
+ * Each map consists of one or more {@link Layer}s that display geographical
+ * data. Each layer has a {@link Source} that provides that data. The Map
+ * component provides several types of layers (for example {@link TileLayer},
+ * {@link VectorLayer}, {@link ImageLayer}), as well as several types of sources
+ * that can be used with each type of layer (for example {@link OSMSource},
+ * {@link XYZSource}, {@link VectorSource}).
+ * <p>
+ * The map component comes pre-configured with a background layer, which by
+ * default is a {@link TileLayer} using an {@link OSMSource}, which means that
+ * it displays tiled image data from the OpenStreeMap service. The background
+ * layer of the map can be replaced using {@link #setBackgroundLayer(Layer)}.
+ * The component is also pre-configured with a {@link FeatureLayer}, accessible
+ * with {@link #getFeatureLayer()}, that allows to quickly display geographical
+ * features, such as markers (see {@link MarkerFeature}), on top of a map.
+ * Custom layers can be added or removed using {@link #addLayer(Layer)} and
+ * {@link #removeLayer(Layer)}.
+ * <p>
+ * The viewport of the map is controlled through a {@link View}, which allows
+ * setting the center, zoom level and rotation. The map's view can be accessed
+ * through {@link Map#getView()}.
+ */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "23.0.0-beta3")
 @JsModule("@vaadin/map/src/vaadin-map.js")
@@ -133,7 +165,7 @@ public class Map extends MapBase {
      * This is a convenience method that delegates to the map's internal
      * {@link View}. See {@link #getView()} for accessing other properties of
      * the view.
-     * 
+     *
      * @return current center of the viewport
      */
     public Coordinate getCenter() {

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
@@ -45,6 +45,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Base class for the map component. Contains all base functionality for the map
+ * component, but does not provide any defaults. This component should not be
+ * used directly, instead use {@link Map}, which also provides some
+ * out-of-the-box conveniences such as a pre-configured background layer, and a
+ * feature layer.
+ */
 public abstract class MapBase extends Component implements HasSize, HasTheme {
     private final Configuration configuration;
     private final MapSerializer serializer;
@@ -64,8 +71,8 @@ public abstract class MapBase extends Component implements HasSize, HasTheme {
     }
 
     /**
-     * Gets the view of the map. The view gives access to properties like center
-     * and zoom level of the viewport.
+     * Gets the {@link View} of the map. The view allows controlling properties
+     * of the map's viewport, such as center, zoom level and rotation.
      *
      * @return the map's view
      */
@@ -96,6 +103,9 @@ public abstract class MapBase extends Component implements HasSize, HasTheme {
         requestConfigurationSync();
     }
 
+    /**
+     * Schedules a configuration sync, if there isn't a scheduled sync already
+     */
     private void requestConfigurationSync() {
         if (pendingConfigurationSync != null) {
             return;
@@ -107,6 +117,10 @@ public abstract class MapBase extends Component implements HasSize, HasTheme {
                 }));
     }
 
+    /**
+     * Synchronize the map configuration to the client-side, into OpenLayers
+     * class instances
+     */
     private void synchronizeConfiguration() {
         // Use a linked hash set to prevent object duplicates, but guarantee
         // that the changes are synchronized in the order that they were added
@@ -138,7 +152,10 @@ public abstract class MapBase extends Component implements HasSize, HasTheme {
     }
 
     /**
-     * Adds event listener for OpenLayers' "moveend" event.
+     * Adds an event listener for changes to the map's viewport. The event will
+     * only be triggered after the user has finished manipulating the viewport,
+     * for example after letting go of the mouse button after a mouse drag
+     * interaction.
      *
      * @param listener
      * @return a registration object for removing the added listener

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
@@ -16,6 +16,11 @@ package com.vaadin.flow.component.map.configuration;
  * #L%
  */
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vaadin.flow.component.map.configuration.layer.Layer;
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -25,6 +30,67 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+/**
+ * Base class for all map configuration objects that represent an OL class. The
+ * class provides functionality to support the synchronization mechanism between
+ * server and client, such as:
+ * <ul>
+ * <li>generates a unique ID for each object, using {@link UUID}</li>
+ * <li>implements change tracking / dirty checking using {@link #markAsDirty()}
+ * and {@link #collectChanges(Consumer)}</li>
+ * <li>implements the observable pattern using {@link PropertyChangeSupport}, in
+ * order to notify the map component about changes to the configuration, see
+ * {@link #notifyChange()}</li>
+ * <li>keeps track of nested configuration objects in order to keep track and
+ * notify about changes to nested objects, see
+ * {@link #addChild(AbstractConfigurationObject)} and
+ * {@link #removeChild(AbstractConfigurationObject)}</li>
+ * </ul>
+ * <p>
+ * When adding new API to the Map component using this class, there are several
+ * rules to follow:
+ * <ul>
+ * <li>Implement {@link #getType()} to return a unique type name. This type name
+ * is used by the client-side synchronization to determine which OpenLayers
+ * class to instantiate for objects of this type. See
+ * {@code META-INF/resources/frontend/vaadin-map/synchronization/index.js} for
+ * how the synchronization resolves type names.</li>
+ * <li>Every setter must call {@link #markAsDirty()} in order to mark this
+ * object as changed, and to trigger a change event to schedule a sync. of this
+ * change. See {@link View#setCenter(Coordinate)} for an example.</li>
+ * <li>Setters for nested objects must keep track of nested references using
+ * {@link #addChild(AbstractConfigurationObject)} and
+ * {@link #removeChild(AbstractConfigurationObject)}. See
+ * {@link Configuration#setView(View)} for an example.</li>
+ * <li>When using collection properties, do not expose the collection directly
+ * for manipulation, as manipulating the collection does not mark the object as
+ * changed, and does not trigger a change event. Instead add methods for
+ * manipulating the collection, and keep track of objects being added / removed
+ * from the collection using {@link #addChild(AbstractConfigurationObject)} and
+ * {@link #removeChild(AbstractConfigurationObject)}. See
+ * {@link Configuration#addLayer(Layer)} and
+ * {@link Configuration#removeLayer(Layer)} for an example.</li>
+ * <li>For properties that contain nested configuration objects, or collections,
+ * use the Jackson {@link JsonIdentityInfo} and {@link JsonIdentityReference}
+ * annotations to only serialize the ID of the object. See
+ * {@link Configuration#getLayers()} for an example.</li>
+ * <li>For properties that are not needed on the client-side, or do not have a
+ * pendant in the OpenLayers API, use the Jackson {@link JsonIgnore} annotation
+ * to reduce the JSON payload that is sent to the client on each
+ * synchronization, and to prevent possible errors by passing unrecognized
+ * options to the OpenLayers API. See {@link View#getExtent()} for an
+ * example.</li>
+ * <li>Not every class used in configuring the map necessarily needs to extend
+ * from {@link AbstractConfigurationObject}. Using this class is only necessary
+ * if an object is supposed to be modified by the developer (e.g. a Layer should
+ * be modifiable to change its visibility). If the object is small, or can be
+ * immutable, it might make sense to not extend from this class, and instead
+ * force the developer to create new instances instead. See {@link Coordinate}
+ * for an example, where making coordinates modifiable / synchronizable would
+ * just add more overhead, and where it's reasonable to just create new
+ * instances instead.</li>
+ * </ul>
+ */
 public abstract class AbstractConfigurationObject implements Serializable {
 
     private String id;
@@ -49,6 +115,11 @@ public abstract class AbstractConfigurationObject implements Serializable {
         this.id = id;
     }
 
+    /**
+     * The unique type name of this class. Used by the client-side
+     * synchronization mechanism to determine which OpenLayers class to
+     * synchronize into.
+     */
     public abstract String getType();
 
     /**
@@ -87,6 +158,17 @@ public abstract class AbstractConfigurationObject implements Serializable {
         children.forEach(AbstractConfigurationObject::deepMarkAsDirty);
     }
 
+    /**
+     * Adds a nested object reference to keep track of. This adds the object to
+     * an internal set that is used when collecting changed / dirty objects for
+     * the next synchronization, and adds a change listener to the nested object
+     * in order to let change events bubble up the configuration hierarchy. This
+     * method also automatically marks this object as dirty, and triggers a
+     * change event to notify observers about changes. One special behavior of
+     * this method is that it will trigger a full sync of the nested hierarchy
+     * that was added, in order to ensure that all added references can be
+     * resolved on the client-side.
+     */
     protected void addChild(AbstractConfigurationObject configurationObject) {
         children.add(configurationObject);
         configurationObject.addPropertyChangeListener(this::notifyChange);
@@ -99,6 +181,12 @@ public abstract class AbstractConfigurationObject implements Serializable {
         configurationObject.deepMarkAsDirty();
     }
 
+    /**
+     * Removes a nested object reference from tracking. This removes the object
+     * from the internal set used for collecting changes, and removes the change
+     * listener on it. This method also automatically marks this object as
+     * dirty, and triggers a change event to notify observers about changes.
+     */
     protected void removeChild(
             AbstractConfigurationObject configurationObject) {
         if (configurationObject == null)
@@ -108,27 +196,60 @@ public abstract class AbstractConfigurationObject implements Serializable {
         markAsDirty();
     }
 
+    /**
+     * Notifies observers that this object has changed. Usually there is no need
+     * to use this directly, instead {@link #markAsDirty()},
+     * {@link #addChild(AbstractConfigurationObject)}, or
+     * {@link #removeChild(AbstractConfigurationObject)} should be used.
+     */
     protected void notifyChange() {
         if (!trackObjectChanges.get())
             return;
         propertyChangeSupport.firePropertyChange("property", null, null);
     }
 
+    /**
+     * Same behavior as {@link #notifyChange()}, can be used as a shortcut to
+     * relay events from nested objects.
+     */
     protected void notifyChange(PropertyChangeEvent event) {
         if (!trackObjectChanges.get())
             return;
         propertyChangeSupport.firePropertyChange("property", null, null);
     }
 
+    /**
+     * Adds a change listener to the object. This will be called on any change
+     * made to the object that results in a call to {@link #notifyChange()}.
+     */
     protected void addPropertyChangeListener(PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * Removes a change listener from the object.
+     */
     protected void removePropertyChangeListener(
             PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
+    /**
+     * Updates an object using a {@link Runnable} that executes code for
+     * manipulating this object. The method has a parameter for controlling
+     * whether the manipulations from the runnable should trigger change events,
+     * and mark the object as dirty. This can be useful to prevent change events
+     * and resulting synchronizations when updating the server-side with state
+     * from the client. See
+     * {@link View#updateInternalViewState(Coordinate, float, float, Extent)}
+     * for an example.
+     *
+     * @param updater
+     *            a runnable containing code to manipulate this object
+     * @param trackObjectChanges
+     *            whether to enable or disable change tracking when executing
+     *            the runnable
+     */
     protected void update(Runnable updater, boolean trackObjectChanges) {
         AbstractConfigurationObject.trackObjectChanges.set(trackObjectChanges);
         try {
@@ -138,6 +259,15 @@ public abstract class AbstractConfigurationObject implements Serializable {
         }
     }
 
+    /**
+     * Collects all changed objects from a configuration hierarchy. If this
+     * object has been marked as dirty / changed, then it will be collected, and
+     * then marked as non-dirty / unchanged. Additionally, all nested objects
+     * are also checked, resulting in a recursive collection of changes. It is
+     * important that nested objects are collected first, so that during the
+     * client-side sync these instances are created and updated first, before
+     * higher-level instances that reference them.
+     */
     protected void collectChanges(
             Consumer<AbstractConfigurationObject> changeCollector) {
         children.forEach(child -> child.collectChanges(changeCollector));

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObject.java
@@ -41,9 +41,8 @@ import java.util.function.Consumer;
  * <li>implements the observable pattern using {@link PropertyChangeSupport}, in
  * order to notify the map component about changes to the configuration, see
  * {@link #notifyChange()}</li>
- * <li>keeps track of nested configuration objects in order to keep track and
- * notify about changes to nested objects, see
- * {@link #addChild(AbstractConfigurationObject)} and
+ * <li>keeps track of, and notifies about changes to nested configuration
+ * objects, see {@link #addChild(AbstractConfigurationObject)} and
  * {@link #removeChild(AbstractConfigurationObject)}</li>
  * </ul>
  * <p>

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Configuration.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Configuration.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+/**
+ * Contains the configuration for the map, such as layers, sources, features.
+ */
 public class Configuration extends AbstractConfigurationObject {
     private final List<Layer> layers = new ArrayList<>();
     private View view;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Constants.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Constants.java
@@ -16,6 +16,11 @@ package com.vaadin.flow.component.map.configuration;
  * #L%
  */
 
+/**
+ * Defines constants for OpenLayers types, which are uses by the client-side
+ * synchronization mechanism to identify which OL class to construct and
+ * synchronize into.
+ */
 public class Constants {
     // Layers
     public static final String OL_LAYER_IMAGE = "ol/layer/Image";
@@ -38,6 +43,4 @@ public class Constants {
     public static final String OL_MAP = "ol/Map";
     public static final String OL_VIEW = "ol/View";
     public static final String OL_FEATURE = "ol/Feature";
-
-    // Vaadin-specific abstractions
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
@@ -32,6 +32,16 @@ public class Coordinate {
         this(0, 0);
     }
 
+    /**
+     * Constructs a new coordinate instance from x and y coordinates. Unless the
+     * map's view uses a custom projection, it is assumed that the coordinates
+     * are in {@code EPSG:3857} / Web Mercator Sphere projection. To create
+     * coordinates from latitude and longitude, see
+     * {@link #fromLonLat(double, double)}.
+     *
+     * @param x
+     * @param y
+     */
     public Coordinate(double x, double y) {
         this.x = x;
         this.y = y;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Extent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Extent.java
@@ -1,8 +1,25 @@
 package com.vaadin.flow.component.map.configuration;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 /**
- * Defines an area within a map using min/max coordinates, which are by default
- * in EPSG:3857 format
+ * Defines an area within a map using min/max coordinates. The coordinates are
+ * by default in {@code EPSG:3857} / Web Mercator Sphere projection, unless the
+ * map's {@link View} uses a custom projection.
  */
 public class Extent {
     private final double minX;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Feature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Feature.java
@@ -26,9 +26,8 @@ import com.vaadin.flow.component.map.configuration.style.Style;
 import java.util.Objects;
 
 /**
- * A geographic feature to be displayed on a map. A feature can be anything that
- * should be displayed on top of a map, such as points of interest, vehicles or
- * people.
+ * A geographic feature to be displayed on a map. A feature represents a point
+ * of interest, such as an address, a building, a vehicle, or any other entity.
  */
 public abstract class Feature extends AbstractConfigurationObject {
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Projection.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Projection.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.configuration;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 /**
  * Defines constants for map coordinate projections. This is not an exhaustive
  * list of projections that can be used with the map component, it is possible

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
@@ -143,11 +143,12 @@ public class View extends AbstractConfigurationObject {
     }
 
     /**
-     * Gets the extent of the view's currently visible area, default value is
-     * {@code 0} for all coordinates.
+     * Gets the extent (or bounding box) of the view's currently visible area.
+     * Can be used to check whether a specific coordinate is within the
+     * viewport.
      * <p>
-     * The extent is calculated on the client-side and will only be available
-     * after the first view change event.
+     * <b>NOTE:</b> The extent is calculated on the client-side and will only be
+     * available after the first view change event.
      *
      * @return the coordinates of the view's extent
      */

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/ImageLayer.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/layer/ImageLayer.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.configuration.layer;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/ImageSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/ImageSource.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.configuration.source;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 /**
  * Abstract base class for all sources providing a single image
  */

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/ImageWMSSource.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/source/ImageWMSSource.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.configuration.source;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 import com.vaadin.flow.component.map.configuration.Constants;
 
 import java.util.Map;
@@ -36,7 +52,7 @@ public class ImageWMSSource extends ImageSource {
 
     /**
      * The WMS service URL
-     * 
+     *
      * @return the current URL
      */
     public String getUrl() {
@@ -45,7 +61,7 @@ public class ImageWMSSource extends ImageSource {
 
     /**
      * Sets the WMS service URL
-     * 
+     *
      * @param url
      *            the new URL
      */

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapClickEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapClickEvent.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.events;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapFeatureClickEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapFeatureClickEvent.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.events;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapViewMoveEndEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapViewMoveEndEvent.java
@@ -1,11 +1,28 @@
 package com.vaadin.flow.component.map.events;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.map.MapBase;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Extent;
+import com.vaadin.flow.component.map.configuration.View;
 import elemental.json.JsonArray;
 
 /**
@@ -19,15 +36,6 @@ public class MapViewMoveEndEvent extends ComponentEvent<MapBase> {
     private final Coordinate center;
     private final Extent extent;
 
-    /**
-     * Creates a new event using the given source and indicator whether the
-     * event originated from the client side or the server side.
-     *
-     * @param source
-     *            the source component
-     * @param fromClient
-     *            <code>true</code> if the event originated from the client
-     */
     public MapViewMoveEndEvent(MapBase source, boolean fromClient,
             @EventData("event.detail.rotation") double rotation,
             @EventData("event.detail.zoom") double zoom,
@@ -42,36 +50,36 @@ public class MapViewMoveEndEvent extends ComponentEvent<MapBase> {
     }
 
     /**
-     * Gets the view's updated rotation after map's "moveend" event.
+     * Gets the {@link View}'s updated rotation
      *
-     * @return latest rotation in radians
+     * @return updated rotation in radians
      */
     public float getRotation() {
         return rotation;
     }
 
     /**
-     * Gets the view's updated zoom level after map's "moveend" event.
+     * Gets the {@link View}'s updated zoom level
      *
-     * @return latest zoom level
+     * @return updated zoom level
      */
     public float getZoom() {
         return zoom;
     }
 
     /**
-     * Gets the view's updated center coordinates after map's "moveend" event.
+     * Gets the {@link View}'s updated center coordinates
      *
-     * @return latest center coordinates
+     * @return updated center coordinates
      */
     public Coordinate getCenter() {
         return center;
     }
 
     /**
-     * Gets the view's updated extent after map's "moveend" event.
+     * Gets the {@link View}'s updated extent
      *
-     * @return latest view
+     * @return updated view
      */
     public Extent getExtent() {
         return extent;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapViewMoveEndEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapViewMoveEndEvent.java
@@ -77,9 +77,11 @@ public class MapViewMoveEndEvent extends ComponentEvent<MapBase> {
     }
 
     /**
-     * Gets the {@link View}'s updated extent
+     * Gets the updated extent (or bounding box) of the {@link View}'s currently
+     * visible area. Can be used to check whether a specific coordinate is
+     * within the viewport.
      *
-     * @return updated view
+     * @return updated extent
      */
     public Extent getExtent() {
         return extent;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MouseEventDetails.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MouseEventDetails.java
@@ -1,13 +1,16 @@
 package com.vaadin.flow.component.map.events;
 
-/*-
+/*
  * #%L
- * Vaadin Charts for Flow
+ * Vaadin Map
  * %%
- * Copyright (C) 2014 - 2020 Vaadin Ltd
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
  * %%
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
  *
  * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  * #L%

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/serialization/MapSerializer.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/serialization/MapSerializer.java
@@ -1,5 +1,21 @@
 package com.vaadin.flow.component.map.serialization;
 
+/*
+ * #%L
+ * Vaadin Map
+ * %%
+ * Copyright (C) 2022 - 2022 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * #L%
+ */
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +35,10 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Custom JSON serializer for the map component using a Jackson
+ * {@link ObjectMapper}
+ */
 public class MapSerializer {
 
     private final ObjectWriter writer;
@@ -33,6 +53,17 @@ public class MapSerializer {
         writer = mapper.writer();
     }
 
+    /**
+     * Serializes a map configuration object to JSON using a Jackson
+     * {@link ObjectMapper}, and returns the value as a {@link JsonValue} to
+     * provide it in a type that is compatible with Flow.
+     * <p>
+     * Throws a runtime exception if the object can not be serialized to JSON.
+     *
+     * @param value
+     *            the map configuration object to be serialized into JSON
+     * @return a {@link JsonValue} representing the configuration object as JSON
+     */
     public JsonValue toJson(Object value) {
         String json;
         try {
@@ -45,6 +76,13 @@ public class MapSerializer {
         return new JreJsonFactory().parse(json);
     }
 
+    /**
+     * Custom Jackson serializer for {@link StreamResource}s. The serializer
+     * guarantees that all stream resources encountered during serialization of
+     * a configuration object are registered in a Flow session's stream resource
+     * registry, and are available under a dynamic URL. The serializer also
+     * returns the dynamic URL as serialized value.
+     */
     private static class StreamResourceSerializer
             extends StdSerializer<StreamResource> {
         private final Map<StreamResource, URI> streamResourceURICache = new HashMap<>();


### PR DESCRIPTION
## Description

Polishes the Map JavaDocs a bit, adds JavaDoc for AbstractConfigurationObject to better document the inner workings of the configuration sync, and adds missing license headers.

Fixes https://github.com/vaadin/flow-components/issues/2602
Fixes https://github.com/vaadin/flow-components/issues/2646
