### PR TITLE
chore: remove bean validation from integration tests

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -54,11 +54,6 @@
             <artifactId>vaadin-lumo-theme</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>6.1.0.Final</version>
-        </dependency>
-        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-core</artifactId>
             <scope>test</scope>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
@@ -5,7 +5,6 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Route("vaadin-date-picker/binder-validation")
@@ -41,7 +40,6 @@ public class BinderValidationView extends Div {
 
     public static class AData {
 
-        @NotNull
         private LocalDate date;
 
         public LocalDate getDate() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/BinderValidationPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/BinderValidationPage.java
@@ -20,7 +20,6 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 
-import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Route("vaadin-date-time-picker/binder-validation")
@@ -55,7 +54,6 @@ public class BinderValidationPage extends Div {
 
     public static class AData {
 
-        @NotNull
         private LocalDateTime time;
 
         public LocalDateTime getDateTime() {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/Entity.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/Entity.java
@@ -15,11 +15,8 @@
  */
 package com.vaadin.flow.component.radiobutton.tests;
 
-import javax.validation.constraints.NotNull;
-
 public class Entity {
 
-    @NotNull
     private String gender;
 
     public void setGender(String gender) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/BinderValidationPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/BinderValidationPage.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 
-import javax.validation.constraints.NotNull;
 import java.time.LocalTime;
 
 @Route("vaadin-time-picker/binder-validation")
@@ -58,7 +57,6 @@ public class BinderValidationPage extends Div {
 
     public static class AData {
 
-        @NotNull
         private LocalTime time;
 
         public LocalTime getTime() {


### PR DESCRIPTION
## Description

Removes the `hibernate-validator` dependency, and removes all bean validation constraints from all modules.

The `hibernate-validator` dependency is only necessary when using bean validation, for example by annotating a property with a constraint like `@NotNull`. In order to use bean validation, you need to use `BeanValidationBinder` instead of `Binder` [(see here)](https://vaadin.com/docs/latest/flow/binding-data/components-binder-beans/#defining-constraints-for-properties). However none of the integration tests actually use `BeanValidationBinder`, which means the dependency, and all bean validation constraints are not used at the moment. Also several IT modules have bean validation constraints without having the `hibernate-validator` dependency, which also would not work.

I checked if some of the tests actually rely on the bean validation constraints, and I could not find any, which in turn means none of the tests are actually broken. That means we can safely remove both. 

Another argument for removing bean validation from our tests is that when testing the integration of `Binder` with our components, we do not need to verify that bean validation works, that is a binder internal thing. For our test cases it's good enough to define custom validators, for example using `withValidator`. So there is also no need to keep  bean validation, or add it again in the future.

Makes #2764 obsolete.