### PR TITLE
fix: remove confirm dialog modality on close event

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/ModalityPage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/ModalityPage.java
@@ -9,20 +9,13 @@ import com.vaadin.flow.router.Route;
 @Route(value = "vaadin-confirm-dialog/modality")
 public class ModalityPage extends Div {
     public ModalityPage() {
-        // Dialog automatically adds itself to UI on open
-        ConfirmDialog autoAddedDialog = new ConfirmDialog();
-        autoAddedDialog.setId("auto-added-dialog");
-        Button openAutoAddedDialog = new Button("Open auto-added dialog",
-                e -> autoAddedDialog.open());
-        openAutoAddedDialog.setId("open-auto-added-dialog");
+        ConfirmDialog dialog = new ConfirmDialog();
 
-        // Dialog is manually added to the UI
-        ConfirmDialog manuallyAddedDialog = new ConfirmDialog();
-        manuallyAddedDialog.setId("manually-added-dialog");
-        Button openManuallyAddedDialog = new Button("Open auto-added dialog",
-                e -> manuallyAddedDialog.open());
-        openManuallyAddedDialog.setId("open-manually-added-dialog");
-        add(manuallyAddedDialog);
+        Button addDialog = new Button("Add dialog to UI", e -> add(dialog));
+        addDialog.setId("add-dialog");
+
+        Button openDialog = new Button("Open dialog", e -> dialog.open());
+        openDialog.setId("open-dialog");
 
         Span testClickResult = new Span();
         testClickResult.setId("test-click-result");
@@ -30,7 +23,7 @@ public class ModalityPage extends Div {
                 event -> testClickResult.setText("Click event received"));
         testClick.setId("test-click");
 
-        add(new Div(openAutoAddedDialog, openManuallyAddedDialog));
+        add(new Div(addDialog, openDialog));
         add(new Div(testClick, testClickResult));
     }
 }

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/ModalityPage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/ModalityPage.java
@@ -3,44 +3,34 @@ package com.vaadin.flow.component.confirmdialog.examples;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 @Route(value = "vaadin-confirm-dialog/modality")
 public class ModalityPage extends Div {
-
-    private Log log = new Log();
-
     public ModalityPage() {
-        ConfirmDialog confirmDialog = new ConfirmDialog();
-        confirmDialog.setHeader("My header");
-        confirmDialog.setText("Here is my text");
-        Button showDialogButton = new Button("Show dialog",
-                e -> confirmDialog.open());
-        showDialogButton.setId("open-dialog");
+        // Dialog automatically adds itself to UI on open
+        ConfirmDialog autoAddedDialog = new ConfirmDialog();
+        autoAddedDialog.setId("auto-added-dialog");
+        Button openAutoAddedDialog = new Button("Open auto-added dialog",
+                e -> autoAddedDialog.open());
+        openAutoAddedDialog.setId("open-auto-added-dialog");
 
-        Button logButton = new Button("Log", event -> log.log("Clicked"));
-        logButton.setId("log");
+        // Dialog is manually added to the UI
+        ConfirmDialog manuallyAddedDialog = new ConfirmDialog();
+        manuallyAddedDialog.setId("manually-added-dialog");
+        Button openManuallyAddedDialog = new Button("Open auto-added dialog",
+                e -> manuallyAddedDialog.open());
+        openManuallyAddedDialog.setId("open-manually-added-dialog");
+        add(manuallyAddedDialog);
 
-        add(showDialogButton, logButton, new Hr(), log);
-    }
+        Span testClickResult = new Span();
+        testClickResult.setId("test-click-result");
+        Button testClick = new Button("Test click",
+                event -> testClickResult.setText("Click event received"));
+        testClick.setId("test-click");
 
-    public static class Log extends Div {
-
-        public static final String LOG_ID = "log-output";
-
-        private int logCount;
-
-        public Log() {
-            setId(LOG_ID);
-        }
-
-        public void log(String msg) {
-            Div div = new Div();
-            div.addClassName("log");
-            logCount++;
-            div.setText(logCount + ". " + msg);
-            add(div);
-        }
+        add(new Div(openAutoAddedDialog, openManuallyAddedDialog));
+        add(new Div(testClick, testClickResult));
     }
 }

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/ModalityIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/ModalityIT.java
@@ -5,8 +5,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/ModalityIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/ModalityIT.java
@@ -1,70 +1,64 @@
 package com.vaadin.flow.component.confirmdialog.test;
 
-import com.vaadin.flow.component.html.testbench.SpanElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
-import org.openqa.selenium.By;
 
 @TestPath("vaadin-confirm-dialog/modality")
 public class ModalityIT extends AbstractComponentIT {
 
-    private ButtonElement openAutoAddedDialog;
-    private ButtonElement openManuallyAddedDialog;
+    private ButtonElement addDialog;
+    private ButtonElement openDialog;
     private ButtonElement testClick;
     private SpanElement testClickResult;
 
     @Before
     public void init() {
         open();
-        openAutoAddedDialog = $(ButtonElement.class)
-                .id("open-auto-added-dialog");
-        openManuallyAddedDialog = $(ButtonElement.class)
-                .id("open-manually-added-dialog");
+        addDialog = $(ButtonElement.class).id("add-dialog");
+        openDialog = $(ButtonElement.class).id("open-dialog");
         testClick = $(ButtonElement.class).id("test-click");
         testClickResult = $(SpanElement.class).id("test-click-result");
     }
 
     @Test
-    public void openAutoAddedDialog_noClicksOnElementsInBackgroundAllowed() {
-        openAutoAddedDialog.click();
-        // Wait for dialog to exist in DOM
-        getDialog("auto-added-dialog");
+    public void openDialog_noClicksOnElementsInBackgroundAllowed() {
+        openDialog.click();
+        $(ConfirmDialogElement.class).waitForFirst();
         assertBackgroundButtonIsNotClickable();
     }
 
     @Test
-    public void openAndCloseAutoAddedDialog_clicksOnElementsInBackgroundAllowed() {
-        openAutoAddedDialog.click();
-        ConfirmDialogElement dialogElement = getDialog("auto-added-dialog");
+    public void openAndCloseDialog_clicksOnElementsInBackgroundAllowed() {
+        openDialog.click();
+        ConfirmDialogElement dialogElement = $(ConfirmDialogElement.class)
+                .waitForFirst();
         dialogElement.getConfirmButton().click();
         assertBackgroundButtonIsClickable();
     }
 
     @Test
-    public void openManuallyAddedDialog_noClicksOnElementsInBackgroundAllowed() {
-        openManuallyAddedDialog.click();
-        // Wait for dialog to exist in DOM
-        getDialog("manually-added-dialog");
+    public void addDialog_openDialog_noClicksOnElementsInBackgroundAllowed() {
+        addDialog.click();
+        openDialog.click();
+        $(ConfirmDialogElement.class).waitForFirst();
         assertBackgroundButtonIsNotClickable();
     }
 
     @Test
-    public void openAndCloseManuallyAddedDialog_clicksOnElementsInBackgroundAllowed() {
-        openManuallyAddedDialog.click();
-        ConfirmDialogElement dialogElement = getDialog("manually-added-dialog");
+    public void addDialog_openAndCloseDialog_clicksOnElementsInBackgroundAllowed() {
+        addDialog.click();
+        openDialog.click();
+        ConfirmDialogElement dialogElement = $(ConfirmDialogElement.class)
+                .waitForFirst();
         dialogElement.getConfirmButton().click();
         assertBackgroundButtonIsClickable();
-    }
-
-    private ConfirmDialogElement getDialog(String id) {
-        waitForElementPresent(By.id(id));
-        return $(ConfirmDialogElement.class).id(id);
     }
 
     private void assertBackgroundButtonIsNotClickable() {

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/ModalityIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/ModalityIT.java
@@ -1,57 +1,81 @@
 package com.vaadin.flow.component.confirmdialog.test;
 
+import com.vaadin.flow.component.html.testbench.SpanElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
-import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
-import com.vaadin.tests.AbstractParallelTest;
-
-import static com.vaadin.flow.component.confirmdialog.examples.BasicUseView.Log.LOG_ID;
+import org.openqa.selenium.By;
 
 @TestPath("vaadin-confirm-dialog/modality")
 public class ModalityIT extends AbstractComponentIT {
 
+    private ButtonElement openAutoAddedDialog;
+    private ButtonElement openManuallyAddedDialog;
+    private ButtonElement testClick;
+    private SpanElement testClickResult;
+
     @Before
     public void init() {
         open();
-        Assert.assertEquals("No log messages should exist on open", 0,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+        openAutoAddedDialog = $(ButtonElement.class)
+                .id("open-auto-added-dialog");
+        openManuallyAddedDialog = $(ButtonElement.class)
+                .id("open-manually-added-dialog");
+        testClick = $(ButtonElement.class).id("test-click");
+        testClickResult = $(SpanElement.class).id("test-click-result");
     }
 
     @Test
-    public void openConfirmDialog_removeBackdrop_logClickNotAccepted() {
-        $(ButtonElement.class).id("open-dialog").click();
-        final DivElement backdrop = $(TestBenchElement.class).id("overlay")
-                .$(DivElement.class).id("backdrop");
-
-        executeScript("arguments[0].remove()", backdrop);
-
-        Assert.assertFalse("Backdrop was not removed from dom",
-                $(TestBenchElement.class).id("overlay").$(DivElement.class)
-                        .attributeContains("id", "backdrop").exists());
-
-        $(ButtonElement.class).id("log").click();
-
-        Assert.assertTrue("Dialog should not have closed",
-                $(ConfirmDialogElement.class).exists());
-        Assert.assertEquals("Click on button should not generate a log message",
-                0, $(DivElement.class).id(LOG_ID).$("div").all().size());
-
-        $(ConfirmDialogElement.class).first().getConfirmButton().click();
-
-        Assert.assertFalse("Dialog should have closed",
-                $(ConfirmDialogElement.class).exists());
-
-        $(ButtonElement.class).id("log").click();
-
-        Assert.assertEquals("Click should have resulted in a log message", 1,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+    public void openAutoAddedDialog_noClicksOnElementsInBackgroundAllowed() {
+        openAutoAddedDialog.click();
+        // Wait for dialog to exist in DOM
+        getDialog("auto-added-dialog");
+        assertBackgroundButtonIsNotClickable();
     }
 
+    @Test
+    public void openAndCloseAutoAddedDialog_clicksOnElementsInBackgroundAllowed() {
+        openAutoAddedDialog.click();
+        ConfirmDialogElement dialogElement = getDialog("auto-added-dialog");
+        dialogElement.getConfirmButton().click();
+        assertBackgroundButtonIsClickable();
+    }
+
+    @Test
+    public void openManuallyAddedDialog_noClicksOnElementsInBackgroundAllowed() {
+        openManuallyAddedDialog.click();
+        // Wait for dialog to exist in DOM
+        getDialog("manually-added-dialog");
+        assertBackgroundButtonIsNotClickable();
+    }
+
+    @Test
+    public void openAndCloseManuallyAddedDialog_clicksOnElementsInBackgroundAllowed() {
+        openManuallyAddedDialog.click();
+        ConfirmDialogElement dialogElement = getDialog("manually-added-dialog");
+        dialogElement.getConfirmButton().click();
+        assertBackgroundButtonIsClickable();
+    }
+
+    private ConfirmDialogElement getDialog(String id) {
+        waitForElementPresent(By.id(id));
+        return $(ConfirmDialogElement.class).id(id);
+    }
+
+    private void assertBackgroundButtonIsNotClickable() {
+        testClick.click();
+        Assert.assertEquals("Button in background is clickable", "",
+                testClickResult.getText());
+    }
+
+    private void assertBackgroundButtonIsClickable() {
+        testClick.click();
+        Assert.assertEquals("Button in background is not clickable",
+                "Click event received", testClickResult.getText());
+    }
 }

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -133,6 +133,9 @@ public class ConfirmDialog extends Component
      */
     public ConfirmDialog() {
         getElement().addEventListener("opened-changed", event -> {
+            if (!isOpened()) {
+                setModality(false);
+            }
             if (autoAddedToTheUi && !isOpened()) {
                 getElement().removeFromParent();
                 autoAddedToTheUi = false;
@@ -568,10 +571,14 @@ public class ConfirmDialog extends Component
         if (opened) {
             ensureAttached();
         }
-        if (isAttached()) {
-            getUI().ifPresent(ui -> ui.setChildComponentModal(this, opened));
-        }
+        setModality(opened);
         getElement().setProperty("opened", opened);
+    }
+
+    private void setModality(boolean modal) {
+        if (isAttached()) {
+            getUI().ifPresent(ui -> ui.setChildComponentModal(this, modal));
+        }
     }
 
     private UI getCurrentUI() {


### PR DESCRIPTION
## Description

Fixes the confirm dialog to remove its server-side modality when the dialog is closed. Fixes a regression from #2608 . I think the assumption was that clicking one of the closing buttons in the confirm dialog would also call `close` or `setOpened` in the dialog. However for confirm dialog that is not the case, as the web component controls the default confirm / cancel buttons, adds the event listeners on them, and closes the dialog when they are clicked. The previous test case was only working because it was set up so that the element automatically removed itself from the UI on close, which I assume will also remove its server-side modality. 

Fixes #2706 

## Type of change

- [x] Bugfix
