### PR TITLE
chore: update parent project to 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,9 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.5</version>
     </parent>
+    <url>https://vaadin.com/components</url>
     <properties>
         <flow.version>23.0-SNAPSHOT</flow.version>
         <testbench.version>8.0.0</testbench.version>


### PR DESCRIPTION
the older parent version generate invalid url for projects.

