### PR TITLE
test: make sure menu item theme is preserved during item visibility toggle

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -82,14 +82,18 @@ public class MenuBarTestPage extends Div {
         });
         resetWidthButton.setId("reset-width");
 
-        NativeButton disableButton = new NativeButton("toggle disable items",
+        NativeButton disableItemButton = new NativeButton("toggle disable items",
                 e -> menuBar.getItems()
                         .forEach(item -> item.setEnabled(!item.isEnabled())));
-        disableButton.setId("toggle-disable");
+        disableItemButton.setId("toggle-disable");
 
-        NativeButton visibleButton = new NativeButton("toggle visible item 2",
+        NativeButton toggleItem1VisibilityButton = new NativeButton("toggle item 1 visibility",
+                e -> item1.setVisible(!item1.isVisible()));
+        toggleItem1VisibilityButton.setId("toggle-item-1-visibility");
+
+        NativeButton toggleItem2VisibilityButton = new NativeButton("toggle item 2 visibility",
                 e -> item2.setVisible(!item2.isVisible()));
-        visibleButton.setId("toggle-visible");
+        toggleItem2VisibilityButton.setId("toggle-item-2-visibility");
 
         NativeButton checkedButton = new NativeButton("toggle checked",
                 e -> checkable.setChecked(!checkable.isChecked()));
@@ -120,7 +124,7 @@ public class MenuBarTestPage extends Div {
                 });
         toggleMenuBarThemeButton.setId("toggle-theme");
 
-        NativeButton toggleMenuItemThemeButton = new NativeButton(
+        NativeButton toggleItem1ThemeButton = new NativeButton(
                 "toggle item theme", e -> {
                     if (item1.hasThemeName(MENU_ITEM_THEME)) {
                         item1.removeThemeNames(MENU_ITEM_THEME);
@@ -128,7 +132,7 @@ public class MenuBarTestPage extends Div {
                         item1.addThemeNames(MENU_ITEM_THEME);
                     }
                 });
-        toggleMenuItemThemeButton.setId("toggle-item-theme");
+        toggleItem1ThemeButton.setId("toggle-item-1-theme");
 
         NativeButton toggleSubItemThemeButton = new NativeButton(
                 "toggle sub theme", e -> {
@@ -142,9 +146,9 @@ public class MenuBarTestPage extends Div {
 
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
-                disableButton, visibleButton, checkedButton,
+                disableItemButton, toggleItem1VisibilityButton, toggleItem2VisibilityButton, checkedButton,
                 toggleAttachedButton, setI18nButton, toggleAttachedButton,
-                toggleMenuBarThemeButton, toggleMenuItemThemeButton,
+                toggleMenuBarThemeButton, toggleItem1ThemeButton,
                 toggleSubItemThemeButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -301,15 +301,15 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     @Test
     public void toggleItemVisible_buttonRemovedAndAdded() {
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
         assertButtonContents("item 1");
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
         assertButtonContents("item 1", "<p>item 2</p>");
     }
 
     @Test
     public void hiddenItemOverflows_overflowButtonNotRendered() {
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
         click("set-width");
         waitForResizeObserver();
         Assert.assertNull(menuBar.getOverflowButton());
@@ -320,14 +320,14 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("add-root-item");
         click("set-width");
         waitForResizeObserver();
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
 
         menuBar.getOverflowButton().click();
         assertOverlayContents("added item");
 
         clickBody();
         verifyClosed();
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
 
         menuBar.getOverflowButton().click();
         assertOverlayContents("<p>item 2</p>", "added item");
@@ -336,15 +336,15 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void hideParentButton_noClientError() {
         click("add-sub-item");
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
         checkLogsForErrors();
     }
 
     @Test
     public void hideParentButton_setVisible_subMenuRendered() {
         click("add-sub-item");
-        click("toggle-visible");
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
+        click("toggle-item-2-visibility");
         menuBar.getButtons().get(1).click();
         verifyNumOfOverlays(1);
         assertOverlayContents("added sub item");
@@ -359,7 +359,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
         // Verify client-code with setVisible functionality:
         menuBar = $(MenuBarElement.class).first();
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
         assertButtonContents("item 1");
     }
 
@@ -371,7 +371,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
         // Verify client-code with setVisible functionality:
         menuBar = $(MenuBarElement.class).first();
-        click("toggle-visible");
+        click("toggle-item-2-visibility");
         assertButtonContents("item 1");
     }
 
@@ -435,13 +435,22 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void toggleMenuItemTheme_themeIsToggled() {
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
         Assert.assertFalse(menuButton1.hasAttribute("theme"));
-        click("toggle-item-theme");
+        click("toggle-item-1-theme");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("theme"),
                 MenuBarTestPage.MENU_ITEM_THEME);
-        click("toggle-item-theme");
+        click("toggle-item-1-theme");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertFalse(menuButton1.hasAttribute("theme"));
+    }
+
+    @Test
+    public void setMenuItemTheme_toggleMenuItemVisibility_themeIsPreserved() {
+        click("toggle-item-1-theme");
+        click("toggle-item-1-visibility");
+        click("toggle-item-1-visibility");
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertEquals(menuButton1.getAttribute("theme"), MenuBarTestPage.MENU_ITEM_THEME);
     }
 
     @Test
@@ -466,7 +475,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void toggleMenuBarTheme_toggleMenuItemTheme_themeIsOverridden() {
         click("toggle-theme");
-        click("toggle-item-theme");
+        click("toggle-item-1-theme");
 
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(MenuBarTestPage.MENU_ITEM_THEME,

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -445,12 +445,22 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setMenuItemTheme_toggleMenuItemVisibility_themeIsPreserved() {
+    public void setMenuItemTheme_toggleVisibility_themeIsPreserved() {
         click("toggle-item-1-theme");
         click("toggle-item-1-visibility");
         click("toggle-item-1-visibility");
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("theme"), MenuBarTestPage.MENU_ITEM_THEME);
+    }
+
+    @Test
+    public void setMenuItemTheme_hide_resetTheme_show_themeIsNotSet() {
+        click("toggle-item-1-theme");
+        click("toggle-item-1-visibility");
+        click("toggle-item-1-theme");
+        click("toggle-item-1-visibility");
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("theme"));
     }
 
     @Test

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -454,7 +454,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setMenuItemTheme_hide_resetTheme_show_themeIsNotSet() {
+    public void setMenuItemTheme_hide_resetTheme_show_themeIsUnset() {
         click("toggle-item-1-theme");
         click("toggle-item-1-visibility");
         click("toggle-item-1-theme");


### PR DESCRIPTION
## Description

Added a couple of missing tests for the `MenuBar` component that make sure:

- The menu item `theme` attribute is preserved during the item's visibility toggle in the case the theme has been specified initially.
- The menu item `theme` attribute is also removed in the visible state after resetting the theme in the hidden state.

They are intended to cover the following logic:

https://github.com/vaadin/flow-components/blob/9615db2466baf55cb86c90f9e71aa294d47fd9df/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java#L51

https://github.com/vaadin/flow-components/blob/9615db2466baf55cb86c90f9e71aa294d47fd9df/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java#L224-L229

I would like to mention in advance that these tests are expected to start failing after we get merged https://github.com/vaadin/web-components/pull/3529 because it introduces the same-named `_theme` property in the menu-bar web component and which is read-only. This will be fixed in a separate PR.

A follow-up to https://github.com/vaadin/web-components/pull/3529.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
