### PR TITLE
feat: add shorthand constructors for CheckboxGroup 

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxDemoPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxDemoPage.java
@@ -127,15 +127,14 @@ public class CheckboxDemoPage extends Div {
         checkbox.setLabelComponent(vaadinImg);
 
         NativeButton button = new NativeButton("Change label", event -> {
-            Image newImage = new Image("https://vaadin.com/images/vaadin-logo.svg",
-                    "");
+            Image newImage = new Image(
+                    "https://vaadin.com/images/vaadin-logo.svg", "");
             newImage.setWidth("30px");
             checkbox.setLabelComponent(newImage);
         });
         button.setId("change-img-component-label");
 
-        addCard("Checkbox with the image component label", checkbox,
-                button);
+        addCard("Checkbox with the image component label", checkbox, button);
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -104,11 +104,113 @@ public class CheckboxGroup<T>
 
     private SerializableConsumer<UI> sizeRequest;
 
+    /**
+     * Creates an empty checkbox group
+     */
     public CheckboxGroup() {
         super(Collections.emptySet(), Collections.emptySet(), JsonArray.class,
                 CheckboxGroup::presentationToModel,
                 CheckboxGroup::modelToPresentation, true);
         registerValidation();
+    }
+
+    /**
+     * Creates an empty checkbox group with the defined label.
+     *
+     * @param label
+     *            the label describing the checkbox group
+     * @see #setLabel(String)
+     */
+    public CheckboxGroup(String label) {
+        this();
+        setLabel(label);
+    }
+
+    /**
+     * Creates a checkbox group with the defined label and populated with the
+     * items in the collection.
+     *
+     * @param label
+     *            the label describing the checkbox group
+     * @param items
+     *            the items to be shown in the list of the checkbox group
+     * @see #setLabel(String)
+     * @see #setItems(Collection)
+     */
+    public CheckboxGroup(String label, Collection<T> items) {
+        this();
+        setLabel(label);
+        setItems(items);
+    }
+
+    /**
+     * Creates a checkbox group with the defined label and populated with the
+     * items in the array.
+     *
+     * @param label
+     *            the label describing the checkbox group
+     * @param items
+     *            the items to be shown in the list of the checkbox group
+     * @see #setLabel(String)
+     * @see #setItems(Object...)
+     */
+    @SafeVarargs
+    public CheckboxGroup(String label, T... items) {
+        this();
+        setLabel(label);
+        setItems(items);
+    }
+
+    /**
+     * Constructs a checkbox group with a value change listener.
+     *
+     * @param listener
+     *            the value change listener to add
+     * @see #addValueChangeListener(ValueChangeListener)
+     */
+    public CheckboxGroup(
+            ValueChangeListener<ComponentValueChangeEvent<CheckboxGroup<T>, Set<T>>> listener) {
+        this();
+        addValueChangeListener(listener);
+    }
+
+    /**
+     * Constructs a checkbox group with the defined label and a value change
+     * listener.
+     *
+     * @param label
+     *            the label describing the checkbox group
+     * @param listener
+     *            the value change listener to add
+     * @see #setLabel(String)
+     * @see #addValueChangeListener(ValueChangeListener)
+     */
+    public CheckboxGroup(String label,
+            ValueChangeListener<ComponentValueChangeEvent<CheckboxGroup<T>, Set<T>>> listener) {
+        this(label);
+        addValueChangeListener(listener);
+    }
+
+    /**
+     * Constructs a checkbox group with the defined label, a value change
+     * listener and populated with the items in the array.
+     *
+     * @param label
+     *            the label describing the checkbox group
+     * @param listener
+     *            the value change listener to add
+     * @param items
+     *            the items to be shown in the list of the checkbox group
+     * @see #setLabel(String)
+     * @see #addValueChangeListener(ValueChangeListener)
+     * @see #setItems(Object...)
+     */
+    @SafeVarargs
+    public CheckboxGroup(String label,
+            ValueChangeListener<ComponentValueChangeEvent<CheckboxGroup<T>, Set<T>>> listener,
+            T... items) {
+        this(label, listener);
+        setItems(items);
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -521,6 +521,23 @@ public class CheckboxGroupTest {
                 .get().getId());
     }
 
+    @Test
+    public void setItems_createsLabelValueEventAndItems() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+
+        AtomicReference<HasValue.ValueChangeEvent> capture = new AtomicReference<>();
+        CheckboxGroup<CustomItem> checkboxGroup = new CheckboxGroup<>("label",
+                capture::set, first, second, third);
+
+        Assert.assertEquals("Invalid number of items", 3,
+                checkboxGroup.getChildren().count());
+
+        Assert.assertEquals("Invalid label for checkbox group ", "label",
+                checkboxGroup.getElement().getProperty("label"));
+    }
+
     private CheckboxGroup<Wrapper> getRefreshEventCheckboxGroup(
             List<Wrapper> items) {
         CheckboxGroup<Wrapper> checkboxGroup = new CheckboxGroup<>();


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->

## Description

 Add shorthand constructors for CheckboxGroup

Fixes #3033

## Type of change

- Feature

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
