### PR TITLE
chore: attempt to make IronListIT more reliable

### DIFF
--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListIT.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListIT.java
@@ -212,7 +212,6 @@ public class IronListIT extends AbstractComponentIT {
         Assert.assertThat(list.getAttribute("innerText"), CoreMatchers
                 .not(CoreMatchers.containsString("the-placeholder")));
 
-        getCommandExecutor().disableWaitForVaadin();
         // Scroll to bottom and set an attribute when a placeholder becomes
         // visible.
         executeScript(

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListIT.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListIT.java
@@ -212,6 +212,7 @@ public class IronListIT extends AbstractComponentIT {
         Assert.assertThat(list.getAttribute("innerText"), CoreMatchers
                 .not(CoreMatchers.containsString("the-placeholder")));
 
+        getCommandExecutor().disableWaitForVaadin();
         // Scroll to bottom and set an attribute when a placeholder becomes
         // visible.
         executeScript(
@@ -229,7 +230,7 @@ public class IronListIT extends AbstractComponentIT {
           + "    setTimeout(isPlaceholderVisible, 20);"
           + "  }"
           + "}"
-          + "isPlaceholderVisible();",
+          + "setTimeout(isPlaceholderVisible);",
         //@formatter:on
                 list);
 


### PR DESCRIPTION
## Description

`IronListIT.listWithComponentRendererWithBeansAndPlaceholder_scrollToBottom_placeholderIsShown` fails randomly, it seems there is a race condition between checking if the list has rendered a placeholder after scrolling, and the Flow request resolving before that with updated data (in which case no placeholders are needed). 

The problem could be that the first check for a placeholder runs immediately after scrolling, at which point the list might not have re-rendered yet. The second check for a placeholder runs 20ms later, at which point the server-side roundtrip for new data could be completed. Attempt to fix this by adding a timeout for the first check, so that the list can re-render after scrolling.

Attempting this fix, because it affects the upgrade PRs for some reason:
- https://github.com/vaadin/flow-components/pull/2955
- https://github.com/vaadin/flow-components/pull/2911