### PR TITLE
chore: remove obsolete repos from tryCatchWrapper

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -4,7 +4,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Combo Box', 'vaadin-combo-box');
+        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Combo Box');
     };
 
     window.Vaadin.Flow.comboBoxConnector = {
@@ -155,7 +155,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             comboBox.$connector.clear = tryCatchWrapper((start, length) => {
                 const firstPageToClear = Math.floor(start / comboBox.pageSize);
                 const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
-                
+
                 for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
                     delete cache[i];
                 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -1,11 +1,7 @@
 import * as Gestures from "@vaadin/component-base/src/gestures.js";
 (function() {
   const tryCatchWrapper = function(callback) {
-    return window.Vaadin.Flow.tryCatchWrapper(
-      callback,
-      "Vaadin Context Menu",
-      "vaadin-context-menu-flow"
-    );
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu');
   };
 
   window.Vaadin.Flow.contextMenuConnector = {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -4,7 +4,7 @@ import dateFnsIsValid from 'date-fns/isValid';
 
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker', 'vaadin-date-picker');
+        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker');
     };
 
     /* helper class for parsing regex from formatted date string */

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -6,7 +6,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
 (function () {
   const tryCatchWrapper = function (callback) {
-    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid', 'vaadin-grid');
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid');
   };
 
   let isItemCacheInitialized = false;

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -1,6 +1,6 @@
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid Pro', 'vaadin-grid-pro');
+        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid Pro');
     };
 
     function isEditedRow(grid, rowData) {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -16,7 +16,7 @@
 
 (function () {
   const tryCatchWrapper = function (callback) {
-    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Menu Bar', 'vaadin-menu-bar');
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Menu Bar');
   };
 
   window.Vaadin.Flow.menubarConnector = {

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/resources/META-INF/resources/frontend/messageListConnector.js
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/resources/META-INF/resources/frontend/messageListConnector.js
@@ -16,7 +16,7 @@
 
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Message List', 'vaadin-messages');
+        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Message List');
     };
 
     window.Vaadin.Flow.messageListConnector = {

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
@@ -1,6 +1,6 @@
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select', 'vaadin-select');
+        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select');
     };
 
     window.Vaadin.Flow.selectConnector = {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -1,6 +1,6 @@
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker', 'vaadin-time-picker');
+        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker');
     };
 
     // Execute callback when predicate returns true.


### PR DESCRIPTION
## Description

Flow has been already updated to mention `flow-components` repo in the errors: https://github.com/vaadin/flow/pull/12074
The third parameter for `tryCatchWrapper` which was used for the repo can now be removed.

Closes #1829

## Type of change

- Internal change