### PR TITLE
Formatter should always use LF line ending

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,7 @@
                 <configuration>
                     <configFile>https://raw.githubusercontent.com/vaadin/flow/master/eclipse/VaadinJavaConventions.xml</configFile>
                     <skipHtmlFormatting>true</skipHtmlFormatting>
+                    <lineEnding>LF</lineEnding>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This avoids issues when running `mvn formatter:format` on Windows machine. 