### PR TITLE
fix: remove server-side modality on outside click

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPage.java
@@ -37,22 +37,31 @@ public class ModalityDialogsPage extends Div {
 
         Dialog nonModalDialog = setupNonModalDialog();
 
-        NativeButton modalButton = new NativeButton("Open modal dialog",
+        NativeButton openModal = new NativeButton("Open modal dialog",
                 event -> modalDialog.open());
-        modalButton.setId("open-modal-dialog");
+        openModal.setId("open-modal-dialog");
 
-        NativeButton button = new NativeButton("Open non modal dialog",
+        NativeButton addModal = new NativeButton("Add modal dialog to UI",
+                event -> add(modalDialog));
+        addModal.setId("add-modal-dialog");
+
+        NativeButton enableCloseOnOutsideClick = new NativeButton("Enable close on outside click",
+                event -> modalDialog.setCloseOnOutsideClick(true));
+        enableCloseOnOutsideClick.setId("enable-close-on-outside-click");
+
+        NativeButton openNonModal = new NativeButton("Open non modal dialog",
                 event -> nonModalDialog.open());
-        button.setId("open-dialog");
+        openNonModal.setId("open-non-modal-dialog");
 
-        NativeButton logButton = new NativeButton("Log",
-                event -> log.log("Clicked"));
-        logButton.setId("log");
+        NativeButton log = new NativeButton("Log",
+                event -> this.log.log("Clicked"));
+        log.setId("log");
 
         final NativeButton showModal = new NativeButton("Show Hidden Modal",
                 e -> modalDialog.setVisible(true));
         showModal.setId("show");
-        add(modalButton, showModal, button, logButton, new Hr(), log);
+
+        add(openModal, addModal, enableCloseOnOutsideClick, showModal, openNonModal, log, new Hr(), this.log);
     }
 
     private Dialog setupNonModalDialog() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
@@ -40,7 +40,7 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
     @Test
     public void openNonModalDialog_logButtonClickable() {
-        $(NativeButtonElement.class).id("open-dialog").click();
+        $(NativeButtonElement.class).id("open-non-modal-dialog").click();
 
         Assert.assertTrue("No dialog opened", $(DialogElement.class).exists());
         Assert.assertEquals("Only one dialog expected", 1,
@@ -87,6 +87,23 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
         $(NativeButtonElement.class).id("log").click();
 
+        Assert.assertEquals("Click should have resulted in a log message", 1,
+                $(DivElement.class).id(LOG_ID).$("div").all().size());
+    }
+
+    @Test
+    public void openModalDialog_outsideClickToCloseDialog_logButtonClickable() {
+        $(NativeButtonElement.class).id("add-modal-dialog").click();
+        $(NativeButtonElement.class).id("enable-close-on-outside-click").click();
+        $(NativeButtonElement.class).id("open-modal-dialog").click();
+
+        // Click anything to close dialog
+        $("body").first().click();
+        Assert.assertFalse("Dialog should be hidden",
+                $(DialogElement.class).first().isDisplayed());
+
+        // Now that dialog is closed, verify that click events work
+        $(NativeButtonElement.class).id("log").click();
         Assert.assertEquals("Click should have resulted in a log message", 1,
                 $(DivElement.class).id(LOG_ID).$("div").all().size());
     }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -87,6 +87,9 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         setOpened(false);
 
         getElement().addEventListener("opened-changed", event -> {
+            if (!isOpened()) {
+                setModality(false);
+            }
             if (autoAddedToTheUi && !isOpened()) {
                 getElement().removeFromParent();
                 autoAddedToTheUi = false;
@@ -586,10 +589,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         if (opened) {
             ensureAttached();
         }
-        if (isAttached()) {
-            getUI().ifPresent(ui -> ui.setChildComponentModal(this,
-                    opened ? isModal() : false));
-        }
+        setModality(opened && isModal());
         super.setOpened(opened);
     }
 
@@ -600,6 +600,12 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      */
     public boolean isOpened() {
         return super.isOpenedBoolean();
+    }
+
+    private void setModality(boolean modal) {
+        if (isAttached()) {
+            getUI().ifPresent(ui -> ui.setChildComponentModal(this, modal));
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes Dialog to remove server-side modality when closing the dialog on outside click, in case it has been added manually to the UI. 

Fixes a regression from #2608

## Type of change

- [x] Bugfix