### PR TITLE
feat: add HasStyle interface to CookieConsent

### DIFF
--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
@@ -64,6 +64,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-polymer-template</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${flow.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/main/java/com/vaadin/flow/component/cookieconsent/examples/StylingPage.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/main/java/com/vaadin/flow/component/cookieconsent/examples/StylingPage.java
@@ -1,0 +1,35 @@
+package com.vaadin.flow.component.cookieconsent.examples;
+
+import com.vaadin.flow.component.cookieconsent.CookieConsent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-cookie-consent/styling")
+public class StylingPage extends Div {
+    public StylingPage() {
+        // Show buttons below the cookie banner
+        getStyle().set("padding-top", "100px");
+
+        CookieConsent consent = new CookieConsent();
+
+        NativeButton addConsent = new NativeButton("Add consent",
+                e -> add(consent));
+        addConsent.setId("add-consent");
+
+        NativeButton addClassEdgeless = new NativeButton("Set edgeless theme",
+                e -> {
+                    consent.addClassName("cc-theme-edgeless");
+                });
+        addClassEdgeless.setId("add-edgeless");
+
+        NativeButton setClassBottom = new NativeButton("Set position bottom",
+                e -> {
+                    consent.removeClassName("cc-top");
+                    consent.addClassName("cc-bottom");
+                });
+        setClassBottom.setId("set-bottom");
+
+        add(addConsent, addClassEdgeless, setClassBottom);
+    }
+}

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/StylingIT.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/StylingIT.java
@@ -1,0 +1,57 @@
+package com.vaadin.flow.component.cookieconsent;
+
+import com.vaadin.flow.component.cookieconsent.testbench.CookieConsentElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@TestPath("vaadin-cookie-consent/styling")
+public class StylingIT extends AbstractComponentIT {
+
+    private NativeButtonElement addConsent;
+    private NativeButtonElement addClassEdgeless;
+    private NativeButtonElement setClassBottom;
+
+    @Before
+    public void init() {
+        open();
+        addConsent = $(NativeButtonElement.class).id("add-consent");
+        addClassEdgeless = $(NativeButtonElement.class).id("add-edgeless");
+        setClassBottom = $(NativeButtonElement.class).id("set-bottom");
+    }
+
+    @Test
+    public void addClassBeforeAdd() {
+        addClassEdgeless.click();
+
+        addConsent.click();
+
+        String classValue = getBannerClassName();
+        Assert.assertTrue(classValue.contains("cc-theme-edgeless"));
+    }
+
+    @Test
+    public void addClassAfterAdd() {
+        addConsent.click();
+
+        setClassBottom.click();
+
+        String classValue = getBannerClassName();
+        Assert.assertFalse(classValue.contains("cc-top"));
+        Assert.assertTrue(classValue.contains("cc-bottom"));
+    }
+
+    private WebElement getConsentBanner() {
+        return findElement(By.cssSelector("div[role='alert']"));
+    }
+
+    private String getBannerClassName() {
+        return getConsentBanner().getAttribute("class");
+    }
+}

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/resources/META-INF/resources/frontend/cookieConsentConnector.js
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/resources/META-INF/resources/frontend/cookieConsentConnector.js
@@ -1,0 +1,31 @@
+(function () {
+    function copyClassName(consent) {
+        const popup = consent._getPopup();
+        if (popup) {
+            popup.className = consent.className;
+        }
+    }
+
+    const observer = new MutationObserver((records) => {
+        records.forEach((mutation) => {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                copyClassName(mutation.target);
+            }
+        });
+    });
+
+
+    window.Vaadin.Flow.cookieConsentConnector = {
+        initLazy: function (consent) {
+            if (consent.$connector) {
+                return;
+            }
+
+            consent.$connector = {};
+
+            observer.observe(consent, { attributes: true, attributeFilter: ['class'] });
+
+            copyClassName(consent);
+        }
+    };
+})();


### PR DESCRIPTION
## Description

Added `HasStyle` and the connector to copy CSS class names from the host to the cookie banner.
The classes initially set on the client side are collected on attach before initializing the connector.

Fixes #2855

## Type of change

- Feature