### PR TITLE
refactor: change add/remove API from dialog header/footer

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -554,7 +554,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      * Gets the object from which components can be added or removed from the
      * dialog header area. The header is displayed only if there's a
      * {@link #getHeaderTitle()} or at least one component added with
-     * {@link DialogHeaderFooter#add(Component)}.
+     * {@link DialogHeaderFooter#add(Component...)}.
      *
      * @return the header object
      */
@@ -568,7 +568,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     /**
      * Gets the object from which components can be added or removed from the
      * dialog footer area. The footer is displayed only if there's at least one
-     * component added with {@link DialogHeaderFooter#add(Component)}.
+     * component added with {@link DialogHeaderFooter#add(Component...)}.
      *
      * @return the header object
      */
@@ -618,31 +618,40 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         }
 
         /**
-         * Adds the component to the container.
+         * Adds the given components to the container.
          *
-         * @param component
-         *            the component to be added.
+         * @param components
+         *            the components to be added.
          */
-        public void add(Component component) {
-            root.appendChild(component.getElement());
+        public void add(Component... components) {
+            Objects.requireNonNull(components, "Components should not be null");
+            for (Component component: components) {
+                Objects.requireNonNull(component, "Component to add cannot be null");
+                root.appendChild(component.getElement());
+            }
             if (!isRendererCreated()) {
                 initRenderer();
             }
         }
 
         /**
-         * Removes the component from the container.
+         * Removes the given components from the container.
          *
          * <p>
          * Note that the component needs to be removed from this method in order
          * to guarantee the correct state of the component.
          *
-         * @param component
-         *            the component to be removed.
+         * @param components
+         *            the components to be removed.
          */
-        public void remove(Component component) {
-            if (root.equals(component.getElement().getParent())) {
-                root.removeChild(component.getElement());
+        public void remove(Component... components) {
+            Objects.requireNonNull(components, "Components should not be null");
+            for (Component component :
+                    components) {
+                Objects.requireNonNull(component, "Component to remove cannot be null");
+                if (root.equals(component.getElement().getParent())) {
+                    root.removeChild(component.getElement());
+                }
             }
             if (root.getChildCount() == 0) {
                 dialog.getElement()
@@ -680,7 +689,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
          * JavaScript execution to get the information from the client, this is
          * done on the server by setting it to <code>true</code> on
          * {@link #initRenderer()} and to <code>false</code> when the last child is removed
-         * in {@link #remove(Component)} or when an auto attached dialog is
+         * in {@link #remove(Component...)} or when an auto attached dialog is
          * closed.
          *
          * @param rendererCreated

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.dialog;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.component.html.Span;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
@@ -382,5 +383,56 @@ public class DialogTest {
     public void dialogHasStyle() {
         Dialog dialog = new Dialog();
         Assert.assertTrue(dialog instanceof HasStyle);
+    }
+
+    @Test
+    public void elementAddedToHeaderOrFooter_elementShouldHaveDialogAsParent() {
+        Dialog dialog = new Dialog();
+        Span content = new Span("content");
+        dialog.getHeader().add(content);
+
+        Assert.assertTrue(content.getParent().isPresent());
+        Assert.assertEquals(content.getParent().get(), dialog);
+
+        Span secondContent = new Span("second_content");
+        Span thirdContent = new Span("third_content");
+
+        dialog.getHeader().add(secondContent, thirdContent);
+
+        Assert.assertTrue(secondContent.getParent().isPresent());
+        Assert.assertEquals(secondContent.getParent().get(), dialog);
+
+        Assert.assertTrue(thirdContent.getParent().isPresent());
+        Assert.assertEquals(thirdContent.getParent().get(), dialog);
+    }
+
+    @Test
+    public void elementRemovedFromHeaderOrFooter_elementShouldNotHaveDialogAsParent() {
+        Dialog dialog = new Dialog();
+        Span content = new Span("content");
+        Span secondContent = new Span("second_content");
+        Span thirdContent = new Span("third_content");
+
+        dialog.getHeader().add(content, secondContent, thirdContent);
+
+        dialog.getHeader().remove(content);
+
+        Assert.assertFalse(content.getParent().isPresent());
+
+        dialog.getHeader().remove(secondContent, thirdContent);
+        Assert.assertFalse(secondContent.getParent().isPresent());
+        Assert.assertFalse(thirdContent.getParent().isPresent());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void callAddToHeaderOrFooter_withNull_shouldThrowError() {
+        Dialog dialog = new Dialog();
+        dialog.getHeader().add(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void callAddToHeaderOrFooter_withAnyNullValue_shouldThrowError() {
+        Dialog dialog = new Dialog();
+        dialog.getHeader().add(new Span("content"), null);
     }
 }


### PR DESCRIPTION
Change `DialogHeaderFooter#add(Component)` into `DialogHeaderFooter#add(Component...)` and `DialogHeadeFooter#remove(Componento)` into `DialogHeaderFooter#remove(Component...) to make it easier to add one or more items in one call.
