### PR TITLE
fix: don't throw on grid details cell focus

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
@@ -50,6 +50,14 @@ public class GridDetailsRowIT extends AbstractComponentIT {
         assertElementHasButton(detailsElement.get(1), "Person 2");
     }
 
+    @Test
+    public void shouldNotThrowOnDetailsClick() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+        grid.getRow(1).getDetails().click(0, 0);
+        checkLogsForErrors();
+    }
+
     /**
      * Click on an item, hide the other details
      */

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1037,7 +1037,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         const expectedSectionValues = ['header', 'body', 'footer'];
 
         if(expectedSectionValues.indexOf(eventContext.section) === -1) {
-          throw new Error('Unexpected value for section: ' + eventContext.section);
+          return;
         }
 
         grid.dispatchEvent(new CustomEvent('grid-cell-focus', {


### PR DESCRIPTION
Fixes #2727 

This PR makes the connector not throw when a `cell-focus` event originates from "details" section.

NOTE:
This is merely a bugfix to avoid the client-side exception, and doesn't add the missing support for details cell-focus events. Adding the missing feat is a separate topic and requires some design (for example, do we want to add "details" to the `GridSection` enum or use the existing "body" section with `null` column for details cell focus...) 