### PR TITLE
chore: add the missing lumo-theme to dialog-integration-tests

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-lumo-theme</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-util</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Before:
![Screenshot 2022-03-10 at 15 17 22](https://user-images.githubusercontent.com/1222264/157670073-0ed51feb-767c-4a09-9698-6d88fc7f8604.png)

After:
![Screenshot 2022-03-10 at 15 12 06](https://user-images.githubusercontent.com/1222264/157670105-ec970db8-974e-4bed-9925-b25afbf43255.png)