### PR TITLE
fix: throw exception instead of downloading node.js

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/NodeRunner.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/NodeRunner.java
@@ -13,23 +13,54 @@
 
 package com.vaadin.flow.component.charts.export;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vaadin.flow.server.frontend.FrontendTools;
-import com.vaadin.flow.server.frontend.FrontendToolsSettings;
+import com.vaadin.flow.server.frontend.FrontendToolsLocator;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 class NodeRunner {
 
+    private final FrontendToolsLocator frontendToolsLocator;
+
+    NodeRunner() {
+        this(new FrontendToolsLocator());
+    }
+
+    NodeRunner(FrontendToolsLocator frontendToolsLocator) {
+        this.frontendToolsLocator = frontendToolsLocator;
+    }
+
+    /**
+     * Returns the absolute file path to a Node.js executable.
+     * First tries to find a global installation, and as a fallback looks for an installation in the Vaadin home directory.
+     * Throws if no Node.js installation could be found.
+     * @return the absolute path to the Node.js executable
+     * @throws IllegalStateException when no Node.js installation could be found
+     */
+    String findNodeExecutable() {
+        // Try resolve global node installation
+        String nodeExecutableName = FrontendUtils.isWindows() ? "node.exe" : "node";
+        File nodeExecutableFile = frontendToolsLocator.tryLocateTool(nodeExecutableName).orElse(null);
+        if (nodeExecutableFile != null) {
+            return nodeExecutableFile.getAbsolutePath();
+        }
+        // Try resolve installation from Vaadin home
+        // This covers development setups where developers rely on the Node.js installation provided by Flow's frontend toolchain
+        nodeExecutableFile = new File(FrontendUtils.getVaadinHomeDirectory(), FrontendUtils.isWindows() ? "node/node.exe" : "node/node");
+        if (frontendToolsLocator.verifyTool(nodeExecutableFile)) {
+            return nodeExecutableFile.getAbsolutePath();
+        }
+
+        throw new IllegalStateException("Node not found");
+    }
+
     int runJavascript(String script) throws InterruptedException, IOException {
-        FrontendToolsSettings settings = new FrontendToolsSettings("",
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
-        FrontendTools tools = new FrontendTools(settings);
-        String node = tools.getNodeExecutable();
+        String nodeExecutable = findNodeExecutable();
         List<String> command = new ArrayList<>();
-        command.add(node);
+        command.add(nodeExecutable);
         command.add("-e");
         // this check is necessary since running a script on windows eats up
         // double quotes

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/NodeRunner.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/NodeRunner.java
@@ -34,23 +34,30 @@ class NodeRunner {
     }
 
     /**
-     * Returns the absolute file path to a Node.js executable.
-     * First tries to find a global installation, and as a fallback looks for an installation in the Vaadin home directory.
-     * Throws if no Node.js installation could be found.
+     * Returns the absolute file path to a Node.js executable. First tries to
+     * find a global installation, and as a fallback looks for an installation
+     * in the Vaadin home directory. Throws if no Node.js installation could be
+     * found.
+     *
      * @return the absolute path to the Node.js executable
-     * @throws IllegalStateException when no Node.js installation could be found
+     * @throws IllegalStateException
+     *             when no Node.js installation could be found
      */
     String findNodeExecutable() {
         // Try resolve global node installation
-        String nodeExecutableName = FrontendUtils.isWindows() ? "node.exe" : "node";
-        File nodeExecutableFile = frontendToolsLocator.tryLocateTool(nodeExecutableName).orElse(null);
+        String nodeExecutableName = FrontendUtils.isWindows() ? "node.exe"
+                : "node";
+        File nodeExecutableFile = frontendToolsLocator
+                .tryLocateTool(nodeExecutableName).orElse(null);
         if (nodeExecutableFile != null) {
             return nodeExecutableFile.getAbsolutePath();
         }
         // Try resolve installation from Vaadin home
-        // This covers development setups where developers rely on the Node.js installation provided by Flow's frontend toolchain
+        // This covers development setups where developers rely on the Node.js
+        // installation provided by Flow's frontend toolchain
         File vaadinHomeDirectory = FrontendUtils.getVaadinHomeDirectory();
-        nodeExecutableFile = new File(vaadinHomeDirectory, FrontendUtils.isWindows() ? "node/node.exe" : "node/node");
+        nodeExecutableFile = new File(vaadinHomeDirectory,
+                FrontendUtils.isWindows() ? "node/node.exe" : "node/node");
         if (frontendToolsLocator.verifyTool(nodeExecutableFile)) {
             return nodeExecutableFile.getAbsolutePath();
         }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/NodeRunner.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/java/com/vaadin/flow/component/charts/export/NodeRunner.java
@@ -49,12 +49,15 @@ class NodeRunner {
         }
         // Try resolve installation from Vaadin home
         // This covers development setups where developers rely on the Node.js installation provided by Flow's frontend toolchain
-        nodeExecutableFile = new File(FrontendUtils.getVaadinHomeDirectory(), FrontendUtils.isWindows() ? "node/node.exe" : "node/node");
+        File vaadinHomeDirectory = FrontendUtils.getVaadinHomeDirectory();
+        nodeExecutableFile = new File(vaadinHomeDirectory, FrontendUtils.isWindows() ? "node/node.exe" : "node/node");
         if (frontendToolsLocator.verifyTool(nodeExecutableFile)) {
             return nodeExecutableFile.getAbsolutePath();
         }
 
-        throw new IllegalStateException("Node not found");
+        throw new IllegalStateException(String.format(
+                "The SVG generator requires a Node.js installation, however none could be found. Searched for a global installation in PATH, and in the Vaadin home directory: %s",
+                vaadinHomeDirectory.getAbsolutePath()));
     }
 
     int runJavascript(String script) throws InterruptedException, IOException {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/NodeRunnerTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/NodeRunnerTest.java
@@ -1,0 +1,66 @@
+package com.vaadin.flow.component.charts.export;
+
+import com.vaadin.flow.server.frontend.FrontendToolsLocator;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class NodeRunnerTest {
+
+    private Pattern vaadinHomeNodeRegexp;
+    private ArgumentMatcher<File> matchesVaadinHomeNode;
+
+    @Before
+    public void setup() {
+        String vaadinHome = FrontendUtils.getVaadinHomeDirectory().getAbsolutePath();
+        vaadinHomeNodeRegexp = Pattern.compile(vaadinHome + "/node/node(.exe)?");
+        matchesVaadinHomeNode = file -> vaadinHomeNodeRegexp.matcher(file.getAbsolutePath()).matches();
+    }
+
+    @Test()
+    public void findNodeExecutable_globalNodeAndVaadinHomeNode_usesGlobalNode() {
+        FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
+        // Mock being able to locate global node installation
+        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.anyString())).thenReturn(Optional.of(new File("/usr/local/bin/node")));
+        // Mock being able to locate node installation in Vaadin home
+        Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(true);
+
+        NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);
+        String nodeExecutable = nodeRunner.findNodeExecutable();
+
+        Assert.assertEquals("/usr/local/bin/node", nodeExecutable);
+    }
+
+    @Test()
+    public void findNodeExecutable_noGlobalNodeAndVaadinHomeNode_usesVaadinHomeNode() {
+        FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
+        // Mock not being able to locate global node installation
+        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.anyString())).thenReturn(Optional.empty());
+        // Mock being able to locate node installation in Vaadin home
+        Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(true);
+
+        NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);
+        String nodeExecutable = nodeRunner.findNodeExecutable();
+
+        Assert.assertTrue(vaadinHomeNodeRegexp.matcher(nodeExecutable).matches());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void findNodeExecutable_noGlobalNodeAndNoVaadinHomeNode_throwsException() {
+        FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
+        // Mock not being able to locate any node installation
+        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.anyString())).thenReturn(Optional.empty());
+        Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(false);
+
+        NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);
+        nodeRunner.findNodeExecutable();
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/NodeRunnerTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/NodeRunnerTest.java
@@ -20,18 +20,26 @@ public class NodeRunnerTest {
 
     @Before
     public void setup() {
-        String vaadinHome = FrontendUtils.getVaadinHomeDirectory().getAbsolutePath();
-        vaadinHomeNodeRegexp = Pattern.compile(vaadinHome + "/node/node(.exe)?");
-        matchesVaadinHomeNode = file -> vaadinHomeNodeRegexp.matcher(file.getAbsolutePath()).matches();
+        String vaadinHome = FrontendUtils.getVaadinHomeDirectory()
+                .getAbsolutePath();
+        vaadinHomeNodeRegexp = Pattern
+                .compile(vaadinHome + "/node/node(.exe)?");
+        matchesVaadinHomeNode = file -> vaadinHomeNodeRegexp
+                .matcher(file.getAbsolutePath()).matches();
     }
 
     @Test()
     public void findNodeExecutable_globalNodeAndVaadinHomeNode_usesGlobalNode() {
-        FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
+        FrontendToolsLocator frontendToolsLocatorMock = Mockito
+                .mock(FrontendToolsLocator.class);
         // Mock being able to locate global node installation
-        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.matches("node(.exe)?"))).thenReturn(Optional.of(new File("/usr/local/bin/node")));
+        Mockito.when(frontendToolsLocatorMock
+                .tryLocateTool(Mockito.matches("node(.exe)?")))
+                .thenReturn(Optional.of(new File("/usr/local/bin/node")));
         // Mock being able to locate node installation in Vaadin home
-        Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(true);
+        Mockito.when(frontendToolsLocatorMock
+                .verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode)))
+                .thenReturn(true);
 
         NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);
         String nodeExecutable = nodeRunner.findNodeExecutable();
@@ -41,24 +49,35 @@ public class NodeRunnerTest {
 
     @Test()
     public void findNodeExecutable_noGlobalNodeAndVaadinHomeNode_usesVaadinHomeNode() {
-        FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
+        FrontendToolsLocator frontendToolsLocatorMock = Mockito
+                .mock(FrontendToolsLocator.class);
         // Mock not being able to locate global node installation
-        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.matches("node(.exe)?"))).thenReturn(Optional.empty());
+        Mockito.when(frontendToolsLocatorMock
+                .tryLocateTool(Mockito.matches("node(.exe)?")))
+                .thenReturn(Optional.empty());
         // Mock being able to locate node installation in Vaadin home
-        Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(true);
+        Mockito.when(frontendToolsLocatorMock
+                .verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode)))
+                .thenReturn(true);
 
         NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);
         String nodeExecutable = nodeRunner.findNodeExecutable();
 
-        Assert.assertTrue(vaadinHomeNodeRegexp.matcher(nodeExecutable).matches());
+        Assert.assertTrue(
+                vaadinHomeNodeRegexp.matcher(nodeExecutable).matches());
     }
 
     @Test(expected = IllegalStateException.class)
     public void findNodeExecutable_noGlobalNodeAndNoVaadinHomeNode_throwsException() {
-        FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
+        FrontendToolsLocator frontendToolsLocatorMock = Mockito
+                .mock(FrontendToolsLocator.class);
         // Mock not being able to locate any node installation
-        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.matches("node(.exe)?"))).thenReturn(Optional.empty());
-        Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(false);
+        Mockito.when(frontendToolsLocatorMock
+                .tryLocateTool(Mockito.matches("node(.exe)?")))
+                .thenReturn(Optional.empty());
+        Mockito.when(frontendToolsLocatorMock
+                .verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode)))
+                .thenReturn(false);
 
         NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);
         nodeRunner.findNodeExecutable();

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/NodeRunnerTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/NodeRunnerTest.java
@@ -29,7 +29,7 @@ public class NodeRunnerTest {
     public void findNodeExecutable_globalNodeAndVaadinHomeNode_usesGlobalNode() {
         FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
         // Mock being able to locate global node installation
-        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.anyString())).thenReturn(Optional.of(new File("/usr/local/bin/node")));
+        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.matches("node(.exe)?"))).thenReturn(Optional.of(new File("/usr/local/bin/node")));
         // Mock being able to locate node installation in Vaadin home
         Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(true);
 
@@ -43,7 +43,7 @@ public class NodeRunnerTest {
     public void findNodeExecutable_noGlobalNodeAndVaadinHomeNode_usesVaadinHomeNode() {
         FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
         // Mock not being able to locate global node installation
-        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.anyString())).thenReturn(Optional.empty());
+        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.matches("node(.exe)?"))).thenReturn(Optional.empty());
         // Mock being able to locate node installation in Vaadin home
         Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(true);
 
@@ -57,7 +57,7 @@ public class NodeRunnerTest {
     public void findNodeExecutable_noGlobalNodeAndNoVaadinHomeNode_throwsException() {
         FrontendToolsLocator frontendToolsLocatorMock = Mockito.mock(FrontendToolsLocator.class);
         // Mock not being able to locate any node installation
-        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.anyString())).thenReturn(Optional.empty());
+        Mockito.when(frontendToolsLocatorMock.tryLocateTool(Mockito.matches("node(.exe)?"))).thenReturn(Optional.empty());
         Mockito.when(frontendToolsLocatorMock.verifyTool(ArgumentMatchers.argThat(matchesVaadinHomeNode))).thenReturn(false);
 
         NodeRunner nodeRunner = new NodeRunner(frontendToolsLocatorMock);


### PR DESCRIPTION
## Description

Prevent the SVG generator from downloading node.js if it can not be found, and throw an exception instead. First tries to locate a global node installation, and as a fallback looks for a node installation provided by Flow's frontend toolchain to cover development setups where developers don't use a global node installation.

Fixes #2837

## Type of change

- Bugfix

