### PR TITLE
fix: make AM/PM parser case and space insensitive

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -134,6 +134,17 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     }
 
     @Test
+    public void testAMSpaceSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 A M", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 a m", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A. M.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a. m.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A.M.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a.m.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오 전 1", "오전 1:00");
+    }
+
+    @Test
     public void testPMCaseSensitivity() {
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 PM", "1:00 PM");
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 pm", "1:00 PM");
@@ -142,6 +153,17 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
         assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P. M.", "1:00 p. m.");
         assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p. m.", "1:00 p. m.");
         assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오후 1", "오후 1:00");
+    }
+
+    @Test
+    public void testPMSpaceSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 P M", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 p m", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P. M.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p. m.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P.M.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p.m.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오 후 1", "오후 1:00");
     }
 
     public void assertTimeIsParsedCorrectly(Locale locale, String value, String expected) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -122,6 +122,34 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
         runReduceStepTest(new Locale("es", "PA"), "16:00", "p. m.");
     }
 
+    @Test
+    public void testAMCaseSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 AM", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 am", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A.M.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a.m.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A. M.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a. m.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오전 1", "오전 1:00");
+    }
+
+    @Test
+    public void testPMCaseSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 PM", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 pm", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P.M.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p.m.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P. M.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p. m.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오후 1", "오후 1:00");
+    }
+
+    public void assertTimeIsParsedCorrectly(Locale locale, String value, String expected) {
+        selectLocale(locale);
+        getTimePickerElement().selectByText(value);
+        Assert.assertEquals(expected, getTimePickerInputValueWithNormalSpaces());
+    }
+
     private void runReduceStepTest(Locale locale, String initialValue4PM,
             String pmString) {
         ArrayList<String> errors = new ArrayList<>(0);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -45,7 +45,7 @@
     // Turn `amPmString` into a space-insensitive regexp representation.
     const tokenRegExpString = amPmString.split(/\s*/).map(escapeRegExp).join('\\s*');
 
-    // Create an actual regexp with the enabled case-insensitivity.
+    // Create a regexp without case-sensitivity.
     const tokenRegExp = new RegExp(tokenRegExpString, 'i');
 
     // Match the regexp against the time string.

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -39,7 +39,7 @@
    * @param {string} amPmString
    * @return {string | null}
    */
-  function searchAmPmToken(timeString, amPmString) {
+  function searchAmOrPmToken(timeString, amOrPmString) {
     if (!amPmString) return null;
 
     // Turn `amPmString` into a space-insensitive regexp representation.

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -25,25 +25,25 @@
 
   /**
    * Searches for either an AM or PM token in the given time string
-   * depending on what is provided in `amPmString`.
+   * depending on what is provided in `amOrPmString`.
    *
    * The search is case and space insensitive.
    *
    * @example
-   * `searchAmPmToken('1 P M', 'PM')` => `'P M'`
+   * `searchAmOrPmToken('1 P M', 'PM')` => `'P M'`
    *
    * @example
-   * `searchAmPmToken('1 a.m.', 'A. M.')` => `a.m.`
+   * `searchAmOrPmToken('1 a.m.', 'A. M.')` => `a.m.`
    *
    * @param {string} timeString
-   * @param {string} amPmString
+   * @param {string} amOrPmString
    * @return {string | null}
    */
   function searchAmOrPmToken(timeString, amOrPmString) {
-    if (!amPmString) return null;
+    if (!amOrPmString) return null;
 
-    // Turn `amPmString` into a space-insensitive regexp representation.
-    const tokenRegExpString = amPmString.split(/\s*/).map(escapeRegExp).join('\\s*');
+    // Create a regexp string for searching for AM/PM without space-sensitivity.
+    const tokenRegExpString = amOrPmString.split(/\s*/).map(escapeRegExp).join('\\s*');
 
     // Create a regexp without case-sensitivity.
     const tokenRegExp = new RegExp(tokenRegExpString, 'i');
@@ -240,8 +240,8 @@
                 return cachedTimeObject;
               }
               if (timeString) {
-                const amToken = searchAmPmToken(timeString, amString);
-                const pmToken = searchAmPmToken(timeString, pmString);
+                const amToken = searchAmOrPmToken(timeString, amString);
+                const pmToken = searchAmOrPmToken(timeString, pmString);
 
                 const numbersOnlyTimeString = timeString
                   .replace(amToken || '', '')


### PR DESCRIPTION
## Description

The PR fixes a bug of TimePicker where `PM` could be interpreted as `AM` when it was written in lowercase. The fix improves the time parser to make it case and space insensitive.

Fixes #1179

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
