### PR TITLE
feat: forward ConfirmDialog class name to overlay

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/StylingPage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/StylingPage.java
@@ -1,0 +1,39 @@
+package com.vaadin.flow.component.confirmdialog.examples;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-confirm-dialog/styling")
+public class StylingPage extends Div {
+    public StylingPage() {
+        ConfirmDialog dialog = new ConfirmDialog();
+
+        Button addDialog = new Button("Add dialog", e -> add(dialog));
+        addDialog.setId("add-dialog");
+
+        Button openDialog = new Button("Open dialog", e -> dialog.open());
+        openDialog.setId("open-dialog");
+
+        Button addClassNameFoo = new Button("Add class foo",
+                e -> dialog.addClassName("foo"));
+        addClassNameFoo.setId("add-foo");
+
+        Button setClassNameBar = new Button("Set class bar", e -> {
+            dialog.setClassName("foo bar");
+            dialog.getClassNames().set("foo", false);
+        });
+        setClassNameBar.setId("set-bar");
+
+        Button removeClassNames = new Button("Remove classes", e -> {
+            dialog.removeClassNames("foo", "bar");
+        });
+        removeClassNames.setId("remove-all");
+
+        dialog.add(setClassNameBar, removeClassNames);
+
+        add(addDialog, openDialog, addClassNameFoo);
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/StylingPage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/StylingPage.java
@@ -3,7 +3,6 @@ package com.vaadin.flow.component.confirmdialog.examples;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 @Route(value = "vaadin-confirm-dialog/styling")

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/StylingIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/StylingIT.java
@@ -1,7 +1,6 @@
 package com.vaadin.flow.component.confirmdialog.test;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.confirmdialog.examples.Dimensions;
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.flow.testutil.TestPath;

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/StylingIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/StylingIT.java
@@ -1,0 +1,83 @@
+package com.vaadin.flow.component.confirmdialog.test;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.confirmdialog.examples.Dimensions;
+import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-confirm-dialog/styling")
+public class StylingIT extends AbstractComponentIT {
+
+    private ButtonElement addDialog;
+    private ButtonElement openDialog;
+    private ButtonElement addFoo;
+
+    @Before
+    public void init() {
+        open();
+        addDialog = $(ButtonElement.class).id("add-dialog");
+        openDialog = $(ButtonElement.class).id("open-dialog");
+        addFoo = $(ButtonElement.class).id("add-foo");
+    }
+
+    @Test
+    public void addClassBeforeAdd() {
+        addFoo.click();
+
+        addDialog.click();
+        openDialog.click();
+
+        String value = getOverlayClassName();
+        Assert.assertEquals("foo", value);
+    }
+
+    @Test
+    public void addClassBeforeOpen() {
+        addDialog.click();
+
+        addFoo.click();
+        openDialog.click();
+
+        String value = getOverlayClassName();
+        Assert.assertEquals("foo", value);
+    }
+
+    @Test
+    public void addClassAfterOpen() {
+        openDialog.click();
+
+        $(ButtonElement.class).id("set-bar").click();
+
+        String value = getOverlayClassName();
+        Assert.assertEquals("bar", value);
+    }
+
+    @Test
+    public void removeClassAfterOpen() {
+        addFoo.click();
+        openDialog.click();
+
+        $(ButtonElement.class).id("remove-all").click();
+
+        String value = getOverlayClassName();
+        Assert.assertEquals("", value);
+    }
+
+    private ConfirmDialogElement getConfirmDialog() {
+        return $(ConfirmDialogElement.class).waitForFirst();
+    }
+
+    private TestBenchElement getOverlay() {
+        return ((TestBenchElement) getConfirmDialog().getContext());
+    }
+
+    private String getOverlayClassName() {
+        return getOverlay().getAttribute("class");
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/StylingIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/StylingIT.java
@@ -39,9 +39,8 @@ public class StylingIT extends AbstractComponentIT {
 
     @Test
     public void addClassBeforeOpen() {
-        addDialog.click();
-
         addFoo.click();
+
         openDialog.click();
 
         String value = getOverlayClassName();

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -16,6 +16,7 @@ package com.vaadin.flow.component.confirmdialog;
  * #L%
  */
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -43,6 +44,7 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@vaadin/confirm-dialog", version = "23.0.2")
 @NpmPackage(value = "@vaadin/vaadin-confirm-dialog", version = "23.0.2")
 @JsModule("@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js")
+@JsModule("./confirmDialogConnector.js")
 public class ConfirmDialog extends Component
         implements HasSize, HasStyle, HasOrderedComponents {
 
@@ -124,6 +126,17 @@ public class ConfirmDialog extends Component
 
     public void updateHeight() {
         this.getElement().executeJs("this._setHeight($0)", this.height);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        initConnector();
+    }
+
+    private void initConnector() {
+        getElement().executeJs(
+                "window.Vaadin.Flow.confirmDialogConnector.initLazy(this)");
     }
 
     private boolean autoAddedToTheUi;

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -126,6 +127,16 @@ public class ConfirmDialog extends Component
 
     public void updateHeight() {
         this.getElement().executeJs("this._setHeight($0)", this.height);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     *            ConfirmDialog does not support adding styles to overlay
+     */
+    @Override
+    public Style getStyle() {
+        throw new UnsupportedOperationException(
+                "ConfirmDialog does not support adding styles to overlay");
     }
 
     @Override

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/resources/META-INF/resources/frontend/confirmDialogConnector.js
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/resources/META-INF/resources/frontend/confirmDialogConnector.js
@@ -1,0 +1,34 @@
+(function () {
+    function copyClassName(dialog) {
+        const overlay = dialog._overlayElement;
+        if (overlay) {
+            overlay.className = dialog.className;
+        }
+    }
+
+    const observer = new MutationObserver((records) => {
+        records.forEach((mutation) => {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                copyClassName(mutation.target);
+            }
+        });
+    });
+
+    window.Vaadin.Flow.confirmDialogConnector = {
+        initLazy: function (dialog) {
+            if (dialog.$connector) {
+                return;
+            }
+
+            dialog.$connector = {};
+
+            dialog.addEventListener('opened-changed', (e) => {
+                if (e.detail.value) {
+                    copyClassName(dialog);
+                }
+            });
+
+            observer.observe(dialog, { attributes: true, attributeFilter: ['class'] });
+        }
+    };
+})();

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/resources/META-INF/resources/frontend/confirmDialogConnector.js
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/resources/META-INF/resources/frontend/confirmDialogConnector.js
@@ -29,6 +29,9 @@
             });
 
             observer.observe(dialog, { attributes: true, attributeFilter: ['class'] });
+
+            // Copy initial class
+            copyClassName(dialog);
         }
     };
 })();


### PR DESCRIPTION
## Description

Added logic to copy `className` from `vaadin-confirm-dialog` to its overlay element for styling.

Fixes #2909

## Type of change

- Feature