### PR TITLE
chore: bump frontend maven plugin version (14.8)

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.1</version>
+                <version>1.11.3</version>
                 <configuration>
                     <nodeVersion>v14.17.4</nodeVersion>
                     <workingDirectory>date-fns</workingDirectory>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>1.12.1</version>
                 <configuration>
                     <nodeVersion>v14.17.4</nodeVersion>
                     <workingDirectory>date-fns</workingDirectory>


### PR DESCRIPTION
## Description

Bumps the version of `frontend-maven-plugin` that is used in the `vaadin-date-picker-flow` build to be compatible with M1 Macs. The current version of the plugin tries to download the node releases that do not exist, which results in a 404:
```
[INFO] Downloading https://nodejs.org/dist/v14.17.4/node-v14.17.4-darwin-arm64.tar.gz to /Users/sascha/.m2/repository/com/github/eirslett/node/14.17.4/node-14.17.4-darwin-arm64.tar.gz
```

Reference: https://github.com/eirslett/frontend-maven-plugin/issues/952
