### PR TITLE
Add HasStyle interface to Crud #2853

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasTheme;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -73,7 +74,7 @@ import java.util.stream.Collectors;
 @NpmPackage(value = "@vaadin/vaadin-crud", version = "23.0.1")
 @JsModule("@vaadin/crud/src/vaadin-crud.js")
 @JsModule("@vaadin/crud/src/vaadin-crud-edit-column.js")
-public class Crud<E> extends Component implements HasSize, HasTheme {
+public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
 
     private static final String EDIT_COLUMN_KEY = "vaadin-crud-edit-column";
     private static final String EVENT_PREVENT_DEFAULT_JS = "event.preventDefault()";

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -96,8 +96,7 @@ public class CrudTest {
 
     @Test
     public void crudHasStyle() {
-        Crud<String> c = new Crud<>();
-        Assert.assertTrue(c instanceof HasStyle);
+        Assert.assertTrue(systemUnderTest instanceof HasStyle);
     }
 
     private Grid<Thing> createFakeGrid() {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudTest.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.crud;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.provider.DataCommunicator;
@@ -91,6 +92,12 @@ public class CrudTest {
     public void getToolbarVisible_setVisibleToFalse_returnsFalse() {
         systemUnderTest.setToolbarVisible(false);
         Assert.assertEquals(false, systemUnderTest.getToolbarVisible());
+    }
+
+    @Test
+    public void crudHasStyle() {
+        Crud<String> c = new Crud<>();
+        Assert.assertTrue(c instanceof HasStyle);
     }
 
     private Grid<Thing> createFakeGrid() {


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->

## Description
 
feat: Add HasStyle interface to CRUD component

Some Flow components currently didn't implement the HasStyle interface, making it awkward to apply CSS classnames and inline styles to them. 

This code change adds this functionality.


Fixes #2853

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
