### PR TITLE
fix: re-enable lazy loading when reducing page size

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -66,6 +66,8 @@ public class LazyLoadingPage extends Div {
         createCallbackDataProviderWhichReturnsZeroItems();
         addSeparator();
         createComboBoxWithCustomPageSizeAndLazyLoading();
+        addSeparator();
+        createComboBoxWithDisabledLazyLoading();
     }
 
     private void createListDataProviderWithStringsAutoOpenDisabled() {
@@ -273,6 +275,24 @@ public class LazyLoadingPage extends Div {
         changePageSizeButton.setId("change-page-size-button");
 
         add(comboBox, changePageSizeButton);
+    }
+
+    private void createComboBoxWithDisabledLazyLoading() {
+        addTitle("ComboBox with disabled lazy loading");
+        ComboBox<Integer> comboBox = new ComboBox<>(100);
+        comboBox.setId("disabled-lazy-loading");
+        // Having a number of items less than or equal than the page size will
+        // disable lazy-loading
+        List<Integer> items = IntStream.range(0, 100).boxed()
+                .collect(Collectors.toList());
+        comboBox.setItems(items);
+
+        NativeButton enableLazyLoading = new NativeButton("Enable lazy loading",
+                // Reducing page size should enable lazy-loading
+                event -> comboBox.setPageSize(50));
+        enableLazyLoading.setId("enable-lazy-loading");
+
+        add(comboBox, enableLazyLoading);
     }
 
     public static List<String> generateStrings(int count) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -37,6 +37,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     private ComboBoxElement templateBox;
     private ComboBoxElement emptyCallbackBox;
     private ComboBoxElement lazyCustomPageSize;
+    private ComboBoxElement disabledLazyLoadingBox;
 
     private WebElement lazySizeRequestCountSpan;
 
@@ -59,6 +60,8 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
                 .id("lazy-custom-page-size");
         lazySizeRequestCountSpan = findElement(
                 By.id("callback-dataprovider-size-request-count"));
+        disabledLazyLoadingBox = $(ComboBoxElement.class)
+                .id("disabled-lazy-loading");
     }
 
     @Test
@@ -550,6 +553,25 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         waitUntilTextInContent("300");
         // page size should be 41
         assertMessage("41");
+    }
+
+    @Test
+    public void disabledLazyLoading_reducePageSize_enablesLazyLoading() {
+        disabledLazyLoadingBox.openPopup();
+        assertLoadedItemsCount("Initially all 100 items should be loaded", 100,
+                disabledLazyLoadingBox);
+        lazyCustomPageSize.closePopup();
+
+        clickButton("enable-lazy-loading");
+        disabledLazyLoadingBox.openPopup();
+        assertLoadedItemsCount(
+                "After reducing page size, 50 items should be loaded", 50,
+                disabledLazyLoadingBox);
+
+        scrollToItem(disabledLazyLoadingBox, 100);
+        assertLoadedItemsCount("Scrolling down should load further pages", 100,
+                disabledLazyLoadingBox);
+        assertRendered("99");
     }
 
     private void assertMessage(String expectedMessage) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -980,8 +980,10 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void refreshAllData(boolean forceServerSideFiltering) {
-        setClientSideFilter(!forceServerSideFiltering
-                && dataCommunicator.getItemCount() <= getPageSizeDouble());
+        if (dataCommunicator != null) {
+            setClientSideFilter(!forceServerSideFiltering
+                    && dataCommunicator.getItemCount() <= getPageSizeDouble());
+        }
 
         reset();
     }
@@ -1198,7 +1200,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (dataCommunicator != null) {
             dataCommunicator.setPageSize(pageSize);
         }
-        reset();
+        refreshAllData(shouldForceServerSideFiltering);
     }
 
     /**


### PR DESCRIPTION
## Description

The combo box connector has an internal mode where it disables lazy loading (or rather all data provider requests) if the page size is less than or equal the total number of items. This PR fixes a bug where reducing the page size would not disable that mode.

Fixes #2736 

## Type of change

- [x] Bugfix
