### PR TITLE
fix: ensure TimePicker initializes client side value property

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -871,7 +871,7 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
         // Only apply initial value if the element does not already have a value
         // (this can be the case when binding to an existing element from a Lit
         // template), or if isInitialValueOptional enforces setting the initial
-        // value, which is the case when calling a DatePicker constructor with a
+        // value, which is the case when calling a TimePicker constructor with a
         // custom initial value.
         if ((getElement().getProperty("value") == null
                 || !isInitialValueOptional)) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -868,8 +868,13 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
             boolean isInitialValueOptional) {
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
+        // Only apply initial value if the element does not already have a value
+        // (this can be the case when binding to an existing element from a Lit
+        // template), or if isInitialValueOptional enforces setting the initial
+        // value, which is the case when calling a DatePicker constructor with a
+        // custom initial value.
         if ((getElement().getProperty("value") == null
-                || !isInitialValueOptional) && initialValue != null) {
+                || !isInitialValueOptional)) {
             setPresentationValue(initialValue);
         }
     }
@@ -913,9 +918,7 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
     public GeneratedVaadinTimePicker(T initialValue, T defaultValue,
             boolean acceptNullValues) {
         super("value", defaultValue, acceptNullValues);
-        if (initialValue != null) {
-            setPresentationValue(initialValue);
-        }
+        setPresentationValue(initialValue);
     }
 
     /**
@@ -943,9 +946,7 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
             SerializableBiFunction<R, T, P> modelToPresentation) {
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
-        if (initialValue != null) {
-            setPresentationValue(initialValue);
-        }
+        setPresentationValue(initialValue);
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -29,7 +29,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.timepicker.GeneratedVaadinTimePicker;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
@@ -39,23 +38,30 @@ import com.vaadin.flow.server.VaadinSession;
 public class TimePickerTest {
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 
-    private static LocalTime TEST_VALUE = LocalTime.now();
+    @Test
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
+        TimePicker picker = new TimePicker();
+        Assert.assertNull(picker.getValue());
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
+    }
 
-    private static class TestTimePicker
-            extends GeneratedVaadinTimePicker<TestTimePicker, LocalTime> {
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        TimePicker picker = new TimePicker((LocalTime) null);
+        Assert.assertNull(picker.getValue());
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
+    }
 
-        TestTimePicker() {
-            super(TEST_VALUE, null, String.class, value -> null, value -> null,
-                    true);
-        }
+    @Test
+    public void initialValueIsTime_valuePropertyHasInitialValue() {
+        TimePicker picker = new TimePicker(LocalTime.of(9, 32));
+        assertEquals(LocalTime.of(9, 32), picker.getValue());
+        assertEquals("09:32", picker.getElement().getProperty("value"));
     }
 
     @Test
     public void timePicker_basicCases() {
         TimePicker picker = new TimePicker();
-
-        assertEquals(null, picker.getValue());
-        assertFalse(picker.getElement().hasProperty("value"));
 
         picker.setValue(LocalTime.of(5, 30));
         assertEquals("05:30", picker.getElement().getProperty("value"));
@@ -69,13 +75,6 @@ public class TimePickerTest {
         TimePicker timePicker = new TimePicker();
         timePicker.setValue(null);
         assertEquals(null, timePicker.getValue());
-    }
-
-    @Test
-    public void setInitialValue() {
-        TimePicker picker = new TimePicker(LocalTime.of(9, 32));
-        assertEquals(LocalTime.of(9, 32), picker.getValue());
-        assertEquals("09:32", picker.getElement().getProperty("value"));
     }
 
     @Test
@@ -242,7 +241,7 @@ public class TimePickerTest {
     public void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
         Element element = new Element("vaadin-time-picker");
 
-        String value = TEST_VALUE.plus(31l, ChronoUnit.MINUTES).toString();
+        String value = LocalTime.now().plus(31l, ChronoUnit.MINUTES).toString();
         element.setProperty("value", value);
         UI ui = new UI();
         UI.setCurrent(ui);
@@ -255,10 +254,10 @@ public class TimePickerTest {
 
         Mockito.when(service.getInstantiator()).thenReturn(instantiator);
 
-        Mockito.when(instantiator.createComponent(TestTimePicker.class))
-                .thenAnswer(invocation -> new TestTimePicker());
+        Mockito.when(instantiator.createComponent(TimePicker.class))
+                .thenAnswer(invocation -> new TimePicker());
 
-        TestTimePicker field = Component.from(element, TestTimePicker.class);
+        TimePicker field = Component.from(element, TimePicker.class);
         Assert.assertEquals(value, field.getElement().getPropertyRaw("value"));
     }
 


### PR DESCRIPTION
## Description

Fixes TimePicker so that it initializes the web component's `value` property with an empty string rather than leaves it to be `null` when TimePicker is being instantiated with no value. This is needed to prevent the `value-changed` event on the server side which comes from the client side as a result of Polymer converting `null` to `""`.

Part of #2691

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.