### PR TITLE
fix: Use English when converting code properties to lower case

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -1,5 +1,9 @@
 package com.vaadin.flow.component.applayout;
 
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Objects;
+
 /*
  * #%L
  * Vaadin App Layout
@@ -33,9 +37,6 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.router.RouterLayout;
-
-import java.io.Serializable;
-import java.util.Objects;
 
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
@@ -354,7 +355,7 @@ public class AppLayout extends Component implements RouterLayout {
         NAVBAR, DRAWER;
 
         public String toWebcomponentValue() {
-            return this.name().toLoweCase(Locale.ENGLISH)();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
 
         public static Section fromWebcomponentValue(String webcomponentValue) {

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -354,7 +354,7 @@ public class AppLayout extends Component implements RouterLayout {
         NAVBAR, DRAWER;
 
         public String toWebcomponentValue() {
-            return this.name().toLowerCase();
+            return this.name().toLoweCase(Locale.ENGLISH)();
         }
 
         public static Section fromWebcomponentValue(String webcomponentValue) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/NodeLayout.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/NodeLayout.java
@@ -20,6 +20,6 @@ public enum NodeLayout implements ChartEnum {
     NORMAL, HANGING;
 
     public String toString() {
-        return name().toLowerCase();
+        return name().toLowerCase(Locale.ENGLISH);
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/NodeLayout.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/NodeLayout.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.charts.model;
 
+import java.util.Locale;
+
 /*-
  * #%L
  * Vaadin Charts for Flow

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.cookieconsent;
 
+import java.util.Locale;
+
 /*
  * #%L
  * Cookie Consent for Vaadin Flow

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -116,7 +116,7 @@ public class CookieConsent extends Component {
      */
     public void setPosition(Position position) {
         getElement().setProperty("position",
-                position.name().toLowerCase().replace('_', '-'));
+                position.name().toLowerCase(Locale.ENGLISH).replace('_', '-'));
     }
 
     /**

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.gridpro.examples;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/examples/MainView.java
@@ -177,7 +177,7 @@ public class MainView extends VerticalLayout {
             String stringRepresentation) {
         for (Department type : Department.values()) {
             if (type.getStringRepresentation()
-                    .equals(stringRepresentation.toLowerCase())) {
+                    .equals(stringRepresentation.toLowerCase(Locale.ENGLISH))) {
                 return type;
             }
         }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
@@ -24,6 +24,8 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Locale;
+
 /**
  * Scroller is a component container which enables scrolling overflowing
  * content.

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
@@ -161,7 +161,7 @@ public class Scroller extends Component implements HasSize, HasStyle {
         VERTICAL, HORIZONTAL, BOTH, NONE;
 
         private String toWebComponentValue() {
-            return BOTH == this ? null : this.name().toLowerCase();
+            return BOTH == this ? null : this.name().toLowerCase(Locale.ENGLISH);
         }
 
         private static ScrollDirection fromWebComponentValue(

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.splitlayout;
 
+import java.util.Locale;
 import java.util.Objects;
 
 import com.vaadin.flow.component.Component;

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -193,7 +193,7 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      */
     public void setOrientation(Orientation orientation) {
         Objects.requireNonNull(orientation, "Orientation cannot be null");
-        this.setOrientation(orientation.toString().toLowerCase());
+        this.setOrientation(orientation.toString().toLowerCase(Locale.ENGLISH));
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -406,7 +406,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      */
     public void setOrientation(Orientation orientation) {
         getElement().setProperty("orientation",
-                orientation.name().toLowerCase());
+                orientation.name().toLowerCase(Locale.ENGLISH));
     }
 
     /**


### PR DESCRIPTION
Fixes #2715

