### PR TITLE
fix: ensure DateTimePicker initializes client side value property

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -144,12 +144,14 @@ public class DateTimePicker
             setPresentationValue(initialDateTime);
             synchronizeChildComponentValues(initialDateTime);
         } else if (this.getElement().getProperty("value") == null) {
-            // Apply `null` as a value to force the client side `value` property to be initialized with an empty string.
-            // Having an empty string will prevent `ValueChangeEvent` which otherwise can be triggered
-            // as a result of Polymer converting `null` to an empty string by itself.
+            // Apply `null` as a value to force the client side `value` property
+            // to be initialized with an empty string. Having an empty string
+            // will prevent `ValueChangeEvent` which otherwise can be triggered
+            // in response to Polymer converting `null` to an empty string by
+            // itself.
             // Only apply `null` if the element does not already have a value,
-            // which can be the case when binding to an existing element from a Lit
-            // template.
+            // which can be the case when binding to an existing element from a
+            // Lit template.
             setPresentationValue(null);
         }
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -143,6 +143,11 @@ public class DateTimePicker
             initialDateTime = sanitizeValue(initialDateTime);
             setPresentationValue(initialDateTime);
             synchronizeChildComponentValues(initialDateTime);
+        } else if (this.getElement().getProperty("value") == null) {
+            // Only apply initial value if the element does not already have a value,
+            // which can be the case when binding to an existing element from a Lit
+            // template.
+            setPresentationValue(null);
         }
 
         addToSlot(datePicker, "date-picker");

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -144,7 +144,10 @@ public class DateTimePicker
             setPresentationValue(initialDateTime);
             synchronizeChildComponentValues(initialDateTime);
         } else if (this.getElement().getProperty("value") == null) {
-            // Only apply initial value if the element does not already have a value,
+            // Apply `null` as a value to force the client side `value` property to be initialized with an empty string.
+            // Having an empty string will prevent `ValueChangeEvent` which otherwise can be triggered
+            // as a result of Polymer converting `null` to an empty string by itself.
+            // Only apply `null` if the element does not already have a value,
             // which can be the case when binding to an existing element from a Lit
             // template.
             setPresentationValue(null);

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -71,9 +71,12 @@ public class DateTimePickerTest {
 
     @Test
     public void initialValueIsDateTime_valuePropertyHasInitialValue() {
-        DateTimePicker picker = new DateTimePicker(LocalDateTime.of(2018, 4, 25, 13, 45, 10));
-        Assert.assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10), picker.getValue());
-        Assert.assertEquals("2018-04-25T13:45:10", picker.getElement().getProperty("value"));
+        DateTimePicker picker = new DateTimePicker(
+                LocalDateTime.of(2018, 4, 25, 13, 45, 10));
+        Assert.assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
+                picker.getValue());
+        Assert.assertEquals("2018-04-25T13:45:10",
+                picker.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -16,6 +16,10 @@
 package com.vaadin.flow.component.datetimepicker;
 
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -25,9 +29,12 @@ import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -46,6 +53,27 @@ public class DateTimePickerTest {
     @After
     public void tearDown() {
         UI.setCurrent(null);
+    }
+
+    @Test
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
+        DateTimePicker picker = new DateTimePicker();
+        Assert.assertNull(picker.getValue());
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        DateTimePicker picker = new DateTimePicker((LocalDateTime) null);
+        Assert.assertNull(picker.getValue());
+        Assert.assertEquals("", picker.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsDateTime_valuePropertyHasInitialValue() {
+        DateTimePicker picker = new DateTimePicker(LocalDateTime.of(2018, 4, 25, 13, 45, 10));
+        Assert.assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10), picker.getValue());
+        Assert.assertEquals("2018-04-25T13:45:10", picker.getElement().getProperty("value"));
     }
 
     @Test
@@ -153,5 +181,29 @@ public class DateTimePickerTest {
         picker.setAutoOpen(true);
         assertTrue("Should be possible to enable auto-open",
                 picker.isAutoOpen());
+    }
+
+    @Test
+    public void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
+        Element element = new Element("vaadin-date-time-picker");
+
+        String value = LocalDateTime.now().toString();
+        element.setProperty("value", value);
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(DateTimePicker.class))
+                .thenAnswer(invocation -> new DateTimePicker());
+
+        DateTimePicker field = Component.from(element, DateTimePicker.class);
+        Assert.assertEquals(value, field.getElement().getProperty("value"));
     }
 }


### PR DESCRIPTION
## Description

Fixes DateTimePicker so that it initializes the web component's `value` property with an empty string rather than leave it to be `null` when DateTimePicker is being instantiated with no value. This is needed to prevent the `value-changed` event on the server side which comes from the client side as a result of Polymer converting `null` to `""`.

Part of #2691

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
