### PR TITLE
fix: re-generate items on the hidden or disabled property change

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityPage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-menu-bar/menu-bar-visibility")
+public class MenuBarVisibilityPage extends Div {
+    public MenuBarVisibilityPage() {
+        MenuBar menuBar = new MenuBar();
+        MenuItem menuItem = menuBar.addItem("Item");
+
+        NativeButton toggleMenuBarVisibility = new NativeButton("Toggle menu bar visibility", (event) -> {
+            menuBar.setVisible(!menuBar.isVisible());
+        });
+        toggleMenuBarVisibility.setId("toggle-menu-bar-visibility");
+
+        NativeButton toggleMenuItemVisibility = new NativeButton("Toggle menu item visibility", (event) -> {
+            menuItem.setVisible(!menuItem.isVisible());
+        });
+        toggleMenuItemVisibility.setId("toggle-menu-item-visibility");
+
+        NativeButton toggleMenuItemEnabled = new NativeButton("Toggle menu item enabled", (event) -> {
+            menuItem.setEnabled(!menuItem.isEnabled());
+        });
+        toggleMenuItemEnabled.setId("toggle-menu-item-enabled");
+
+        add(menuBar, toggleMenuBarVisibility, toggleMenuItemVisibility, toggleMenuItemEnabled);
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -248,6 +248,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         executeScript("arguments[0].disabled=false;"
                 + "arguments[0].querySelector('vaadin-context-menu-item').disabled=false;",
                 button2);
+        button2 = menuBar.getButtons().get(1);
         button2.click();
         assertMessage("");
     }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityIT.java
@@ -38,8 +38,6 @@ public class MenuBarVisibilityIT extends AbstractComponentIT {
     toggleMenuBarVisibility.click();
     Assert.assertTrue(menuBar.isDisplayed());
 
-    waitForMutationObserver();
-
     // Check that the menu item is disabled.
     TestBenchElement button = menuBar.getButtons().get(0);
     Assert.assertTrue(button.getPropertyBoolean("disabled"));
@@ -62,15 +60,7 @@ public class MenuBarVisibilityIT extends AbstractComponentIT {
     toggleMenuBarVisibility.click();
     Assert.assertTrue(menuBar.isDisplayed());
 
-    waitForMutationObserver();
-
     // Check that the menu item is visible.
     Assert.assertFalse(menuBar.getButtons().isEmpty());
-  }
-
-  private void waitForMutationObserver() {
-    getCommandExecutor().getDriver().executeAsyncScript(
-            "var callback = arguments[arguments.length - 1];"
-                    + "requestAnimationFrame(callback)");
   }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityIT.java
@@ -1,0 +1,76 @@
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-menu-bar/menu-bar-visibility")
+public class MenuBarVisibilityIT extends AbstractComponentIT {
+  private MenuBarElement menuBar;
+  private TestBenchElement toggleMenuBarVisibility;
+  private TestBenchElement toggleMenuItemVisibility;
+  private TestBenchElement toggleMenuItemEnabled;
+
+  @Before
+  public void init() {
+      open();
+      menuBar = $(MenuBarElement.class).waitForFirst();
+      toggleMenuBarVisibility = $("button").id("toggle-menu-bar-visibility");
+      toggleMenuItemVisibility = $("button").id("toggle-menu-item-visibility");
+      toggleMenuItemEnabled = $("button").id("toggle-menu-item-enabled");
+  }
+
+  @Test
+  public void hide_disableMenuItem_show_buttonIsDisabled() {
+    // Hide the menu bar.
+    toggleMenuBarVisibility.click();
+    Assert.assertFalse(menuBar.isDisplayed());
+
+    // Disable the menu item.
+    toggleMenuItemEnabled.click();
+
+    // Show the menu bar.
+    toggleMenuBarVisibility.click();
+    Assert.assertTrue(menuBar.isDisplayed());
+
+    waitForMutationObserver();
+
+    // Check that the menu item is disabled.
+    TestBenchElement button = menuBar.getButtons().get(0);
+    Assert.assertTrue(button.getPropertyBoolean("disabled"));
+  }
+
+  @Test
+  public void hideMenuItem_hide_showMenuItem_show_buttonIsVisible() {
+    // Hide the menu item.
+    toggleMenuItemVisibility.click();
+    Assert.assertTrue(menuBar.getButtons().isEmpty());
+
+    // Hide the menu bar.
+    toggleMenuBarVisibility.click();
+    Assert.assertFalse(menuBar.isDisplayed());
+
+    // Show the menu item.
+    toggleMenuItemVisibility.click();
+
+    // Show the menu bar.
+    toggleMenuBarVisibility.click();
+    Assert.assertTrue(menuBar.isDisplayed());
+
+    waitForMutationObserver();
+
+    // Check that the menu item is visible.
+    Assert.assertFalse(menuBar.getButtons().isEmpty());
+  }
+
+  private void waitForMutationObserver() {
+    getCommandExecutor().getDriver().executeAsyncScript(
+            "var callback = arguments[arguments.length - 1];"
+                    + "requestAnimationFrame(callback)");
+  }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -35,24 +35,6 @@ class MenuBarRootItem extends MenuItem {
         }
     }
 
-    @Override
-    public void setEnabled(boolean enabled) {
-        if (enabled == isEnabled()) {
-            return;
-        }
-        super.setEnabled(enabled);
-        menuBar.updateButtons();
-    }
-
-    @Override
-    public void setVisible(boolean visible) {
-        if (visible == isVisible()) {
-            return;
-        }
-        super.setVisible(visible);
-        menuBar.resetContent();
-    }
-
     /**
      * Adds one or more theme names to this item. Multiple theme names can be
      * specified by using multiple parameters.

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -31,8 +31,16 @@
         return;
       }
 
-      const observer = new MutationObserver(() => {
-        menubar.$connector.generateItems();
+      const observer = new MutationObserver((records) => {
+        const hasChangedAttributes = records.some((entry) => {
+          const oldValue = entry.oldValue;
+          const newValue = entry.target.getAttribute(entry.attributeName);
+          return oldValue !== newValue;
+        });
+
+        if (hasChangedAttributes) {
+          menubar.$connector.generateItems();
+        }
       });
 
       menubar.$connector = {
@@ -76,7 +84,8 @@
           // to sync the new attribute values with the corresponding properties in the items array.
           items.forEach((item) => {
             observer.observe(item.component, {
-              attributeFilter: ['hidden', 'disabled']
+              attributeFilter: ['hidden', 'disabled'],
+              attributeOldValue: true
             });
           });
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -31,6 +31,10 @@
         return;
       }
 
+      const observer = new MutationObserver(() => {
+        menubar.$connector.generateItems();
+      });
+
       menubar.$connector = {
         /**
          * Generates and assigns the items to the menu bar.
@@ -65,7 +69,18 @@
           //
           // The items-prop needs to be set even when all items are visible
           // to update the disabled state and re-render buttons.
-          menubar.items = items.filter(item => !item.component.hidden);
+          items = items.filter(item => !item.component.hidden);
+
+          // Observe for hidden and disabled attributes in case they are changed by Flow.
+          // When a change occurs, the observer will re-generate items on top of the existing tree
+          // to sync the new attribute values with the corresponding properties in the items array.
+          items.forEach((item) => {
+            observer.observe(item.component, {
+              attributeFilter: ['hidden', 'disabled']
+            });
+          });
+
+          menubar.items = items;
 
           // Propagate click events from the menu buttons to the item components
           menubar._buttons.forEach(button => {


### PR DESCRIPTION
## Description

This PR adds a MutationObserver to the menu bar connector that watches for the `hidden` and `disabled` attributes and triggers re-generating the menu bar items if an attribute change occurs.

It solves the issue where changing the visibility or disabled state of a menu item wouldn't be applied if an ancestor of the menu bar was hidden at the same time. 

Fixes #2134

Depends on #3025 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
