### PR TITLE
feat: add dialog title, header and footer API

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterPage.java
@@ -1,0 +1,84 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-dialog/header-footer")
+public class DialogHeaderFooterPage extends Div {
+    public static String HEADER_TITLE = "__HEADER_TITLE__";
+    public static String HEADER_CONTENT = "__HEADER_CONTENT__";
+    public static String ANOTHER_HEADER_CONTENT = "__ANOTHER_HEADER_CONTENT__";
+    public static String FOOTER_CONTENT = "__FOOTER_CONTENT__";
+    public static String ANOTHER_FOOTER_CONTENT = "__ANOTHER_FOOTER_CONTENT__";
+
+    public DialogHeaderFooterPage() {
+        Dialog dialog = new Dialog();
+        dialog.setCloseOnOutsideClick(false);
+        dialog.add("Dialog content");
+
+        NativeButton openDialog = new NativeButton("open dialog",
+                e -> dialog.open());
+        openDialog.setId("open-dialog-button");
+
+        NativeButton attachDialog = new NativeButton("attach dialog",
+                e -> add(dialog));
+        attachDialog.setId("attach-dialog-button");
+
+        NativeButton addHeaderTitle = new NativeButton("add header title",
+                e -> dialog.setHeaderTitle(HEADER_TITLE));
+        addHeaderTitle.setId("add-header-title-button");
+        NativeButton removeHeaderTitle = new NativeButton("remove header title",
+                e -> dialog.setHeaderTitle(null));
+        removeHeaderTitle.setId("remove-header-title-button");
+
+        Span headerContent = new Span(HEADER_CONTENT);
+        NativeButton addHeaderContent = new NativeButton("add header content",
+                e -> dialog.getHeader().add(headerContent));
+        addHeaderContent.setId("add-header-content-button");
+
+        NativeButton removeHeaderContent = new NativeButton(
+                "remove header content",
+                e -> dialog.getHeader().remove(headerContent));
+        removeHeaderContent.setId("remove-header-content-button");
+
+        NativeButton addSecondHeaderContent = new NativeButton(
+                "add second header content",
+                e -> dialog.getHeader().add(new Span(ANOTHER_HEADER_CONTENT)));
+        addSecondHeaderContent.setId("add-second-header-content-button");
+
+        Span footerContent = new Span(FOOTER_CONTENT);
+        NativeButton addFooterContent = new NativeButton("add footer content",
+                e -> dialog.getFooter().add(footerContent));
+        addFooterContent.setId("add-footer-content-button");
+
+        NativeButton removeFooterContent = new NativeButton(
+                "remove footer content",
+                e -> dialog.getFooter().remove(footerContent));
+        removeFooterContent.setId("remove-footer-content-button");
+
+        NativeButton addSecondFooterContent = new NativeButton(
+                "add second footer content",
+                e -> dialog.getFooter().add(new Span(ANOTHER_FOOTER_CONTENT)));
+        addSecondFooterContent.setId("add-second-footer-content-button");
+
+        Div buttonsContainer = new Div(openDialog, attachDialog, addHeaderTitle,
+                removeHeaderTitle, addHeaderContent, removeHeaderContent,
+                addSecondHeaderContent, addFooterContent, removeFooterContent,
+                addSecondFooterContent);
+
+        NativeButton moveButtons = new NativeButton("move buttons",
+                e -> dialog.add(buttonsContainer));
+        moveButtons.setId("move-buttons-button");
+        dialog.add(moveButtons);
+
+        NativeButton closeDialog = new NativeButton("close dialog",
+                e -> dialog.setOpened(false));
+        closeDialog.setId("close-dialog-button");
+        dialog.add(closeDialog);
+
+        add(buttonsContainer);
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterIT.java
@@ -1,0 +1,195 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@TestPath("vaadin-dialog/header-footer")
+public class DialogHeaderFooterIT extends AbstractComponentIT {
+
+    private static final String OPEN_DIALOG_BUTTON = "open-dialog-button";
+    private static final String CLOSE_DIALOG_BUTTON = "close-dialog-button";
+    private static final String ATTACH_DIALOG_BUTTON = "attach-dialog-button";
+    private static final String MOVE_BUTTONS_BUTTON = "move-buttons-button";
+    private static final String ADD_HEADER_TITLE_BUTTON = "add-header-title-button";
+    private static final String REMOVE_HEADER_TITLE_BUTTON = "remove-header-title-button";
+    private static final String ADD_HEADER_CONTENT_BUTTON = "add-header-content-button";
+    private static final String ADD_SECOND_HEADER_CONTENT_BUTTON = "add-second-header-content-button";
+    private static final String REMOVE_HEADER_CONTENT_BUTTON = "remove-header-content-button";
+    private static final String ADD_FOOTER_CONTENT_BUTTON = "add-footer-content-button";
+    private static final String ADD_SECOND_FOOTER_CONTENT_BUTTON = "add-second-footer-content-button";
+    private static final String REMOVE_FOOTER_CONTENT_BUTTON = "remove-footer-content-button";
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void closedDialog_headerTitleIsSet_titleRendered() {
+        clickButton(ADD_HEADER_TITLE_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_TITLE);
+    }
+
+    @Test
+    public void openedDialog_headerTitleIsSet_titleRendered() {
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(ADD_HEADER_TITLE_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_TITLE);
+    }
+
+    @Test
+    public void openedDialogWithHeaderTitle_headerTitleIsUnset_noTitleRendered() {
+        clickButton(ADD_HEADER_TITLE_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(MOVE_BUTTONS_BUTTON);
+
+        clickButton(REMOVE_HEADER_TITLE_BUTTON);
+
+        assertDialogNotContains(DialogHeaderFooterPage.HEADER_TITLE);
+    }
+
+    @Test
+    public void closedDialog_headerRendererIsSet_contentIsRenderer() {
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_CONTENT);
+    }
+
+    @Test
+    public void attachedAndClosedDialog_headerContentIsSet_contentIsRendered() {
+        clickButton(ATTACH_DIALOG_BUTTON);
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_CONTENT);
+    }
+
+    @Test
+    public void autoAttachedDialogWithHeaderContent_dialogReopened_contentIsRendered() {
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(CLOSE_DIALOG_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_CONTENT);
+    }
+
+    @Test
+    public void attachedDialogWithHeaderContent_dialogReopened_contentIsRendered() {
+        clickButton(ATTACH_DIALOG_BUTTON);
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(CLOSE_DIALOG_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_CONTENT);
+    }
+
+    @Test
+    public void openedDialogWithHeaderContent_anotherContentIsAdded_allElementsAreRendered() {
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(ADD_SECOND_HEADER_CONTENT_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.HEADER_CONTENT);
+        assertDialogContains(DialogHeaderFooterPage.ANOTHER_HEADER_CONTENT);
+    }
+
+    @Test
+    public void openedDialogWithHeaderContent_removeContent_noContentIsRendered() {
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(REMOVE_HEADER_CONTENT_BUTTON);
+
+        assertDialogNotContains(DialogHeaderFooterPage.HEADER_CONTENT);
+    }
+
+    @Test
+    public void closedDialog_footerRendererIsSet_contentIsRenderer() {
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.FOOTER_CONTENT);
+    }
+
+    @Test
+    public void attachedAndClosedDialog_footerContentIsSet_contentIsRendered() {
+        clickButton(ATTACH_DIALOG_BUTTON);
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.FOOTER_CONTENT);
+    }
+
+    @Test
+    public void autoAttachedDialogWithFooterContent_dialogReopened_contentIsRendered() {
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(CLOSE_DIALOG_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.FOOTER_CONTENT);
+    }
+
+    @Test
+    public void attachedDialogWithFooterContent_dialogReopened_contentIsRendered() {
+        clickButton(ATTACH_DIALOG_BUTTON);
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(CLOSE_DIALOG_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.FOOTER_CONTENT);
+    }
+
+    @Test
+    public void openedDialogWithFooterContent_anotherContentIsAdded_allElementsAreRendered() {
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(ADD_SECOND_FOOTER_CONTENT_BUTTON);
+
+        assertDialogContains(DialogHeaderFooterPage.FOOTER_CONTENT);
+        assertDialogContains(DialogHeaderFooterPage.ANOTHER_FOOTER_CONTENT);
+    }
+
+    @Test
+    public void openedDialogWithFooterContent_removeContent_noContentIsRendered() {
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(REMOVE_FOOTER_CONTENT_BUTTON);
+
+        assertDialogNotContains(DialogHeaderFooterPage.FOOTER_CONTENT);
+    }
+
+    private void clickButton(String id) {
+        findElement(By.id(id)).click();
+    }
+
+    private void assertDialogContains(String text) {
+        var overlay = getOverlayElement();
+        Assert.assertTrue("Dialog should contains text " + text, overlay.getText().contains(text));
+    }
+
+    private void assertDialogNotContains(String text) {
+        var overlay = getOverlayElement();
+        Assert.assertFalse("Dialog should not contain text " + text, overlay.getText().contains(text));
+    }
+
+    private WebElement getOverlayElement() {
+        return findElement(By.tagName("vaadin-dialog-overlay"));
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -529,6 +529,24 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     }
 
     /**
+     * Sets the title to be rendered on the dialog header.
+     *
+     * @param title title to be rendered
+     */
+    public void setHeaderTitle(String title) {
+        getElement().setProperty("headerTitle", title);
+    }
+
+    /**
+     * Gets the title set for the dialog header.
+     *
+     * @return the title or an empty string, if a header title is not defined.
+     */
+    public String getHeaderTitle() {
+        return getElement().getProperty("headerTitle", "");
+    }
+
+    /**
      * Set the visibility of the dialog.
      * <p>
      * For a modal dialog the server-side modality will be removed when dialog


### PR DESCRIPTION
## Description

Add API for setting/getting dialog title and for adding/removing components from the header and footer areas.

The new API consistent in:

- `getHeaderTitle()`/`setHeaderTitle()` for the title
- `getHeader()`/`getFooter()` for the header and footer, respectively
  - Both getters return an object with two methods: `add()`/`remove()`


Fixes #2860 

## Type of change

- [ ] Bugfix
- [X] Feature

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
