### PR TITLE
feat: add theme variants support for CustomField

### DIFF
--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -21,6 +21,8 @@ package com.vaadin.flow.component.customfield;
  */
 
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -32,6 +34,7 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Synchronize;
@@ -58,7 +61,7 @@ import com.vaadin.flow.dom.Element;
 @JsModule("@vaadin/custom-field/src/vaadin-custom-field.js")
 public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
         implements HasSize, HasValidation, Focusable<CustomField>, HasHelper,
-        HasLabel {
+        HasLabel, HasTheme {
 
     /**
      * Default constructor.
@@ -229,4 +232,27 @@ public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
         getElement().setProperty("label", label);
     }
 
+    /**
+     * Adds theme variants to the component.
+     *
+     * @param variants
+     *            theme variants to add
+     */
+    public void addThemeVariants(CustomFieldVariant... variants) {
+        getThemeNames().addAll(
+                Stream.of(variants).map(CustomFieldVariant::getVariantName)
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Removes theme variants from the component.
+     *
+     * @param variants
+     *            theme variants to remove
+     */
+    public void removeThemeVariants(CustomFieldVariant... variants) {
+        getThemeNames().removeAll(
+                Stream.of(variants).map(CustomFieldVariant::getVariantName)
+                        .collect(Collectors.toList()));
+    }
 }

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomFieldVariant.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomFieldVariant.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.component.customfield;
+
+/**
+ * The set of theme variants applicable to the {@code vaadin-custom-field}
+ * component.
+ */
+public enum CustomFieldVariant {
+
+    LUMO_SMALL("small"), LUMO_HELPER_ABOVE_FIELD(
+            "helper-above-field"), LUMO_WHITESPACE("whitespace");
+
+    private final String variant;
+
+    CustomFieldVariant(String variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the variant name.
+     *
+     * @return variant name
+     */
+    public String getVariantName() {
+        return variant;
+    }
+}

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/CustomFieldVariantTest.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/CustomFieldVariantTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.customfield;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+
+public class CustomFieldVariantTest {
+
+    private CustomField<String> customField;
+
+    @Before
+    public void initTest() {
+        customField = new CustomField<String>() {
+            @Override
+            protected String generateModelValue() {
+                return null;
+            }
+
+            @Override
+            protected void setPresentationValue(String newPresentationValue) {
+
+            }
+        };
+    }
+
+    @Test
+    public void addLumoSmall_themeAttributeUpdated() {
+        assertThemeAttribute(null);
+        customField.addThemeVariants(CustomFieldVariant.LUMO_SMALL);
+        assertThemeAttribute("small");
+    }
+
+    @Test
+    public void addLumoHelperAboveField_themeAttributeUpdated() {
+        assertThemeAttribute(null);
+        customField
+                .addThemeVariants(CustomFieldVariant.LUMO_HELPER_ABOVE_FIELD);
+        assertThemeAttribute("helper-above-field");
+    }
+
+    @Test
+    public void addLumoWhitespace_themeAttributeUpdated() {
+        assertThemeAttribute(null);
+        customField.addThemeVariants(CustomFieldVariant.LUMO_WHITESPACE);
+        assertThemeAttribute("whitespace");
+    }
+
+    @Test
+    public void addAndRemoveMultipleVariants_themeAttributeUpdated() {
+        assertThemeAttribute(null);
+        customField.addThemeVariants(CustomFieldVariant.LUMO_SMALL);
+        customField
+                .addThemeVariants(CustomFieldVariant.LUMO_HELPER_ABOVE_FIELD);
+        assertThemeAttributeContains("helper-above-field");
+        assertThemeAttributeContains("small");
+        customField.removeThemeVariants(
+                CustomFieldVariant.LUMO_HELPER_ABOVE_FIELD);
+        assertThemeAttribute("small");
+    }
+
+    @Test
+    public void addAndRemoveAllMultipleVariants_themeAttributeUpdated() {
+        assertThemeAttribute(null);
+        customField.addThemeVariants(CustomFieldVariant.LUMO_SMALL);
+        customField
+                .addThemeVariants(CustomFieldVariant.LUMO_HELPER_ABOVE_FIELD);
+        customField.getThemeNames().clear();
+        assertThemeAttribute(null);
+    }
+
+    private void assertThemeAttribute(String expected) {
+        String actual = customField.getThemeName();
+        assertEquals("Unexpected theme attribute on custom field", expected,
+                actual);
+    }
+
+    private void assertThemeAttributeContains(String expected) {
+        String actual = customField.getThemeName();
+        assertTrue("Theme attribute not present on custom field",
+                actual.contains(expected));
+    }
+}


### PR DESCRIPTION
## Description

Added `HasTheme` and corresponding theme variants:

- [`small`](https://github.com/vaadin/web-components/blob/c24d5b231876be92d3efef93ed79870df818d98e/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js#L74)
- [`helper-above-field`](https://github.com/vaadin/web-components/blob/c24d5b231876be92d3efef93ed79870df818d98e/packages/vaadin-lumo-styles/mixins/helper.js#L37)
- [`whitespace`](https://github.com/vaadin/web-components/blob/c24d5b231876be92d3efef93ed79870df818d98e/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js#L88)

Part of #2343

## Type of change

- Feature