### PR TITLE
fix: Catch StaleElementReferenceException in selectByText

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxNavigationView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxNavigationView.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("combobox-navigation")
+public class ComboBoxNavigationView extends Div {
+
+    public ComboBoxNavigationView() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems("One", "Two", "Three", "Four");
+        comboBox.addValueChangeListener(event -> {
+            UI.getCurrent().navigate("combobox-navigation-out");
+        });
+
+        add(comboBox);
+    }
+
+    @Route("combobox-navigation-out")
+    public static class DummyView extends Div {
+        public DummyView() {
+            setId("dummy-view");
+            setText("Nothing here");
+        }
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxNavigationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxNavigationIT.java
@@ -29,6 +29,9 @@ public class ComboBoxNavigationIT extends AbstractComponentIT {
 
     @Test
     public void comboBoxNavigationTest() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
         ComboBoxElement combo = $(ComboBoxElement.class).first();
         combo.selectByText("Four");
         findElement(By.id("dummy-view"));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxNavigationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxNavigationIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("combobox-navigation")
+public class ComboBoxNavigationIT extends AbstractComponentIT {
+
+    @Test
+    public void comboBoxNavigationTest() {
+        ComboBoxElement combo = $(ComboBoxElement.class).first();
+        combo.selectByText("Four");
+        findElement(By.id("dummy-view"));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.combobox.testbench;
 import java.util.List;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
@@ -76,7 +76,11 @@ public class ComboBoxElement extends TestBenchElement
                 + "  var value = combobox._getItemValue(matches[0]);"
                 + "  combobox.value = value;" + "  return true;" //
                 + "}", this, text);
-        closePopup();
+        try {
+            closePopup();
+        } catch (StaleElementReferenceException e) {
+            // This can happen in navigation
+        }
         if (!success) {
             throw new IllegalArgumentException(
                     "Value '" + text + "' not found in the combobox");


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/2870