### PR TITLE
fix: ensure deselectAllowed is preserved on re-attach (#2711) (CP 22.0)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridSingleSelectionModel;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-grid/detach-reattach-page")
+public class DetachReattachPage extends Div {
+    public DetachReattachPage() {
+        Grid<String> grid = new Grid<String>();
+        grid.setItems("A", "B", "C");
+        grid.addColumn(x -> x).setHeader("Col");
+
+        grid.setSelectionMode(Grid.SelectionMode.SINGLE);
+
+        NativeButton btnAttach = new NativeButton("Attach", e -> add(grid));
+        btnAttach.setId("attach-button");
+
+        NativeButton btnDetach = new NativeButton("Detach", e -> remove(grid));
+        btnDetach.setId("detach-button");
+
+        NativeButton btnDisallowDeselect = new NativeButton("Disallow deselect",
+                e -> {
+                    GridSingleSelectionModel<String> singleSelect = (GridSingleSelectionModel<String>) grid
+                            .getSelectionModel();
+                    singleSelect.setDeselectAllowed(false);
+                });
+        btnDisallowDeselect.setId("disallow-deselect-button");
+
+        add(btnAttach, btnDetach, btnDisallowDeselect, grid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+@TestPath("vaadin-grid/detach-reattach-page")
+public class DetachReattachIt extends AbstractComponentIT {
+
+    @Test
+    public void detachAndReattach_setDeselectAllowedPreserved() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        grid.getRow(1).select();
+        Assert.assertTrue("Row is selected.", grid.getRow(1).isSelected());
+
+        // Disable de-selection
+        $("button").id("disallow-deselect-button").click();
+
+        grid.getRow(1).deselect();
+        Assert.assertTrue("Row is still selected as deselection is disallowed.",
+                grid.getRow(1).isSelected());
+
+        // Detach and re-attach
+        $("button").id("detach-button").click();
+
+        $("button").id("attach-button").click();
+
+        Assert.assertTrue(
+                "Selected row is preserved after detach and re-attach.",
+                grid.getRow(1).isSelected());
+
+        grid.getRow(1).deselect();
+        Assert.assertTrue("Deselection is still disallowed after re-attach.",
+                grid.getRow(1).isSelected());
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -269,7 +269,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     @Override
                     public void setDeselectAllowed(boolean deselectAllowed) {
                         super.setDeselectAllowed(deselectAllowed);
-                        grid.getElement().setProperty("__deselectDisallowed", !deselectAllowed);
+                        grid.getElement().setProperty("__deselectDisallowed",
+                                !deselectAllowed);
                     }
                 };
             }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -269,9 +269,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     @Override
                     public void setDeselectAllowed(boolean deselectAllowed) {
                         super.setDeselectAllowed(deselectAllowed);
-                        grid.getElement().executeJs(
-                                "this.$connector.deselectAllowed = $0",
-                                deselectAllowed);
+                        grid.getElement().setProperty("__deselectDisallowed", !deselectAllowed);
                     }
                 };
             }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -209,7 +209,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         }
         if (!newVal) {
           if (oldVal && selectedKeys[oldVal.key]) {
-            if (!grid.$connector.deselectAllowed) {
+            if (grid.__deselectDisallowed) {
               grid.activeItem = oldVal;
             } else {
               grid.$connector.doDeselection([oldVal], true);
@@ -930,8 +930,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           throw 'Attempted to set an invalid selection mode';
         }
       });
-
-      grid.$connector.deselectAllowed = true;
 
       // TODO: should be removed once https://github.com/vaadin/vaadin-grid/issues/1471 gets implemented
       grid.$connector.setVerticalScrollingEnabled = tryCatchWrapper(function(enabled) {


### PR DESCRIPTION
Cherry pick of https://github.com/vaadin/flow-components/pull/2711
(cherry picked from commit 0650abe33b966e38b8179d8ec4c787fe3d6e3378)