### PR TITLE
feat: add HasStyle to Notification and forward class to card

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-testbench</artifactId>
-            <version>23.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -89,6 +89,12 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-button-testbench</artifactId>
+            <version>23.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesPage.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesPage.java
@@ -24,18 +24,16 @@ import com.vaadin.flow.router.Route;
 public class NotificationWithClassNamesPage extends Div {
 
     public NotificationWithClassNamesPage() {
-        final Notification notification = new Notification();
+        final Notification notification = new Notification("Notification");
         notification.addClassName("custom");
 
         Button addClass = new Button("Add a class",
                 event -> notification.addClassName("added"));
-        addClass.setId("add-notification-btn");
-        notification.add(addClass);
+        addClass.setId("add-class-btn");
 
         Button clearAllClass = new Button("Clear all classes",
                 event -> notification.getClassNames().clear());
-        clearAllClass.setId("clear-notification-btn");
-        notification.add(clearAllClass);
+        clearAllClass.setId("clear-classes-btn");
 
         Button close = new Button("Close notification",
                 event -> notification.close());
@@ -44,19 +42,19 @@ public class NotificationWithClassNamesPage extends Div {
         Button open = new Button("Open notification",
                 event -> notification.open());
         open.setId("open-notification-btn");
-        add(open, close);
+        add(addClass, clearAllClass, open, close);
 
-        createDefaultNotification();
+        createOtherNotification();
     }
 
-    private void createDefaultNotification() {
+    private void createOtherNotification() {
         Button button = new Button("Open other notification");
         Notification notification = new Notification(
                 "This notification has text content", 3000);
         notification.addClassName("other");
         button.addClickListener(event -> notification.open());
         button.setId("open-other-notification-btn");
-        notification.setId("default-notification");
+        notification.setId("other-notification");
         add(button);
     }
 }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesPage.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesPage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.notification.tests;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-notification/notification-class-names-test")
+public class NotificationWithClassNamesPage extends Div {
+
+    public NotificationWithClassNamesPage() {
+        final Notification notification = new Notification();
+        notification.addClassName("custom");
+
+        Button addClass = new Button("Add a class",
+                event -> notification.addClassName("added"));
+        addClass.setId("add-notification-btn");
+        notification.add(addClass);
+
+        Button clearAllClass = new Button("Clear all classes",
+                event -> notification.getClassNames().clear());
+        clearAllClass.setId("clear-notification-btn");
+        notification.add(clearAllClass);
+
+        Button close = new Button("Close notification",
+                event -> notification.close());
+        close.setId("close-notification-btn");
+
+        Button open = new Button("Open notification",
+                event -> notification.open());
+        open.setId("open-notification-btn");
+        add(open, close);
+
+        createDefaultNotification();
+    }
+
+    private void createDefaultNotification() {
+        Button button = new Button("Open other notification");
+        Notification notification = new Notification(
+                "This notification has text content", 3000);
+        notification.addClassName("other");
+        button.addClickListener(event -> notification.open());
+        button.setId("open-other-notification-btn");
+        notification.setId("default-notification");
+        add(button);
+    }
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.notification.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.notification.testbench.NotificationElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-notification/notification-class-names-test")
+public class NotificationWithClassNamesIT extends AbstractComponentIT {
+
+    public static final String NOTIFICATION_CARD = "vaadin-notification-card";
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void openNotification_cardHasSameClassNames() {
+        findElement(By.id("open-notification-btn")).click();
+
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD));
+        NotificationElement notification = $(NotificationElement.class).first();
+
+        WebElement card = $(NOTIFICATION_CARD).first();
+
+        String cardClassNames = card.getAttribute("class");
+        String notificationClassNames = notification.getAttribute("class");
+
+        Assert.assertEquals("custom", notificationClassNames);
+        Assert.assertEquals("custom", cardClassNames);
+    }
+
+    @Test
+    public void openNotification_cardChangeClassName() {
+        findElement(By.id("open-notification-btn")).click();
+
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD));
+
+        findElement(By.id("add-notification-btn")).click();
+
+        WebElement card = $(NOTIFICATION_CARD).first();
+        NotificationElement notification = $(NotificationElement.class).first();
+
+        String cardClassNames = card.getAttribute("class");
+        String notificationClassNames = notification.getAttribute("class");
+
+        Assert.assertEquals("custom added", notificationClassNames);
+        Assert.assertEquals("custom added", cardClassNames);
+    }
+
+    @Test
+    public void openNotification_cardNoClassNameAfterClearClassName() {
+        findElement(By.id("open-notification-btn")).click();
+
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD));
+
+        findElement(By.id("clear-notification-btn")).click();
+
+        WebElement card = $(NOTIFICATION_CARD).first();
+        NotificationElement notification = $(NotificationElement.class).first();
+
+        String cardClassNames = card.getAttribute("class");
+        String notificationClassNames = notification.getAttribute("class");
+
+        Assert.assertEquals("", notificationClassNames);
+        Assert.assertEquals("", cardClassNames);
+    }
+
+    @Test
+    public void openNotification_cardChagedClassNameAfterSecondOpening() {
+        findElement(By.id("open-notification-btn")).click();
+
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD));
+
+        findElement(By.id("clear-notification-btn")).click();
+        findElement(By.id("add-notification-btn")).click();
+
+        findElement(By.id("close-notification-btn")).click();
+        waitForElementNotPresent(By.tagName(NOTIFICATION_CARD));
+
+        findElement(By.id("open-notification-btn")).click();
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD));
+
+        WebElement card = $(NOTIFICATION_CARD).first();
+        NotificationElement notification = $(NotificationElement.class).first();
+
+        String cardClassNames = card.getAttribute("class");
+        String notificationClassNames = notification.getAttribute("class");
+
+        Assert.assertEquals("added", notificationClassNames);
+        Assert.assertEquals("added", cardClassNames);
+    }
+
+    @Test
+    public void openTwoNotification_CorrectClassNamesApplied() {
+        findElement(By.id("open-notification-btn")).click();
+        findElement(By.id("open-other-notification-btn")).click();
+
+        waitForElementPresent(By.className("custom"));
+        waitForElementPresent(By.className("other"));
+
+        findElement(By.id("add-notification-btn")).click();
+
+        NotificationElement notification = $(NotificationElement.class).first();
+        WebElement card = $(NOTIFICATION_CARD).first();
+
+        NotificationElement otherNotification = $(NotificationElement.class)
+                .get(1);
+        WebElement otherCard = $(NOTIFICATION_CARD).get(1);
+
+        String cardClassNames = card.getAttribute("class");
+        String notificationClassNames = notification.getAttribute("class");
+
+        Assert.assertEquals("custom added", notificationClassNames);
+        Assert.assertEquals("custom added", cardClassNames);
+
+        String otherCardClassNames = otherCard.getAttribute("class");
+        String otherNotificationClassNames = otherNotification
+                .getAttribute("class");
+
+        Assert.assertEquals("other", otherCardClassNames);
+        Assert.assertEquals("other", otherNotificationClassNames);
+    }
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesIT.java
@@ -21,8 +21,10 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.notification.testbench.NotificationElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-notification/notification-class-names-test")
@@ -30,116 +32,101 @@ public class NotificationWithClassNamesIT extends AbstractComponentIT {
 
     public static final String NOTIFICATION_CARD = "vaadin-notification-card";
 
+    private ButtonElement openNotification;
+    private ButtonElement closeNotification;
+    private ButtonElement openOtherNotification;
+    private ButtonElement addClassName;
+    private ButtonElement clearClassNames;
+
     @Before
     public void init() {
         open();
+        openNotification = $(ButtonElement.class).id("open-notification-btn");
+        closeNotification = $(ButtonElement.class).id("close-notification-btn");
+        openOtherNotification = $(ButtonElement.class)
+                .id("open-other-notification-btn");
+        addClassName = $(ButtonElement.class).id("add-class-btn");
+        clearClassNames = $(ButtonElement.class).id("clear-classes-btn");
     }
 
     @Test
     public void openNotification_cardHasSameClassNames() {
-        findElement(By.id("open-notification-btn")).click();
-
+        openNotification.click();
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
+
         NotificationElement notification = $(NotificationElement.class).first();
-
-        WebElement card = $(NOTIFICATION_CARD).first();
-
-        String cardClassNames = card.getAttribute("class");
-        String notificationClassNames = notification.getAttribute("class");
-
-        Assert.assertEquals("custom", notificationClassNames);
-        Assert.assertEquals("custom", cardClassNames);
+        assertClassAttribute(notification, "custom");
     }
 
     @Test
     public void openNotification_cardChangeClassName() {
-        findElement(By.id("open-notification-btn")).click();
-
+        openNotification.click();
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
-        findElement(By.id("add-notification-btn")).click();
+        addClassName.click();
 
-        WebElement card = $(NOTIFICATION_CARD).first();
         NotificationElement notification = $(NotificationElement.class).first();
-
-        String cardClassNames = card.getAttribute("class");
-        String notificationClassNames = notification.getAttribute("class");
-
-        Assert.assertEquals("custom added", notificationClassNames);
-        Assert.assertEquals("custom added", cardClassNames);
+        assertClassAttribute(notification, "custom added");
     }
 
     @Test
     public void openNotification_cardNoClassNameAfterClearClassName() {
-        findElement(By.id("open-notification-btn")).click();
 
+        openNotification.click();
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
-        findElement(By.id("clear-notification-btn")).click();
+        clearClassNames.click();
 
-        WebElement card = $(NOTIFICATION_CARD).first();
         NotificationElement notification = $(NotificationElement.class).first();
-
-        String cardClassNames = card.getAttribute("class");
-        String notificationClassNames = notification.getAttribute("class");
-
-        Assert.assertEquals("", notificationClassNames);
-        Assert.assertEquals("", cardClassNames);
+        assertClassAttribute(notification, "");
     }
 
     @Test
     public void openNotification_cardChagedClassNameAfterSecondOpening() {
-        findElement(By.id("open-notification-btn")).click();
-
+        openNotification.click();
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
-        findElement(By.id("clear-notification-btn")).click();
-        findElement(By.id("add-notification-btn")).click();
+        clearClassNames.click();
+        addClassName.click();
 
-        findElement(By.id("close-notification-btn")).click();
+        closeNotification.click();
         waitForElementNotPresent(By.tagName(NOTIFICATION_CARD));
 
-        findElement(By.id("open-notification-btn")).click();
+        openNotification.click();
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
-        WebElement card = $(NOTIFICATION_CARD).first();
         NotificationElement notification = $(NotificationElement.class).first();
-
-        String cardClassNames = card.getAttribute("class");
-        String notificationClassNames = notification.getAttribute("class");
-
-        Assert.assertEquals("added", notificationClassNames);
-        Assert.assertEquals("added", cardClassNames);
+        assertClassAttribute(notification, "added");
     }
 
     @Test
     public void openTwoNotification_CorrectClassNamesApplied() {
-        findElement(By.id("open-notification-btn")).click();
-        findElement(By.id("open-other-notification-btn")).click();
+        openNotification.click();
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
-        waitForElementPresent(By.className("custom"));
-        waitForElementPresent(By.className("other"));
+        openOtherNotification.click();
 
-        findElement(By.id("add-notification-btn")).click();
+        waitForElementPresent(
+                By.cssSelector("vaadin-notification-card.custom"));
+        waitForElementPresent(By.cssSelector("vaadin-notification-card.other"));
+
+        addClassName.click();
 
         NotificationElement notification = $(NotificationElement.class).first();
-        WebElement card = $(NOTIFICATION_CARD).first();
+        assertClassAttribute(notification, "custom added");
 
         NotificationElement otherNotification = $(NotificationElement.class)
                 .get(1);
-        WebElement otherCard = $(NOTIFICATION_CARD).get(1);
+        assertClassAttribute(otherNotification, "other");
+    }
 
-        String cardClassNames = card.getAttribute("class");
-        String notificationClassNames = notification.getAttribute("class");
+    private void assertClassAttribute(TestBenchElement notification,
+            String expected) {
+        String className = notification.getAttribute("class");
+        Assert.assertEquals(expected, className);
 
-        Assert.assertEquals("custom added", notificationClassNames);
-        Assert.assertEquals("custom added", cardClassNames);
-
-        String otherCardClassNames = otherCard.getAttribute("class");
-        String otherNotificationClassNames = otherNotification
-                .getAttribute("class");
-
-        Assert.assertEquals("other", otherCardClassNames);
-        Assert.assertEquals("other", otherNotificationClassNames);
+        TestBenchElement card = (TestBenchElement) notification.getContext();
+        String cardClassName = card.getAttribute("class");
+        Assert.assertEquals(expected, cardClassName);
     }
 }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -28,12 +28,14 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.HtmlUtils;
 import com.vaadin.flow.shared.Registration;
@@ -44,8 +46,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @JsModule("./flow-component-renderer.js")
+@JsModule("./notificationConnector.js")
 public class Notification extends GeneratedVaadinNotification<Notification>
-        implements HasComponents, HasTheme {
+        implements HasComponents, HasTheme, HasStyle {
 
     private static final int DEFAULT_DURATION = 5000;
     private static final Position DEFAULT_POSITION = Position.BOTTOM_START;
@@ -78,7 +81,7 @@ public class Notification extends GeneratedVaadinNotification<Notification>
      * Enumeration of all available positions for notification component
      */
     public enum Position {
-        TOP_STRETCH, TOP_START, TOP_CENTER, TOP_END, MIDDLE, BOTTOM_START, BOTTOM_CENTER, BOTTOM_END, BOTTOM_STRETCH,;
+        TOP_STRETCH, TOP_START, TOP_CENTER, TOP_END, MIDDLE, BOTTOM_START, BOTTOM_CENTER, BOTTOM_END, BOTTOM_STRETCH;
 
         private final String clientName;
 
@@ -548,5 +551,26 @@ public class Notification extends GeneratedVaadinNotification<Notification>
         deferredJob = new AttachComponentTemplate();
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, context -> deferredJob.accept(ui)));
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        initConnector();
+    }
+
+    private void initConnector() {
+        getElement().executeJs(
+                "window.Vaadin.Flow.notificationConnector.initLazy(this)");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     *             Notification does not support adding styles to card element
+     */
+    @Override
+    public Style getStyle() {
+        throw new UnsupportedOperationException(
+                "Notification does not support adding styles to card element");
     }
 }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/resources/META-INF/resources/frontend/notificationConnector.js
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/resources/META-INF/resources/frontend/notificationConnector.js
@@ -1,0 +1,35 @@
+(function () {
+    function copyClassName(notification) {
+        const card = notification._card;
+        if (card) {
+            card.className = notification.className;
+        }
+    }
+
+    const observer = new MutationObserver((records) => {
+        records.forEach((mutation) => {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                copyClassName(mutation.target);
+            }
+        });
+    });
+
+    window.Vaadin.Flow.notificationConnector = {
+        initLazy: function (notification) {
+            if (notification.$connector) {
+                return;
+            }
+            notification.$connector = {};
+
+            notification.addEventListener('opened-changed', (e) => {
+                if (e.detail.value) {
+                    copyClassName(notification);
+                }
+            });
+
+            observer.observe(notification, { attributes: true, attributeFilter: ['class'] });
+
+            copyClassName(notification);
+        }
+    };
+})();

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -26,14 +26,17 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.VaadinSession;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,7 +46,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class NotificationTest {
 
-    private UI ui = new UI();
+    private final UI ui = new UI();
 
     @Before
     public void setUp() {
@@ -182,7 +185,10 @@ public class NotificationTest {
 
         notification.open();
 
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        UIInternals internals = ui.getInternals();
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        internals.setSession(session);
+        internals.getStateTree().runExecutionsBeforeClientResponse();
 
         Element templateElement = notification.getElement().getChildren()
                 .findFirst().get();
@@ -200,7 +206,10 @@ public class NotificationTest {
 
         notification.open();
 
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        UIInternals internals = ui.getInternals();
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        internals.setSession(session);
+        internals.getStateTree().runExecutionsBeforeClientResponse();
 
         Element templateElement = notification.getElement().getChildren()
                 .findFirst().get();

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
@@ -224,5 +225,11 @@ public class NotificationTest {
 
         Div div = new Div();
         notification.addComponentAtIndex(index, div);
+    }
+
+    @Test
+    public void hasStyle() {
+        Notification notification = new Notification();
+        Assert.assertTrue(notification instanceof HasStyle);
     }
 }


### PR DESCRIPTION
Added HasStyle and the connector to copy CSS class names from the host to the notifications.

Fixes #2857

## Type of change

- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.
