### PR TITLE
fix: grid selection column indeterminate state

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -31,7 +31,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
     private static final String SELECT_ALL_CHECKBOX_ID = "selectAllCheckbox";
 
     @Test
-    public void selectAllCheckbox() {
+    public void selectAllCheckbox_visibility() {
         open();
         WebElement definedItemCountLazyGrid = findElement(By.id(
                 GridMultiSelectionColumnPage.DEFINED_ITEM_COUNT_LAZY_GRID_ID));
@@ -58,29 +58,73 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         Assert.assertNull(
                 "in-memory grid selectAllCheckbox should be visible by default",
                 selectAllCheckbox.getAttribute("hidden"));
+    }
 
-        selectAllCheckbox.click();
+    @Test
+    public void selectAllCheckbox_state() {
+        open();
+        WebElement grid = findElement(
+                By.id(GridMultiSelectionColumnPage.IN_MEMORY_GRID_ID));
+        WebElement selectAllCheckbox = grid
+                .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
+        WebElement selectCheckbox = grid
+                .findElements(By.tagName("vaadin-checkbox")).get(5);
         WebElement message = findElement(By.id("selected-item-count"));
+
+        // Initial
+        Assert.assertNull("Select all checkbox should not be checked initially",
+                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertNull(
+                "Select all checkbox should not be in indeterminate state initially",
+                selectAllCheckbox.getAttribute("indeterminate"));
+
+        // Select single
+        selectCheckbox.click();
+        Assert.assertEquals("Selected item count: 1", message.getText());
+        Assert.assertNull(
+                "Select all checkbox is checked even though not all items selected",
+                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not in indeterminate state even though an item is selected",
+                "true", selectAllCheckbox.getAttribute("indeterminate"));
+
+        // Select all
+        selectAllCheckbox.click();
         Assert.assertEquals(
                 "Selected item count: "
                         + GridMultiSelectionColumnPage.ITEM_COUNT,
                 message.getText());
-        Assert.assertEquals("true", selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not checked even though all items selected",
+                "true", selectAllCheckbox.getAttribute("checked"));
+        Assert.assertNull(
+                "Select all checkbox is in indeterminate state even though all items are selected",
+                selectAllCheckbox.getAttribute("indeterminate"));
 
-        WebElement selectCheckbox = grid
-                .findElements(By.tagName("vaadin-checkbox")).get(5);
-        Assert.assertEquals("true", selectCheckbox.getAttribute("checked"));
+        // Deselect single
         selectCheckbox.click();
-        Assert.assertNull("Item 5 selected even though it shouldn't be",
-                selectCheckbox.getAttribute("checked"));
-        Assert.assertNull("Select all check even though not all items selected",
-                selectAllCheckbox.getAttribute("checked"));
-
-        // On deselected item
         Assert.assertEquals(
                 "Selected item count: "
                         + (GridMultiSelectionColumnPage.ITEM_COUNT - 1),
                 message.getText());
+        Assert.assertNull(
+                "Select all checkbox is checked even though not all items selected",
+                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not in indeterminate state even though not all items selected",
+                "true", selectAllCheckbox.getAttribute("indeterminate"));
+
+        // Deselect all, needs to toggle the checkbox twice, first to select all
+        // again, then to deselect all
+        selectAllCheckbox.click();
+        selectAllCheckbox.click();
+        Assert.assertEquals("Selected item count: 0", message.getText());
+        Assert.assertNull(
+                "Select all checkbox is checked even though no items selected",
+                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertNull(
+                "Select all checkbox is in indeterminate state even though no items are selected",
+                selectAllCheckbox.getAttribute("indeterminate"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -121,7 +121,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
             }
 
             long size = getDataProviderSize();
-            selectionColumn.setSelectAllCheckboxState(size == selected.size());
+            selectionColumn.setSelectAllCheckboxState(
+                    !isHierarchicalDataProvider() && size == selected.size());
             selectionColumn.setSelectAllCheckboxIndeterminateState(
                     isHierarchicalDataProvider() ? selected.size() > 0
                             : selected.size() > 0 && selected.size() < size);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -52,8 +52,6 @@ public class GridSelectionColumn extends Component {
             SerializableRunnable deselectAllCallback) {
         this.selectAllCallback = selectAllCallback;
         this.deselectAllCallback = deselectAllCallback;
-        setSelectAllCheckboxState(false);
-        setSelectAllCheckboxIndeterminateState(false);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -52,6 +52,8 @@ public class GridSelectionColumn extends Component {
             SerializableRunnable deselectAllCallback) {
         this.selectAllCallback = selectAllCallback;
         this.deselectAllCallback = deselectAllCallback;
+        setSelectAllCheckboxState(false);
+        setSelectAllCheckboxIndeterminateState(false);
     }
 
     /**
@@ -62,6 +64,16 @@ public class GridSelectionColumn extends Component {
      */
     public void setSelectAllCheckboxState(boolean selectAll) {
         getElement().setProperty("selectAll", selectAll);
+    }
+
+    /**
+     * Sets the indeterminate state of the select all checkbox on the client.
+     *
+     * @param indeterminate
+     *            the new indeterminate state of the select all checkbox
+     */
+    public void setSelectAllCheckboxIndeterminateState(boolean indeterminate) {
+        getElement().setProperty("indeterminate", indeterminate);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -43,6 +43,16 @@ import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
           notify: true
         },
 
+        /**
+         * Whether to display the select all checkbox in indeterminate state,
+         * which means some, but not all, items are selected
+         */
+        indeterminate: {
+          type: Boolean,
+          value: false,
+          notify: true
+        },
+
         selectAllHidden: Boolean
       };
     }
@@ -55,7 +65,7 @@ import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 
     static get observers() {
       return [
-        '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, selectAllHidden)'
+        '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, indeterminate, selectAllHidden)'
       ];
     }
 
@@ -96,6 +106,7 @@ import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
       const checked = this.selectAll;
       checkbox.hidden = this.selectAllHidden;
       checkbox.checked = checked;
+      checkbox.indeterminate = this.indeterminate;
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -23,7 +23,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.data.selection.SelectionListener;
+import com.vaadin.flow.dom.Element;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,6 +43,7 @@ public class AbstractGridMultiSelectionModelTest {
     private Set<String> selected;
     private Set<String> deselected;
     private Grid<String> grid;
+    private TreeGrid<String> treeGrid;
     private DataCommunicatorTest.MockUI ui;
 
     @Before
@@ -64,8 +67,15 @@ public class AbstractGridMultiSelectionModelTest {
                 return true;
             }
         };
+
+        treeGrid = new TreeGrid<>();
+        // Data provider with only two root items
+        treeGrid.setItems(Arrays.asList("foo", "bar"),
+                root -> Collections.emptyList());
+        treeGrid.setSelectionMode(SelectionMode.MULTI);
+
         ui = new DataCommunicatorTest.MockUI();
-        ui.add(grid);
+        ui.add(grid, treeGrid);
     }
 
     @Test
@@ -299,7 +309,344 @@ public class AbstractGridMultiSelectionModelTest {
         verifyUpdateSelectAllCheckboxStateWhenSelectFromClientInMultiSelectMode(
                 false, true, false, false,
                 GridMultiSelectionModel.SelectAllCheckboxVisibility.HIDDEN);
+    }
 
+    @Test
+    public void select_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // select first
+        grid.getSelectionModel().select("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // select second, which equals all selected
+        grid.getSelectionModel().select("bar");
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void selectFromClient_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // select first
+        grid.getSelectionModel().selectFromClient("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // select second, which equals all selected
+        grid.getSelectionModel().selectFromClient("bar");
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void deselect_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // start with all selected
+        ((GridMultiSelectionModel<String>) grid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect first
+        grid.getSelectionModel().deselect("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect second, which equals none selected
+        grid.getSelectionModel().deselect("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void deselectFromClient_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // start with all selected
+        ((GridMultiSelectionModel<String>) grid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect first
+        grid.getSelectionModel().deselectFromClient("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect second, which equals none selected
+        grid.getSelectionModel().deselectFromClient("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void selectAll_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        ((GridMultiSelectionModel<String>) grid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void clientSelectAll_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void deselectAll_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // start with all selected
+        ((GridMultiSelectionModel<String>) grid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        grid.getSelectionModel().deselectAll();
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void clientDeselectAll_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // start with all selected
+        ((GridMultiSelectionModel<String>) grid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel())
+                .clientDeselectAll();
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void updateSelection_updatesCheckboxStates() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setItems("foo", "bar");
+        Element columnElement = getGridSelectionColumn(grid).getElement();
+
+        // Select all
+        grid.asMultiSelect().updateSelection(Set.of("foo", "bar"), Set.of());
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // Deselect single
+        grid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // Deselect all
+        grid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_select_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // select first
+        treeGrid.getSelectionModel().select("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // select second, which equals all selected
+        // with hierarchical data provider we can not detect whether all are
+        // selected, so should still be indeterminate
+        treeGrid.getSelectionModel().select("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_selectFromClient_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // select first
+        treeGrid.getSelectionModel().selectFromClient("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // select second, which equals all selected
+        // with hierarchical data provider we can not detect whether all are
+        // selected, so should still be indeterminate
+        treeGrid.getSelectionModel().selectFromClient("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_deselect_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect first
+        treeGrid.getSelectionModel().deselect("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect second, which equals none selected
+        treeGrid.getSelectionModel().deselect("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_deselectFromClient_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect first
+        treeGrid.getSelectionModel().deselectFromClient("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect second, which equals none selected
+        treeGrid.getSelectionModel().deselectFromClient("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_clientSelectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_deselectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        treeGrid.getSelectionModel().deselectAll();
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_clientDeselectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientDeselectAll();
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void hierarchicalDataProvider_updateSelection_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // Select all
+        // with hierarchical data provider we can not detect whether all are
+        // selected, so should still be indeterminate
+        treeGrid.asMultiSelect().updateSelection(Set.of("foo", "bar"),
+                Set.of());
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // Deselect single
+        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // Deselect all
+        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
     }
 
     private void verifySelectAllCheckboxVisibilityInMultiSelectMode(
@@ -341,7 +688,8 @@ public class AbstractGridMultiSelectionModelTest {
                 .size(Mockito.any(Query.class));
 
         Assert.assertEquals(expectedCheckboxStateUpdate ? "true" : "false",
-                grid.getElement().getChild(0).getProperty("selectAll"));
+                getGridSelectionColumn(grid).getElement()
+                        .getProperty("selectAll"));
     }
 
     private DataProvider<String, ?> customiseMultiSelectGridAndDataProvider(
@@ -397,6 +745,16 @@ public class AbstractGridMultiSelectionModelTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {
         });
+    }
+
+    private <T> GridSelectionColumn getGridSelectionColumn(Grid<T> grid) {
+        Component child = grid.getChildren().findFirst().orElseThrow(
+                () -> new IllegalStateException("Grid does not have a child"));
+        if (!(child instanceof GridSelectionColumn)) {
+            throw new IllegalStateException(
+                    "First Grid child is not a GridSelectionColumn");
+        }
+        return (GridSelectionColumn) child;
     }
 
     public static class TestEntity {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -15,10 +15,7 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -32,7 +29,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
-import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -43,7 +39,6 @@ public class AbstractGridMultiSelectionModelTest {
     private Set<String> selected;
     private Set<String> deselected;
     private Grid<String> grid;
-    private TreeGrid<String> treeGrid;
     private DataCommunicatorTest.MockUI ui;
 
     @Before
@@ -68,14 +63,8 @@ public class AbstractGridMultiSelectionModelTest {
             }
         };
 
-        treeGrid = new TreeGrid<>();
-        // Data provider with only two root items
-        treeGrid.setItems(Arrays.asList("foo", "bar"),
-                root -> Collections.emptyList());
-        treeGrid.setSelectionMode(SelectionMode.MULTI);
-
         ui = new DataCommunicatorTest.MockUI();
-        ui.add(grid, treeGrid);
+        ui.add(grid);
     }
 
     @Test
@@ -114,21 +103,6 @@ public class AbstractGridMultiSelectionModelTest {
 
         grid.getSelectionModel().deselectFromClient("foo");
         Assert.assertEquals(0, deselected.size());
-    }
-
-    @Test
-    public void treegrid_select_singleItemSignature_selectFromClient() {
-        TreeGrid<String> grid = new TreeGrid<>();
-
-        grid.setSelectionMode(SelectionMode.MULTI);
-        List<String> roots = Arrays.asList("foo", "bar");
-        grid.setItems(roots,
-                root -> roots.contains(root) ? Arrays.asList(root + 1, root + 2)
-                        : Collections.emptyList());
-        // Asserting that selectFromClient does not throw any exception
-        grid.getSelectionModel().selectFromClient("foo");
-
-        Assert.assertEquals(1, grid.getSelectedItems().size());
     }
 
     @Test
@@ -486,164 +460,6 @@ public class AbstractGridMultiSelectionModelTest {
 
         // Deselect all
         grid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_select_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // select first
-        treeGrid.getSelectionModel().select("foo");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // select second, which equals all selected
-        // with hierarchical data provider we can not detect whether all are
-        // selected, so should still be indeterminate
-        treeGrid.getSelectionModel().select("bar");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_selectFromClient_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // select first
-        treeGrid.getSelectionModel().selectFromClient("foo");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // select second, which equals all selected
-        // with hierarchical data provider we can not detect whether all are
-        // selected, so should still be indeterminate
-        treeGrid.getSelectionModel().selectFromClient("bar");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_deselect_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // start with all selected
-        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
-                .clientSelectAll();
-        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // deselect first
-        treeGrid.getSelectionModel().deselect("foo");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // deselect second, which equals none selected
-        treeGrid.getSelectionModel().deselect("bar");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_deselectFromClient_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // start with all selected
-        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
-                .clientSelectAll();
-        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // deselect first
-        treeGrid.getSelectionModel().deselectFromClient("foo");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // deselect second, which equals none selected
-        treeGrid.getSelectionModel().deselectFromClient("bar");
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_clientSelectAll_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
-                .clientSelectAll();
-        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_deselectAll_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // start with all selected
-        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
-                .clientSelectAll();
-        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        treeGrid.getSelectionModel().deselectAll();
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_clientDeselectAll_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // start with all selected
-        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
-                .clientSelectAll();
-        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
-                .clientDeselectAll();
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-    }
-
-    @Test
-    public void hierarchicalDataProvider_updateSelection_updatesCheckboxStates() {
-        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
-
-        // Select all
-        // with hierarchical data provider we can not detect whether all are
-        // selected, so should still be indeterminate
-        treeGrid.asMultiSelect().updateSelection(Set.of("foo", "bar"),
-                Set.of());
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // Deselect single
-        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
-        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
-        Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
-
-        // Deselect all
-        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
                 (boolean) columnElement.getPropertyRaw("indeterminate"));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -1,0 +1,199 @@
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.flow.dom.Element;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
+    private TreeGrid<String> treeGrid;
+    private DataCommunicatorTest.MockUI ui;
+
+    @Before
+    public void init() {
+        treeGrid = new TreeGrid<>();
+        // Data provider with only two root items, we don't need any nested
+        // items for the test cases (so far)
+        treeGrid.setItems(Arrays.asList("foo", "bar"),
+                root -> Collections.emptyList());
+        treeGrid.setSelectionMode(Grid.SelectionMode.MULTI);
+
+        ui = new DataCommunicatorTest.MockUI();
+        ui.add(treeGrid);
+    }
+
+    @Test
+    public void select_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // select first
+        treeGrid.getSelectionModel().select("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // select second, which equals all selected
+        // with hierarchical data provider we can not detect whether all are
+        // selected, so should still be indeterminate
+        treeGrid.getSelectionModel().select("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void selectFromClient_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // select first
+        treeGrid.getSelectionModel().selectFromClient("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // select second, which equals all selected
+        // with hierarchical data provider we can not detect whether all are
+        // selected, so should still be indeterminate
+        treeGrid.getSelectionModel().selectFromClient("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void deselect_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect first
+        treeGrid.getSelectionModel().deselect("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect second, which equals none selected
+        treeGrid.getSelectionModel().deselect("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void deselectFromClient_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect first
+        treeGrid.getSelectionModel().deselectFromClient("foo");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // deselect second, which equals none selected
+        treeGrid.getSelectionModel().deselectFromClient("bar");
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void clientSelectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void deselectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        treeGrid.getSelectionModel().deselectAll();
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void clientDeselectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // start with all selected
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientDeselectAll();
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void updateSelection_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        // Select all
+        // with hierarchical data provider we can not detect whether all are
+        // selected, so should still be indeterminate
+        treeGrid.asMultiSelect().updateSelection(Set.of("foo", "bar"),
+                Set.of());
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // Deselect single
+        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertTrue(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+
+        // Deselect all
+        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
+        Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    private <T> GridSelectionColumn getGridSelectionColumn(Grid<T> grid) {
+        Component child = grid.getChildren().findFirst().orElseThrow(
+                () -> new IllegalStateException("Grid does not have a child"));
+        if (!(child instanceof GridSelectionColumn)) {
+            throw new IllegalStateException(
+                    "First Grid child is not a GridSelectionColumn");
+        }
+        return (GridSelectionColumn) child;
+    }
+}


### PR DESCRIPTION
## Description

Adds the missing indeterminate state to the Flow grid selection column.

Fixes #1060 

## Type of change

- [x] Bugfix
