### PR TITLE
feat: add method to disable "close on Esc" for ConfirmDialog

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/EventView.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/EventView.java
@@ -1,0 +1,35 @@
+package com.vaadin.flow.component.confirmdialog.examples;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-confirm-dialog/events")
+public class EventView extends Div {
+
+    public EventView() {
+        ConfirmDialog dialog = new ConfirmDialog();
+
+        Button showDialogButton = new Button("Show dialog", e -> dialog.open());
+        showDialogButton.setId("open-dialog");
+
+        ConfirmDialog dialogCloseOnEsc = new ConfirmDialog();
+        dialogCloseOnEsc.setCloseOnEsc(true);
+
+        Button showDialogCloseOnEscButton = new Button("Show escape dialog",
+                e -> dialogCloseOnEsc.open());
+        showDialogCloseOnEscButton.setId("open-esc-dialog");
+
+        ConfirmDialog dialogNoCloseOnEsc = new ConfirmDialog();
+        dialogNoCloseOnEsc.setCloseOnEsc(false);
+
+        Button showDialogNoCloseOnEscButton = new Button(
+                "Show no escape dialog", e -> dialogNoCloseOnEsc.open());
+        showDialogNoCloseOnEscButton.setId("open-no-esc-dialog");
+
+        add(dialog, showDialogButton, dialogNoCloseOnEsc,
+                showDialogCloseOnEscButton, dialogNoCloseOnEsc,
+                showDialogNoCloseOnEscButton);
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/EventView.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/EventView.java
@@ -14,22 +14,10 @@ public class EventView extends Div {
         Button showDialogButton = new Button("Show dialog", e -> dialog.open());
         showDialogButton.setId("open-dialog");
 
-        ConfirmDialog dialogCloseOnEsc = new ConfirmDialog();
-        dialogCloseOnEsc.setCloseOnEsc(true);
+        Button toggleCloseOnEscButton = new Button("Toggle close on Esc",
+                e -> dialog.setCloseOnEsc(!dialog.isCloseOnEsc()));
+        toggleCloseOnEscButton.setId("toggle-close-on-esc");
 
-        Button showDialogCloseOnEscButton = new Button("Show escape dialog",
-                e -> dialogCloseOnEsc.open());
-        showDialogCloseOnEscButton.setId("open-esc-dialog");
-
-        ConfirmDialog dialogNoCloseOnEsc = new ConfirmDialog();
-        dialogNoCloseOnEsc.setCloseOnEsc(false);
-
-        Button showDialogNoCloseOnEscButton = new Button(
-                "Show no escape dialog", e -> dialogNoCloseOnEsc.open());
-        showDialogNoCloseOnEscButton.setId("open-no-esc-dialog");
-
-        add(dialog, showDialogButton, dialogNoCloseOnEsc,
-                showDialogCloseOnEscButton, dialogNoCloseOnEsc,
-                showDialogNoCloseOnEscButton);
+        add(dialog, showDialogButton, toggleCloseOnEscButton);
     }
 }

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/EventIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/EventIT.java
@@ -1,0 +1,69 @@
+package com.vaadin.flow.component.confirmdialog.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-confirm-dialog/events")
+public class EventIT extends AbstractComponentIT {
+
+    private ButtonElement openDialogBtn;
+    private ButtonElement openEscDialogBtn;
+    private ButtonElement openNoEscDialogBtn;
+
+    @Before
+    public void init() {
+        open();
+        openDialogBtn = $(ButtonElement.class).id("open-dialog");
+        openEscDialogBtn = $(ButtonElement.class).id("open-esc-dialog");
+        openNoEscDialogBtn = $(ButtonElement.class).id("open-no-esc-dialog");
+    }
+
+    @Test
+    public void testRegularDialog_closeOnEsc() {
+        openDialogBtn.click();
+        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+
+        closeDialogByEscKey();
+
+        waitForElementNotPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+
+        Assert.assertFalse("Dialog must be closed after esc key",
+                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
+    }
+
+    @Test
+    public void testCloseOnEscDialog_closeOnEsc() {
+        openEscDialogBtn.click();
+        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+
+        closeDialogByEscKey();
+
+        waitForElementNotPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+
+        Assert.assertFalse("Dialog must be closed after esc key",
+                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
+    }
+
+    @Test
+    public void testNoCloseOnEscDialog_NoCloseOnEsc() {
+        openNoEscDialogBtn.click();
+        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+
+        closeDialogByEscKey();
+
+        Assert.assertTrue("Dialog must be open after esc key",
+                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
+    }
+
+    private void closeDialogByEscKey() {
+        new Actions(getDriver()).sendKeys(Keys.ESCAPE).build().perform();
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/EventIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/EventIT.java
@@ -14,53 +14,66 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-confirm-dialog/events")
 public class EventIT extends AbstractComponentIT {
 
+    static final String DIALOG_OVERLAY_TAG = "vaadin-confirm-dialog-overlay";
+
     private ButtonElement openDialogBtn;
-    private ButtonElement openEscDialogBtn;
-    private ButtonElement openNoEscDialogBtn;
+    private ButtonElement toggleCloseOnEscBtn;
 
     @Before
     public void init() {
         open();
         openDialogBtn = $(ButtonElement.class).id("open-dialog");
-        openEscDialogBtn = $(ButtonElement.class).id("open-esc-dialog");
-        openNoEscDialogBtn = $(ButtonElement.class).id("open-no-esc-dialog");
+        toggleCloseOnEscBtn = $(ButtonElement.class).id("toggle-close-on-esc");
     }
 
     @Test
-    public void testRegularDialog_closeOnEsc() {
+    public void openDialog_closeOnEsc() {
         openDialogBtn.click();
-        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+        checkDialogIsOpened();
 
         closeDialogByEscKey();
 
-        waitForElementNotPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+        checkDialogIsClosed();
 
         Assert.assertFalse("Dialog must be closed after esc key",
-                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
+                isElementPresent(By.tagName(DIALOG_OVERLAY_TAG)));
     }
 
     @Test
-    public void testCloseOnEscDialog_closeOnEsc() {
-        openEscDialogBtn.click();
-        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+    public void openDialog_closeOnEscIsDisallowed() {
+        openDialogBtn.click();
+        checkDialogIsOpened();
 
-        closeDialogByEscKey();
-
-        waitForElementNotPresent(By.tagName("vaadin-confirm-dialog-overlay"));
-
-        Assert.assertFalse("Dialog must be closed after esc key",
-                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
-    }
-
-    @Test
-    public void testNoCloseOnEscDialog_NoCloseOnEsc() {
-        openNoEscDialogBtn.click();
-        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+        toggleCloseOnEscBtn.click();
 
         closeDialogByEscKey();
 
         Assert.assertTrue("Dialog must be open after esc key",
-                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
+                isElementPresent(By.tagName(DIALOG_OVERLAY_TAG)));
+    }
+
+    @Test
+    public void testCloseOnEscDialog_closeOnEscIsRestored() {
+        openDialogBtn.click();
+        checkDialogIsOpened();
+
+        toggleCloseOnEscBtn.click();
+        toggleCloseOnEscBtn.click();
+
+        closeDialogByEscKey();
+
+        checkDialogIsClosed();
+
+        Assert.assertFalse("Dialog must be closed after esc key",
+                isElementPresent(By.tagName(DIALOG_OVERLAY_TAG)));
+    }
+
+    private void checkDialogIsClosed() {
+        waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
+    }
+
+    private void checkDialogIsOpened() {
+        waitForElementPresent(By.tagName(DIALOG_OVERLAY_TAG));
     }
 
     private void closeDialogByEscKey() {

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -620,6 +620,31 @@ public class ConfirmDialog extends Component
         getElement().setProperty("opened", opened);
     }
 
+    /**
+     * Gets whether this dialog can be closed by hitting the esc-key or not.
+     * <p>
+     * By default, the dialog is closable with esc.
+     *
+     * @return {@code true} if this dialog can be closed with the esc-key,
+     *         {@code false} otherwise
+     */
+    public boolean isCloseOnEsc() {
+        return !getElement().getProperty("noCloseOnEsc", false);
+    }
+
+    /**
+     * Sets whether this dialog can be closed by hitting the esc-key or not.
+     * <p>
+     * By default, the dialog is closable with esc.
+     *
+     * @param closeOnEsc
+     *            {@code true} to enable closing this dialog with the esc-key,
+     *            {@code false} to disable it
+     */
+    public void setCloseOnEsc(boolean closeOnEsc) {
+        getElement().setProperty("noCloseOnEsc", !closeOnEsc);
+    }
+
     private void setModality(boolean modal) {
         if (isAttached()) {
             getUI().ifPresent(ui -> ui.setChildComponentModal(this, modal));


### PR DESCRIPTION
## Description

Add methods to disable "close on Esc" for ConfirmDialog

Fixes #1678

## Type of change

- [X] Feature

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
