### PR TITLE
fix: postpone tryCatchWrapper until Flow app is initialized

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -12,90 +12,106 @@
     }
   }
 
-  window.Vaadin.Flow.contextMenuConnector = {
-    /**
-     * Initializes the connector for a context menu element.
-     *
-     * @param {HTMLElement} contextMenu
-     * @param {string} appId
-     */
-    initLazy: tryCatchWrapper((contextMenu, appId) => {
-      if (contextMenu.$connector) {
-        return;
-      }
+  /**
+   * Initializes the connector for a context menu element.
+   *
+   * @param {HTMLElement} contextMenu
+   * @param {string} appId
+   */
+  function initLazy(contextMenu, appId) {
+    if (contextMenu.$connector) {
+      return;
+    }
 
-      contextMenu.$connector = {
-        /**
-         * Generates and assigns the items to the context menu.
-         *
-         * @param {number} nodeId
-         */
-        generateItems: tryCatchWrapper((nodeId) => {
-          const items = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(appId, nodeId);
+    contextMenu.$connector = {
+      /**
+       * Generates and assigns the items to the context menu.
+       *
+       * @param {number} nodeId
+       */
+      generateItems: tryCatchWrapper((nodeId) => {
+        const items = generateItemsTree(appId, nodeId);
 
-          contextMenu.items = items;
-        })
+        contextMenu.items = items;
+      })
+    };
+  }
+
+  /**
+   * Generates an items tree compatible with the context-menu web component
+   * by traversing the given Flow DOM tree of context menu item nodes
+   * whose root node is identified by the `nodeId` argument.
+   *
+   * The app id is required to access the store of Flow DOM nodes.
+   *
+   * @param {string} appId
+   * @param {number} nodeId
+   */
+  function generateItemsTree(appId, nodeId) {
+    const container = getContainer(appId, nodeId);
+    if (!container) {
+      return;
+    }
+
+    return Array.from(container.children).map((child) => {
+      const item = {
+        component: child,
+        checked: child._checked,
+        theme: child.__theme
       };
-    }),
-
-    /**
-     * Generates an items tree compatible with the context-menu web component
-     * by traversing the given Flow DOM tree of context menu item nodes
-     * whose root node is identified by the `nodeId` argument.
-     *
-     * The app id is required to access the store of Flow DOM nodes.
-     *
-     * @param {string} appId
-     * @param {number} nodeId
-     */
-    generateItemsTree: tryCatchWrapper(function generateItemsTree(appId, nodeId) {
-      const container = getContainer(appId, nodeId);
-      if (!container) {
-        return;
+      if (child.localName == 'vaadin-context-menu-item' && child._containerNodeId) {
+        item.children = generateItemsTree(appId, child._containerNodeId);
       }
+      child._item = item;
+      return item;
+    });
+  }
 
-      return Array.from(container.children).map((child) => {
-        const item = {
-          component: child,
-          checked: child._checked,
-          theme: child.__theme
-        };
-        if (child.localName == 'vaadin-context-menu-item' && child._containerNodeId) {
-          item.children = generateItemsTree(appId, child._containerNodeId);
-        }
-        child._item = item;
-        return item;
-      });
-    }),
+  /**
+   * Sets the checked state for a context menu item.
+   *
+   * This method is supposed to be called when the context menu item is closed,
+   * so there is no need for triggering a re-render eagarly.
+   *
+   * @param {HTMLElement} component
+   * @param {boolean} checked
+   */
+  function setChecked(component, checked) {
+    if (component._item) {
+      component._item.checked = checked;
+    }
+  }
 
-    /**
-     * Sets the checked state for a context menu item.
-     *
-     * This method is supposed to be called when the context menu item is closed,
-     * so there is no need for triggering a re-render eagarly.
-     *
-     * @param {HTMLElement} component
-     * @param {boolean} checked
-     */
-    setChecked: tryCatchWrapper((component, checked) => {
-      if (component._item) {
-        component._item.checked = checked;
-      }
-    }),
+  /**
+   * Sets the theme for a context menu item.
+   *
+   * This method is supposed to be called when the context menu item is closed,
+   * so there is no need for triggering a re-render eagarly.
+   *
+   * @param {HTMLElement} component
+   * @param {string | undefined | null} theme
+   */
+  function setTheme(component, theme) {
+    if (component._item) {
+      component._item.theme = theme;
+    }
+  }
 
-    /**
-     * Sets the theme for a context menu item.
-     *
-     * This method is supposed to be called when the context menu item is closed,
-     * so there is no need for triggering a re-render eagarly.
-     *
-     * @param {HTMLElement} component
-     * @param {string | undefined | null} theme
-     */
-    setTheme: tryCatchWrapper((component, theme) => {
-      if (component._item) {
-        component._item.theme = theme;
-      }
-    })
+  window.Vaadin.Flow.contextMenuConnector = {
+    initLazy(...args) {
+      return tryCatchWrapper(initLazy)(...args);
+    },
+
+    generateItemsTree(...args) {
+      return tryCatchWrapper(generateItemsTree)(...args);
+    },
+
+    setChecked(...args) {
+      return tryCatchWrapper(setChecked)(...args);
+    },
+
+    setTheme(...args) {
+      return tryCatchWrapper(setTheme)(...args);
+    }
   };
 })();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
@@ -5,62 +5,66 @@ import * as Gestures from '@vaadin/component-base/src/gestures.js';
     return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu Target');
   }
 
-  window.Vaadin.Flow.contextMenuTargetConnector = {
-    init: tryCatchWrapper(function (target) {
-      if (target.$contextMenuTargetConnector) {
-        return;
-      }
+  function init(target) {
+    if (target.$contextMenuTargetConnector) {
+      return;
+    }
 
-      target.$contextMenuTargetConnector = {
-        openOnHandler: tryCatchWrapper(function (e) {
-          e.preventDefault();
-          e.stopPropagation();
-          this.$contextMenuTargetConnector.openEvent = e;
-          let detail = {};
-          if (target.getContextMenuBeforeOpenDetail) {
-            detail = target.getContextMenuBeforeOpenDetail(e);
-          }
-          target.dispatchEvent(
-            new CustomEvent('vaadin-context-menu-before-open', {
-              detail: detail
-            })
-          );
-        }),
+    target.$contextMenuTargetConnector = {
+      openOnHandler: tryCatchWrapper(function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.$contextMenuTargetConnector.openEvent = e;
+        let detail = {};
+        if (target.getContextMenuBeforeOpenDetail) {
+          detail = target.getContextMenuBeforeOpenDetail(e);
+        }
+        target.dispatchEvent(
+          new CustomEvent('vaadin-context-menu-before-open', {
+            detail: detail
+          })
+        );
+      }),
 
-        updateOpenOn: tryCatchWrapper(function (eventType) {
-          this.removeListener();
-          this.openOnEventType = eventType;
+      updateOpenOn: tryCatchWrapper(function (eventType) {
+        this.removeListener();
+        this.openOnEventType = eventType;
 
-          customElements.whenDefined('vaadin-context-menu').then(
-            tryCatchWrapper(() => {
-              if (Gestures.gestures[eventType]) {
-                Gestures.addListener(target, eventType, this.openOnHandler);
-              } else {
-                target.addEventListener(eventType, this.openOnHandler);
-              }
-            })
-          );
-        }),
-
-        removeListener: tryCatchWrapper(function () {
-          if (this.openOnEventType) {
-            if (Gestures.gestures[this.openOnEventType]) {
-              Gestures.removeListener(target, this.openOnEventType, this.openOnHandler);
+        customElements.whenDefined('vaadin-context-menu').then(
+          tryCatchWrapper(() => {
+            if (Gestures.gestures[eventType]) {
+              Gestures.addListener(target, eventType, this.openOnHandler);
             } else {
-              target.removeEventListener(this.openOnEventType, this.openOnHandler);
+              target.addEventListener(eventType, this.openOnHandler);
             }
+          })
+        );
+      }),
+
+      removeListener: tryCatchWrapper(function () {
+        if (this.openOnEventType) {
+          if (Gestures.gestures[this.openOnEventType]) {
+            Gestures.removeListener(target, this.openOnEventType, this.openOnHandler);
+          } else {
+            target.removeEventListener(this.openOnEventType, this.openOnHandler);
           }
-        }),
+        }
+      }),
 
-        openMenu: tryCatchWrapper(function (contextMenu) {
-          contextMenu.open(this.openEvent);
-        }),
+      openMenu: tryCatchWrapper(function (contextMenu) {
+        contextMenu.open(this.openEvent);
+      }),
 
-        removeConnector: tryCatchWrapper(function () {
-          this.removeListener();
-          target.$contextMenuTargetConnector = undefined;
-        })
-      };
-    })
+      removeConnector: tryCatchWrapper(function () {
+        this.removeListener();
+        target.$contextMenuTargetConnector = undefined;
+      })
+    };
+  }
+
+  window.Vaadin.Flow.contextMenuTargetConnector = {
+    init(...args) {
+      return tryCatchWrapper(init)(...args);
+    }
   };
 })();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -19,88 +19,92 @@
     return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Menu Bar');
   };
 
-  window.Vaadin.Flow.menubarConnector = {
-    /**
-     * Initializes the connector for a menu bar element.
-     *
-     * @param {HTMLElement} menubar
-     * @param {string} appId
-     */
-    initLazy: tryCatchWrapper(function (menubar, appId) {
-      if (menubar.$connector) {
-        return;
-      }
+  /**
+   * Initializes the connector for a menu bar element.
+   *
+   * @param {HTMLElement} menubar
+   * @param {string} appId
+   */
+  function initLazy(menubar, appId) {
+    if (menubar.$connector) {
+      return;
+    }
 
-      const observer = new MutationObserver((records) => {
-        const hasChangedAttributes = records.some((entry) => {
-          const oldValue = entry.oldValue;
-          const newValue = entry.target.getAttribute(entry.attributeName);
-          return oldValue !== newValue;
-        });
-
-        if (hasChangedAttributes) {
-          menubar.$connector.generateItems();
-        }
+    const observer = new MutationObserver((records) => {
+      const hasChangedAttributes = records.some((entry) => {
+        const oldValue = entry.oldValue;
+        const newValue = entry.target.getAttribute(entry.attributeName);
+        return oldValue !== newValue;
       });
 
-      menubar.$connector = {
-        /**
-         * Generates and assigns the items to the menu bar.
-         *
-         * When the method is called without providing a node id,
-         * the previously generated items tree will be used.
-         * That can be useful if you only want to sync the disabled and hidden properties of root items.
-         *
-         * @param {number | undefined} nodeId
-         */
-        generateItems: tryCatchWrapper((nodeId) => {
-          if (!menubar.shadowRoot) {
-            // workaround for https://github.com/vaadin/flow/issues/5722
-            setTimeout(() => menubar.$connector.generateItems(nodeId));
-            return;
-          }
+      if (hasChangedAttributes) {
+        menubar.$connector.generateItems();
+      }
+    });
 
-          if (nodeId) {
-            menubar.__generatedItems = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(appId, nodeId);
-          }
+    menubar.$connector = {
+      /**
+       * Generates and assigns the items to the menu bar.
+       *
+       * When the method is called without providing a node id,
+       * the previously generated items tree will be used.
+       * That can be useful if you only want to sync the disabled and hidden properties of root items.
+       *
+       * @param {number | undefined} nodeId
+       */
+      generateItems: tryCatchWrapper((nodeId) => {
+        if (!menubar.shadowRoot) {
+          // workaround for https://github.com/vaadin/flow/issues/5722
+          setTimeout(() => menubar.$connector.generateItems(nodeId));
+          return;
+        }
 
-          let items = menubar.__generatedItems || [];
+        if (nodeId) {
+          menubar.__generatedItems = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(appId, nodeId);
+        }
 
-          // Propagate disabled state from items to parent buttons
-          items.forEach((item) => (item.disabled = item.component.disabled));
+        let items = menubar.__generatedItems || [];
 
-          // Remove hidden items entirely from the array. Just hiding them
-          // could cause the overflow button to be rendered without items.
-          //
-          // The items-prop needs to be set even when all items are visible
-          // to update the disabled state and re-render buttons.
-          items = items.filter((item) => !item.component.hidden);
+        // Propagate disabled state from items to parent buttons
+        items.forEach((item) => (item.disabled = item.component.disabled));
 
-          // Observe for hidden and disabled attributes in case they are changed by Flow.
-          // When a change occurs, the observer will re-generate items on top of the existing tree
-          // to sync the new attribute values with the corresponding properties in the items array.
-          items.forEach((item) => {
-            observer.observe(item.component, {
-              attributeFilter: ['hidden', 'disabled'],
-              attributeOldValue: true
+        // Remove hidden items entirely from the array. Just hiding them
+        // could cause the overflow button to be rendered without items.
+        //
+        // The items-prop needs to be set even when all items are visible
+        // to update the disabled state and re-render buttons.
+        items = items.filter((item) => !item.component.hidden);
+
+        // Observe for hidden and disabled attributes in case they are changed by Flow.
+        // When a change occurs, the observer will re-generate items on top of the existing tree
+        // to sync the new attribute values with the corresponding properties in the items array.
+        items.forEach((item) => {
+          observer.observe(item.component, {
+            attributeFilter: ['hidden', 'disabled'],
+            attributeOldValue: true
+          });
+        });
+
+        menubar.items = items;
+
+        // Propagate click events from the menu buttons to the item components
+        menubar._buttons.forEach((button) => {
+          if (button.item && button.item.component) {
+            button.addEventListener('click', (e) => {
+              if (e.composedPath().indexOf(button.item.component) === -1) {
+                button.item.component.click();
+                e.stopPropagation();
+              }
             });
-          });
+          }
+        });
+      })
+    };
+  }
 
-          menubar.items = items;
-
-          // Propagate click events from the menu buttons to the item components
-          menubar._buttons.forEach((button) => {
-            if (button.item && button.item.component) {
-              button.addEventListener('click', (e) => {
-                if (e.composedPath().indexOf(button.item.component) === -1) {
-                  button.item.component.click();
-                  e.stopPropagation();
-                }
-              });
-            }
-          });
-        })
-      };
-    })
+  window.Vaadin.Flow.menubarConnector = {
+    initLazy(...args) {
+      return tryCatchWrapper(initLazy)(...args);
+    }
   };
 })();


### PR DESCRIPTION
## Description

The PR fixes the regression that was accidentally introduced in #2134. 

When using `tryCatchWrapper` with static connector methods, it is always worth taking into account that the Flow utilities can be not defined at that time yet. In order to prevent the `window.Vaadin.Flow.tryCatchWrapper is not a function` error, `tryCatchWrapper` should be invoked in the static method's scope. Note, that don't concern connector methods defined directly on the element, such as `element.$connector.open(...)`

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
