### PR TITLE
chore: rename single selection IT

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
@@ -63,7 +63,7 @@ public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
     @SuppressWarnings("rawtypes")
     private Grid<String> buildGrid(boolean deselectAllowed, String id) {
         Grid<String> grid = new Grid<>();
-        grid.addColumn(string -> String.valueOf(Math.random()))
+        grid.addColumn(string -> String.valueOf(Math.random())) // NOSONAR
                 .setHeader("column 1");
         grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf));
         grid.setAllRowsVisible(true);
@@ -77,7 +77,7 @@ public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
 
     @SuppressWarnings("rawtypes")
     private Grid<String> setItemsGrid(Grid grid, String id) {
-        grid.addColumn(string -> String.valueOf(Math.random()))
+        grid.addColumn(string -> String.valueOf(Math.random())) // NOSONAR
                 .setHeader("column 1");
         grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf));
         grid.setAllRowsVisible(true);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
@@ -27,8 +27,8 @@ import com.vaadin.flow.router.Route;
 /**
  * Test view for variants of grid single selection mode.
  */
-@Route("vaadin-grid/grid-single-selection")
-public class GridSingleSelectionPage extends VerticalLayout {
+@Route("vaadin-grid/grid-single-selection-deselect-allowed")
+public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
 
     public static final String DESELECT_ALLOWED_GRID_ID = "deselect-allowed-grid";
     public static final String DESELECT_ALLOWED_TOGGLE_ID = "deselect-allowed-toggle";
@@ -37,7 +37,7 @@ public class GridSingleSelectionPage extends VerticalLayout {
     public static final String SET_ITEMS = "set-item-toggle";
     public static final String ITEMS_GRID = "items-grid";
 
-    public GridSingleSelectionPage() {
+    public GridSingleSelectionDeselectAllowedPage() {
         setSizeUndefined();
         setWidthFull();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedIT.java
@@ -24,16 +24,16 @@ import com.vaadin.flow.testutil.TestPath;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-@TestPath("vaadin-grid/grid-single-selection")
-public class GridSingleSelectionIT extends AbstractComponentIT {
+@TestPath("vaadin-grid/grid-single-selection-deselect-allowed")
+public class GridSingleSelectionDeselectAllowedIT extends AbstractComponentIT {
 
     @Test
     public void checkDeselectionAllowedByDefault() {
         open();
 
         // Ensure that de-selection is allowed by default
-        GridElement grid = $(GridElement.class)
-                .id(GridSingleSelectionPage.DESELECT_ALLOWED_GRID_ID);
+        GridElement grid = $(GridElement.class).id(
+                GridSingleSelectionDeselectAllowedPage.DESELECT_ALLOWED_GRID_ID);
 
         grid.getRow(1).select();
         Assert.assertTrue("Row 1 was not selected after selecting it.",
@@ -44,7 +44,8 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
                 !grid.getRow(1).isSelected());
 
         // Disable de-selection on the fly and test again
-        $("button").id(GridSingleSelectionPage.DESELECT_ALLOWED_TOGGLE_ID)
+        $("button").id(
+                GridSingleSelectionDeselectAllowedPage.DESELECT_ALLOWED_TOGGLE_ID)
                 .click();
 
         grid.getRow(1).select();
@@ -63,8 +64,8 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
 
         // Ensure that de-selection is not possible when it has been disallowed
         // initially
-        GridElement grid = $(GridElement.class)
-                .id(GridSingleSelectionPage.DESELECT_DISALLOWED_GRID_ID);
+        GridElement grid = $(GridElement.class).id(
+                GridSingleSelectionDeselectAllowedPage.DESELECT_DISALLOWED_GRID_ID);
 
         grid.getRow(1).select();
         Assert.assertTrue("Row 1 was not selected after selecting it.",
@@ -76,7 +77,8 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
                 grid.getRow(1).isSelected());
 
         // Enable de-selection on the fly and test again
-        $("button").id(GridSingleSelectionPage.DESELECT_DISALLOWED_TOGGLE_ID)
+        $("button").id(
+                GridSingleSelectionDeselectAllowedPage.DESELECT_DISALLOWED_TOGGLE_ID)
                 .click();
 
         grid.getRow(1).select();
@@ -95,14 +97,16 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
         // De-selection is not allowed(deselectAllowed is false) and then
         // setting items for grid
         GridElement grid = $(GridElement.class)
-                .id(GridSingleSelectionPage.ITEMS_GRID);
+                .id(GridSingleSelectionDeselectAllowedPage.ITEMS_GRID);
 
         grid.getRow(1).select();
         Assert.assertTrue("Row 1 was selected after selecting it.",
                 grid.getRow(1).isSelected());
         // Set Items again by clicking the button
-        $("button").id(GridSingleSelectionPage.SET_ITEMS).click();
-        $("button").id(GridSingleSelectionPage.SET_ITEMS).click();
+        $("button").id(GridSingleSelectionDeselectAllowedPage.SET_ITEMS)
+                .click();
+        $("button").id(GridSingleSelectionDeselectAllowedPage.SET_ITEMS)
+                .click();
     }
 
     @Test
@@ -112,7 +116,7 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
         // De-selection is not allowed(deselectAllowed is false) and then
         // setting items for grid
         GridElement grid = $(GridElement.class)
-                .id(GridSingleSelectionPage.ITEMS_GRID);
+                .id(GridSingleSelectionDeselectAllowedPage.ITEMS_GRID);
 
         grid.getRow(0).select();
 


### PR DESCRIPTION
## Description

Renames existing grid single selection IT to clarify it's about testing single selection in combination with deselect allowed specifically.

Preparation for #3008 