### PR TITLE
fix: preserve setDetailsVisibleOnClick on re-attach

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -19,6 +19,8 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridSingleSelectionModel;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
 
 @Route(value = "vaadin-grid/detach-reattach-page")
@@ -44,6 +46,23 @@ public class DetachReattachPage extends Div {
                 });
         btnDisallowDeselect.setId("disallow-deselect-button");
 
-        add(btnAttach, btnDetach, btnDisallowDeselect, grid);
+        NativeButton addItemDetailsButton = new NativeButton("Add item details",
+                e -> {
+                    grid.setSelectionMode(Grid.SelectionMode.NONE);
+                    grid.setItemDetailsRenderer(new ComponentRenderer<>(
+                            item -> new Span("Item details")));
+                });
+        addItemDetailsButton.setId("add-item-details-button");
+
+        NativeButton toggleDetailsVisibleOnClick = new NativeButton(
+                "Toggle details visible on click", e -> {
+                    grid.setDetailsVisibleOnClick(
+                            !grid.isDetailsVisibleOnClick());
+                });
+        toggleDetailsVisibleOnClick
+                .setId("toggle-details-visible-click-button");
+
+        add(btnAttach, btnDetach, btnDisallowDeselect, addItemDetailsButton,
+                toggleDetailsVisibleOnClick, grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
@@ -20,6 +20,8 @@ import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 @TestPath("vaadin-grid/detach-reattach-page")
 public class DetachReattachIt extends AbstractComponentIT {
@@ -51,5 +53,50 @@ public class DetachReattachIt extends AbstractComponentIT {
         grid.getRow(1).deselect();
         Assert.assertTrue("Deselection is still disallowed after re-attach.",
                 grid.getRow(1).isSelected());
+    }
+
+    @Test
+    public void detachAndReattach_setDetailsVisibleOnClickPreserved() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        // Add item details
+        $("button").id("add-item-details-button").click();
+
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
+
+        WebElement detailsElement = grid
+                .findElement(By.tagName("flow-component-renderer"));
+
+        Assert.assertTrue("Item details are visible on cell click by default.",
+                detailsElement.isDisplayed());
+
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
+        Assert.assertFalse("Item details are hidden on subsequent cell click.",
+                detailsElement.isDisplayed());
+
+        // Do not show details on click
+        $("button").id("toggle-details-visible-click-button").click();
+
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
+        Assert.assertFalse(
+                "Item details are hidden with setDetailsVisibleOnClick(false).",
+                detailsElement.isDisplayed());
+
+        // Detach and re-attach
+        $("button").id("detach-button").click();
+
+        $("button").id("attach-button").click();
+
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
+        Assert.assertFalse(
+                "Item details are still hidden after detach and re-attach.",
+                detailsElement.isDisplayed());
+
+    }
+
+    private WebElement getRow(GridElement grid, int row) {
+        return grid.$("*").id("items").findElements(By.cssSelector("tr"))
+                .get(row);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1170,7 +1170,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final DetailsManager detailsManager;
     private Element detailsTemplate;
-    private boolean detailsVisibleOnClick = true;
 
     private Map<String, Column<T>> idToColumnMap = new HashMap<>();
     private Map<String, Column<T>> keyToColumnMap = new HashMap<>();
@@ -3031,10 +3030,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see #setItemDetailsRenderer(Renderer)
      */
     public void setDetailsVisibleOnClick(boolean detailsVisibleOnClick) {
-        if (this.detailsVisibleOnClick != detailsVisibleOnClick) {
-            this.detailsVisibleOnClick = detailsVisibleOnClick;
-            getElement().setProperty("__disallowDetailsOnClick", !detailsVisibleOnClick);
-        }
+        getElement().setProperty("__disallowDetailsOnClick", !detailsVisibleOnClick);
     }
 
     /**
@@ -3046,7 +3042,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see #setItemDetailsRenderer(Renderer)
      */
     public boolean isDetailsVisibleOnClick() {
-        return detailsVisibleOnClick;
+        return !getElement().getProperty("__disallowDetailsOnClick", false);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3033,8 +3033,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void setDetailsVisibleOnClick(boolean detailsVisibleOnClick) {
         if (this.detailsVisibleOnClick != detailsVisibleOnClick) {
             this.detailsVisibleOnClick = detailsVisibleOnClick;
-            getElement().callJsFunction("$connector.setDetailsVisibleOnClick",
-                    detailsVisibleOnClick);
+            getElement().setProperty("__disallowDetailsOnClick", !detailsVisibleOnClick);
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -111,8 +111,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
       let selectedKeys = {};
       let selectionMode = 'SINGLE';
 
-      let detailsVisibleOnClick = true;
-
       let sorterDirectionsSetFromServer = false;
 
       grid.size = 0; // To avoid NaN here and there before we get proper data
@@ -222,7 +220,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
       grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
 
       grid.__activeItemChangedDetails = tryCatchWrapper(function(newVal, oldVal) {
-        if(!detailsVisibleOnClick) {
+        if (grid.__disallowDetailsOnClick) {
           return;
         }
         // when grid is attached, newVal is not set and oldVal is undefined
@@ -237,10 +235,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         }
       })
       grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
-
-      grid.$connector.setDetailsVisibleOnClick = tryCatchWrapper(function(visibleOnClick) {
-        detailsVisibleOnClick = visibleOnClick;
-      });
 
       grid.$connector._getPageIfSameLevel = tryCatchWrapper(function(parentKey, index, defaultPage) {
         let cacheAndIndex = grid._cache.getCacheAndIndex(index);


### PR DESCRIPTION
## Description

Similarly to #2711, use `getElement().setProperty()` so that Flow would take care of synchronizing the state on reattach.

Fixes #1485

## Type of change

- Bugfix