### PR TITLE
fix: implement UpdateQueue.clear in ComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -202,7 +202,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         @Override
         public void clear(int start, int length) {
-            // NO-OP
+            enqueue("$connector.clear", start, length);
         }
 
         @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -152,6 +152,15 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
                 }
             }
 
+            comboBox.$connector.clear = tryCatchWrapper((start, length) => {
+                const firstPageToClear = Math.floor(start / comboBox.pageSize);
+                const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
+                
+                for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
+                    delete cache[i];
+                }
+            });
+
             comboBox.$connector.filter = tryCatchWrapper(function (item, filter) {
                 filter = filter ? filter.toString().toLowerCase() : '';
                 return comboBox._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;


### PR DESCRIPTION
Fixes #1993 

I couldn't find a way to test this automatically so an IT isn't included. You can verify the fix manually:
- open http://localhost:8080/vaadin-combo-box/lazy-loading
- click "set renderer"
- furiously scroll the "ListDataProvider with beans" ComboBox
- scroll slowly and see the item content

Before:

https://user-images.githubusercontent.com/1222264/155691175-50b37a0f-c256-4ef4-ac73-234f8a3b6ca4.mp4

After:

https://user-images.githubusercontent.com/1222264/155691196-cd41a344-b2f0-4056-b808-81710cb274d0.mp4
