### PR TITLE
feat: Enable smoother update of the TreeGrid when using TreeData

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -956,4 +956,24 @@ public class TreeGrid<T> extends Grid<T>
     public void scrollToIndex(int rowIndex) {
         super.scrollToIndex(rowIndex);
     }
+
+    @Override
+    public void onEnabledStateChanged(boolean enabled) {
+        if (getElement().getNode().hasFeature(ElementData.class)) {
+            getElement().setAttribute("disabled", !enabled);
+        }
+
+        if (getTreeData() != null) {
+            refreshChildItems(getTreeData().getRootItems());
+        } else {
+            getDataCommunicator().reset();
+        }
+    }
+
+    private void refreshChildItems(List<T> rootItems) {
+        for (T item : rootItems) {
+            getDataProvider().refreshItem(item, false);
+            refreshChildItems(getTreeData().getChildren(item));
+        }
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -60,6 +60,7 @@ import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementData;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.JsonArray;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -960,13 +960,25 @@ public class TreeGrid<T> extends Grid<T>
 
     @Override
     public void onEnabledStateChanged(boolean enabled) {
+        // If the node has feature ElementData, then we know that the state
+        // provider accepts attributes
         if (getElement().getNode().hasFeature(ElementData.class)) {
             getElement().setAttribute("disabled", !enabled);
         }
 
         if (getTreeData() != null) {
+            /*
+             * DataCommunicator.reset() will cause collapse - expand cycle
+             * and thus flicker. In case of TreeData we can avoid this.
+             */
             refreshChildItems(getTreeData().getRootItems());
         } else {
+            /*
+             * The DataCommunicator needs to be reset so components rendered
+             * inside the cells can be updated to the new enabled state. The
+             * enabled state is passed as a property to the client via
+             * DataGenerators.
+             */
             getDataCommunicator().reset();
         }
     }


### PR DESCRIPTION
DataCommunicator.reset() will cause collapse - expand cycle and thus flicker when setEnabled(..) is called. In case of TreeData we can avoid this.

This change is neutral with regards integration tests as the final outcome will not change.

Fixes: #2713