### PR TITLE
fix: generate sorter aria-label using text content

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -78,6 +78,17 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInitialSortOrder_sorterAriaLabels() {
+        findElement(By.id("sort-by-age")).click();
+        List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter").all();
+        // The first sorter uses a ComponentRenderer so an aria-label can't be
+        // generated
+        Assert.assertEquals(false, sorters.get(0).hasAttribute("aria-label"));
+        Assert.assertEquals("Sort by Age",
+                sorters.get(1).getAttribute("aria-label"));
+    }
+
+    @Test
     public void setInitialSortOrder_updateHeaderText_sortIndicatorsRemain() {
         findElement(By.id("sort-by-age")).click();
         assertAscendingSorter("Age");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -240,9 +240,14 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     protected String addGridSorter(String templateInnerHtml) {
         String escapedColumnId = HtmlUtils
                 .escape(getBottomLevelColumn().getInternalId());
+
+        String textContent = org.jsoup.Jsoup.parse(templateInnerHtml).text();
+        String sortBy = textContent.isBlank() ? ""
+                : "aria-label='Sort by " + textContent + "'";
+
         return String.format(
-                "<vaadin-grid-sorter path='%s' aria-label='Sort by %s'>%s</vaadin-grid-sorter>",
-                escapedColumnId, templateInnerHtml, templateInnerHtml);
+                "<vaadin-grid-sorter path='%s' %s>%s</vaadin-grid-sorter>",
+                escapedColumnId, sortBy, templateInnerHtml);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/3470

The current implementation that generates `aria-label='Sort by [content]'` for a `<vaadin-grid-sorter>` from its content doesn't take into account that a `ComponentRenderer` may be used for the sorter content.

The new implementation uses `org.jsoup.Jsoup.parse` to obtain the text content from the sorter content HTML and if non-empty, uses that for the `aria-label`.