### PR TITLE
refactor: use display:contents on header/footer root

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -594,8 +594,6 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     final public static class DialogFooter extends DialogHeaderFooter {
         private DialogFooter(Dialog dialog) {
             super("footerRenderer", dialog);
-            root.getStyle().set("flex", "1");
-            root.getStyle().set("justify-content", "flex-end");
         }
     }
 
@@ -616,7 +614,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
             this.rendererFunction = rendererFunction;
             this.dialog = dialog;
             root = new Element("div");
-            root.getStyle().set("display", "flex");
+            root.getStyle().set("display", "contents");
         }
 
         /**


### PR DESCRIPTION
Dialog new header and footer API add a root element on the server side to be used as the parent for the components to be added to these areas. 

One side effect with that approach is that it "blocks" the default styling behavior defined on the web-component by the Lumo/Material themes. Using `display: contents` to solve this, by making the styles applied to `[part=header]` and `[part=footer]` "go through" these roots and be applied to their children.