### PR TITLE
chore: remove usages of deprecated WebDriverWait API

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -29,6 +29,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 /**
  * Integration tests for the ButtonView.
  */
@@ -308,7 +310,8 @@ public class ButtonIT extends AbstractComponentIT {
         final String expected = "Button " + messageString + " was clicked.";
         WebElement message = layout.findElement(By.id("buttonMessage"));
 
-        WebDriverWait wait = new WebDriverWait(getDriver(), 5);
+        WebDriverWait wait = new WebDriverWait(getDriver(),
+                Duration.ofSeconds(5));
         wait.until(driver -> {
             String msg = message.getText();
             wait.withMessage("Expected '" + expected + "' but found '"

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
@@ -38,6 +38,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.vaadin.flow.testutil.TestPath;
 
+import java.time.Duration;
+
 /**
  * Integration tests for changing the ValueChangeMode of TextField, TextArea and
  * PasswordField.
@@ -211,12 +213,14 @@ public class ValueChangeModeIT extends AbstractComponentIT {
     }
 
     private void waitUntilMessageUpdated() {
-        waitUntilMessageUpdated(2000,
-                "It took more than 2000ms to change the message, probably CI performance problems");
+        waitUntilMessageUpdated(2,
+                "It took more than 2s to change the message, probably CI performance problems");
     }
 
-    private void waitUntilMessageUpdated(long timeout, String failMessage) {
-        new WebDriverWait(getDriver(), timeout).withMessage(failMessage)
+    private void waitUntilMessageUpdated(long timeoutInSeconds,
+            String failMessage) {
+        new WebDriverWait(getDriver(), Duration.ofSeconds(timeoutInSeconds))
+                .withMessage(failMessage)
                 .until(webDriver -> isMessageUpdated());
     }
 }


### PR DESCRIPTION
## Description

Removes usages of `WebDriverWait` constructor that accepts seconds, in order to prepare for bumping the testbench version which will also bump Selenium to a version that does not contain that constructor anymore.
