### PR TITLE
chore: Improve Javadocs 

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -35,8 +35,25 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Accordion is a a vertically stacked set of expandable panels. Only one panel
- * can be opened at a time.
+ * Accordion is a vertically stacked set of expandable panels. It reduces
+ * clutter and helps maintain the user’s focus by showing only the relevant
+ * content at a time.<br>
+ * <br>
+ *
+ * Accordion consists of stacked panels, each composed of two parts: a summary
+ * and a content area. Only one panel can be expanded at a time.<br>
+ * <br>
+ *
+ * The summary is the part that is always visible, and typically describes the
+ * contents, for example, with a title. Clicking on the summary toggles the
+ * content area’s visibility.<br>
+ * <br>
+ *
+ * The content area is the collapsible part of a panel. It can contain any
+ * component. When the content area is collapsed, the content is invisible and
+ * inaccessible by keyboard or screen reader.
+ *
+ * @author Vaadin Ltd
  */
 @Tag("vaadin-accordion")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.3")

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -40,14 +40,12 @@ import com.vaadin.flow.shared.Registration;
  * content at a time.
  * <p>
  * Accordion consists of stacked panels, each composed of two parts: a summary
- * and a content area. Only one panel can be expanded at a time.<br>
- * <br>
- *
+ * and a content area. Only one panel can be expanded at a time.
+ * <p>
  * The summary is the part that is always visible, and typically describes the
  * contents, for example, with a title. Clicking on the summary toggles the
- * content area’s visibility.<br>
- * <br>
- *
+ * content area’s visibility.
+ * <p>
  * The content area is the collapsible part of a panel. It can contain any
  * component. When the content area is collapsed, the content is invisible and
  * inaccessible by keyboard or screen reader.

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -37,9 +37,8 @@ import com.vaadin.flow.shared.Registration;
 /**
  * Accordion is a vertically stacked set of expandable panels. It reduces
  * clutter and helps maintain the user’s focus by showing only the relevant
- * content at a time.<br>
- * <br>
- *
+ * content at a time.
+ * <p>
  * Accordion consists of stacked panels, each composed of two parts: a summary
  * and a content area. Only one panel can be expanded at a time.<br>
  * <br>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -43,15 +43,13 @@ import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
 /**
- * App Layout is a component for building common application layouts.<br>
- * <br>
- *
+ * App Layout is a component for building common application layouts.
+ * <p>
  * The layout consists of three sections: a horizontal navigation bar (navbar),
  * a collapsible navigation drawer (drawer) and a content area. An application’s
  * main navigation blocks should be positioned in the navbar and/or drawer while
- * views are rendered in the content area.<br>
- * <br>
- *
+ * views are rendered in the content area.
+ * <p>
  * App Layout is responsive and adjusts automatically to fit desktop, tablet,
  * and mobile screen sizes.
  *

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -43,8 +43,19 @@ import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
 /**
- * Server-side component for the {@code <vaadin-app-layout>} element. Provides a
- * quick and easy way to get a common application layout.
+ * App Layout is a component for building common application layouts.<br>
+ * <br>
+ *
+ * The layout consists of three sections: a horizontal navigation bar (navbar),
+ * a collapsible navigation drawer (drawer) and a content area. An application’s
+ * main navigation blocks should be positioned in the navbar and/or drawer while
+ * views are rendered in the content area.<br>
+ * <br>
+ *
+ * App Layout is responsive and adjusts automatically to fit desktop, tablet,
+ * and mobile screen sizes.
+ *
+ * @author Vaadin Ltd
  */
 @Tag("vaadin-app-layout")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.3")

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -34,25 +34,20 @@ import java.util.stream.Stream;
 
 /**
  * Avatar is a graphical representation of an object or entity, for example a
- * person or an organisation.<br>
- * <br>
- *
- * Avatar has three properties: name, abbreviation and image.<br>
- * <br>
- *
+ * person or an organisation.
+ * <p>
+ * Avatar has three properties: name, abbreviation and image.
+ * <p>
  * The name is shown on hover in a tooltip. When a name is set, Avatar will
  * auto-generate and display an abbreviation of the specified name. For example,
- * “Allison Torres” becomes “AT”, “John Smith” becomes “JS”, etc.<br>
- * <br>
- *
+ * “Allison Torres” becomes “AT”, “John Smith” becomes “JS”, etc.
+ * <p>
  * The abbreviation can also be set manually. Abbreviations should be kept to a
- * maximum of 2–3 characters.<br>
- * <br>
- *
+ * maximum of 2–3 characters.
+ * <p>
  * Avatar can be used to display images, such as user profile pictures or
- * company logos. Abbreviations are not shown when images are used.<br>
- * <br>
- *
+ * company logos. Abbreviations are not shown when images are used.
+ * <p>
  * Note that this component is optimized for use with Collaboration Engine — a
  * simple way to build real-time collaboration into your app — but can also be
  * used standalone as a regular component.

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -33,7 +33,29 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Server-side component for the <code>vaadin-avatar</code> element.
+ * Avatar is a graphical representation of an object or entity, for example a
+ * person or an organisation.<br>
+ * <br>
+ *
+ * Avatar has three properties: name, abbreviation and image.<br>
+ * <br>
+ *
+ * The name is shown on hover in a tooltip. When a name is set, Avatar will
+ * auto-generate and display an abbreviation of the specified name. For example,
+ * “Allison Torres” becomes “AT”, “John Smith” becomes “JS”, etc.<br>
+ * <br>
+ *
+ * The abbreviation can also be set manually. Abbreviations should be kept to a
+ * maximum of 2–3 characters.<br>
+ * <br>
+ *
+ * Avatar can be used to display images, such as user profile pictures or
+ * company logos. Abbreviations are not shown when images are used.<br>
+ * <br>
+ *
+ * Note that this component is optimized for use with Collaboration Engine — a
+ * simple way to build real-time collaboration into your app — but can also be
+ * used standalone as a regular component.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -50,7 +50,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Server-side component for the <code>vaadin-avatar-group</code> element.
+ * Avatar Group is used to group multiple Avatars together. It can be used, for
+ * example, to show that there are multiple users viewing the same page or for
+ * listing members of a project.<br>
+ * <br>
+ *
+ * You can specify the max number of items an Avatar Group should display. Items
+ * that overflow are grouped into a single Avatar that displays the overflow
+ * count. The name of each hidden item is shown on hover in a tooltip. Clicking
+ * the overflow item displays the overflowing avatars and names in a list.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -52,9 +52,8 @@ import java.util.stream.Stream;
 /**
  * Avatar Group is used to group multiple Avatars together. It can be used, for
  * example, to show that there are multiple users viewing the same page or for
- * listing members of a project.<br>
- * <br>
- *
+ * listing members of a project.
+ * <p>
  * You can specify the max number of items an Avatar Group should display. Items
  * that overflow are grouped into a single Avatar that displays the overflow
  * count. The name of each hidden item is shown on hover in a tooltip. Clicking

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -34,7 +34,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Server-side component for the <code>vaadin-button</code> element.
+ * The Button component allows users to perform actions. It comes in several
+ * different style variants, and supports icons in addition to text labels.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
@@ -76,6 +76,21 @@ import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 import elemental.json.impl.JreJsonFactory;
 
+/**
+ * Vaadin Charts is a feature-rich interactive charting library for Vaadin. It
+ * provides multiple different chart types for visualizing one- or
+ * two-dimensional tabular data, or scatter data with free X and Y values. You
+ * can configure all the chart elements with a powerful API as well as the
+ * visual style using CSS. The built-in functionalities allow the user to
+ * interact with the chart elements in various ways, and you can define custom
+ * interaction with events.<br>
+ * <br>
+ *
+ * The Chart is a regular Vaadin component, which you can add to any Vaadin
+ * layout.
+ *
+ * @author Vaadin Ltd
+ */
 @Tag("vaadin-chart")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.3")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
@@ -83,9 +83,8 @@ import elemental.json.impl.JreJsonFactory;
  * can configure all the chart elements with a powerful API as well as the
  * visual style using CSS. The built-in functionalities allow the user to
  * interact with the chart elements in various ways, and you can define custom
- * interaction with events.<br>
- * <br>
- *
+ * interaction with events.
+ * <p>
  * The Chart is a regular Vaadin component, which you can add to any Vaadin
  * layout.
  *

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -28,9 +28,8 @@ import com.vaadin.flow.dom.PropertyChangeListener;
  * value is unchecked.
  * <p>
  * Checkbox also has a indeterminate mode, see {@link #isIndeterminate()} for
- * more info.<br>
- * <br>
- *
+ * more info.
+ * <p>
  * Use {@link com.vaadin.flow.component.checkbox CheckboxGroup} to group related
  * items. Individual checkboxes should be used for options that are not related
  * to each other in any way.

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -28,7 +28,12 @@ import com.vaadin.flow.dom.PropertyChangeListener;
  * value is unchecked.
  * <p>
  * Checkbox also has a indeterminate mode, see {@link #isIndeterminate()} for
- * more info.
+ * more info.<br>
+ * <br>
+ *
+ * Use {@link com.vaadin.flow.component.checkbox CheckboxGroup} to group related
+ * items. Individual checkboxes should be used for options that are not related
+ * to each other in any way.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -22,12 +22,9 @@ import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.dom.PropertyChangeListener;
 
 /**
- * Server-side component for the {@code vaadin-checkbox} element.
+ * Checkbox is an input field representing a binary choice.
  * <p>
- * Checkbox is a value component that can be checked or unchecked. The default
- * value is unchecked.
- * <p>
- * Checkbox also has a indeterminate mode, see {@link #isIndeterminate()} for
+ * Checkbox also has an indeterminate mode, see {@link #isIndeterminate()} for
  * more info.
  * <p>
  * Use {@link com.vaadin.flow.component.checkbox CheckboxGroup} to group related

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -65,7 +65,11 @@ import elemental.json.JsonArray;
  * Server-side component for the {@code vaadin-checkbox-group} element.
  * <p>
  * CheckBoxGroup is a multiselection component where items are displayed as
- * check boxes.
+ * check boxes.<br>
+ * <br>
+ *
+ * Use CheckBoxGroup to group related items. Individual checkboxes should be
+ * used for options that are not related to each other in any way.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -65,9 +65,8 @@ import elemental.json.JsonArray;
  * Server-side component for the {@code vaadin-checkbox-group} element.
  * <p>
  * CheckBoxGroup is a multiselection component where items are displayed as
- * check boxes.<br>
- * <br>
- *
+ * check boxes.
+ * <p>
  * Use CheckBoxGroup to group related items. Individual checkboxes should be
  * used for options that are not related to each other in any way.
  *

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -62,9 +62,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 
 /**
- * Server-side component for the {@code vaadin-checkbox-group} element.
- * <p>
- * CheckBoxGroup is a multiselection component where items are displayed as
+ * CheckBoxGroup is a multi-selection component where items are displayed as
  * check boxes.
  * <p>
  * Use CheckBoxGroup to group related items. Individual checkboxes should be

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -35,7 +35,24 @@ import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Server-side component for the {@code <vaadin-confirm-dialog>} element.
+ * Confirm Dialog is a modal Dialog used to confirm user actions.<br>
+ * <br>
+ *
+ * Confirm Dialog consists of:<br>
+ * <ul>
+ * <li>Title</li>
+ * <li>Message</li>
+ * <li>Footer</li>
+ * <ul>
+ * <li>“Cancel” button</li>
+ * <li>“Reject” button</li>
+ * <li>“Confirm” button</li>
+ * </ul>
+ * </ul>
+ *
+ * Each Confirm Dialog should have a title and/or message. The “Confirm” button
+ * is shown by default, while the two other buttons are not (they must be
+ * explicitly enabled to be displayed).
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -35,9 +35,8 @@ import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Confirm Dialog is a modal Dialog used to confirm user actions.<br>
- * <br>
- *
+ * Confirm Dialog is a modal Dialog used to confirm user actions.
+ * <p>
  * Confirm Dialog consists of:<br>
  * <ul>
  * <li>Title</li>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -25,9 +25,8 @@ import com.vaadin.flow.function.SerializableRunnable;
  * context menu. The menu appears on right (default) or left click. On a touch
  * device, a long press opens the context menu. You can use dividers to separate
  * and group related content. Use dividers sparingly, though, to avoid creating
- * unnecessary visual clutter.<br>
- * <br>
- *
+ * unnecessary visual clutter.
+ * <p>
  * Context Menu, like Menu Bar, supports multi-level sub-menus. You can use a
  * hierarchical menu to organize a large set of options and group related items.
  * Moreover, Context Menu supports checkable menu items that can be used to
@@ -35,9 +34,8 @@ import com.vaadin.flow.function.SerializableRunnable;
  * that they are unavailable. Menu items can also be customized to include more
  * than a single line of text. You can use left-click to open Context Menu in
  * situations where left-click does not have any other function, for example a
- * Grid without selection support.<br>
- * <br>
- *
+ * Grid without selection support.
+ * <p>
  * Best Practices:<br>
  * Context Menu is used to provide shortcuts to the user. You should not use it
  * as the only or primary means to complete a task. The primary way should be

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -21,7 +21,30 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.function.SerializableRunnable;
 
 /**
- * Server-side component for {@code <vaadin-context-menu>}.
+ * Context Menu is a component that you can attach to any component to display a
+ * context menu. The menu appears on right (default) or left click. On a touch
+ * device, a long press opens the context menu. You can use dividers to separate
+ * and group related content. Use dividers sparingly, though, to avoid creating
+ * unnecessary visual clutter.<br>
+ * <br>
+ *
+ * Context Menu, like Menu Bar, supports multi-level sub-menus. You can use a
+ * hierarchical menu to organize a large set of options and group related items.
+ * Moreover, Context Menu supports checkable menu items that can be used to
+ * toggle a setting on and off. It also supports disabling menu items to show
+ * that they are unavailable. Menu items can also be customized to include more
+ * than a single line of text. You can use left-click to open Context Menu in
+ * situations where left-click does not have any other function, for example a
+ * Grid without selection support.<br>
+ * <br>
+ *
+ * Best Practices:<br>
+ * Context Menu is used to provide shortcuts to the user. You should not use it
+ * as the only or primary means to complete a task. The primary way should be
+ * accessible elsewhere in the UI. Also note that you should use Context Menu
+ * when there is no dedicated button for opening an overlay menu, such as
+ * right-clicking a grid row. When there is a dedicated element/component, such
+ * as an overflow menu, use Menu Bar.
  *
  * @author Vaadin Ltd.
  */

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -31,7 +31,16 @@ import com.vaadin.flow.dom.Style;
 /**
  * Server-side component for the <code>vaadin-cookie-consent</code> element,
  * used for showing a cookie consent banner the first time a user visits the
- * application, until the banner is dismissed.
+ * application, until the banner is dismissed.<br>
+ * <br>
+ *
+ * By default, the banner is shown at the top of the screen with a predefined
+ * text, a link to cookiesandyou.com which explains what cookies are, and a
+ * consent button.<br>
+ * <br>
+ *
+ * Cookie Consent is fully customizable. You can customize the message, the
+ * "Learn More" link, the "Dismiss" button, as well as the component’s position.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -29,8 +29,8 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Style;
 
 /**
- * Cookie Consent is a component for showing a cookie consent banner the first time a user visits the
- * application, until the banner is dismissed.
+ * Cookie Consent is a component for showing a cookie consent banner the first
+ * time a user visits the application, until the banner is dismissed.
  * <p>
  * By default, the banner is shown at the top of the screen with a predefined
  * text, a link to cookiesandyou.com which explains what cookies are, and a

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -29,8 +29,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Style;
 
 /**
- * Server-side component for the <code>vaadin-cookie-consent</code> element,
- * used for showing a cookie consent banner the first time a user visits the
+ * Cookie Consent is a component for showing a cookie consent banner the first time a user visits the
  * application, until the banner is dismissed.
  * <p>
  * By default, the banner is shown at the top of the screen with a predefined

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -31,14 +31,12 @@ import com.vaadin.flow.dom.Style;
 /**
  * Server-side component for the <code>vaadin-cookie-consent</code> element,
  * used for showing a cookie consent banner the first time a user visits the
- * application, until the banner is dismissed.<br>
- * <br>
- *
+ * application, until the banner is dismissed.
+ * <p>
  * By default, the banner is shown at the top of the screen with a predefined
  * text, a link to cookiesandyou.com which explains what cookies are, and a
- * consent button.<br>
- * <br>
- *
+ * consent button.
+ * <p>
  * Cookie Consent is fully customizable. You can customize the message, the
  * "Learn More" link, the "Dismiss" button, as well as the component’s position.
  *

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -45,12 +45,11 @@ import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
 /**
- * Server-side component that encapsulates the functionality of the
- * {@code vaadin-date-picker} webcomponent.
+ * Date Picker is an input field that allows the user to enter a date by typing or by selecting from a calendar overlay.
  * <p>
- * It allows setting and getting {@link LocalDate} objects, setting minimum and
- * maximum date ranges and has internationalization support by using the
- * {@link DatePickerI18n} object.
+ * DatePicker allows setting and getting {@link LocalDate} objects, setting
+ * minimum and maximum date ranges and has internationalization support by using
+ * the {@link DatePickerI18n} object.
  * <p>
  * This component allows the date to be entered directly using the keyboard in
  * the format of the current locale or through the date picker overlay. The

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -45,7 +45,8 @@ import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
 /**
- * Date Picker is an input field that allows the user to enter a date by typing or by selecting from a calendar overlay.
+ * Date Picker is an input field that allows the user to enter a date by typing
+ * or by selecting from a calendar overlay.
  * <p>
  * DatePicker allows setting and getting {@link LocalDate} objects, setting
  * minimum and maximum date ranges and has internationalization support by using

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -50,8 +50,15 @@ import elemental.json.JsonType;
  * <p>
  * It allows setting and getting {@link LocalDate} objects, setting minimum and
  * maximum date ranges and has internationalization support by using the
- * {@link DatePickerI18n} object.
+ * {@link DatePickerI18n} object.<br>
+ * <br>
  *
+ * This component allows the date to be entered directly using the keyboard in
+ * the format of the current locale or through the date picker overlay. The
+ * overlay opens when the field is clicked and/or any input is entered when the
+ * field is focused.
+ *
+ * @author Vaadin Ltd
  */
 @JsModule("./datepickerConnector.js")
 @NpmPackage(value = "date-fns", version = "2.23.0")

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -50,9 +50,8 @@ import elemental.json.JsonType;
  * <p>
  * It allows setting and getting {@link LocalDate} objects, setting minimum and
  * maximum date ranges and has internationalization support by using the
- * {@link DatePickerI18n} object.<br>
- * <br>
- *
+ * {@link DatePickerI18n} object.
+ * <p>
  * This component allows the date to be entered directly using the keyboard in
  * the format of the current locale or through the date picker overlay. The
  * overlay opens when the field is clicked and/or any input is entered when the

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -63,9 +63,13 @@ class DateTimePickerTimePicker
 }
 
 /**
- * Server-side component that encapsulates the functionality of the
- * {@code vaadin-date-time-picker} web component.
+ * Date Time Picker is an input field for selecting both a date and a time. The
+ * date and time can be entered directly using a keyboard in the format of the
+ * current locale or through the Date Time Picker’s two overlays. The overlays
+ * open when their respective fields are clicked or any input is entered when
+ * the fields are focused.
  *
+ * @author Vaadin Ltd
  */
 @Tag("vaadin-date-time-picker")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.3")

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -40,6 +40,25 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.shared.Registration;
 
+/**
+ * Details is an expandable panel for showing and hiding content from the user
+ * to make the UI less crowded. Details consists of a summary and a content
+ * area.<br>
+ * <br>
+ *
+ * The Summary is the part that is always visible, and typically describes the
+ * contents, for example, with a title. Clicking on the summary toggles the
+ * content area’s visibility. The summary supports rich content and can contain
+ * any component. This can be utilized for example to indicate the status of the
+ * corresponding content.<br>
+ * <br>
+ *
+ * The content area is the collapsible part of Details. It can contain any
+ * component. When the content area is collapsed, the content is invisible and
+ * inaccessible by keyboard or screen reader.
+ *
+ * @author Vaadin Ltd
+ */
 @Tag("vaadin-details")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.0.3")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -43,16 +43,14 @@ import com.vaadin.flow.shared.Registration;
 /**
  * Details is an expandable panel for showing and hiding content from the user
  * to make the UI less crowded. Details consists of a summary and a content
- * area.<br>
- * <br>
- *
+ * area.
+ * <p>
  * The Summary is the part that is always visible, and typically describes the
  * contents, for example, with a title. Clicking on the summary toggles the
  * content area’s visibility. The summary supports rich content and can contain
  * any component. This can be utilized for example to indicate the status of the
- * corresponding content.<br>
- * <br>
- *
+ * corresponding content.
+ * <p>
  * The content area is the collapsible part of Details. It can contain any
  * component. When the content area is collapsed, the content is invisible and
  * inaccessible by keyboard or screen reader.

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -42,26 +42,22 @@ import com.vaadin.flow.shared.Registration;
 
 /**
  * A Dialog is a small window that can be used to present information and user
- * interface elements in an overlay.<br>
- * <br>
- *
+ * interface elements in an overlay.
+ * <p>
  * Dialogs can be made modal or non-modal. A modal Dialog blocks the user from
  * interacting with the rest of the user interface while the Dialog is open, as
- * opposed to a non-modal Dialog, which does not block interaction.<br>
- * <br>
- *
+ * opposed to a non-modal Dialog, which does not block interaction.
+ * <p>
  * Dialogs can be made draggable and resizable. When draggable, the user is able
  * to move them around using a pointing device. It is recommended to make
  * non-modal Dialogs draggable so that the user can interact with content that
  * might otherwise be obscured by the Dialog. A resizable Dialog allows the user
  * to resize the Dialog by dragging from the edges of the Dialog with a pointing
- * device. Dialogs are not resizable by default.<br>
- * <br>
- *
+ * device. Dialogs are not resizable by default.
+ * <p>
  * Dialogs automatically become scrollable when their content overflows. Custom
- * scrollable areas can be created using the Scroller component.<br>
- * <br>
- *
+ * scrollable areas can be created using the Scroller component.
+ * <p>
  * Best Practices:<br>
  * Dialogs are disruptive by nature and should be used sparingly. Do not use
  * them to communicate nonessential information, such as success messages like

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -41,7 +41,32 @@ import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Server-side component for the {@code <vaadin-dialog>} element.
+ * A Dialog is a small window that can be used to present information and user
+ * interface elements in an overlay.<br>
+ * <br>
+ *
+ * Dialogs can be made modal or non-modal. A modal Dialog blocks the user from
+ * interacting with the rest of the user interface while the Dialog is open, as
+ * opposed to a non-modal Dialog, which does not block interaction.<br>
+ * <br>
+ *
+ * Dialogs can be made draggable and resizable. When draggable, the user is able
+ * to move them around using a pointing device. It is recommended to make
+ * non-modal Dialogs draggable so that the user can interact with content that
+ * might otherwise be obscured by the Dialog. A resizable Dialog allows the user
+ * to resize the Dialog by dragging from the edges of the Dialog with a pointing
+ * device. Dialogs are not resizable by default.<br>
+ * <br>
+ *
+ * Dialogs automatically become scrollable when their content overflows. Custom
+ * scrollable areas can be created using the Scroller component.<br>
+ * <br>
+ *
+ * Best Practices:<br>
+ * Dialogs are disruptive by nature and should be used sparingly. Do not use
+ * them to communicate nonessential information, such as success messages like
+ * “Logged in”, “Copied”, and so on. Instead, use Notifications when
+ * appropriate.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -40,23 +40,20 @@ import elemental.json.JsonValue;
  * Form Layout allows you to build responsive forms with multiple columns and to
  * position input labels on top or to the side of the input. Form Layout has two
  * columns by default meaning it displays two input fields per line. When the
- * layout width is smaller it adjusts to a single column layout.<br>
- * <br>
- *
+ * layout width is smaller it adjusts to a single column layout.
+ * <p>
  * You can define how many columns Form Layout should use based on the screen
  * width. A single column layout is preferable to a multi column one. A multi
  * column layout is more prone to cause confusion and to be misinterpreted by
  * the user. However, closely related fields can be placed in line without
  * issue. For example, first and last name, address fields such as postal code
- * and city, as well as ranged input for dates, time, currency, etc.<br>
- * <br>
- *
+ * and city, as well as ranged input for dates, time, currency, etc.
+ * <p>
  * Best Practices:<br>
  * Longer forms should be split into smaller, more manageable and user-friendly
  * sections using subheadings, Tabs, Details or separate views when possible.
- * Each section should consist of related content and/or fields.<br>
- * <br>
- *
+ * Each section should consist of related content and/or fields.
+ * <p>
  * Also, use the following guidelines for Button placement in forms:<br>
  * <ul>
  * <li>Buttons should be placed below the form they’re associated with.</li>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -37,7 +37,33 @@ import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
 /**
- * Server-side component for the {@code <vaadin-form-layout>} element.
+ * Form Layout allows you to build responsive forms with multiple columns and to
+ * position input labels on top or to the side of the input. Form Layout has two
+ * columns by default meaning it displays two input fields per line. When the
+ * layout width is smaller it adjusts to a single column layout.<br>
+ * <br>
+ *
+ * You can define how many columns Form Layout should use based on the screen
+ * width. A single column layout is preferable to a multi column one. A multi
+ * column layout is more prone to cause confusion and to be misinterpreted by
+ * the user. However, closely related fields can be placed in line without
+ * issue. For example, first and last name, address fields such as postal code
+ * and city, as well as ranged input for dates, time, currency, etc.<br>
+ * <br>
+ *
+ * Best Practices:<br>
+ * Longer forms should be split into smaller, more manageable and user-friendly
+ * sections using subheadings, Tabs, Details or separate views when possible.
+ * Each section should consist of related content and/or fields.<br>
+ * <br>
+ *
+ * Also, use the following guidelines for Button placement in forms:<br>
+ * <ul>
+ * <li>Buttons should be placed below the form they’re associated with.</li>
+ * <li>Buttons should be aligned left.</li>
+ * <li>Primary action first, followed by other actions, in order of
+ * importance.</li>
+ * </ul>
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/ImageWMSSourceTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/ImageWMSSourceTest.java
@@ -19,7 +19,8 @@ public class ImageWMSSourceTest {
         Assert.assertEquals("testServerType", source.getServerType());
         Assert.assertEquals("testCrossOrigin", source.getCrossOrigin());
         Assert.assertEquals("testProjection", source.getProjection());
-        Assert.assertEquals("testAttributions", source.getAttributions().get(0));
+        Assert.assertEquals("testAttributions",
+                source.getAttributions().get(0));
         Assert.assertFalse(source.isAttributionsCollapsible());
     }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/OSMSourceTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/OSMSourceTest.java
@@ -15,7 +15,8 @@ public class OSMSourceTest {
         Assert.assertEquals("https://example.com", source.getUrl());
         Assert.assertEquals("testCrossOrigin", source.getCrossOrigin());
         Assert.assertEquals("testProjection", source.getProjection());
-        Assert.assertEquals("testAttributions", source.getAttributions().get(0));
+        Assert.assertEquals("testAttributions",
+                source.getAttributions().get(0));
         Assert.assertFalse(source.isAttributionsCollapsible());
         Assert.assertTrue(source.isOpaque());
     }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/TileWMSSourceTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/TileWMSSourceTest.java
@@ -18,7 +18,8 @@ public class TileWMSSourceTest {
         Assert.assertEquals("testServerType", source.getServerType());
         Assert.assertEquals("testCrossOrigin", source.getCrossOrigin());
         Assert.assertEquals("testProjection", source.getProjection());
-        Assert.assertEquals("testAttributions", source.getAttributions().get(0));
+        Assert.assertEquals("testAttributions",
+                source.getAttributions().get(0));
         Assert.assertFalse(source.isAttributionsCollapsible());
         Assert.assertTrue(source.isOpaque());
     }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/VectorSourceTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/VectorSourceTest.java
@@ -13,7 +13,8 @@ public class VectorSourceTest {
         VectorSource source = new VectorSource(options);
 
         Assert.assertEquals("testProjection", source.getProjection());
-        Assert.assertEquals("testAttributions", source.getAttributions().get(0));
+        Assert.assertEquals("testAttributions",
+                source.getAttributions().get(0));
         Assert.assertFalse(source.isAttributionsCollapsible());
     }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/XYZSourceTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/source/XYZSourceTest.java
@@ -15,7 +15,8 @@ public class XYZSourceTest {
         Assert.assertEquals("https://example.com", source.getUrl());
         Assert.assertEquals("testCrossOrigin", source.getCrossOrigin());
         Assert.assertEquals("testProjection", source.getProjection());
-        Assert.assertEquals("testAttributions", source.getAttributions().get(0));
+        Assert.assertEquals("testAttributions",
+                source.getAttributions().get(0));
         Assert.assertFalse(source.isAttributionsCollapsible());
         Assert.assertTrue(source.isOpaque());
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -29,7 +29,14 @@ import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
 
 /**
- * Server-side component for the {@code vaadin-email-field} element.
+ * Email Field is an extension of Text Field that only accepts email addresses
+ * as input. If the given address is invalid, the field is highlighted in red
+ * and an error message appears underneath the input. The validity of the email
+ * addresses is checked according to the RFC 5322 standard, which includes the
+ * format for email addresses. The component also supports supplying additional
+ * validation criteria using a regular expression (see
+ * {@link #setPattern(String)}). These extra validation criteria can be used,
+ * for example, to require a specific email domain.
  *
  * @author Vaadin Ltd.
  */


### PR DESCRIPTION
The new descriptions of the components are mostly taken from their descriptions in the [docs](https://vaadin.com/docs/latest/ds/components). 

For example, instead of the Button docs saying
```
/**
 * Server-side component for the <code>vaadin-button</code> element.
 */
```

It will be changed to say
```
/**
 * The Button component allows users to perform actions. It comes in several
 * style variants, and supports icons in addition to text labels.
 */
```