### PR TITLE
fix: ensure DatePicker initializes client side value property

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -83,10 +83,6 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
      */
     public DatePicker() {
         this((LocalDate) null, true);
-        // Trigger model-to-presentation conversion in constructor, so that
-        // the client side component has a correct initial value of an empty
-        // string
-        this.setPresentationValue(null);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -83,6 +83,10 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
      */
     public DatePicker() {
         this((LocalDate) null, true);
+        // Trigger model-to-presentation conversion in constructor, so that
+        // the client side component has a correct initial value of an empty
+        // string
+        this.setPresentationValue(null);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1197,6 +1197,11 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
             boolean isInitialValueOptional) {
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
+        // Only apply initial value if the element does not already have a value
+        // (this can be the case when binding to an existing element from a Lit
+        // template), or if isInitialValueOptional enforces setting the initial
+        // value, which is the case when calling a DatePicker constructor with a
+        // custom initial value.
         if ((getElement().getProperty("value") == null
                 || !isInitialValueOptional)) {
             setPresentationValue(initialValue);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1198,7 +1198,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
         if ((getElement().getProperty("value") == null
-                || !isInitialValueOptional) && initialValue != null) {
+                || !isInitialValueOptional) || initialValue == null) {
             setPresentationValue(initialValue);
         }
     }
@@ -1217,9 +1217,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     public GeneratedVaadinDatePicker(T initialValue, T defaultValue,
             boolean acceptNullValues) {
         super("value", defaultValue, acceptNullValues);
-        if (initialValue != null) {
-            setPresentationValue(initialValue);
-        }
+        setPresentationValue(initialValue);
     }
 
     /**
@@ -1247,9 +1245,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
             SerializableBiFunction<R, T, P> modelToPresentation) {
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
-        if (initialValue != null) {
-            setPresentationValue(initialValue);
-        }
+        setPresentationValue(initialValue);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1198,7 +1198,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
         if ((getElement().getProperty("value") == null
-                || !isInitialValueOptional) || initialValue == null) {
+                || !isInitialValueOptional)) {
             setPresentationValue(initialValue);
         }
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -38,17 +38,6 @@ public class DatePickerTest {
 
     private static final String OPENED_PROPERTY_NOT_UPDATED = "The server-side \"opened\"-property was not updated synchronously";
 
-    private static final LocalDate TEST_VALUE = LocalDate.now();
-
-    private static class TestDatePicker
-            extends GeneratedVaadinDatePicker<TestDatePicker, LocalDate> {
-
-        TestDatePicker() {
-            super(TEST_VALUE, null, String.class, value -> null, value -> null,
-                    true);
-        }
-    }
-
     @Test
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         DatePicker picker = new DatePicker();
@@ -146,12 +135,12 @@ public class DatePickerTest {
 
         Mockito.when(service.getInstantiator()).thenReturn(instantiator);
 
-        Mockito.when(instantiator.createComponent(TestDatePicker.class))
-                .thenAnswer(invocation -> new TestDatePicker());
+        Mockito.when(instantiator.createComponent(DatePicker.class))
+                .thenAnswer(invocation -> new DatePicker());
 
-        TestDatePicker field = Component.from(element, TestDatePicker.class);
+        DatePicker field = Component.from(element, DatePicker.class);
         Assert.assertEquals("2007-12-03",
-                field.getElement().getPropertyRaw("value"));
+                field.getElement().getProperty("value"));
     }
 
     public void assertClearButtonPropertyValueEquals(DatePicker picker,

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -54,7 +54,7 @@ public class DatePickerTest {
         DatePicker picker = new DatePicker();
 
         Assert.assertNull(picker.getValue());
-        Assert.assertFalse(picker.getElement().hasProperty("value"));
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
 
         picker.setValue(LocalDate.of(2018, 4, 25));
         Assert.assertEquals("2018-04-25",
@@ -73,7 +73,7 @@ public class DatePickerTest {
     public void defaultCtor_does_not_update_values() {
         DatePicker picker = new DatePicker();
         Assert.assertNull(picker.getValue());
-        Assert.assertNull(picker.getElement().getProperty("value"));
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -50,11 +50,22 @@ public class DatePickerTest {
     }
 
     @Test
-    public void datePicker_basicCases() {
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         DatePicker picker = new DatePicker();
-
         Assert.assertNull(picker.getValue());
         Assert.assertEquals("", picker.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        DatePicker picker = new DatePicker((LocalDate) null);
+        Assert.assertNull(picker.getValue());
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void datePicker_basicCases() {
+        DatePicker picker = new DatePicker();
 
         picker.setValue(LocalDate.of(2018, 4, 25));
         Assert.assertEquals("2018-04-25",
@@ -67,13 +78,6 @@ public class DatePickerTest {
         // https://github.com/vaadin/flow/issues/3994
         picker.getElement().setProperty("value", null);
         Assert.assertNull(picker.getValue());
-    }
-
-    @Test
-    public void defaultCtor_does_not_update_values() {
-        DatePicker picker = new DatePicker();
-        Assert.assertNull(picker.getValue());
-        Assert.assertEquals("", picker.getElement().getProperty("value"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes DatePicker such that to make it initialize the web component's `value` property with an empty string rather than leave it to be `null` when DatePicker is being instantiated with no value. This is needed to prevent the `value-changed` event on the server side which happens as a result of Polymer converting `null` to `""`.

It pretty much reproduces the fix made for Select a while ago in https://github.com/vaadin/flow-components/commit/14676def81188ec9a674bfe202ebac8d71b65067#diff-1c027c9076652ce3a2c641ac7407c10cc3a87846a37ee152c27aa9fe59aad609R126-R129

The same fix will be made for TimePicker, but in a separate PR.

Part of #2691

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.