### PR TITLE
chore: use correct folder name for IT views

### DIFF
--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/main/java/com/vaadin/flow/component/cookieconsent/examples/CustomMessages.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/main/java/com/vaadin/flow/component/cookieconsent/examples/CustomMessages.java
@@ -1,4 +1,4 @@
-package com.vaadin.flow.component.confirmdialog.examples;
+package com.vaadin.flow.component.cookieconsent.examples;
 
 import com.vaadin.flow.component.cookieconsent.CookieConsent;
 import com.vaadin.flow.component.cookieconsent.CookieConsent.Position;

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/main/java/com/vaadin/flow/component/cookieconsent/examples/DefaultSettings.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/main/java/com/vaadin/flow/component/cookieconsent/examples/DefaultSettings.java
@@ -1,4 +1,4 @@
-package com.vaadin.flow.component.confirmdialog.examples;
+package com.vaadin.flow.component.cookieconsent.examples;
 
 import com.vaadin.flow.component.cookieconsent.CookieConsent;
 import com.vaadin.flow.component.html.Div;

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/CustomMessagesIT.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/CustomMessagesIT.java
@@ -2,7 +2,7 @@ package com.vaadin.flow.component.cookieconsent;
 
 import org.junit.Test;
 
-import com.vaadin.flow.component.confirmdialog.examples.CustomMessages;
+import com.vaadin.flow.component.cookieconsent.examples.CustomMessages;
 
 public class CustomMessagesIT extends AbstractParallelTest {
 

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/DefaultSettingsIT.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/DefaultSettingsIT.java
@@ -2,7 +2,7 @@ package com.vaadin.flow.component.cookieconsent;
 
 import org.junit.Test;
 
-import com.vaadin.flow.component.confirmdialog.examples.DefaultSettings;
+import com.vaadin.flow.component.cookieconsent.examples.DefaultSettings;
 import com.vaadin.flow.component.cookieconsent.testbench.CookieConsentElement.DefaultValues;
 
 public class DefaultSettingsIT extends AbstractParallelTest {


### PR DESCRIPTION
## Description

Fixed copy-paste: folder called `confirmdialog` placed in the `vaadin-cookie-consent-flow` IT package 🙈 

## Type of change

- Internal change