### PR TITLE
refactor: rename private property `_theme` to `__theme`

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
         extends Component implements HasText, HasComponents, HasEnabled {
 
-    private static final String PRIVATE_THEME_ATTRIBUTE = "_theme";
+    private static final String PRIVATE_THEME_ATTRIBUTE = "__theme";
 
     private final C contextMenu;
     private S subMenu;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -92,7 +92,7 @@ import * as Gestures from "@vaadin/component-base/src/gestures.js";
               const item = {
                   component: child,
                   checked: child._checked,
-                  theme: child._theme
+                  theme: child.__theme
               };
               if (
                 child.tagName == "VAADIN-CONTEXT-MENU-ITEM" &&


### PR DESCRIPTION
## Description

The private property `_theme` that Flow uses internally for storing the menu bar item theme must be renamed to `__theme` in order to prevent it from possible interference with the web component's property `_theme` that has recently appeared in https://github.com/vaadin/web-components/pull/3529.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
