### PR TITLE
 feat: Add HasStyle interface to AppLayout #2854

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -24,14 +24,7 @@ import java.util.Objects;
  * #L%
  */
 
-import com.vaadin.flow.component.AttachEvent;
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasElement;
-import com.vaadin.flow.component.PropertyDescriptor;
-import com.vaadin.flow.component.PropertyDescriptors;
-import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.*;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.SerializableConsumer;
@@ -51,7 +44,7 @@ import elemental.json.JsonType;
 @NpmPackage(value = "@vaadin/app-layout", version = "23.0.1")
 @NpmPackage(value = "@vaadin/vaadin-app-layout", version = "23.0.1")
 @JsModule("@vaadin/app-layout/src/vaadin-app-layout.js")
-public class AppLayout extends Component implements RouterLayout {
+public class AppLayout extends Component implements RouterLayout, HasStyle {
     private static final PropertyDescriptor<String, String> primarySectionProperty = PropertyDescriptors
             .propertyWithDefault("primarySection",
                     Section.NAVBAR.toWebcomponentValue());

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -24,7 +24,15 @@ import java.util.Objects;
  * #L%
  */
 
-import com.vaadin.flow.component.*;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.PropertyDescriptor;
+import com.vaadin.flow.component.PropertyDescriptors;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.SerializableConsumer;

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
@@ -184,8 +184,7 @@ public class AppLayoutTest {
 
     @Test
     public void hasStyle() {
-        AppLayout appLayout = new AppLayout();
-        Assert.assertTrue(appLayout instanceof HasStyle);
+        Assert.assertTrue(systemUnderTest instanceof HasStyle);
     }
 
     private void testDrawerOpened(boolean expectedDrawerOpened) {

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
@@ -2,8 +2,11 @@ package com.vaadin.flow.component.applayout;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -177,6 +180,12 @@ public class AppLayoutTest {
                 .setDrawer("Custom Drawer");
         systemUnderTest.setI18n(i18n);
         assertEquals(i18n, systemUnderTest.getI18n());
+    }
+
+    @Test
+    public void hasStyle() {
+        AppLayout appLayout = new AppLayout();
+        Assert.assertTrue(appLayout instanceof HasStyle);
     }
 
     private void testDrawerOpened(boolean expectedDrawerOpened) {


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->

## Description
 
feat: Add HasStyle interface to App layout component

Some Flow components currently didn't implement the HasStyle interface, making it awkward to apply CSS classnames and inline styles to them. 

This code change adds this functionality.


Fixes #2853

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
