### PR TITLE
fix: disable client-side validation for CheckboxGroup

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/ValidationPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/ValidationPage.java
@@ -31,9 +31,11 @@ public class ValidationPage extends Div {
 
         Span logOutput = new Span();
         logOutput.setId("log-output");
-        NativeButton logInvalidState = new NativeButton("Log Invalid State", e -> {
-            logOutput.setText(String.valueOf(checkboxGroup.isInvalid()));
-        });
+        NativeButton logInvalidState = new NativeButton("Log Invalid State",
+                e -> {
+                    logOutput
+                            .setText(String.valueOf(checkboxGroup.isInvalid()));
+                });
         logInvalidState.setId("log-invalid-state");
 
         add(checkboxGroup);

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/ValidationPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/ValidationPage.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-checkbox/validation")
+public class ValidationPage extends Div {
+    public ValidationPage() {
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setItems("foo", "bar");
+        checkboxGroup.setLabel("CheckboxGroup");
+
+        NativeButton setInvalid = new NativeButton("Set invalid", e -> {
+            checkboxGroup.setInvalid(true);
+            checkboxGroup.setErrorMessage("Error message from server");
+        });
+        setInvalid.setId("set-invalid");
+
+        NativeButton attach = new NativeButton("Attach", e -> {
+            add(checkboxGroup);
+        });
+        attach.setId("attach");
+
+        NativeButton detach = new NativeButton("Detach", e -> {
+            remove(checkboxGroup);
+        });
+        detach.setId("detach");
+
+        Span logOutput = new Span();
+        logOutput.setId("log-output");
+        NativeButton logInvalidState = new NativeButton("Log Invalid State", e -> {
+            logOutput.setText(String.valueOf(checkboxGroup.isInvalid()));
+        });
+        logInvalidState.setId("log-invalid-state");
+
+        add(checkboxGroup);
+        add(new Div(setInvalid, attach, detach, logInvalidState, logOutput));
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -191,9 +191,6 @@ public class CheckboxGroupIT extends AbstractComponentIT {
                 "Correct error message should be shown after the button clicks",
                 "Field has been set to invalid from server side",
                 errorMessage.getText());
-
-        executeScript("arguments[0].value=['2'];", group);
-        verifyGroupValid(group, errorMessage);
     }
 
     @Test

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/ValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/ValidationIT.java
@@ -1,0 +1,61 @@
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-checkbox/validation")
+public class ValidationIT extends AbstractComponentIT {
+
+    private TestBenchElement checkboxGroup;
+    private TestBenchElement setInvalid;
+    private TestBenchElement attach;
+    private TestBenchElement detach;
+    private TestBenchElement logInvalidState;
+    private TestBenchElement logOutput;
+
+    @Before
+    public void init() {
+        open();
+        checkboxGroup = $("vaadin-checkbox-group").waitForFirst();
+        setInvalid = $("button").id("set-invalid");
+        attach = $("button").id("attach");
+        detach = $("button").id("detach");
+        logInvalidState = $("button").id("log-invalid-state");
+        logOutput = $("span").id("log-output");
+    }
+
+    @Test
+    public void overridesClientValidation() {
+        setInvalid.click();
+
+        executeScript("arguments[0].validate()", checkboxGroup);
+
+        Assert.assertEquals(true, checkboxGroup.getPropertyBoolean("invalid"));
+    }
+
+    @Test
+    public void detach_reattach_overridesClientValidation() {
+        setInvalid.click();
+        detach.click();
+        attach.click();
+
+        checkboxGroup = $("vaadin-checkbox-group").waitForFirst();
+        executeScript("arguments[0].validate()", checkboxGroup);
+
+        Assert.assertEquals(true, checkboxGroup.getPropertyBoolean("invalid"));
+    }
+
+    @Test
+    public void changeInvalidOnClient_notSynchronizedToServer() {
+        setInvalid.click();
+
+        executeScript("arguments[0].invalid = false", checkboxGroup);
+        logInvalidState.click();
+
+        Assert.assertEquals("true", logOutput.getText());
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasHelper;
@@ -105,6 +106,13 @@ public class CheckboxGroup<T>
                 CheckboxGroup::presentationToModel,
                 CheckboxGroup::modelToPresentation, true);
         registerValidation();
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+
+        FieldValidationUtil.disableClientValidation(this);
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/FieldValidationUtil.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/FieldValidationUtil.java
@@ -33,8 +33,7 @@ class FieldValidationUtil {
         // Wait until the response is being written as the validation state
         // should not change after that
         component.getUI().ifPresent(ui -> ui.beforeClientResponse(component,
-                        executionContext -> overrideClientValidation(
-                                component)));
+                executionContext -> overrideClientValidation(component)));
     }
 
     private static <T> void overrideClientValidation(

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/FieldValidationUtil.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/FieldValidationUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox;
+
+class FieldValidationUtil {
+    private FieldValidationUtil() {
+    }
+
+    static <T> void disableClientValidation(CheckboxGroup<T> component) {
+        // Since this method should be called for every time when the component
+        // is attached to the UI, lets check that it is actually so
+        if (!component.isAttached()) {
+            throw new IllegalStateException(String.format(
+                    "Component %s is not attached. Client side validation "
+                            + "should be disabled when the component is "
+                            + "attached, thus this method needs to be called "
+                            + "from the onAttach method of the component.",
+                    component));
+        }
+        // Wait until the response is being written as the validation state
+        // should not change after that
+        component.getUI().ifPresent(ui -> ui.beforeClientResponse(component,
+                        executionContext -> overrideClientValidation(
+                                component)));
+    }
+
+    private static <T> void overrideClientValidation(
+            CheckboxGroup<T> component) {
+        StringBuilder expression = new StringBuilder(
+                "this.validate = function () {return this.checkValidity();};");
+
+        if (component.isInvalid()) {
+            /*
+             * By default the invalid flag is set to false. Workaround the case
+             * where the client side validation overrides the invalid state
+             * before the validation function itself is overridden above.
+             */
+            expression.append("this.invalid = true;");
+        }
+        component.getElement().executeJs(expression.toString());
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
@@ -288,14 +288,9 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * </p>
      * <p>
      * This property is set to true when the control value is invalid.
-     * <p>
-     * This property is synchronized automatically from client side when a
-     * 'invalid-changed' event happens.
-     * </p>
      *
      * @return the {@code invalid} property from the webcomponent
      */
-    @Synchronize(property = "invalid", value = "invalid-changed")
     protected boolean isInvalidBoolean() {
         return getElement().getProperty("invalid", false);
     }


### PR DESCRIPTION
## Description

Disables client-side validation for the CheckboxGroup component, by overriding the client-side validation function and removing synchronization of the `invalid` property. The solution is adapted from a similar fix for RadioButtonGroup (https://github.com/vaadin/flow-components/pull/461). Note that the fix in RadioButtonGroup has changed quite a bit over time.

Fixes #2823 

## Type of change

- [x] Bugfix