### PR TITLE
fix: re-enable lazy loading when reducing page size (#2744) (CP: 14.8)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -44,7 +44,6 @@ public class LazyLoadingPage extends Div {
         message.setId("message");
         add(message);
 
-        addSeparator();
         createListDataProviderWithStringsAutoOpenDisabled();
         addSeparator();
         createListDataProviderWithStrings();
@@ -60,6 +59,9 @@ public class LazyLoadingPage extends Div {
         createComboBoxInATemplate();
         addSeparator();
         createCallbackDataProviderWhichReturnsZeroItems();
+        addSeparator();
+        createComboBoxWithDisabledLazyLoading();
+        addSeparator();
     }
 
     private void createListDataProviderWithStringsAutoOpenDisabled() {
@@ -243,6 +245,24 @@ public class LazyLoadingPage extends Div {
         add(comboBox);
     }
 
+    private void createComboBoxWithDisabledLazyLoading() {
+        addTitle("ComboBox with disabled lazy loading");
+        ComboBox<Integer> comboBox = new ComboBox<>(100);
+        comboBox.setId("disabled-lazy-loading");
+        // Having a number of items less than or equal than the page size will
+        // disable lazy-loading
+        List<Integer> items = IntStream.range(0, 100).boxed()
+                .collect(Collectors.toList());
+        comboBox.setItems(items);
+
+        NativeButton enableLazyLoading = new NativeButton("Enable lazy loading",
+                // Reducing page size should enable lazy-loading
+                event -> comboBox.setPageSize(50));
+        enableLazyLoading.setId("enable-lazy-loading");
+
+        add(comboBox, enableLazyLoading);
+    }
+
     public static List<String> generateStrings(int count) {
         List<String> items = IntStream.range(0, count)
                 .mapToObj(i -> "Item " + i).collect(Collectors.toList());
@@ -250,6 +270,14 @@ public class LazyLoadingPage extends Div {
     }
 
     private void addSeparator() {
+        // Add a vertical spacer div after each test setup. This avoids issues
+        // with the tests being dependent on the screen size, regarding in which
+        // direction the combo boxes open, and how much space vertical space the
+        // combo box overlay gets.
+        Div spacer = new Div();
+        spacer.getStyle().set("height", "100px");
+        add(spacer);
+        // Add visual separator
         getElement().appendChild(new Element("hr"));
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -41,6 +41,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     private ComboBoxElement callbackBox;
     private ComboBoxElement templateBox;
     private ComboBoxElement emptyCallbackBox;
+    private ComboBoxElement disabledLazyLoadingBox;
 
     @Before
     public void init() {
@@ -57,6 +58,8 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         templateBox = $("combo-box-in-a-template").id("template")
                 .$(ComboBoxElement.class).first();
         emptyCallbackBox = $(ComboBoxElement.class).id("empty-callback");
+        disabledLazyLoadingBox = $(ComboBoxElement.class)
+                .id("disabled-lazy-loading");
     }
 
     @Test
@@ -535,6 +538,25 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
                 "return arguments[0].focusElement.value", beanBox);
         Assert.assertEquals("The ComboBox filter text got modified",
                 "Person 111", filterText);
+    }
+
+    @Test
+    public void disabledLazyLoading_reducePageSize_enablesLazyLoading() {
+        disabledLazyLoadingBox.openPopup();
+        assertLoadedItemsCount("Initially all 100 items should be loaded", 100,
+                disabledLazyLoadingBox);
+        disabledLazyLoadingBox.closePopup();
+
+        clickButton("enable-lazy-loading");
+        disabledLazyLoadingBox.openPopup();
+        assertLoadedItemsCount(
+                "After reducing page size, 50 items should be loaded", 50,
+                disabledLazyLoadingBox);
+
+        scrollToItem(disabledLazyLoadingBox, 100);
+        assertLoadedItemsCount("Scrolling down should load further pages", 100,
+                disabledLazyLoadingBox);
+        assertRendered("99");
     }
 
     private void assertMessage(String expectedMessage) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -603,8 +603,10 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void refreshAllData(boolean forceServerSideFiltering) {
-        setClientSideFilter(!forceServerSideFiltering && getDataProvider()
-                .size(new Query<>()) <= getPageSizeDouble());
+        if (getDataProvider() != null) {
+            setClientSideFilter(!forceServerSideFiltering && getDataProvider()
+                    .size(new Query<>()) <= getPageSizeDouble());
+        }
 
         reset();
     }
@@ -765,7 +767,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                     "Page size should be greater than zero.");
         }
         super.setPageSize(pageSize);
-        reset();
+        refreshAllData(shouldForceServerSideFiltering);
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of #2744 as requested [here](https://github.com/vaadin/flow-components/issues/2736#issuecomment-1057795594).

(cherry picked from commit 1a5cb4f1761d1fecfc2ee46f5a2c8923587f40b7)
