### PR TITLE
fix: make AM/PM parser case and space insensitive (#3044) (CP: 23.0)

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -122,6 +122,56 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
         runReduceStepTest(new Locale("es", "PA"), "16:00", "p. m.");
     }
 
+    @Test
+    public void testAMCaseSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 AM", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 am", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A.M.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a.m.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A. M.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a. m.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오전 1", "오전 1:00");
+    }
+
+    @Test
+    public void testAMSpaceSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 A M", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 a m", "1:00 AM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A. M.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a. m.", "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A.M.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a.m.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오 전 1", "오전 1:00");
+    }
+
+    @Test
+    public void testPMCaseSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 PM", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 pm", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P.M.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p.m.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P. M.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p. m.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오후 1", "오후 1:00");
+    }
+
+    @Test
+    public void testPMSpaceSensitivity() {
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 P M", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 p m", "1:00 PM");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P. M.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p. m.", "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P.M.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p.m.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오 후 1", "오후 1:00");
+    }
+
+    public void assertTimeIsParsedCorrectly(Locale locale, String value, String expected) {
+        selectLocale(locale);
+        getTimePickerElement().selectByText(value);
+        Assert.assertEquals(expected, getTimePickerInputValueWithNormalSpaces());
+    }
+
     private void runReduceStepTest(Locale locale, String initialValue4PM,
             String pmString) {
         ArrayList<String> errors = new ArrayList<>(0);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -126,10 +126,14 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     public void testAMCaseSensitivity() {
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 AM", "1:00 AM");
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 am", "1:00 AM");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A.M.", "1:00 a.m.");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a.m.", "1:00 a.m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A. M.", "1:00 a. m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a. m.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A.M.",
+                "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a.m.",
+                "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A. M.",
+                "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a. m.",
+                "1:00 a. m.");
         assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오전 1", "오전 1:00");
     }
 
@@ -137,10 +141,14 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     public void testAMSpaceSensitivity() {
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 A M", "1:00 AM");
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 a m", "1:00 AM");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A. M.", "1:00 a.m.");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a. m.", "1:00 a.m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A.M.", "1:00 a. m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a.m.", "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 A. M.",
+                "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 a. m.",
+                "1:00 a.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 A.M.",
+                "1:00 a. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 a.m.",
+                "1:00 a. m.");
         assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오 전 1", "오전 1:00");
     }
 
@@ -148,10 +156,14 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     public void testPMCaseSensitivity() {
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 PM", "1:00 PM");
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 pm", "1:00 PM");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P.M.", "1:00 p.m.");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p.m.", "1:00 p.m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P. M.", "1:00 p. m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p. m.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P.M.",
+                "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p.m.",
+                "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P. M.",
+                "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p. m.",
+                "1:00 p. m.");
         assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오후 1", "오후 1:00");
     }
 
@@ -159,17 +171,23 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     public void testPMSpaceSensitivity() {
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 P M", "1:00 PM");
         assertTimeIsParsedCorrectly(new Locale("en", "US"), "1 p m", "1:00 PM");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P. M.", "1:00 p.m.");
-        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p. m.", "1:00 p.m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P.M.", "1:00 p. m.");
-        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p.m.", "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 P. M.",
+                "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("en", "CA"), "1 p. m.",
+                "1:00 p.m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 P.M.",
+                "1:00 p. m.");
+        assertTimeIsParsedCorrectly(new Locale("es", "PA"), "1 p.m.",
+                "1:00 p. m.");
         assertTimeIsParsedCorrectly(new Locale("ko", "KR"), "오 후 1", "오후 1:00");
     }
 
-    public void assertTimeIsParsedCorrectly(Locale locale, String value, String expected) {
+    public void assertTimeIsParsedCorrectly(Locale locale, String value,
+            String expected) {
         selectLocale(locale);
         getTimePickerElement().selectByText(value);
-        Assert.assertEquals(expected, getTimePickerInputValueWithNormalSpaces());
+        Assert.assertEquals(expected,
+                getTimePickerInputValueWithNormalSpaces());
     }
 
     private void runReduceStepTest(Locale locale, String initialValue4PM,


### PR DESCRIPTION
## Description

The PR cherry-picks the following fix to `23.0`:

- #3044

Fixes #1179

Depends on https://github.com/vaadin/flow-components/pull/3060

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
