### PR TITLE
feat: add HasStyle interface to CustomField

### DIFF
--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,7 @@ import com.vaadin.flow.dom.Element;
 @JsModule("@vaadin/custom-field/src/vaadin-custom-field.js")
 public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
         implements HasSize, HasValidation, Focusable<CustomField>, HasHelper,
-        HasLabel, HasTheme {
+        HasLabel, HasTheme, HasStyle {
 
     /**
      * Default constructor.

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/HasStyleTest.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/HasStyleTest.java
@@ -24,12 +24,13 @@ public class HasStyleTest {
     @Test
     public void customField() {
         CustomField<String> c = new CustomField<String>() {
-            @Override protected String generateModelValue() {
+            @Override
+            protected String generateModelValue() {
                 return null;
             }
 
-            @Override protected void setPresentationValue(
-                    String newPresentationValue) {
+            @Override
+            protected void setPresentationValue(String newPresentationValue) {
 
             }
         };

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/HasStyleTest.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/HasStyleTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.customfield;
+
+import com.vaadin.flow.component.HasStyle;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HasStyleTest {
+
+    @Test
+    public void customField() {
+        CustomField<String> c = new CustomField<String>() {
+            @Override protected String generateModelValue() {
+                return null;
+            }
+
+            @Override protected void setPresentationValue(
+                    String newPresentationValue) {
+
+            }
+        };
+        Assert.assertTrue(c instanceof HasStyle);
+    }
+
+}


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->

## Description
 
feat: Add HasStyle interface to CustomField

Some Flow components currently didn't implement the HasStyle interface, making it awkward to apply CSS classnames and inline styles to them. 

This code change adds this functionality.


Fixes #2852

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
