### PR TITLE
refactor: extract target connector, refactor items tree construction logic

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -48,6 +48,7 @@ import elemental.json.JsonObject;
 @SuppressWarnings("serial")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./contextMenuConnector.js")
+@JsModule("./contextMenuTargetConnector.js")
 public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
         extends GeneratedVaadinContextMenu<C> implements HasComponents {
 
@@ -101,7 +102,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
             targetBeforeOpenRegistration.remove();
             targetAttachRegistration.remove();
             getTarget().getElement()
-                    .callJsFunction("$contextMenuConnector.removeConnector");
+                    .callJsFunction("$contextMenuTargetConnector.removeConnector");
             if (isTargetJsPending()) {
                 targetJsRegistration.cancelExecution();
                 targetJsRegistration = null;
@@ -385,8 +386,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
                 targetJsRegistration.cancelExecution();
             }
             targetJsRegistration = target.getElement().executeJs(
-                    "window.Vaadin.Flow.contextMenuConnector.init(this);"
-                            + "this.$contextMenuConnector.updateOpenOn($0);",
+                    "window.Vaadin.Flow.contextMenuTargetConnector.init(this);"
+                            + "this.$contextMenuTargetConnector.updateOpenOn($0);",
                     openOnEventName);
         }
     }
@@ -403,7 +404,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
         if (shouldOpenMenu) {
             addContextMenuToUi();
-            target.getElement().callJsFunction("$contextMenuConnector.openMenu",
+            target.getElement().callJsFunction("$contextMenuTargetConnector.openMenu",
                     getElement());
         }
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -84,7 +84,11 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         });
 
         menuItemsArrayGenerator = new MenuItemsArrayGenerator<>(this);
-        addAttachListener(event -> resetContent());
+        addAttachListener(event -> {
+            String appId = event.getUI().getInternals().getAppId();
+            initConnector(appId);
+            resetContent();
+        });
     }
 
     /**
@@ -429,5 +433,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
                     + "'UI::access' or from tests without proper initialization.");
         }
         return ui;
+    }
+
+    private void initConnector(String appId) {
+        getElement().executeJs(
+                "window.Vaadin.Flow.contextMenuConnector.initLazy(this, $0)", appId);
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemsArrayGenerator.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemsArrayGenerator.java
@@ -62,11 +62,7 @@ public class MenuItemsArrayGenerator<I extends MenuItemBase<?, I, ?>>
             getItems().forEach(this::resetContainers);
 
             int containerNodeId = createNewContainer(menu.getChildren());
-            String appId = ui.getInternals().getAppId();
-
-            ui.getPage().executeJavaScript(
-                    "window.Vaadin.Flow.contextMenuConnector.generateItems($0, $1, $2)",
-                    getElement(), appId, containerNodeId);
+            getElement().callJsFunction("$connector.generateItems", containerNodeId);
 
             updateScheduled = false;
         });

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -1,76 +1,9 @@
-import * as Gestures from "@vaadin/component-base/src/gestures.js";
 (function() {
   const tryCatchWrapper = function(callback) {
     return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu');
   };
 
   window.Vaadin.Flow.contextMenuConnector = {
-    // NOTE: This is for the TARGET component, not for the <vaadin-context-menu> itself
-    init: target =>
-      tryCatchWrapper(function(target) {
-        if (target.$contextMenuConnector) {
-          return;
-        }
-
-        target.$contextMenuConnector = {
-          openOnHandler: tryCatchWrapper(function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            this.$contextMenuConnector.openEvent = e;
-            let detail = {};
-            if (target.getContextMenuBeforeOpenDetail) {
-              detail = target.getContextMenuBeforeOpenDetail(e);
-            }
-            target.dispatchEvent(
-              new CustomEvent("vaadin-context-menu-before-open", {
-                detail: detail
-              })
-            );
-          }),
-
-          updateOpenOn: tryCatchWrapper(function(eventType) {
-            this.removeListener();
-            this.openOnEventType = eventType;
-
-            customElements.whenDefined("vaadin-context-menu").then(
-              tryCatchWrapper(() => {
-                if (Gestures.gestures[eventType]) {
-                  Gestures.addListener(target, eventType, this.openOnHandler);
-                } else {
-                  target.addEventListener(eventType, this.openOnHandler);
-                }
-              })
-            );
-          }),
-
-          removeListener: tryCatchWrapper(function() {
-            if (this.openOnEventType) {
-              if (Gestures.gestures[this.openOnEventType]) {
-                Gestures.removeListener(
-                  target,
-                  this.openOnEventType,
-                  this.openOnHandler
-                );
-              } else {
-                target.removeEventListener(
-                  this.openOnEventType,
-                  this.openOnHandler
-                );
-              }
-            }
-          }),
-
-          openMenu: tryCatchWrapper(function(contextMenu) {
-            contextMenu.open(this.openEvent);
-          }),
-
-          removeConnector: tryCatchWrapper(function() {
-            this.removeListener();
-            target.$contextMenuConnector = undefined;
-          })
-        };
-      })(target),
-
     generateItems: (menu, appId, nodeId) =>
       tryCatchWrapper(function(menu, appId, nodeId) {
         menu._containerNodeId = nodeId;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -25,6 +25,11 @@
       }
 
       contextMenu.$connector = {
+        /**
+         * Generates and assigns the items to the context menu.
+         *
+         * @param {number} nodeId
+         */
         generateItems: tryCatchWrapper((nodeId) => {
           const items = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(
             appId,

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
@@ -1,0 +1,73 @@
+import * as Gestures from "@vaadin/component-base/src/gestures.js";
+
+(function() {
+  function tryCatchWrapper(callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu Target');
+  };
+
+  window.Vaadin.Flow.contextMenuTargetConnector = {
+    init: tryCatchWrapper(function(target) {
+      if (target.$contextMenuTargetConnector) {
+        return;
+      }
+
+      target.$contextMenuTargetConnector = {
+        openOnHandler: tryCatchWrapper(function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.$contextMenuTargetConnector.openEvent = e;
+          let detail = {};
+          if (target.getContextMenuBeforeOpenDetail) {
+            detail = target.getContextMenuBeforeOpenDetail(e);
+          }
+          target.dispatchEvent(
+            new CustomEvent("vaadin-context-menu-before-open", {
+              detail: detail
+            })
+          );
+        }),
+
+        updateOpenOn: tryCatchWrapper(function(eventType) {
+          this.removeListener();
+          this.openOnEventType = eventType;
+
+          customElements.whenDefined("vaadin-context-menu").then(
+            tryCatchWrapper(() => {
+              if (Gestures.gestures[eventType]) {
+                Gestures.addListener(target, eventType, this.openOnHandler);
+              } else {
+                target.addEventListener(eventType, this.openOnHandler);
+              }
+            })
+          );
+        }),
+
+        removeListener: tryCatchWrapper(function() {
+          if (this.openOnEventType) {
+            if (Gestures.gestures[this.openOnEventType]) {
+              Gestures.removeListener(
+                target,
+                this.openOnEventType,
+                this.openOnHandler
+              );
+            } else {
+              target.removeEventListener(
+                this.openOnEventType,
+                this.openOnHandler
+              );
+            }
+          }
+        }),
+
+        openMenu: tryCatchWrapper(function(contextMenu) {
+          contextMenu.open(this.openEvent);
+        }),
+
+        removeConnector: tryCatchWrapper(function() {
+          this.removeListener();
+          target.$contextMenuTargetConnector = undefined;
+        })
+      };
+    })
+  }
+})();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1011,7 +1011,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
       };
 
       grid.addEventListener('vaadin-context-menu-before-open', tryCatchWrapper(function(e) {
-        contextMenuListener(grid.$contextMenuConnector.openEvent);
+        contextMenuListener(grid.$contextMenuTargetConnector.openEvent);
       }));
 
       grid.getContextMenuBeforeOpenDetail = tryCatchWrapper(function(event) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
@@ -120,6 +120,6 @@ public class GridContextMenuTest {
 
         Mockito.verify(registration).remove();
         Mockito.verify(element)
-                .callJsFunction("$contextMenuConnector.removeConnector");
+                .callJsFunction("$contextMenuTargetConnector.removeConnector");
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -77,7 +77,8 @@ public class MenuBar extends Component
                 (menu, contentReset) -> new MenuBarRootItem(this, contentReset),
                 MenuItem.class, null);
         addAttachListener(event -> {
-            initConnector();
+            String appId = event.getUI().getInternals().getAppId();
+            initConnector(appId);
             resetContent();
         });
     }
@@ -341,15 +342,19 @@ public class MenuBar extends Component
             return;
         }
         runBeforeClientResponse(ui -> {
-            getElement().executeJs("this.$connector.updateButtons()");
+            // When calling `generateItems` without providing a node id, it will
+            // use the previously generated items tree, only updating the
+            // disabled and hidden properties of the root items = the menu bar
+            // buttons.
+            getElement().executeJs("this.$connector.generateItems()");
             updateScheduled = false;
         });
         updateScheduled = true;
     }
 
-    private void initConnector() {
+    private void initConnector(String appId) {
         getElement().executeJs(
-                "window.Vaadin.Flow.menubarConnector.initLazy(this)");
+                "window.Vaadin.Flow.menubarConnector.initLazy(this, $0)", appId);
     }
 
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -20,21 +20,45 @@
   };
 
   window.Vaadin.Flow.menubarConnector = {
-    initLazy: function (menubar) {
+    /**
+     * Initializes the connector for a menu bar element.
+     *
+     * @param {HTMLElement} menubar
+     * @param {string} appId
+     */
+    initLazy: tryCatchWrapper(function (menubar, appId) {
       if (menubar.$connector) {
         return;
       }
-      menubar.$connector = {
 
-        updateButtons: tryCatchWrapper(function () {
+      menubar.$connector = {
+        /**
+         * Generates and assigns the items to the menu bar.
+         *
+         * When the method is called without providing a node id,
+         * the previously generated items tree will be used.
+         * That can be useful if you only want to sync the disabled and hidden properties of root items.
+         *
+         * @param {number | undefined} nodeId
+         */
+        generateItems: tryCatchWrapper((nodeId) => {
           if (!menubar.shadowRoot) {
             // workaround for https://github.com/vaadin/flow/issues/5722
-            setTimeout(() => menubar.$connector.updateButtons());
+            setTimeout(() => menubar.$connector.generateItems(nodeId));
             return;
           }
 
+          if (nodeId) {
+            menubar.__generatedItems = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(
+              appId,
+              nodeId
+            )
+          }
+
+          let items = menubar.__generatedItems || [];
+
           // Propagate disabled state from items to parent buttons
-          menubar.items.forEach(item => item.disabled = item.component.disabled);
+          items.forEach(item => item.disabled = item.component.disabled);
 
           // Remove hidden items entirely from the array. Just hiding them
           // could cause the overflow button to be rendered without items.
@@ -42,7 +66,7 @@
           //
           // The items-prop needs to be set even when all items are visible
           // to update the disabled state and re-render buttons.
-          menubar.items = menubar.items.filter(item => !item.component.hidden);
+          menubar.items = items.filter(item => !item.component.hidden);
 
           // Propagate click events from the menu buttons to the item components
           menubar._buttons.forEach(button => {
@@ -57,6 +81,6 @@
           });
         })
       };
-    }
+    })
   };
 })();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -62,7 +62,6 @@
 
           // Remove hidden items entirely from the array. Just hiding them
           // could cause the overflow button to be rendered without items.
-          // resetContent needs to be called to make buttons visible again.
           //
           // The items-prop needs to be set even when all items are visible
           // to update the disabled state and re-render buttons.


### PR DESCRIPTION
## Description

- [x] Extracted the context menu target connector into a separate file (before it was called the context menu connector which was confusing)
- [x] Refactored the items tree construction logic. The menu bar buttons are now saved from an unnecessary re-render that was previously caused by the double assignment of the `items` property: one in `ContextMenuConnector.generateItems` and the other one in `MenuBarConnector.updateButtons`.
- [x] Added JSDoc to some connector methods to clarify their purpose.

A part of #2134 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
