### PR TITLE
chore: format JS connectors with Prettier (CP: 22.0)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "printWidth": 120,
+  "trailingComma": "none",
+  "htmlWhitespaceSensitivity": "strict"
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -3,351 +3,347 @@ import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
 
 (function () {
-    const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Combo Box', 'vaadin-combo-box');
-    };
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Combo Box', 'vaadin-combo-box');
+  };
 
-    window.Vaadin.Flow.comboBoxConnector = {
-        initLazy: comboBox => tryCatchWrapper(function (comboBox) {
+  window.Vaadin.Flow.comboBoxConnector = {
+    initLazy: (comboBox) =>
+      tryCatchWrapper(function (comboBox) {
+        // Check whether the connector was already initialized for the ComboBox
+        if (comboBox.$connector) {
+          return;
+        }
 
-            // Check whether the connector was already initialized for the ComboBox
-            if (comboBox.$connector) {
-                return;
+        comboBox.$connector = {};
+
+        // holds pageIndex -> callback pairs of subsequent indexes (current active range)
+        const pageCallbacks = {};
+        let cache = {};
+        let lastFilter = '';
+        const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
+        const MAX_RANGE_COUNT = Math.max(comboBox.pageSize * 2, 500); // Max item count in active range
+
+        const serverFacade = (() => {
+          // Private variables
+          let lastFilterSentToServer = '';
+          let dataCommunicatorResetNeeded = false;
+
+          // Public methods
+          const needsDataCommunicatorReset = () => (dataCommunicatorResetNeeded = true);
+          const getLastFilterSentToServer = () => lastFilterSentToServer;
+          const requestData = (startIndex, endIndex, params) => {
+            const count = endIndex - startIndex;
+            const filter = params.filter;
+
+            comboBox.$server.setRequestedRange(startIndex, count, filter);
+            lastFilterSentToServer = filter;
+            if (dataCommunicatorResetNeeded) {
+              comboBox.$server.resetDataCommunicator();
+              dataCommunicatorResetNeeded = false;
             }
+          };
 
-            comboBox.$connector = {};
+          return { needsDataCommunicatorReset, getLastFilterSentToServer, requestData };
+        })();
 
-            // holds pageIndex -> callback pairs of subsequent indexes (current active range)
-            const pageCallbacks = {};
-            let cache = {};
-            let lastFilter = '';
-            const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
-            const MAX_RANGE_COUNT = Math.max(comboBox.pageSize * 2, 500); // Max item count in active range
+        const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
+          // Flush and empty the existing requests
+          pages.forEach((page) => {
+            pageCallbacks[page]([], comboBox.size);
+            delete pageCallbacks[page];
 
-            const serverFacade = (() => {
-                // Private variables
-                let lastFilterSentToServer = '';
-                let dataCommunicatorResetNeeded = false;
-
-                // Public methods
-                const needsDataCommunicatorReset = () => dataCommunicatorResetNeeded = true;
-                const getLastFilterSentToServer = () => lastFilterSentToServer;
-                const requestData = (startIndex, endIndex, params) => {
-                    const count = endIndex - startIndex;
-                    const filter = params.filter;
-
-                    comboBox.$server.setRequestedRange(startIndex, count, filter);
-                    lastFilterSentToServer = filter;
-                    if(dataCommunicatorResetNeeded) {
-                        comboBox.$server.resetDataCommunicator();
-                        dataCommunicatorResetNeeded = false;
-                    }
-                };
-
-                return {needsDataCommunicatorReset, getLastFilterSentToServer, requestData};
-
-            })();
-
-            const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
-                // Flush and empty the existing requests
-                pages.forEach(page => {
-                    pageCallbacks[page]([], comboBox.size);
-                    delete pageCallbacks[page];
-
-                    // Empty the comboBox's internal cache without invoking observers by filling
-                    // the filteredItems array with placeholders (comboBox will request for data when it
-                    // encounters a placeholder)
-                    const pageStart = parseInt(page) * comboBox.pageSize;
-                    const pageEnd = pageStart + comboBox.pageSize;
-                    const end = Math.min(pageEnd, comboBox.filteredItems.length);
-                    for (let i = pageStart; i < end; i++) {
-                        comboBox.filteredItems[i] = placeHolder;
-                    }
-                });
+            // Empty the comboBox's internal cache without invoking observers by filling
+            // the filteredItems array with placeholders (comboBox will request for data when it
+            // encounters a placeholder)
+            const pageStart = parseInt(page) * comboBox.pageSize;
+            const pageEnd = pageStart + comboBox.pageSize;
+            const end = Math.min(pageEnd, comboBox.filteredItems.length);
+            for (let i = pageStart; i < end; i++) {
+              comboBox.filteredItems[i] = placeHolder;
             }
+          });
+        };
 
-            comboBox.dataProvider = function (params, callback) {
-                if (params.pageSize != comboBox.pageSize) {
-                    throw 'Invalid pageSize';
-                }
+        comboBox.dataProvider = function (params, callback) {
+          if (params.pageSize != comboBox.pageSize) {
+            throw 'Invalid pageSize';
+          }
 
-                if (comboBox._clientSideFilter) {
-                    // For clientside filter we first make sure we have all data which we also
-                    // filter based on comboBox.filter. While later we only filter clientside data.
+          if (comboBox._clientSideFilter) {
+            // For clientside filter we first make sure we have all data which we also
+            // filter based on comboBox.filter. While later we only filter clientside data.
 
-                    if (cache[0]) {
-                        performClientSideFilter(cache[0], callback)
-                        return;
+            if (cache[0]) {
+              performClientSideFilter(cache[0], callback);
+              return;
+            } else {
+              // If client side filter is enabled then we need to first ask all data
+              // and filter it on client side, otherwise next time when user will
+              // input another filter, eg. continue to type, the local cache will be only
+              // what was received for the first filter, which may not be the whole
+              // data from server (keep in mind that client side filter is enabled only
+              // when the items count does not exceed one page).
+              params.filter = '';
+            }
+          }
 
-                    } else {
-                        // If client side filter is enabled then we need to first ask all data
-                        // and filter it on client side, otherwise next time when user will
-                        // input another filter, eg. continue to type, the local cache will be only
-                        // what was received for the first filter, which may not be the whole
-                        // data from server (keep in mind that client side filter is enabled only
-                        // when the items count does not exceed one page).
-                        params.filter = "";
-                    }
-                }
+          const filterChanged = params.filter !== lastFilter;
+          if (filterChanged) {
+            cache = {};
+            lastFilter = params.filter;
+            this._debouncer = Debouncer.debounce(this._debouncer, timeOut.after(500), () => {
+              if (serverFacade.getLastFilterSentToServer() === params.filter) {
+                // Fixes the case when the filter changes
+                // to something else and back to the original value
+                // within debounce timeout, and the
+                // DataCommunicator thinks it doesn't need to send data
+                serverFacade.needsDataCommunicatorReset();
+              }
+              if (params.filter !== lastFilter) {
+                throw new Error("Expected params.filter to be '" + lastFilter + "' but was '" + params.filter + "'");
+              }
+              // Call the method again after debounce.
+              clearPageCallbacks();
+              comboBox.dataProvider(params, callback);
+            });
+            return;
+          }
 
-                const filterChanged = params.filter !== lastFilter;
-                if (filterChanged) {
-                    cache = {};
-                    lastFilter = params.filter;
-                    this._debouncer = Debouncer.debounce(
-                        this._debouncer,
-                        timeOut.after(500),
-                        () => {
-                            if (serverFacade.getLastFilterSentToServer() === params.filter) {
-                                // Fixes the case when the filter changes
-                                // to something else and back to the original value
-                                // within debounce timeout, and the
-                                // DataCommunicator thinks it doesn't need to send data
-                                serverFacade.needsDataCommunicatorReset();
-                            }
-                            if(params.filter !== lastFilter) {
-                                throw new Error("Expected params.filter to be '"
-                                    + lastFilter + "' but was '" + params.filter + "'");
-                            }
-                            // Call the method again after debounce.
-                            clearPageCallbacks();
-                            comboBox.dataProvider(params, callback)
-                        });
-                    return;
-                }
+          if (cache[params.page]) {
+            // This may happen after skipping pages by scrolling fast
+            commitPage(params.page, callback);
+          } else {
+            pageCallbacks[params.page] = callback;
+            const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
+            const rangeMin = Math.min(...activePages);
+            const rangeMax = Math.max(...activePages);
 
-                if (cache[params.page]) {
-                    // This may happen after skipping pages by scrolling fast
-                    commitPage(params.page, callback);
+            if (activePages.length * params.pageSize > MAX_RANGE_COUNT) {
+              if (params.page === rangeMin) {
+                clearPageCallbacks([String(rangeMax)]);
+              } else {
+                clearPageCallbacks([String(rangeMin)]);
+              }
+              comboBox.dataProvider(params, callback);
+            } else if (rangeMax - rangeMin + 1 !== activePages.length) {
+              // Wasn't a sequential page index, clear the cache so combo-box will request for new pages
+              clearPageCallbacks();
+            } else {
+              // The requested page was sequential, extend the requested range
+              const startIndex = params.pageSize * rangeMin;
+              const endIndex = params.pageSize * (rangeMax + 1);
+
+              if (!this._debouncer || !this._debouncer.isActive()) {
+                serverFacade.requestData(startIndex, endIndex, params);
+              } else {
+                this._debouncer = Debouncer.debounce(this._debouncer, timeOut.after(200), () =>
+                  serverFacade.requestData(startIndex, endIndex, params)
+                );
+              }
+            }
+          }
+        };
+
+        comboBox.$connector.clear = tryCatchWrapper((start, length) => {
+          const firstPageToClear = Math.floor(start / comboBox.pageSize);
+          const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
+
+          for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
+            delete cache[i];
+          }
+        });
+
+        comboBox.$connector.filter = tryCatchWrapper(function (item, filter) {
+          filter = filter ? filter.toString().toLowerCase() : '';
+          return comboBox._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;
+        });
+
+        comboBox.$connector.set = tryCatchWrapper(function (index, items, filter) {
+          if (filter != serverFacade.getLastFilterSentToServer()) {
+            return;
+          }
+
+          if (index % comboBox.pageSize != 0) {
+            throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
+          }
+
+          if (index === 0 && items.length === 0 && pageCallbacks[0]) {
+            // Makes sure that the dataProvider callback is called even when server
+            // returns empty data set (no items match the filter).
+            cache[0] = [];
+            return;
+          }
+
+          const firstPageToSet = index / comboBox.pageSize;
+          const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
+
+          for (let i = 0; i < updatedPageCount; i++) {
+            let page = firstPageToSet + i;
+            let slice = items.slice(i * comboBox.pageSize, (i + 1) * comboBox.pageSize);
+
+            cache[page] = slice;
+          }
+        });
+
+        comboBox.$connector.updateData = tryCatchWrapper(function (items) {
+          // IE11 doesn't work with the transpiled version of the forEach.
+          for (let i = 0; i < items.length; i++) {
+            let item = items[i];
+
+            for (let j = 0; j < comboBox.filteredItems.length; j++) {
+              if (comboBox.filteredItems[j].key === item.key) {
+                comboBox.set('filteredItems.' + j, item);
+                break;
+              }
+            }
+          }
+        });
+
+        comboBox.$connector.updateSize = tryCatchWrapper(function (newSize) {
+          if (!comboBox._clientSideFilter) {
+            // FIXME: It may be that this size set is unnecessary, since when
+            // providing data to combobox via callback we may use data's size.
+            // However, if this size reflect the whole data size, including
+            // data not fetched yet into client side, and combobox expect it
+            // to be set as such, the at least, we don't need it in case the
+            // filter is clientSide only, since it'll increase the height of
+            // the popup at only at first user filter to this size, while the
+            // filtered items count are less.
+            comboBox.size = newSize;
+          }
+        });
+
+        comboBox.$connector.reset = tryCatchWrapper(function () {
+          clearPageCallbacks();
+          cache = {};
+          comboBox.clearCache();
+        });
+
+        comboBox.$connector.confirm = tryCatchWrapper(function (id, filter) {
+          if (filter != serverFacade.getLastFilterSentToServer()) {
+            return;
+          }
+
+          // We're done applying changes from this batch, resolve pending
+          // callbacks
+          let activePages = Object.getOwnPropertyNames(pageCallbacks);
+          for (let i = 0; i < activePages.length; i++) {
+            let page = activePages[i];
+
+            if (cache[page]) {
+              commitPage(page, pageCallbacks[page]);
+            }
+          }
+
+          // Let server know we're done
+          comboBox.$server.confirmUpdate(id);
+        });
+
+        comboBox.addEventListener(
+          'opened-changed',
+          tryCatchWrapper(() => {
+            // Patch once the instance is ready and vaadin-combo-box has
+            // been finalized (i.e. opened-changed is emitted)
+
+            const isItemSelected = comboBox.$.dropdown._scroller.__isItemSelected;
+            // Override comboBox's _isItemSelected logic to handle remapped items
+            comboBox.$.dropdown._scroller.__isItemSelected = (item, selectedItem, itemIdPath) => {
+              let selected = isItemSelected.call(comboBox, item, selectedItem, itemIdPath);
+
+              if (comboBox._selectedKey) {
+                if (comboBox.filteredItems.indexOf(selectedItem) > -1) {
+                  delete comboBox._selectedKey;
                 } else {
-                    pageCallbacks[params.page] = callback
-                    const activePages = Object.keys(pageCallbacks).map(page => parseInt(page));
-                    const rangeMin = Math.min(...activePages);
-                    const rangeMax = Math.max(...activePages);
-
-                    if (activePages.length * params.pageSize > MAX_RANGE_COUNT) {
-                        if (params.page === rangeMin) {
-                            clearPageCallbacks([String(rangeMax)]);
-                        } else {
-                            clearPageCallbacks([String(rangeMin)]);
-                        }
-                        comboBox.dataProvider(params, callback);
-                    } else if (rangeMax - rangeMin + 1 !== activePages.length) {
-                        // Wasn't a sequential page index, clear the cache so combo-box will request for new pages
-                        clearPageCallbacks();
-                    } else {
-                        // The requested page was sequential, extend the requested range
-                        const startIndex = params.pageSize * rangeMin;
-                        const endIndex = params.pageSize * (rangeMax + 1);
-
-                        if (!this._debouncer || !this._debouncer.isActive()) {
-                            serverFacade.requestData(startIndex, endIndex, params);
-                        } else {
-                            this._debouncer = Debouncer.debounce(
-                                this._debouncer,
-                                timeOut.after(200),
-                                () => serverFacade.requestData(startIndex, endIndex, params));
-                        }
-                    }
+                  selected = selected || item.key === comboBox._selectedKey;
                 }
+              }
+
+              return selected;
+            };
+          }),
+          { once: true }
+        );
+
+        comboBox.$connector.enableClientValidation = tryCatchWrapper(function (enable) {
+          if (comboBox.$) {
+            if (enable) {
+              enableClientValidation(comboBox);
+            } else {
+              disableClientValidation(comboBox);
             }
 
-            comboBox.$connector.clear = tryCatchWrapper((start, length) => {
-                const firstPageToClear = Math.floor(start / comboBox.pageSize);
-                const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
-                
-                for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
-                    delete cache[i];
-                }
-            });
+            comboBox.validate();
+          } else {
+            setTimeout(function () {
+              comboBox.$connector.enableClientValidation(enable);
+            }, 10);
+          }
+        });
 
-            comboBox.$connector.filter = tryCatchWrapper(function (item, filter) {
-                filter = filter ? filter.toString().toLowerCase() : '';
-                return comboBox._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;
-            });
+        const disableClientValidation = tryCatchWrapper(function (combo) {
+          if (typeof combo.$checkValidity == 'undefined') {
+            combo.$checkValidity = combo.checkValidity;
+            combo.checkValidity = function () {
+              return !comboBox.invalid;
+            };
+          }
+          if (typeof combo.$validate == 'undefined') {
+            combo.$validate = combo.validate;
+            combo.validate = function () {
+              return !(comboBox.focusElement.invalid = comboBox.invalid);
+            };
+          }
+        });
 
-            comboBox.$connector.set = tryCatchWrapper(function (index, items, filter) {
-                if (filter != serverFacade.getLastFilterSentToServer()) {
-                    return;
-                }
+        const enableClientValidation = tryCatchWrapper(function (combo) {
+          if (combo.$checkValidity) {
+            combo.checkValidity = combo.$checkValidity;
+            delete combo.$checkValidity;
+          }
+          if (combo.$validate) {
+            combo.validate = combo.$validate;
+            delete combo.$validate;
+          }
+        });
 
-                if (index % comboBox.pageSize != 0) {
-                    throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
-                }
+        const commitPage = tryCatchWrapper(function (page, callback) {
+          let data = cache[page];
 
-                if (index === 0 && items.length === 0 && pageCallbacks[0]) {
-                    // Makes sure that the dataProvider callback is called even when server
-                    // returns empty data set (no items match the filter).
-                    cache[0] = [];
-                    return;
-                }
+          if (comboBox._clientSideFilter) {
+            performClientSideFilter(data, callback);
+          } else {
+            // Remove the data if server-side filtering, but keep it for client-side
+            // filtering
+            delete cache[page];
 
-                const firstPageToSet = index / comboBox.pageSize;
-                const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
+            // FIXME: It may be that we ought to provide data.length instead of
+            // comboBox.size and remove updateSize function.
+            callback(data, comboBox.size);
+          }
+        });
 
-                for (let i = 0; i < updatedPageCount; i++) {
-                    let page = firstPageToSet + i;
-                    let slice = items.slice(i * comboBox.pageSize, (i + 1) * comboBox.pageSize);
+        // Perform filter on client side (here) using the items from specified page
+        // and submitting the filtered items to specified callback.
+        // The filter used is the one from combobox, not the lastFilter stored since
+        // that may not reflect user's input.
+        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
+          let filteredItems = page;
 
-                    cache[page] = slice;
-                }
-            });
+          if (comboBox.filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
+          }
 
-            comboBox.$connector.updateData = tryCatchWrapper(function (items) {
-                // IE11 doesn't work with the transpiled version of the forEach.
-                for (let i = 0; i < items.length; i++) {
-                    let item = items[i];
+          callback(filteredItems, filteredItems.length);
+        });
 
-                    for (let j = 0; j < comboBox.filteredItems.length; j++) {
-                        if (comboBox.filteredItems[j].key === item.key) {
-                            comboBox.set('filteredItems.' + j, item);
-                            break;
-                        }
-                    }
-                }
-            });
-
-            comboBox.$connector.updateSize = tryCatchWrapper(function (newSize) {
-                if (!comboBox._clientSideFilter) {
-                    // FIXME: It may be that this size set is unnecessary, since when
-                    // providing data to combobox via callback we may use data's size.
-                    // However, if this size reflect the whole data size, including
-                    // data not fetched yet into client side, and combobox expect it
-                    // to be set as such, the at least, we don't need it in case the
-                    // filter is clientSide only, since it'll increase the height of
-                    // the popup at only at first user filter to this size, while the
-                    // filtered items count are less.
-                    comboBox.size = newSize;
-                }
-            });
-
-            comboBox.$connector.reset = tryCatchWrapper(function () {
-                clearPageCallbacks();
-                cache = {};
-                comboBox.clearCache();
-            });
-
-            comboBox.$connector.confirm = tryCatchWrapper(function (id, filter) {
-
-                if (filter != serverFacade.getLastFilterSentToServer()) {
-                    return;
-                }
-
-                // We're done applying changes from this batch, resolve pending
-                // callbacks
-                let activePages = Object.getOwnPropertyNames(pageCallbacks);
-                for (let i = 0; i < activePages.length; i++) {
-                    let page = activePages[i];
-
-                    if (cache[page]) {
-                        commitPage(page, pageCallbacks[page]);
-                    }
-                }
-
-                // Let server know we're done
-                comboBox.$server.confirmUpdate(id);
-            });
-
-            comboBox.addEventListener('opened-changed', tryCatchWrapper(() => {
-                // Patch once the instance is ready and vaadin-combo-box has
-                // been finalized (i.e. opened-changed is emitted)
-
-                const isItemSelected = comboBox.$.dropdown._scroller.__isItemSelected;
-                // Override comboBox's _isItemSelected logic to handle remapped items
-                comboBox.$.dropdown._scroller.__isItemSelected = (item, selectedItem, itemIdPath) => {
-                    let selected = isItemSelected.call(comboBox, item, selectedItem, itemIdPath);
-
-                    if (comboBox._selectedKey) {
-                        if (comboBox.filteredItems.indexOf(selectedItem) > -1) {
-                            delete comboBox._selectedKey;
-                        } else {
-                            selected = selected || item.key === comboBox._selectedKey;
-                        }
-                    }
-
-                    return selected;
-                }
-            }), { once: true });
-
-            comboBox.$connector.enableClientValidation = tryCatchWrapper(function( enable ){
-                if ( comboBox.$ ){
-                    if ( enable){
-                        enableClientValidation(comboBox);
-                    }
-                    else {
-                        disableClientValidation(comboBox);
-                    }
-
-                    comboBox.validate();
-                }
-                else {
-                    setTimeout( function(){
-                        comboBox.$connector.enableClientValidation(enable);
-                    }, 10);
-                }
-            });
-
-            const disableClientValidation =  tryCatchWrapper(function (combo){
-                if ( typeof combo.$checkValidity == 'undefined'){
-                    combo.$checkValidity = combo.checkValidity;
-                    combo.checkValidity = function() { return !comboBox.invalid; };
-                }
-                if ( typeof combo.$validate == 'undefined'){
-                    combo.$validate = combo.validate;
-                    combo.validate = function() {
-                        return !(comboBox.focusElement.invalid = comboBox.invalid);
-                    };
-                }
-            });
-
-            const enableClientValidation = tryCatchWrapper(function (combo){
-                if ( combo.$checkValidity ){
-                    combo.checkValidity = combo.$checkValidity;
-                    delete combo.$checkValidity;
-                }
-                if ( combo.$validate ){
-                    combo.validate = combo.$validate;
-                    delete combo.$validate;
-                }
-            });
-
-            const commitPage = tryCatchWrapper(function (page, callback) {
-                let data = cache[page];
-
-                if (comboBox._clientSideFilter) {
-                    performClientSideFilter(data, callback)
-
-                } else {
-                    // Remove the data if server-side filtering, but keep it for client-side
-                    // filtering
-                    delete cache[page];
-
-                    // FIXME: It may be that we ought to provide data.length instead of
-                    // comboBox.size and remove updateSize function.
-                    callback(data, comboBox.size);
-                }
-            });
-
-            // Perform filter on client side (here) using the items from specified page
-            // and submitting the filtered items to specified callback.
-            // The filter used is the one from combobox, not the lastFilter stored since
-            // that may not reflect user's input.
-            const performClientSideFilter = tryCatchWrapper(function (page, callback) {
-
-                let filteredItems = page;
-
-                if (comboBox.filter) {
-                    filteredItems = page.filter(item =>
-                        comboBox.$connector.filter(item, comboBox.filter));
-                }
-
-                callback(filteredItems, filteredItems.length);
-            });
-
-            // Prevent setting the custom value as the 'value'-prop automatically
-            comboBox.addEventListener('custom-value-set', tryCatchWrapper(e => e.preventDefault()));
-        })(comboBox)
-    }
+        // Prevent setting the custom value as the 'value'-prop automatically
+        comboBox.addEventListener(
+          'custom-value-set',
+          tryCatchWrapper((e) => e.preventDefault())
+        );
+      })(comboBox)
+  };
 })();
 
 window.Vaadin.ComboBoxPlaceholder = ComboBoxPlaceholder;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -1,24 +1,20 @@
-import { GestureEventListeners } from "@polymer/polymer/lib/mixins/gesture-event-listeners.js";
-import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
-(function() {
-  const tryCatchWrapper = function(callback) {
-    return window.Vaadin.Flow.tryCatchWrapper(
-      callback,
-      "Vaadin Context Menu",
-      "vaadin-context-menu-flow"
-    );
+import { GestureEventListeners } from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';
+import * as Gestures from '@polymer/polymer/lib/utils/gestures.js';
+(function () {
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu', 'vaadin-context-menu-flow');
   };
 
   window.Vaadin.Flow.contextMenuConnector = {
     // NOTE: This is for the TARGET component, not for the <vaadin-context-menu> itself
-    init: target =>
-      tryCatchWrapper(function(target) {
+    init: (target) =>
+      tryCatchWrapper(function (target) {
         if (target.$contextMenuConnector) {
           return;
         }
 
         target.$contextMenuConnector = {
-          openOnHandler: tryCatchWrapper(function(e) {
+          openOnHandler: tryCatchWrapper(function (e) {
             e.preventDefault();
             e.stopPropagation();
             this.$contextMenuConnector.openEvent = e;
@@ -27,17 +23,17 @@ import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
               detail = target.getContextMenuBeforeOpenDetail(e);
             }
             target.dispatchEvent(
-              new CustomEvent("vaadin-context-menu-before-open", {
+              new CustomEvent('vaadin-context-menu-before-open', {
                 detail: detail
               })
             );
           }),
 
-          updateOpenOn: tryCatchWrapper(function(eventType) {
+          updateOpenOn: tryCatchWrapper(function (eventType) {
             this.removeListener();
             this.openOnEventType = eventType;
 
-            customElements.whenDefined("vaadin-context-menu").then(
+            customElements.whenDefined('vaadin-context-menu').then(
               tryCatchWrapper(() => {
                 if (Gestures.gestures[eventType]) {
                   Gestures.addListener(target, eventType, this.openOnHandler);
@@ -48,28 +44,21 @@ import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
             );
           }),
 
-          removeListener: tryCatchWrapper(function() {
+          removeListener: tryCatchWrapper(function () {
             if (this.openOnEventType) {
               if (Gestures.gestures[this.openOnEventType]) {
-                Gestures.removeListener(
-                  target,
-                  this.openOnEventType,
-                  this.openOnHandler
-                );
+                Gestures.removeListener(target, this.openOnEventType, this.openOnHandler);
               } else {
-                target.removeEventListener(
-                  this.openOnEventType,
-                  this.openOnHandler
-                );
+                target.removeEventListener(this.openOnEventType, this.openOnHandler);
               }
             }
           }),
 
-          openMenu: tryCatchWrapper(function(contextMenu) {
+          openMenu: tryCatchWrapper(function (contextMenu) {
             contextMenu.open(this.openEvent);
           }),
 
-          removeConnector: tryCatchWrapper(function() {
+          removeConnector: tryCatchWrapper(function () {
             this.removeListener();
             target.$contextMenuConnector = undefined;
           })
@@ -77,32 +66,29 @@ import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
       })(target),
 
     generateItems: (menu, appId, nodeId) =>
-      tryCatchWrapper(function(menu, appId, nodeId) {
+      tryCatchWrapper(function (menu, appId, nodeId) {
         menu._containerNodeId = nodeId;
 
-        const getContainer = function(nodeId) {
+        const getContainer = function (nodeId) {
           try {
             return window.Vaadin.Flow.clients[appId].getByNodeId(nodeId);
           } catch (error) {
-            console.error("Could not get node %s from app %s", nodeId, appId);
+            console.error('Could not get node %s from app %s', nodeId, appId);
             console.error(error);
           }
         };
 
-        const getChildItems = function(parent) {
+        const getChildItems = function (parent) {
           const container = getContainer(parent._containerNodeId);
           const items =
             container &&
-            Array.from(container.children).map(child => {
+            Array.from(container.children).map((child) => {
               const item = {
-                  component: child,
-                  checked: child._checked,
-                  theme: child._theme
+                component: child,
+                checked: child._checked,
+                theme: child._theme
               };
-              if (
-                child.tagName == "VAADIN-CONTEXT-MENU-ITEM" &&
-                child._containerNodeId
-              ) {
+              if (child.tagName == 'VAADIN-CONTEXT-MENU-ITEM' && child._containerNodeId) {
                 item.children = getChildItems(child);
               }
               child._item = item;
@@ -116,17 +102,17 @@ import * as Gestures from "@polymer/polymer/lib/utils/gestures.js";
       })(menu, appId, nodeId),
 
     setChecked: (component, checked) =>
-      tryCatchWrapper(function(component, checked) {
+      tryCatchWrapper(function (component, checked) {
         if (component._item) {
           component._item.checked = checked;
         }
       })(component, checked),
 
     setTheme: (component, theme) =>
-        tryCatchWrapper((component, theme) => {
-            if (component._item) {
-                component._item.theme = theme;
-            }
-        })(component, theme)
+      tryCatchWrapper((component, theme) => {
+        if (component._item) {
+          component._item.theme = theme;
+        }
+      })(component, theme)
   };
 })();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -3,186 +3,201 @@ import dateFnsParse from 'date-fns/parse';
 import dateFnsIsValid from 'date-fns/isValid';
 
 (function () {
-    const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker', 'vaadin-date-picker');
-    };
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker', 'vaadin-date-picker');
+  };
 
-    /* helper class for parsing regex from formatted date string */
+  /* helper class for parsing regex from formatted date string */
 
-    class FlowDatePickerPart {
-        constructor(initial) {
-            this.initial = initial;
-            this.index = 0;
-            this.value = 0;
-        }
-
-        static compare(part1, part2) {
-            if (part1.index < part2.index) {
-                return -1;
-            }
-            if (part1.index > part2.index) {
-                return 1;
-            }
-            return 0;
-        }
+  class FlowDatePickerPart {
+    constructor(initial) {
+      this.initial = initial;
+      this.index = 0;
+      this.value = 0;
     }
-    window.Vaadin.Flow.datepickerConnector = {
-        initLazy: datepicker => tryCatchWrapper(function (datepicker) {
-            // Check whether the connector was already initialized for the datepicker
-            if (datepicker.$connector) {
-                return;
+
+    static compare(part1, part2) {
+      if (part1.index < part2.index) {
+        return -1;
+      }
+      if (part1.index > part2.index) {
+        return 1;
+      }
+      return 0;
+    }
+  }
+  window.Vaadin.Flow.datepickerConnector = {
+    initLazy: (datepicker) =>
+      tryCatchWrapper(function (datepicker) {
+        // Check whether the connector was already initialized for the datepicker
+        if (datepicker.$connector) {
+          return;
+        }
+
+        datepicker.$connector = {};
+
+        /* init helper parts for reverse-engineering date-regex */
+        datepicker.$connector.dayPart = new FlowDatePickerPart('22');
+        datepicker.$connector.monthPart = new FlowDatePickerPart('11');
+        datepicker.$connector.yearPart = new FlowDatePickerPart('1987');
+        datepicker.$connector.parts = [
+          datepicker.$connector.dayPart,
+          datepicker.$connector.monthPart,
+          datepicker.$connector.yearPart
+        ];
+
+        datepicker.addEventListener(
+          'blur',
+          tryCatchWrapper((e) => {
+            if (!e.target.value && e.target.invalid) {
+              console.warn('Invalid value in the DatePicker.');
+            }
+          })
+        );
+
+        const cleanString = tryCatchWrapper(function (string) {
+          // Clear any non ascii characters from the date string,
+          // mainly the LEFT-TO-RIGHT MARK.
+          // This is a problem for many Microsoft browsers where `toLocaleDateString`
+          // adds the LEFT-TO-RIGHT MARK see https://en.wikipedia.org/wiki/Left-to-right_mark
+          return string.replace(/[^\x00-\x7F]/g, '');
+        });
+
+        const getInputValue = tryCatchWrapper(function () {
+          let inputValue = '';
+          try {
+            inputValue = datepicker._inputValue;
+          } catch (err) {
+            /* component not ready: falling back to stored value */
+            inputValue = datepicker.value || '';
+          }
+          return inputValue;
+        });
+
+        const createLocaleBasedFormatterAndParser = tryCatchWrapper(function (locale) {
+          try {
+            // Check whether the locale is supported or not
+            new Date().toLocaleDateString(locale);
+          } catch (e) {
+            locale = 'en-US';
+            console.warn('The locale is not supported, using default locale setting(en-US).');
+          }
+
+          /* create test-string where to extract parsing regex */
+          let testDate = new Date(
+            Date.UTC(
+              datepicker.$connector.yearPart.initial,
+              datepicker.$connector.monthPart.initial - 1,
+              datepicker.$connector.dayPart.initial
+            )
+          );
+          let testString = cleanString(testDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
+          datepicker.$connector.parts.forEach(function (part) {
+            part.index = testString.indexOf(part.initial);
+          });
+          /* sort items to match correct places in regex groups */
+          datepicker.$connector.parts.sort(FlowDatePickerPart.compare);
+          /* create regex
+           * regex will be the date, so that:
+           * - day-part is '(\d{1,2})' (1 or 2 digits),
+           * - month-part is '(\d{1,2})' (1 or 2 digits),
+           * - year-part is '(\d{1,4})' (1 to 4 digits)
+           *
+           * and everything else is left as is.
+           * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{1,4})".
+           *
+           * The sorting part solves that which part is which (for example,
+           * here the first part is month, second day and third year)
+           *  */
+          datepicker.$connector.regex = testString
+            .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+            .replace(datepicker.$connector.dayPart.initial, '(\\d{1,2})')
+            .replace(datepicker.$connector.monthPart.initial, '(\\d{1,2})')
+            .replace(datepicker.$connector.yearPart.initial, '(\\d{1,4})');
+
+          function formatDate(date) {
+            let rawDate = datepicker._parseDate(`${date.year}-${date.month + 1}-${date.day}`);
+
+            // Workaround for Safari DST offset issue when using Date.toLocaleDateString().
+            // This is needed to keep the correct date in formatted result even if Safari
+            // makes an error of an hour or more in the result with some past dates.
+            // See https://github.com/vaadin/vaadin-date-picker-flow/issues/126#issuecomment-508169514
+            rawDate.setHours(12);
+
+            return cleanString(rawDate.toLocaleDateString(locale));
+          }
+
+          function parseDate(dateString) {
+            dateString = cleanString(dateString);
+
+            if (dateString.length == 0) {
+              return;
             }
 
-            datepicker.$connector = {};
+            let match = dateString.match(datepicker.$connector.regex);
+            if (match && match.length == 4) {
+              for (let i = 1; i < 4; i++) {
+                datepicker.$connector.parts[i - 1].value = parseInt(match[i]);
+              }
+              return {
+                day: datepicker.$connector.dayPart.value,
+                month: datepicker.$connector.monthPart.value - 1,
+                year: datepicker.$connector.yearPart.value
+              };
+            } else {
+              return false;
+            }
+          }
 
-            /* init helper parts for reverse-engineering date-regex */
-            datepicker.$connector.dayPart = new FlowDatePickerPart("22");
-            datepicker.$connector.monthPart = new FlowDatePickerPart("11");
-            datepicker.$connector.yearPart = new FlowDatePickerPart("1987");
-            datepicker.$connector.parts = [datepicker.$connector.dayPart, datepicker.$connector.monthPart, datepicker.$connector.yearPart];
+          return {
+            formatDate: formatDate,
+            parseDate: parseDate
+          };
+        });
 
-            datepicker.addEventListener('blur', tryCatchWrapper(e => {
-                if (!e.target.value && e.target.invalid) {
-                    console.warn("Invalid value in the DatePicker.");
-                }
-            }));
+        const createCustomFormatBasedFormatterAndParser = tryCatchWrapper(function (formats) {
+          if (!formats || formats.length === 0) {
+            throw new Error('Array of custom date formats is null or empty');
+          }
 
-            const cleanString = tryCatchWrapper(function (string) {
-                // Clear any non ascii characters from the date string,
-                // mainly the LEFT-TO-RIGHT MARK.
-                // This is a problem for many Microsoft browsers where `toLocaleDateString`
-                // adds the LEFT-TO-RIGHT MARK see https://en.wikipedia.org/wiki/Left-to-right_mark
-                return string.replace(/[^\x00-\x7F]/g, "");
-            });
+          function formatDate(dateParts) {
+            const format = formats[0];
+            const date = datepicker._parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
 
-            const getInputValue = tryCatchWrapper(function () {
-                let inputValue = '';
-                try {
-                    inputValue = datepicker._inputValue;
-                } catch (err) {
-                    /* component not ready: falling back to stored value */
-                    inputValue = datepicker.value || '';
-                }
-                return inputValue;
-            });
+            return dateFnsFormat(date, format);
+          }
 
-            const createLocaleBasedFormatterAndParser = tryCatchWrapper(function (locale) {
-                try {
-                    // Check whether the locale is supported or not
-                    new Date().toLocaleDateString(locale);
-                } catch (e) {
-                    locale = "en-US";
-                    console.warn("The locale is not supported, using default locale setting(en-US).");
-                }
+          function parseDate(dateString) {
+            for (let format of formats) {
+              const date = dateFnsParse(dateString, format, new Date());
 
-                /* create test-string where to extract parsing regex */
-                let testDate = new Date(Date.UTC(datepicker.$connector.yearPart.initial, datepicker.$connector.monthPart.initial - 1, datepicker.$connector.dayPart.initial));
-                let testString = cleanString(testDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
-                datepicker.$connector.parts.forEach(function (part) {
-                    part.index = testString.indexOf(part.initial);
-                });
-                /* sort items to match correct places in regex groups */
-                datepicker.$connector.parts.sort(FlowDatePickerPart.compare);
-                /* create regex
-                * regex will be the date, so that:
-                * - day-part is '(\d{1,2})' (1 or 2 digits),
-                * - month-part is '(\d{1,2})' (1 or 2 digits),
-                * - year-part is '(\d{1,4})' (1 to 4 digits)
-                *
-                * and everything else is left as is.
-                * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{1,4})".
-                *
-                * The sorting part solves that which part is which (for example,
-                * here the first part is month, second day and third year)
-                *  */
-                datepicker.$connector.regex = testString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
-                    .replace(datepicker.$connector.dayPart.initial, "(\\d{1,2})")
-                    .replace(datepicker.$connector.monthPart.initial, "(\\d{1,2})")
-                    .replace(datepicker.$connector.yearPart.initial, "(\\d{1,4})");
+              if (dateFnsIsValid(date)) {
+                return { day: date.getDate(), month: date.getMonth(), year: date.getFullYear() };
+              }
+            }
+            return false;
+          }
 
-                function formatDate(date) {
-                    let rawDate = datepicker._parseDate(`${date.year}-${date.month + 1}-${date.day}`);
+          return {
+            formatDate: formatDate,
+            parseDate: parseDate
+          };
+        });
 
-                    // Workaround for Safari DST offset issue when using Date.toLocaleDateString().
-                    // This is needed to keep the correct date in formatted result even if Safari
-                    // makes an error of an hour or more in the result with some past dates.
-                    // See https://github.com/vaadin/vaadin-date-picker-flow/issues/126#issuecomment-508169514
-                    rawDate.setHours(12)
+        datepicker.$connector.updateI18n = tryCatchWrapper(function (locale, i18n) {
+          // Create formatting and parsing functions, either based on custom formats set in i18n object,
+          // or based on the locale set in the date picker
+          // Custom formats take priority over locale
+          const hasDateFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
+          const formatterAndParser = hasDateFormats
+            ? createCustomFormatBasedFormatterAndParser(i18n.dateFormats)
+            : locale
+            ? createLocaleBasedFormatterAndParser(locale)
+            : null;
 
-                    return cleanString(rawDate.toLocaleDateString(locale));
-                }
-
-                function parseDate(dateString) {
-                    dateString = cleanString(dateString);
-
-                    if (dateString.length == 0) {
-                        return;
-                    }
-
-                    let match = dateString.match(datepicker.$connector.regex);
-                    if (match && match.length == 4) {
-                        for (let i = 1; i < 4; i++) {
-                            datepicker.$connector.parts[i - 1].value = parseInt(match[i]);
-                        }
-                        return {
-                            day: datepicker.$connector.dayPart.value,
-                            month: datepicker.$connector.monthPart.value - 1,
-                            year: datepicker.$connector.yearPart.value
-                        };
-                    } else {
-                        return false;
-                    }
-                }
-
-                return {
-                    formatDate: formatDate,
-                    parseDate: parseDate,
-                };
-            });
-
-            const createCustomFormatBasedFormatterAndParser = tryCatchWrapper(function (formats) {
-                if (!formats || formats.length === 0) {
-                    throw new Error("Array of custom date formats is null or empty");
-                }
-
-                function formatDate(dateParts) {
-                    const format = formats[0];
-                    const date = datepicker._parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
-
-                    return dateFnsFormat(date, format);
-                }
-
-                function parseDate(dateString) {
-                    for (let format of formats) {
-                        const date = dateFnsParse(dateString, format, new Date());
-
-                        if (dateFnsIsValid(date)) {
-                            return {day: date.getDate(), month: date.getMonth(), year: date.getFullYear()};
-                        }
-                    }
-                    return false;
-                }
-
-                return {
-                    formatDate: formatDate,
-                    parseDate: parseDate,
-                };
-            });
-
-            datepicker.$connector.updateI18n = tryCatchWrapper(function (locale, i18n) {
-                // Create formatting and parsing functions, either based on custom formats set in i18n object,
-                // or based on the locale set in the date picker
-                // Custom formats take priority over locale
-                const hasDateFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
-                const formatterAndParser = hasDateFormats
-                    ? createCustomFormatBasedFormatterAndParser(i18n.dateFormats)
-                    : locale
-                        ? createLocaleBasedFormatterAndParser(locale)
-                        : null;
-
-                // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
-                datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
-            });
-        })(datepicker)
-    };
+          // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
+          datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
+        });
+      })(datepicker)
+  };
 })();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -12,1080 +12,1127 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
   let isItemCacheInitialized = false;
 
   window.Vaadin.Flow.gridConnector = {
-    initLazy: grid => tryCatchWrapper(function(grid) {
-      // Check whether the connector was already initialized for the grid
-      if (grid.$connector){
-        return;
-      }
+    initLazy: (grid) =>
+      tryCatchWrapper(function (grid) {
+        // Check whether the connector was already initialized for the grid
+        if (grid.$connector) {
+          return;
+        }
 
-      // Make sure ItemCache patching is done only once, but delay it for when
-      // a server grid is initialized
-      if (!isItemCacheInitialized) {
-        isItemCacheInitialized = true;
-        // Storing original implementation of the method to be used for client
-        // side only grids
-        ItemCache.prototype.ensureSubCacheForScaledIndexOriginal = ItemCache.prototype.ensureSubCacheForScaledIndex;
-        ItemCache.prototype.ensureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
-          if (!this.grid.$connector) {
-            this.ensureSubCacheForScaledIndexOriginal(scaledIndex);
+        // Make sure ItemCache patching is done only once, but delay it for when
+        // a server grid is initialized
+        if (!isItemCacheInitialized) {
+          isItemCacheInitialized = true;
+          // Storing original implementation of the method to be used for client
+          // side only grids
+          ItemCache.prototype.ensureSubCacheForScaledIndexOriginal = ItemCache.prototype.ensureSubCacheForScaledIndex;
+          ItemCache.prototype.ensureSubCacheForScaledIndex = tryCatchWrapper(function (scaledIndex) {
+            if (!this.grid.$connector) {
+              this.ensureSubCacheForScaledIndexOriginal(scaledIndex);
+              return;
+            }
+
+            if (!this.itemCaches[scaledIndex]) {
+              this.grid.$connector.beforeEnsureSubCacheForScaledIndex(this, scaledIndex);
+            }
+          });
+
+          ItemCache.prototype.isLoadingOriginal = ItemCache.prototype.isLoading;
+          ItemCache.prototype.isLoading = tryCatchWrapper(function () {
+            if (!this.grid.$connector) {
+              return this.isLoadingOriginal();
+            }
+
+            return Boolean(
+              this.grid.$connector.hasEnsureSubCacheQueue() ||
+                Object.keys(this.pendingRequests).length ||
+                Object.keys(this.itemCaches).filter((index) => {
+                  return this.itemCaches[index].isLoading();
+                })[0]
+            );
+          });
+
+          ItemCache.prototype.doEnsureSubCacheForScaledIndex = tryCatchWrapper(function (scaledIndex) {
+            if (!this.itemCaches[scaledIndex]) {
+              const subCache = new ItemCache.prototype.constructor(this.grid, this, this.items[scaledIndex]);
+              subCache.itemkeyCaches = {};
+              if (!this.itemkeyCaches) {
+                this.itemkeyCaches = {};
+              }
+              this.itemCaches[scaledIndex] = subCache;
+              this.itemkeyCaches[this.grid.getItemId(subCache.parentItem)] = subCache;
+              this.grid._loadPage(0, subCache);
+            }
+          });
+
+          ItemCache.prototype.getCacheAndIndexByKey = tryCatchWrapper(function (key) {
+            for (let index in this.items) {
+              if (this.grid.getItemId(this.items[index]) === key) {
+                return { cache: this, scaledIndex: index };
+              }
+            }
+            const keys = Object.keys(this.itemkeyCaches);
+            for (let i = 0; i < keys.length; i++) {
+              const expandedKey = keys[i];
+              const subCache = this.itemkeyCaches[expandedKey];
+              let cacheAndIndex = subCache.getCacheAndIndexByKey(key);
+              if (cacheAndIndex) {
+                return cacheAndIndex;
+              }
+            }
+            return undefined;
+          });
+
+          ItemCache.prototype.getLevel = tryCatchWrapper(function () {
+            let cache = this;
+            let level = 0;
+            while (cache.parentCache) {
+              cache = cache.parentCache;
+              level++;
+            }
+            return level;
+          });
+        }
+
+        const rootPageCallbacks = {};
+        const treePageCallbacks = {};
+        const cache = {};
+
+        /* parentRequestDelay - optimizes parent requests by batching several requests
+         *  into one request. Delay in milliseconds. Disable by setting to 0.
+         *  parentRequestBatchMaxSize - maximum size of the batch.
+         */
+        const parentRequestDelay = 50;
+        const parentRequestBatchMaxSize = 20;
+
+        let parentRequestQueue = [];
+        let parentRequestDebouncer;
+        let ensureSubCacheQueue = [];
+        let ensureSubCacheDebouncer;
+
+        const rootRequestDelay = 150;
+        let rootRequestDebouncer;
+
+        let lastRequestedRanges = {};
+        const root = 'null';
+        lastRequestedRanges[root] = [0, 0];
+
+        const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
+        let selectedKeys = {};
+        let selectionMode = 'SINGLE';
+
+        let detailsVisibleOnClick = true;
+
+        let sorterDirectionsSetFromServer = false;
+
+        grid.size = 0; // To avoid NaN here and there before we get proper data
+        grid.itemIdPath = 'key';
+
+        grid.$connector = {};
+
+        grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(() => ensureSubCacheQueue.length > 0);
+
+        grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
+
+        grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
+          return Object.keys(rootPageCallbacks).length > 0 || (rootRequestDebouncer && rootRequestDebouncer.isActive());
+        });
+
+        grid.$connector.beforeEnsureSubCacheForScaledIndex = tryCatchWrapper(function (targetCache, scaledIndex) {
+          // add call to queue
+          ensureSubCacheQueue.push({
+            cache: targetCache,
+            scaledIndex: scaledIndex,
+            itemkey: grid.getItemId(targetCache.items[scaledIndex]),
+            level: targetCache.getLevel()
+          });
+          // sort by ascending scaledIndex and level
+          ensureSubCacheQueue.sort(function (a, b) {
+            return a.scaledIndex - b.scaledIndex || a.level - b.level;
+          });
+
+          ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
+            while (ensureSubCacheQueue.length) {
+              grid.$connector.flushEnsureSubCache();
+            }
+          });
+        });
+
+        grid.$connector.doSelection = tryCatchWrapper(function (items, userOriginated) {
+          if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
+            return;
+          }
+          if (selectionMode === 'SINGLE') {
+            grid.selectedItems = [];
+            selectedKeys = {};
+          }
+
+          grid.selectedItems = grid.selectedItems.concat(items);
+          items.forEach((item) => {
+            if (item) {
+              selectedKeys[item.key] = item;
+              if (userOriginated) {
+                item.selected = true;
+                grid.$server.select(item.key);
+              }
+            }
+            const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
+            if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
+              grid.activeItem = item;
+            }
+          });
+        });
+
+        grid.$connector.doDeselection = tryCatchWrapper(function (items, userOriginated) {
+          if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
             return;
           }
 
-          if (!this.itemCaches[scaledIndex]) {
-            this.grid.$connector.beforeEnsureSubCacheForScaledIndex(this, scaledIndex);
+          const updatedSelectedItems = grid.selectedItems.slice();
+          while (items.length) {
+            const itemToDeselect = items.shift();
+            for (let i = 0; i < updatedSelectedItems.length; i++) {
+              const selectedItem = updatedSelectedItems[i];
+              if (itemToDeselect && itemToDeselect.key === selectedItem.key) {
+                updatedSelectedItems.splice(i, 1);
+                break;
+              }
+            }
+            if (itemToDeselect) {
+              delete selectedKeys[itemToDeselect.key];
+              if (userOriginated) {
+                delete itemToDeselect.selected;
+                grid.$server.deselect(itemToDeselect.key);
+              }
+            }
+          }
+          grid.selectedItems = updatedSelectedItems;
+        });
+
+        grid.__activeItemChanged = tryCatchWrapper(function (newVal, oldVal) {
+          if (selectionMode != 'SINGLE') {
+            return;
+          }
+          if (!newVal) {
+            if (oldVal && selectedKeys[oldVal.key]) {
+              if (grid.__deselectDisallowed) {
+                grid.activeItem = oldVal;
+              } else {
+                grid.$connector.doDeselection([oldVal], true);
+              }
+            }
+          } else if (!selectedKeys[newVal.key]) {
+            grid.$connector.doSelection([newVal], true);
+          }
+        });
+        grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
+
+        grid.__activeItemChangedDetails = tryCatchWrapper(function (newVal, oldVal) {
+          if (!detailsVisibleOnClick) {
+            return;
+          }
+          // when grid is attached, newVal is not set and oldVal is undefined
+          // do nothing
+          if (newVal == null && oldVal === undefined) {
+            return;
+          }
+          if (newVal && !newVal.detailsOpened) {
+            grid.$server.setDetailsVisible(newVal.key);
+          } else {
+            grid.$server.setDetailsVisible(null);
+          }
+        });
+        grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
+
+        grid.$connector.setDetailsVisibleOnClick = tryCatchWrapper(function (visibleOnClick) {
+          detailsVisibleOnClick = visibleOnClick;
+        });
+
+        grid.$connector._getPageIfSameLevel = tryCatchWrapper(function (parentKey, index, defaultPage) {
+          let cacheAndIndex = grid._cache.getCacheAndIndex(index);
+          let parentItem = cacheAndIndex.cache.parentItem;
+          let parentKeyOfIndex = parentItem ? grid.getItemId(parentItem) : root;
+          if (parentKey !== parentKeyOfIndex) {
+            return defaultPage;
+          } else {
+            return grid._getPageForIndex(cacheAndIndex.scaledIndex);
           }
         });
 
-        ItemCache.prototype.isLoadingOriginal = ItemCache.prototype.isLoading;
-        ItemCache.prototype.isLoading = tryCatchWrapper(function() {
-          if (!this.grid.$connector) {
-            return this.isLoadingOriginal();
-          }
-
-          return Boolean(this.grid.$connector.hasEnsureSubCacheQueue() || Object.keys(this.pendingRequests).length || Object.keys(this.itemCaches).filter(index => {
-            return this.itemCaches[index].isLoading();
-          })[0]);
-        });
-
-        ItemCache.prototype.doEnsureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
-          if (!this.itemCaches[scaledIndex]) {
-            const subCache = new ItemCache.prototype.constructor(this.grid, this, this.items[scaledIndex]);
-            subCache.itemkeyCaches = {};
-            if(!this.itemkeyCaches) {
-              this.itemkeyCaches = {};
-            }
-            this.itemCaches[scaledIndex] = subCache;
-            this.itemkeyCaches[this.grid.getItemId(subCache.parentItem)] = subCache;
-            this.grid._loadPage(0, subCache);
-          }
-        });
-
-        ItemCache.prototype.getCacheAndIndexByKey = tryCatchWrapper(function(key) {
-          for (let index in this.items) {
-            if(this.grid.getItemId(this.items[index]) === key) {
-              return {cache: this, scaledIndex: index};
-            }
-          }
-          const keys = Object.keys(this.itemkeyCaches);
-          for (let i = 0; i < keys.length; i++) {
-            const expandedKey = keys[i];
-            const subCache = this.itemkeyCaches[expandedKey];
-            let cacheAndIndex = subCache.getCacheAndIndexByKey(key);
-            if(cacheAndIndex) {
-              return cacheAndIndex;
-            }
+        grid.$connector.getCacheByKey = tryCatchWrapper(function (key) {
+          let cacheAndIndex = grid._cache.getCacheAndIndexByKey(key);
+          if (cacheAndIndex) {
+            return cacheAndIndex.cache;
           }
           return undefined;
         });
 
-        ItemCache.prototype.getLevel = tryCatchWrapper(function() {
-          let cache = this;
-          let level = 0;
-          while (cache.parentCache) {
-            cache = cache.parentCache;
-            level++;
+        grid.$connector.flushEnsureSubCache = tryCatchWrapper(function () {
+          let pendingFetch = ensureSubCacheQueue.splice(0, 1)[0];
+          let itemkey = pendingFetch.itemkey;
+
+          const visibleRows = grid._getVisibleRows();
+          let start = visibleRows[0].index;
+          let end = visibleRows[visibleRows.length - 1].index;
+
+          let buffer = end - start;
+          let firstNeededIndex = Math.max(0, start - buffer);
+          let lastNeededIndex = Math.min(end + buffer, grid._effectiveSize);
+
+          // only fetch if given item is still in visible range
+          for (let index = firstNeededIndex; index <= lastNeededIndex; index++) {
+            let item = grid._cache.getItemForIndex(index);
+
+            if (grid.getItemId(item) === itemkey) {
+              if (grid._isExpanded(item)) {
+                pendingFetch.cache.doEnsureSubCacheForScaledIndex(pendingFetch.scaledIndex);
+                return true;
+              } else {
+                break;
+              }
+            }
           }
-          return level;
-        });
-      }
-
-      const rootPageCallbacks = {};
-      const treePageCallbacks = {};
-      const cache = {};
-
-      /* parentRequestDelay - optimizes parent requests by batching several requests
-      *  into one request. Delay in milliseconds. Disable by setting to 0.
-      *  parentRequestBatchMaxSize - maximum size of the batch.
-      */
-      const parentRequestDelay = 50;
-      const parentRequestBatchMaxSize = 20;
-
-      let parentRequestQueue = [];
-      let parentRequestDebouncer;
-      let ensureSubCacheQueue = [];
-      let ensureSubCacheDebouncer;
-
-      const rootRequestDelay = 150;
-      let rootRequestDebouncer;
-
-      let lastRequestedRanges = {};
-      const root = 'null';
-      lastRequestedRanges[root] = [0, 0];
-
-      const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
-      let selectedKeys = {};
-      let selectionMode = 'SINGLE';
-
-      let detailsVisibleOnClick = true;
-
-      let sorterDirectionsSetFromServer = false;
-
-      grid.size = 0; // To avoid NaN here and there before we get proper data
-      grid.itemIdPath = 'key';
-
-      grid.$connector = {};
-
-      grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(() => ensureSubCacheQueue.length > 0);
-
-      grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
-
-      grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
-        return Object.keys(rootPageCallbacks).length > 0 || (rootRequestDebouncer && rootRequestDebouncer.isActive());
-      })
-
-      grid.$connector.beforeEnsureSubCacheForScaledIndex = tryCatchWrapper(function(targetCache, scaledIndex) {
-        // add call to queue
-        ensureSubCacheQueue.push({
-          cache: targetCache,
-          scaledIndex: scaledIndex,
-          itemkey: grid.getItemId(targetCache.items[scaledIndex]),
-          level: targetCache.getLevel()
-        });
-        // sort by ascending scaledIndex and level
-        ensureSubCacheQueue.sort(function(a, b) {
-          return a.scaledIndex - b.scaledIndex || a.level - b.level;
+          return false;
         });
 
-        ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame,
-          () => {
-            while (ensureSubCacheQueue.length) {
-              grid.$connector.flushEnsureSubCache();
-            }
+        grid.$connector.flushParentRequests = tryCatchWrapper(function () {
+          let pendingFetches = parentRequestQueue.splice(0, parentRequestBatchMaxSize);
+
+          if (pendingFetches.length) {
+            grid.$server.setParentRequestedRanges(pendingFetches);
+            return true;
           }
-        );
-      })
-
-      grid.$connector.doSelection = tryCatchWrapper(function(items, userOriginated) {
-        if (selectionMode === 'NONE' || !items.length ||
-            (userOriginated && grid.hasAttribute('disabled'))) {
-          return;
-        }
-        if (selectionMode === 'SINGLE') {
-          grid.selectedItems = [];
-          selectedKeys = {};
-        }
-
-        grid.selectedItems = grid.selectedItems.concat(items);
-        items.forEach(item => {
-          if (item) {
-            selectedKeys[item.key] = item;
-            if (userOriginated) {
-              item.selected = true;
-              grid.$server.select(item.key);
-            }
-          }
-          const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
-          if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
-            grid.activeItem = item;
-          }
-        });
-      });
-
-      grid.$connector.doDeselection = tryCatchWrapper(function(items, userOriginated) {
-        if (selectionMode === 'NONE' || !items.length ||
-            (userOriginated && grid.hasAttribute('disabled'))) {
-          return;
-        }
-
-        const updatedSelectedItems = grid.selectedItems.slice();
-        while (items.length) {
-          const itemToDeselect = items.shift();
-          for (let i = 0; i < updatedSelectedItems.length; i++) {
-            const selectedItem = updatedSelectedItems[i];
-            if (itemToDeselect && itemToDeselect.key === selectedItem.key) {
-              updatedSelectedItems.splice(i, 1);
-              break;
-            }
-          }
-          if (itemToDeselect) {
-            delete selectedKeys[itemToDeselect.key];
-            if (userOriginated) {
-              delete itemToDeselect.selected;
-              grid.$server.deselect(itemToDeselect.key);
-            }
-          }
-        }
-        grid.selectedItems = updatedSelectedItems;
-      });
-
-      grid.__activeItemChanged = tryCatchWrapper(function(newVal, oldVal) {
-        if (selectionMode != 'SINGLE') {
-          return;
-        }
-        if (!newVal) {
-          if (oldVal && selectedKeys[oldVal.key]) {
-            if (grid.__deselectDisallowed) {
-              grid.activeItem = oldVal;
-            } else {
-              grid.$connector.doDeselection([oldVal], true);
-            }
-          }
-        } else if (!selectedKeys[newVal.key]) {
-          grid.$connector.doSelection([newVal], true);
-        }
-      });
-      grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
-
-      grid.__activeItemChangedDetails = tryCatchWrapper(function(newVal, oldVal) {
-        if(!detailsVisibleOnClick) {
-          return;
-        }
-        // when grid is attached, newVal is not set and oldVal is undefined
-        // do nothing
-        if ((newVal == null) && (oldVal === undefined)) {
-          return;
-        }
-        if (newVal && !newVal.detailsOpened) {
-          grid.$server.setDetailsVisible(newVal.key);
-        } else {
-          grid.$server.setDetailsVisible(null);
-        }
-      })
-      grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
-
-      grid.$connector.setDetailsVisibleOnClick = tryCatchWrapper(function(visibleOnClick) {
-        detailsVisibleOnClick = visibleOnClick;
-      });
-
-      grid.$connector._getPageIfSameLevel = tryCatchWrapper(function(parentKey, index, defaultPage) {
-        let cacheAndIndex = grid._cache.getCacheAndIndex(index);
-        let parentItem = cacheAndIndex.cache.parentItem;
-        let parentKeyOfIndex = (parentItem) ? grid.getItemId(parentItem) : root;
-        if(parentKey !== parentKeyOfIndex) {
-          return defaultPage;
-        } else {
-          return grid._getPageForIndex(cacheAndIndex.scaledIndex);
-        }
-      })
-
-      grid.$connector.getCacheByKey = tryCatchWrapper(function(key) {
-        let cacheAndIndex = grid._cache.getCacheAndIndexByKey(key);
-        if(cacheAndIndex) {
-          return cacheAndIndex.cache;
-        }
-        return undefined;
-      });
-
-      grid.$connector.flushEnsureSubCache = tryCatchWrapper(function() {
-        let pendingFetch = ensureSubCacheQueue.splice(0, 1)[0];
-        let itemkey =  pendingFetch.itemkey;
-
-        const visibleRows = grid._getVisibleRows();
-        let start = visibleRows[0].index;
-        let end = visibleRows[visibleRows.length - 1].index;
-
-        let buffer = end - start;
-        let firstNeededIndex = Math.max(0, start - buffer);
-        let lastNeededIndex = Math.min(end + buffer, grid._effectiveSize);
-
-        // only fetch if given item is still in visible range
-        for(let index = firstNeededIndex; index <= lastNeededIndex; index++) {
-          let item = grid._cache.getItemForIndex(index);
-
-          if(grid.getItemId(item) === itemkey) {
-            if(grid._isExpanded(item)) {
-              pendingFetch.cache.doEnsureSubCacheForScaledIndex(pendingFetch.scaledIndex);
-              return true;
-            } else {
-              break;
-            }
-          }
-        }
-        return false;
-      })
-
-      grid.$connector.flushParentRequests = tryCatchWrapper(function() {
-        let pendingFetches = parentRequestQueue.splice(0, parentRequestBatchMaxSize);
-
-        if(pendingFetches.length) {
-          grid.$server.setParentRequestedRanges(pendingFetches);
-          return true;
-        }
-        return false;
-      })
-
-      grid.$connector.beforeParentRequest = tryCatchWrapper(function(firstIndex, size, parentKey) {
-        // add request in queue
-        parentRequestQueue.push({
-          firstIndex: firstIndex,
-          size: size,
-          parentKey: parentKey
+          return false;
         });
 
-        parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay),
-          () => {
+        grid.$connector.beforeParentRequest = tryCatchWrapper(function (firstIndex, size, parentKey) {
+          // add request in queue
+          parentRequestQueue.push({
+            firstIndex: firstIndex,
+            size: size,
+            parentKey: parentKey
+          });
+
+          parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay), () => {
             while (parentRequestQueue.length) {
               grid.$connector.flushParentRequests();
             }
-          }
-        );
-      })
-
-      grid.$connector.fetchPage = tryCatchWrapper(function(fetch, page, parentKey) {
-        // Determine what to fetch based on scroll position and not only
-        // what grid asked for
-
-        // The buffer size could be multiplied by some constant defined by the user,
-        // if he needs to reduce the number of items sent to the Grid to improve performance
-        // or to increase it to make Grid smoother when scrolling
-        const visibleRows = grid._getVisibleRows();
-        let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
-        let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
-        let buffer = end - start;
-
-        let firstNeededIndex = Math.max(0, start - buffer);
-        let lastNeededIndex = Math.min(end + buffer, grid._effectiveSize);
-
-        let firstNeededPage = page;
-        let lastNeededPage = page;
-        for(let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
-          firstNeededPage = Math.min(firstNeededPage, grid.$connector._getPageIfSameLevel(parentKey, idx, firstNeededPage));
-          lastNeededPage = Math.max(lastNeededPage, grid.$connector._getPageIfSameLevel(parentKey, idx, lastNeededPage));
-        }
-
-        let firstPage = Math.max(0,  firstNeededPage);
-        let lastPage = (parentKey !== root) ? lastNeededPage: Math.min(lastNeededPage, Math.floor(grid.size / grid.pageSize));
-        let lastRequestedRange = lastRequestedRanges[parentKey];
-        if(!lastRequestedRange) {
-          lastRequestedRange = [-1, -1];
-        }
-        if (lastRequestedRange[0] != firstPage || lastRequestedRange[1] != lastPage) {
-          lastRequestedRange = [firstPage, lastPage];
-          lastRequestedRanges[parentKey] = lastRequestedRange;
-          let count = lastPage - firstPage + 1;
-          fetch(firstPage * grid.pageSize, count * grid.pageSize);
-        }
-      })
-
-      grid.dataProvider = tryCatchWrapper(function(params, callback) {
-        if (params.pageSize != grid.pageSize) {
-          throw 'Invalid pageSize';
-        }
-
-        let page = params.page;
-
-        if(params.parentItem) {
-          let parentUniqueKey = grid.getItemId(params.parentItem);
-          if(!treePageCallbacks[parentUniqueKey]) {
-            treePageCallbacks[parentUniqueKey] = {};
-          }
-
-          let parentCache = grid.$connector.getCacheByKey(parentUniqueKey);
-          let itemCache = (parentCache && parentCache.itemkeyCaches) ? parentCache.itemkeyCaches[parentUniqueKey] : undefined;
-          if(cache[parentUniqueKey] && cache[parentUniqueKey][page] && itemCache) {
-            // workaround: sometimes grid-element gives page index that overflows
-            page = Math.min(page, Math.floor(cache[parentUniqueKey].size / grid.pageSize));
-
-            callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
-          } else {
-            treePageCallbacks[parentUniqueKey][page] = callback;
-          }
-          grid.$connector.fetchPage(
-            (firstIndex, size) => grid.$connector.beforeParentRequest(firstIndex, size, params.parentItem.key),
-            page,
-            parentUniqueKey
-          );
-
-        } else {
-          // workaround: sometimes grid-element gives page index that overflows
-          page = Math.min(page, Math.floor(grid.size / grid.pageSize));
-
-          if (cache[root] && cache[root][page]) {
-            callback(cache[root][page]);
-          } else {
-            rootPageCallbacks[page] = callback;
-          }
-
-          rootRequestDebouncer = Debouncer.debounce(rootRequestDebouncer, timeOut.after(grid._hasData ? rootRequestDelay : 0),
-            () => {
-              grid.$connector.fetchPage((firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size), page, root);
-            }
-          );
-        }
-      })
-
-      const sorterChangeListener = tryCatchWrapper(function(_, oldValue) {
-        if (oldValue !== undefined && !sorterDirectionsSetFromServer) {
-          grid.$server.sortersChanged(grid._sorters.map(function (sorter) {
-            return {
-              path: sorter.path,
-              direction: sorter.direction
-            };
-          }));
-        }
-      })
-
-      grid.$connector.setSorterDirections = tryCatchWrapper(function(directions) {
-        sorterDirectionsSetFromServer = true;
-        setTimeout(tryCatchWrapper(() => {
-          try {
-            const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
-
-            sorters.forEach(sorter => {
-              if (!directions.filter(d => d.column === sorter.getAttribute('path'))[0]) {
-                sorter.direction = null;
-              }
-            });
-
-            directions.reverse().forEach(({column, direction}) => {
-              sorters.forEach(sorter => {
-                if (sorter.getAttribute('path') === column && sorter.direction !== direction) {
-                  sorter.direction = direction
-                }
-              });
-            });
-          } finally {
-            sorterDirectionsSetFromServer = false;
-          }
-        }));
-      })
-      grid._createPropertyObserver("_previousSorters", sorterChangeListener);
-
-      grid._updateItem = tryCatchWrapper(function(row, item) {
-        Grid.prototype._updateItem.call(grid, row, item);
-
-        // There might be inactive component renderers on hidden rows that still refer to the
-        // same component instance as one of the renderers on a visible row. Making the
-        // inactive/hidden renderer attach the component might steal it from a visible/active one.
-        if (!row.hidden) {
-          // make sure that component renderers are updated
-          Array.from(row.children).forEach(cell => {
-            if (cell._content && cell._content.__templateInstance && cell._content.__templateInstance.children) {
-              Array.from(cell._content.__templateInstance.children).forEach(content => {
-                if(content._attachRenderedComponentIfAble) {
-                  content._attachRenderedComponentIfAble();
-                }
-                // In hierarchy column of tree grid, the component renderer is inside its content,
-                // this updates it renderer from innerContent
-                if (content.children) {
-                  Array.from(content.children).forEach(innerContent => {
-                    if(innerContent._attachRenderedComponentIfAble) {
-                        innerContent._attachRenderedComponentIfAble();
-                    }
-                  });
-                }
-             });
-            }
           });
-        }
-      })
+        });
 
-      const itemExpandedChanged = tryCatchWrapper(function(item, expanded) {
-        // method available only for the TreeGrid server-side component
-        if (item == undefined || grid.$server.updateExpandedState == undefined) {
-          return;
-        }
-        let parentKey = grid.getItemId(item);
-        grid.$server.updateExpandedState(parentKey, expanded);
+        grid.$connector.fetchPage = tryCatchWrapper(function (fetch, page, parentKey) {
+          // Determine what to fetch based on scroll position and not only
+          // what grid asked for
 
-        if (!expanded) {
-          delete cache[parentKey];
-          let parentCache = grid.$connector.getCacheByKey(parentKey);
-          if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
-            delete parentCache.itemkeyCaches[parentKey];
-          }
-          if (parentCache && parentCache.itemkeyCaches) {
-            Object.keys(parentCache.itemCaches)
-                .filter(idx => parentCache.items[idx].key === parentKey)
-                .forEach(idx => delete parentCache.itemCaches[idx]);
-          }
-          delete lastRequestedRanges[parentKey];
-        }
-      });
+          // The buffer size could be multiplied by some constant defined by the user,
+          // if he needs to reduce the number of items sent to the Grid to improve performance
+          // or to increase it to make Grid smoother when scrolling
+          const visibleRows = grid._getVisibleRows();
+          let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
+          let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
+          let buffer = end - start;
 
-      // Patch grid.expandItem and grid.collapseItem to have
-      // itemExpandedChanged run when either happens.
-      grid.expandItem = tryCatchWrapper(function(item) {
-        itemExpandedChanged(item, true);
-        Grid.prototype.expandItem.call(grid, item);
-      });
+          let firstNeededIndex = Math.max(0, start - buffer);
+          let lastNeededIndex = Math.min(end + buffer, grid._effectiveSize);
 
-      grid.collapseItem = tryCatchWrapper(function(item) {
-        itemExpandedChanged(item, false);
-        Grid.prototype.collapseItem.call(grid, item);
-      });
-
-      const itemsUpdated = function(items) {
-        if (!items || !Array.isArray(items)) {
-          throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
-        }
-        let detailsOpenedItems = Array.from(grid.detailsOpenedItems);
-        let updatedSelectedItem = false;
-        for (let i = 0; i < items.length; ++i) {
-          const item = items[i];
-          if(!item) {
-            continue;
-          }
-          if (item.detailsOpened) {
-            if(grid._getItemIndexInArray(item, detailsOpenedItems) < 0) {
-              detailsOpenedItems.push(item);
-            }
-          } else if(grid._getItemIndexInArray(item, detailsOpenedItems) >= 0) {
-            detailsOpenedItems.splice(grid._getItemIndexInArray(item, detailsOpenedItems), 1)
-          }
-          if (selectedKeys[item.key]) {
-            selectedKeys[item.key] = item;
-            item.selected = true;
-            updatedSelectedItem = true;
-          }
-        }
-        grid.detailsOpenedItems = detailsOpenedItems;
-        if (updatedSelectedItem) {
-          // IE 11 Object doesn't support method values
-          grid.selectedItems = Object.keys(selectedKeys).map(function(e) {
-            return selectedKeys[e]
-          });
-        }
-      };
-
-      /**
-       * Updates the cache for the given page for grid or tree-grid.
-       *
-       * @param page index of the page to update
-       * @param parentKey the key of the parent item for the page
-       * @returns an array of the updated items for the page, or undefined if no items were cached for the page
-       */
-      const updateGridCache = function(page, parentKey) {
-        let items;
-        if((parentKey || root) !== root) {
-          items = cache[parentKey][page];
-          let parentCache = grid.$connector.getCacheByKey(parentKey);
-          if(parentCache && parentCache.itemkeyCaches) {
-            let _cache = parentCache.itemkeyCaches[parentKey];
-            const callbacksForParentKey = treePageCallbacks[parentKey];
-            const callback = callbacksForParentKey && callbacksForParentKey[page];
-            _updateGridCache(page, items, callback, _cache);
+          let firstNeededPage = page;
+          let lastNeededPage = page;
+          for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
+            firstNeededPage = Math.min(
+              firstNeededPage,
+              grid.$connector._getPageIfSameLevel(parentKey, idx, firstNeededPage)
+            );
+            lastNeededPage = Math.max(
+              lastNeededPage,
+              grid.$connector._getPageIfSameLevel(parentKey, idx, lastNeededPage)
+            );
           }
 
-        } else {
-          items = cache[root][page];
-          _updateGridCache(page, items, rootPageCallbacks[page], grid._cache);
-        }
-        return items;
-      };
-
-      const _updateGridCache = function(page, items, callback, levelcache) {
-        // Force update unless there's a callback waiting
-        if (!callback) {
-          let rangeStart = page * grid.pageSize;
-          let rangeEnd = rangeStart + grid.pageSize;
-          if (!items) {
-            if (levelcache && levelcache.items) {
-              for (let idx = rangeStart; idx < rangeEnd; idx++) {
-                delete levelcache.items[idx];
-              }
-            }
-          } else {
-            if (levelcache && levelcache.items) {
-              for (let idx = rangeStart; idx < rangeEnd; idx++) {
-                if (levelcache.items[idx]) {
-                  levelcache.items[idx] = items[idx - rangeStart];
-                }
-              }
-            }
+          let firstPage = Math.max(0, firstNeededPage);
+          let lastPage =
+            parentKey !== root ? lastNeededPage : Math.min(lastNeededPage, Math.floor(grid.size / grid.pageSize));
+          let lastRequestedRange = lastRequestedRanges[parentKey];
+          if (!lastRequestedRange) {
+            lastRequestedRange = [-1, -1];
           }
-        }
-      };
-
-      /**
-       * Updates all visible grid rows in DOM.
-       */
-      const updateAllGridRowsInDomBasedOnCache = function () {
-        grid._cache.updateSize();
-        grid._effectiveSize = grid._cache.effectiveSize;
-        grid.__updateVisibleRows();
-      };
-
-      /**
-       * Update the given items in DOM if currently visible.
-       *
-       * @param array items the items to update in DOM
-       */
-      const updateGridItemsInDomBasedOnCache = function(items) {
-        if (!items || grid.$.items.childElementCount === 0) {
-          return;
-        }
-
-        const itemKeys = items.map(item => item.key);
-        const indexes = grid._getVisibleRows()
-            .filter(row => row._item && itemKeys.includes(row._item.key))
-            .map(row => row.index);
-        if (indexes.length > 0) {
-          grid.__updateVisibleRows(indexes[0], indexes[indexes.length - 1]);
-        }
-      };
-
-      grid.$connector.set = tryCatchWrapper(function(index, items, parentKey) {
-        if (index % grid.pageSize != 0) {
-          throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
-        }
-        let pkey = parentKey || root;
-
-        const firstPage = index / grid.pageSize;
-        const updatedPageCount = Math.ceil(items.length / grid.pageSize);
-
-        for (let i = 0; i < updatedPageCount; i++) {
-          let page = firstPage + i;
-          let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
-          if(!cache[pkey]) {
-            cache[pkey] = {};
-          }
-          cache[pkey][page] = slice;
-
-          grid.$connector.doSelection(slice.filter(
-            item => item.selected && !isSelectedOnGrid(item)));
-          grid.$connector.doDeselection(slice.filter(
-            item => !item.selected  && (selectedKeys[item.key] || isSelectedOnGrid(item))));
-
-          const updatedItems = updateGridCache(page, pkey);
-          if (updatedItems) {
-            itemsUpdated(updatedItems);
-            updateGridItemsInDomBasedOnCache(updatedItems);
-          }
-        }
-      });
-
-      const itemToCacheLocation = function(item) {
-        let parent = item.parentUniqueKey || root;
-        if(cache[parent]) {
-          for (let page in cache[parent]) {
-            for (let index in cache[parent][page]) {
-              if (grid.getItemId(cache[parent][page][index]) === grid.getItemId(item)) {
-                return {page: page, index: index, parentKey: parent};
-              }
-            }
-          }
-        }
-        return null;
-      };
-
-      /**
-       * Updates the given items for a hierarchical grid.
-       *
-       * @param updatedItems the updated items array
-       */
-      grid.$connector.updateHierarchicalData = tryCatchWrapper(function(updatedItems) {
-        let pagesToUpdate = [];
-        // locate and update the items in cache
-        // find pages that need updating
-        for (let i = 0; i < updatedItems.length; i++) {
-          let cacheLocation = itemToCacheLocation(updatedItems[i]);
-          if (cacheLocation) {
-            cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
-            let key = cacheLocation.parentKey+':'+cacheLocation.page;
-            if (!pagesToUpdate[key]) {
-              pagesToUpdate[key] = {parentKey: cacheLocation.parentKey, page: cacheLocation.page};
-            }
-          }
-        }
-        // IE11 doesn't work with the transpiled version of the forEach.
-        let keys = Object.keys(pagesToUpdate);
-        for (let i = 0; i < keys.length; i++) {
-          let pageToUpdate = pagesToUpdate[keys[i]];
-          const affectedUpdatedItems = updateGridCache(pageToUpdate.page, pageToUpdate.parentKey);
-          if (affectedUpdatedItems) {
-            itemsUpdated(affectedUpdatedItems);
-            updateGridItemsInDomBasedOnCache(affectedUpdatedItems);
-          }
-        }
-      });
-
-      /**
-       * Updates the given items for a non-hierarchical grid.
-       *
-       * @param updatedItems the updated items array
-       */
-      grid.$connector.updateFlatData = tryCatchWrapper(function(updatedItems) {
-        // update (flat) caches
-        for (let i = 0; i < updatedItems.length; i++) {
-          let cacheLocation = itemToCacheLocation(updatedItems[i]);
-          if (cacheLocation) {
-            // update connector cache
-            cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
-
-            // update grid's cache
-            const index = parseInt(cacheLocation.page) * grid.pageSize + parseInt(cacheLocation.index);
-            if (grid._cache.items[index]) {
-              grid._cache.items[index] = updatedItems[i];
-            }
-          }
-        }
-        itemsUpdated(updatedItems);
-
-        updateGridItemsInDomBasedOnCache(updatedItems);
-      });
-
-      grid.$connector.clearExpanded = tryCatchWrapper(function() {
-        grid.expandedItems = [];
-        ensureSubCacheQueue = [];
-        parentRequestQueue = [];
-      })
-
-      grid.$connector.clear = tryCatchWrapper(function(index, length, parentKey) {
-        let pkey = parentKey || root;
-        if (!cache[pkey] || Object.keys(cache[pkey]).length === 0){
-          return;
-        }
-        if (index % grid.pageSize != 0) {
-          throw 'Got cleared data for index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
-        }
-
-        let firstPage = Math.floor(index / grid.pageSize);
-        let updatedPageCount = Math.ceil(length / grid.pageSize);
-
-        for (let i = 0; i < updatedPageCount; i++) {
-          let page = firstPage + i;
-          let items = cache[pkey][page];
-          grid.$connector.doDeselection(items.filter(item => selectedKeys[item.key]));
-          delete cache[pkey][page];
-          const updatedItems = updateGridCache(page, parentKey);
-          if (updatedItems) {
-            itemsUpdated(updatedItems);
-          }
-          updateGridItemsInDomBasedOnCache(items);
-        }
-        let cacheToClear = grid._cache;
-        if(parentKey)  {
-          const cacheAndIndex = grid._cache.getCacheAndIndexByKey(pkey);
-          cacheToClear = cacheAndIndex.cache.itemCaches[cacheAndIndex.scaledIndex];
-        }
-        const endIndex = index + updatedPageCount * grid.pageSize;
-        for(let itemIndex = index; itemIndex < endIndex; itemIndex++) {
-          delete cacheToClear.items[itemIndex];
-          const subcacheToClear = cacheToClear.itemCaches[itemIndex];
-          delete cacheToClear.itemCaches[itemIndex];
-          const itemKeyToRemove = subcacheToClear && subcacheToClear.parentItem.key;
-          if(itemKeyToRemove) {
-            delete cacheToClear.itemkeyCaches[itemKeyToRemove];
-          }
-        }
-        grid._cache.updateSize();
-      });
-
-      const isSelectedOnGrid = function(item) {
-        const selectedItems = grid.selectedItems;
-        for(let i = 0; i < selectedItems; i++) {
-          let selectedItem = selectedItems[i];
-          if (selectedItem.key === item.key) {
-            return true;
-          }
-        }
-        return false;
-      };
-
-      grid.$connector.reset = tryCatchWrapper(function() {
-        grid.size = 0;
-        deleteObjectContents(cache);
-        deleteObjectContents(grid._cache.items);
-        deleteObjectContents(lastRequestedRanges);
-        if(ensureSubCacheDebouncer) {
-          ensureSubCacheDebouncer.cancel();
-        }
-        if(parentRequestDebouncer) {
-          parentRequestDebouncer.cancel();
-        }
-        if (rootRequestDebouncer) {
-          rootRequestDebouncer.cancel();
-        }
-        ensureSubCacheDebouncer = undefined;
-        parentRequestDebouncer = undefined;
-        ensureSubCacheQueue = [];
-        parentRequestQueue = [];
-        updateAllGridRowsInDomBasedOnCache();
-      });
-
-      const deleteObjectContents = obj => Object.keys(obj).forEach(key => delete obj[key]);
-
-      grid.$connector.updateSize = newSize => grid.size = newSize;
-
-      grid.$connector.updateUniqueItemIdPath = path => grid.itemIdPath = path;
-
-      grid.$connector.expandItems = tryCatchWrapper(function(items) {
-        let newExpandedItems = Array.from(grid.expandedItems);
-        items.filter(item => !grid._isExpanded(item))
-          .forEach(item =>
-            newExpandedItems.push(item));
-        grid.expandedItems = newExpandedItems;
-      })
-
-      grid.$connector.collapseItems = tryCatchWrapper(function(items) {
-        let newExpandedItems = Array.from(grid.expandedItems);
-        items.forEach(item => {
-          let index = grid._getItemIndexInArray(item, newExpandedItems);
-          if(index >= 0) {
-            newExpandedItems.splice(index, 1);
+          if (lastRequestedRange[0] != firstPage || lastRequestedRange[1] != lastPage) {
+            lastRequestedRange = [firstPage, lastPage];
+            lastRequestedRanges[parentKey] = lastRequestedRange;
+            let count = lastPage - firstPage + 1;
+            fetch(firstPage * grid.pageSize, count * grid.pageSize);
           }
         });
-        grid.expandedItems = newExpandedItems;
-        items.forEach(item => grid.$connector.removeFromQueue(item));
-      })
 
-      grid.$connector.removeFromQueue = tryCatchWrapper(function(item) {
-        let itemId = grid.getItemId(item);
-        delete treePageCallbacks[itemId];
-        grid.$connector.removeFromArray(ensureSubCacheQueue, item => item.itemkey === itemId);
-        grid.$connector.removeFromArray(parentRequestQueue, item => item.parentKey === itemId);
-      })
+        grid.dataProvider = tryCatchWrapper(function (params, callback) {
+          if (params.pageSize != grid.pageSize) {
+            throw 'Invalid pageSize';
+          }
 
-      grid.$connector.removeFromArray = tryCatchWrapper(function(array, removeTest) {
-        if(array.length) {
-          for(let index = array.length - 1; index--; ) {
-            if (removeTest(array[index])) {
-              array.splice(index, 1);
+          let page = params.page;
+
+          if (params.parentItem) {
+            let parentUniqueKey = grid.getItemId(params.parentItem);
+            if (!treePageCallbacks[parentUniqueKey]) {
+              treePageCallbacks[parentUniqueKey] = {};
             }
-          }
-        }
-      })
 
-      grid.$connector.confirmParent = tryCatchWrapper(function(id, parentKey, levelSize) {
-        if(!treePageCallbacks[parentKey]) {
-          return;
-        }
-        if(cache[parentKey]) {
-          cache[parentKey].size = levelSize;
-        }
-        let outstandingRequests = Object.getOwnPropertyNames(treePageCallbacks[parentKey]);
-        for(let i = 0; i < outstandingRequests.length; i++) {
-          let page = outstandingRequests[i];
+            let parentCache = grid.$connector.getCacheByKey(parentUniqueKey);
+            let itemCache =
+              parentCache && parentCache.itemkeyCaches ? parentCache.itemkeyCaches[parentUniqueKey] : undefined;
+            if (cache[parentUniqueKey] && cache[parentUniqueKey][page] && itemCache) {
+              // workaround: sometimes grid-element gives page index that overflows
+              page = Math.min(page, Math.floor(cache[parentUniqueKey].size / grid.pageSize));
 
-          let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
+              callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
+            } else {
+              treePageCallbacks[parentUniqueKey][page] = callback;
+            }
+            grid.$connector.fetchPage(
+              (firstIndex, size) => grid.$connector.beforeParentRequest(firstIndex, size, params.parentItem.key),
+              page,
+              parentUniqueKey
+            );
+          } else {
+            // workaround: sometimes grid-element gives page index that overflows
+            page = Math.min(page, Math.floor(grid.size / grid.pageSize));
 
-          const callback = treePageCallbacks[parentKey][page];
-          if((cache[parentKey] && cache[parentKey][page]) || page < lastRequestedRange[0] || page > lastRequestedRange[1]) {
-            delete treePageCallbacks[parentKey][page];
-            let items = cache[parentKey][page] || new Array(levelSize);
-            callback(items, levelSize);
-          } else if (callback && levelSize === 0) {
-            // The parent item has 0 child items => resolve the callback with an empty array
-            delete treePageCallbacks[parentKey][page];
-            callback([], levelSize);
-          }
-        }
-        // Let server know we're done
-        grid.$server.confirmParentUpdate(id, parentKey);
-
-        if (!grid.loading) {
-          grid.__updateVisibleRows();
-        }
-      });
-
-      grid.$connector.confirm = tryCatchWrapper(function(id) {
-        // We're done applying changes from this batch, resolve outstanding
-        // callbacks
-        let outstandingRequests = Object.getOwnPropertyNames(rootPageCallbacks);
-        for(let i = 0; i < outstandingRequests.length; i++) {
-          let page = outstandingRequests[i];
-          let lastRequestedRange = lastRequestedRanges[root] || [0, 0];
-
-          const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
-          // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
-          const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
-          // Resolve if we have data or if we don't expect to get data
-          const callback = rootPageCallbacks[page];
-          if ((cache[root] && cache[root][page]) || page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
-            delete rootPageCallbacks[page];
-
-            if (cache[root][page]) {
-              // Cached data is available, resolve the callback
+            if (cache[root] && cache[root][page]) {
               callback(cache[root][page]);
             } else {
-              // No cached data, resolve the callback with an empty array
-              callback(new Array(grid.pageSize));
-              // Request grid for content update
-              grid.requestContentUpdate();
+              rootPageCallbacks[page] = callback;
             }
 
-            // Makes sure to push all new rows before this stack execution is done so any timeout expiration called after will be applied on a fully updated grid
-            //Resolves https://github.com/vaadin/vaadin-grid-flow/issues/511
-            if(grid._debounceIncreasePool){
-              grid._debounceIncreasePool.flush();
-            }
-
-          } else if (callback && grid.size === 0) {
-            // The grid has 0 items => resolve the callback with an empty array
-            delete rootPageCallbacks[page];
-            callback([]);
+            rootRequestDebouncer = Debouncer.debounce(
+              rootRequestDebouncer,
+              timeOut.after(grid._hasData ? rootRequestDelay : 0),
+              () => {
+                grid.$connector.fetchPage(
+                  (firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size),
+                  page,
+                  root
+                );
+              }
+            );
           }
-        }
-
-        // Let server know we're done
-        grid.$server.confirmUpdate(id);
-      })
-
-      grid.$connector.ensureHierarchy = tryCatchWrapper(function() {
-        for (let parentKey in cache) {
-          if(parentKey !== root) {
-            delete cache[parentKey];
-          }
-        }
-        deleteObjectContents(lastRequestedRanges);
-
-        grid._cache.itemCaches = {};
-        grid._cache.itemkeyCaches = {};
-
-        updateAllGridRowsInDomBasedOnCache();
-      })
-
-      grid.$connector.setSelectionMode = tryCatchWrapper(function(mode) {
-        if ((typeof mode === 'string' || mode instanceof String)
-            && validSelectionModes.indexOf(mode) >= 0) {
-          selectionMode = mode;
-          selectedKeys = {};
-        } else {
-          throw 'Attempted to set an invalid selection mode';
-        }
-      });
-
-      // TODO: should be removed once https://github.com/vaadin/vaadin-grid/issues/1471 gets implemented
-      grid.$connector.setVerticalScrollingEnabled = tryCatchWrapper(function(enabled) {
-        // There are two scollable containers in grid so apply the changes for both
-        setVerticalScrollingEnabled(grid.$.table, enabled);
-      });
-
-      const setVerticalScrollingEnabled = function(scrollable, enabled) {
-        // Prevent Y axis scrolling with CSS. This will hide the vertical scrollbar.
-        scrollable.style.overflowY = enabled ? '' : 'hidden';
-        // Clean up an existing listener
-        scrollable.removeEventListener('wheel', scrollable.__wheelListener);
-        // Add a wheel event listener with the horizontal scrolling prevention logic
-        !enabled && scrollable.addEventListener('wheel', scrollable.__wheelListener = tryCatchWrapper(e => {
-          if (e.deltaX) {
-            // If there was some horizontal delta related to the wheel event, force the vertical
-            // delta to 0 and let grid process the wheel event normally
-            Object.defineProperty(e, 'deltaY', { value: 0 });
-          } else {
-            // If there was verical delta only, skip the grid's wheel event processing to
-            // enable scrolling the page even if grid isn't scrolled to end
-            e.stopImmediatePropagation();
-          }
-        }));
-      };
-
-      const contextMenuListener = function(e) {
-        // For `contextmenu` events, we need to access the source event,
-        // when using open on click we just use the click event itself
-        const sourceEvent = e.detail.sourceEvent || e;
-        const eventContext = grid.getEventContext(sourceEvent);
-        const key = eventContext.item && eventContext.item.key;
-        const colId = eventContext.column && eventContext.column.id;
-        grid.$server.updateContextMenuTargetItem(key, colId);
-      };
-
-      grid.addEventListener('vaadin-context-menu-before-open', tryCatchWrapper(function(e) {
-        contextMenuListener(grid.$contextMenuConnector.openEvent);
-      }));
-
-      grid.getContextMenuBeforeOpenDetail = tryCatchWrapper(function(event) {
-        // For `contextmenu` events, we need to access the source event,
-        // when using open on click we just use the click event itself
-        const sourceEvent = event.detail.sourceEvent || event;
-        const eventContext = grid.getEventContext(sourceEvent);
-        return {
-          key: (eventContext.item && eventContext.item.key) || ""
-        };
-      });
-
-      grid.addEventListener('click', tryCatchWrapper(e => _fireClickEvent(e, 'item-click')));
-      grid.addEventListener('dblclick', tryCatchWrapper(e => _fireClickEvent(e, 'item-double-click')));
-
-      grid.addEventListener('column-resize', tryCatchWrapper(e => {
-        const cols = grid._getColumnsInOrder().filter(col => !col.hidden);
-
-        cols.forEach(col => {
-          col.dispatchEvent(new CustomEvent('column-drag-resize'));
         });
 
-        grid.dispatchEvent(new CustomEvent('column-drag-resize', { detail: {
-          resizedColumnKey: e.detail.resizedColumn._flowId
-        }}));
-      }));
+        const sorterChangeListener = tryCatchWrapper(function (_, oldValue) {
+          if (oldValue !== undefined && !sorterDirectionsSetFromServer) {
+            grid.$server.sortersChanged(
+              grid._sorters.map(function (sorter) {
+                return {
+                  path: sorter.path,
+                  direction: sorter.direction
+                };
+              })
+            );
+          }
+        });
 
-      grid.addEventListener('column-reorder', tryCatchWrapper(e => {
-        const columns = grid._columnTree.slice(0).pop()
-          .filter(c => c._flowId)
-          .sort((b, a) => (b._order - a._order))
-          .map(c => c._flowId);
+        grid.$connector.setSorterDirections = tryCatchWrapper(function (directions) {
+          sorterDirectionsSetFromServer = true;
+          setTimeout(
+            tryCatchWrapper(() => {
+              try {
+                const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
-        grid.dispatchEvent(new CustomEvent('column-reorder-all-columns', {
-          detail: { columns }
-        }));
-      }));
+                sorters.forEach((sorter) => {
+                  if (!directions.filter((d) => d.column === sorter.getAttribute('path'))[0]) {
+                    sorter.direction = null;
+                  }
+                });
 
-      grid.addEventListener('cell-focus', tryCatchWrapper(e => {
-        const eventContext = grid.getEventContext(e);
-        const expectedSectionValues = ['header', 'body', 'footer'];
+                directions.reverse().forEach(({ column, direction }) => {
+                  sorters.forEach((sorter) => {
+                    if (sorter.getAttribute('path') === column && sorter.direction !== direction) {
+                      sorter.direction = direction;
+                    }
+                  });
+                });
+              } finally {
+                sorterDirectionsSetFromServer = false;
+              }
+            })
+          );
+        });
+        grid._createPropertyObserver('_previousSorters', sorterChangeListener);
 
-        if(expectedSectionValues.indexOf(eventContext.section) === -1) {
-          return;
+        grid._updateItem = tryCatchWrapper(function (row, item) {
+          Grid.prototype._updateItem.call(grid, row, item);
+
+          // There might be inactive component renderers on hidden rows that still refer to the
+          // same component instance as one of the renderers on a visible row. Making the
+          // inactive/hidden renderer attach the component might steal it from a visible/active one.
+          if (!row.hidden) {
+            // make sure that component renderers are updated
+            Array.from(row.children).forEach((cell) => {
+              if (cell._content && cell._content.__templateInstance && cell._content.__templateInstance.children) {
+                Array.from(cell._content.__templateInstance.children).forEach((content) => {
+                  if (content._attachRenderedComponentIfAble) {
+                    content._attachRenderedComponentIfAble();
+                  }
+                  // In hierarchy column of tree grid, the component renderer is inside its content,
+                  // this updates it renderer from innerContent
+                  if (content.children) {
+                    Array.from(content.children).forEach((innerContent) => {
+                      if (innerContent._attachRenderedComponentIfAble) {
+                        innerContent._attachRenderedComponentIfAble();
+                      }
+                    });
+                  }
+                });
+              }
+            });
+          }
+        });
+
+        const itemExpandedChanged = tryCatchWrapper(function (item, expanded) {
+          // method available only for the TreeGrid server-side component
+          if (item == undefined || grid.$server.updateExpandedState == undefined) {
+            return;
+          }
+          let parentKey = grid.getItemId(item);
+          grid.$server.updateExpandedState(parentKey, expanded);
+
+          if (!expanded) {
+            delete cache[parentKey];
+            let parentCache = grid.$connector.getCacheByKey(parentKey);
+            if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
+              delete parentCache.itemkeyCaches[parentKey];
+            }
+            if (parentCache && parentCache.itemkeyCaches) {
+              Object.keys(parentCache.itemCaches)
+                .filter((idx) => parentCache.items[idx].key === parentKey)
+                .forEach((idx) => delete parentCache.itemCaches[idx]);
+            }
+            delete lastRequestedRanges[parentKey];
+          }
+        });
+
+        // Patch grid.expandItem and grid.collapseItem to have
+        // itemExpandedChanged run when either happens.
+        grid.expandItem = tryCatchWrapper(function (item) {
+          itemExpandedChanged(item, true);
+          Grid.prototype.expandItem.call(grid, item);
+        });
+
+        grid.collapseItem = tryCatchWrapper(function (item) {
+          itemExpandedChanged(item, false);
+          Grid.prototype.collapseItem.call(grid, item);
+        });
+
+        const itemsUpdated = function (items) {
+          if (!items || !Array.isArray(items)) {
+            throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
+          }
+          let detailsOpenedItems = Array.from(grid.detailsOpenedItems);
+          let updatedSelectedItem = false;
+          for (let i = 0; i < items.length; ++i) {
+            const item = items[i];
+            if (!item) {
+              continue;
+            }
+            if (item.detailsOpened) {
+              if (grid._getItemIndexInArray(item, detailsOpenedItems) < 0) {
+                detailsOpenedItems.push(item);
+              }
+            } else if (grid._getItemIndexInArray(item, detailsOpenedItems) >= 0) {
+              detailsOpenedItems.splice(grid._getItemIndexInArray(item, detailsOpenedItems), 1);
+            }
+            if (selectedKeys[item.key]) {
+              selectedKeys[item.key] = item;
+              item.selected = true;
+              updatedSelectedItem = true;
+            }
+          }
+          grid.detailsOpenedItems = detailsOpenedItems;
+          if (updatedSelectedItem) {
+            // IE 11 Object doesn't support method values
+            grid.selectedItems = Object.keys(selectedKeys).map(function (e) {
+              return selectedKeys[e];
+            });
+          }
+        };
+
+        /**
+         * Updates the cache for the given page for grid or tree-grid.
+         *
+         * @param page index of the page to update
+         * @param parentKey the key of the parent item for the page
+         * @returns an array of the updated items for the page, or undefined if no items were cached for the page
+         */
+        const updateGridCache = function (page, parentKey) {
+          let items;
+          if ((parentKey || root) !== root) {
+            items = cache[parentKey][page];
+            let parentCache = grid.$connector.getCacheByKey(parentKey);
+            if (parentCache && parentCache.itemkeyCaches) {
+              let _cache = parentCache.itemkeyCaches[parentKey];
+              const callbacksForParentKey = treePageCallbacks[parentKey];
+              const callback = callbacksForParentKey && callbacksForParentKey[page];
+              _updateGridCache(page, items, callback, _cache);
+            }
+          } else {
+            items = cache[root][page];
+            _updateGridCache(page, items, rootPageCallbacks[page], grid._cache);
+          }
+          return items;
+        };
+
+        const _updateGridCache = function (page, items, callback, levelcache) {
+          // Force update unless there's a callback waiting
+          if (!callback) {
+            let rangeStart = page * grid.pageSize;
+            let rangeEnd = rangeStart + grid.pageSize;
+            if (!items) {
+              if (levelcache && levelcache.items) {
+                for (let idx = rangeStart; idx < rangeEnd; idx++) {
+                  delete levelcache.items[idx];
+                }
+              }
+            } else {
+              if (levelcache && levelcache.items) {
+                for (let idx = rangeStart; idx < rangeEnd; idx++) {
+                  if (levelcache.items[idx]) {
+                    levelcache.items[idx] = items[idx - rangeStart];
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        /**
+         * Updates all visible grid rows in DOM.
+         */
+        const updateAllGridRowsInDomBasedOnCache = function () {
+          grid._cache.updateSize();
+          grid._effectiveSize = grid._cache.effectiveSize;
+          grid.__updateVisibleRows();
+        };
+
+        /**
+         * Update the given items in DOM if currently visible.
+         *
+         * @param array items the items to update in DOM
+         */
+        const updateGridItemsInDomBasedOnCache = function (items) {
+          if (!items || grid.$.items.childElementCount === 0) {
+            return;
+          }
+
+          const itemKeys = items.map((item) => item.key);
+          const indexes = grid
+            ._getVisibleRows()
+            .filter((row) => row._item && itemKeys.includes(row._item.key))
+            .map((row) => row.index);
+          if (indexes.length > 0) {
+            grid.__updateVisibleRows(indexes[0], indexes[indexes.length - 1]);
+          }
+        };
+
+        grid.$connector.set = tryCatchWrapper(function (index, items, parentKey) {
+          if (index % grid.pageSize != 0) {
+            throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
+          }
+          let pkey = parentKey || root;
+
+          const firstPage = index / grid.pageSize;
+          const updatedPageCount = Math.ceil(items.length / grid.pageSize);
+
+          for (let i = 0; i < updatedPageCount; i++) {
+            let page = firstPage + i;
+            let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
+            if (!cache[pkey]) {
+              cache[pkey] = {};
+            }
+            cache[pkey][page] = slice;
+
+            grid.$connector.doSelection(slice.filter((item) => item.selected && !isSelectedOnGrid(item)));
+            grid.$connector.doDeselection(
+              slice.filter((item) => !item.selected && (selectedKeys[item.key] || isSelectedOnGrid(item)))
+            );
+
+            const updatedItems = updateGridCache(page, pkey);
+            if (updatedItems) {
+              itemsUpdated(updatedItems);
+              updateGridItemsInDomBasedOnCache(updatedItems);
+            }
+          }
+        });
+
+        const itemToCacheLocation = function (item) {
+          let parent = item.parentUniqueKey || root;
+          if (cache[parent]) {
+            for (let page in cache[parent]) {
+              for (let index in cache[parent][page]) {
+                if (grid.getItemId(cache[parent][page][index]) === grid.getItemId(item)) {
+                  return { page: page, index: index, parentKey: parent };
+                }
+              }
+            }
+          }
+          return null;
+        };
+
+        /**
+         * Updates the given items for a hierarchical grid.
+         *
+         * @param updatedItems the updated items array
+         */
+        grid.$connector.updateHierarchicalData = tryCatchWrapper(function (updatedItems) {
+          let pagesToUpdate = [];
+          // locate and update the items in cache
+          // find pages that need updating
+          for (let i = 0; i < updatedItems.length; i++) {
+            let cacheLocation = itemToCacheLocation(updatedItems[i]);
+            if (cacheLocation) {
+              cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+              let key = cacheLocation.parentKey + ':' + cacheLocation.page;
+              if (!pagesToUpdate[key]) {
+                pagesToUpdate[key] = { parentKey: cacheLocation.parentKey, page: cacheLocation.page };
+              }
+            }
+          }
+          // IE11 doesn't work with the transpiled version of the forEach.
+          let keys = Object.keys(pagesToUpdate);
+          for (let i = 0; i < keys.length; i++) {
+            let pageToUpdate = pagesToUpdate[keys[i]];
+            const affectedUpdatedItems = updateGridCache(pageToUpdate.page, pageToUpdate.parentKey);
+            if (affectedUpdatedItems) {
+              itemsUpdated(affectedUpdatedItems);
+              updateGridItemsInDomBasedOnCache(affectedUpdatedItems);
+            }
+          }
+        });
+
+        /**
+         * Updates the given items for a non-hierarchical grid.
+         *
+         * @param updatedItems the updated items array
+         */
+        grid.$connector.updateFlatData = tryCatchWrapper(function (updatedItems) {
+          // update (flat) caches
+          for (let i = 0; i < updatedItems.length; i++) {
+            let cacheLocation = itemToCacheLocation(updatedItems[i]);
+            if (cacheLocation) {
+              // update connector cache
+              cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+
+              // update grid's cache
+              const index = parseInt(cacheLocation.page) * grid.pageSize + parseInt(cacheLocation.index);
+              if (grid._cache.items[index]) {
+                grid._cache.items[index] = updatedItems[i];
+              }
+            }
+          }
+          itemsUpdated(updatedItems);
+
+          updateGridItemsInDomBasedOnCache(updatedItems);
+        });
+
+        grid.$connector.clearExpanded = tryCatchWrapper(function () {
+          grid.expandedItems = [];
+          ensureSubCacheQueue = [];
+          parentRequestQueue = [];
+        });
+
+        grid.$connector.clear = tryCatchWrapper(function (index, length, parentKey) {
+          let pkey = parentKey || root;
+          if (!cache[pkey] || Object.keys(cache[pkey]).length === 0) {
+            return;
+          }
+          if (index % grid.pageSize != 0) {
+            throw (
+              'Got cleared data for index ' + index + ' which is not aligned with the page size of ' + grid.pageSize
+            );
+          }
+
+          let firstPage = Math.floor(index / grid.pageSize);
+          let updatedPageCount = Math.ceil(length / grid.pageSize);
+
+          for (let i = 0; i < updatedPageCount; i++) {
+            let page = firstPage + i;
+            let items = cache[pkey][page];
+            grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
+            delete cache[pkey][page];
+            const updatedItems = updateGridCache(page, parentKey);
+            if (updatedItems) {
+              itemsUpdated(updatedItems);
+            }
+            updateGridItemsInDomBasedOnCache(items);
+          }
+          let cacheToClear = grid._cache;
+          if (parentKey) {
+            const cacheAndIndex = grid._cache.getCacheAndIndexByKey(pkey);
+            cacheToClear = cacheAndIndex.cache.itemCaches[cacheAndIndex.scaledIndex];
+          }
+          const endIndex = index + updatedPageCount * grid.pageSize;
+          for (let itemIndex = index; itemIndex < endIndex; itemIndex++) {
+            delete cacheToClear.items[itemIndex];
+            const subcacheToClear = cacheToClear.itemCaches[itemIndex];
+            delete cacheToClear.itemCaches[itemIndex];
+            const itemKeyToRemove = subcacheToClear && subcacheToClear.parentItem.key;
+            if (itemKeyToRemove) {
+              delete cacheToClear.itemkeyCaches[itemKeyToRemove];
+            }
+          }
+          grid._cache.updateSize();
+        });
+
+        const isSelectedOnGrid = function (item) {
+          const selectedItems = grid.selectedItems;
+          for (let i = 0; i < selectedItems; i++) {
+            let selectedItem = selectedItems[i];
+            if (selectedItem.key === item.key) {
+              return true;
+            }
+          }
+          return false;
+        };
+
+        grid.$connector.reset = tryCatchWrapper(function () {
+          grid.size = 0;
+          deleteObjectContents(cache);
+          deleteObjectContents(grid._cache.items);
+          deleteObjectContents(lastRequestedRanges);
+          if (ensureSubCacheDebouncer) {
+            ensureSubCacheDebouncer.cancel();
+          }
+          if (parentRequestDebouncer) {
+            parentRequestDebouncer.cancel();
+          }
+          if (rootRequestDebouncer) {
+            rootRequestDebouncer.cancel();
+          }
+          ensureSubCacheDebouncer = undefined;
+          parentRequestDebouncer = undefined;
+          ensureSubCacheQueue = [];
+          parentRequestQueue = [];
+          updateAllGridRowsInDomBasedOnCache();
+        });
+
+        const deleteObjectContents = (obj) => Object.keys(obj).forEach((key) => delete obj[key]);
+
+        grid.$connector.updateSize = (newSize) => (grid.size = newSize);
+
+        grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
+
+        grid.$connector.expandItems = tryCatchWrapper(function (items) {
+          let newExpandedItems = Array.from(grid.expandedItems);
+          items.filter((item) => !grid._isExpanded(item)).forEach((item) => newExpandedItems.push(item));
+          grid.expandedItems = newExpandedItems;
+        });
+
+        grid.$connector.collapseItems = tryCatchWrapper(function (items) {
+          let newExpandedItems = Array.from(grid.expandedItems);
+          items.forEach((item) => {
+            let index = grid._getItemIndexInArray(item, newExpandedItems);
+            if (index >= 0) {
+              newExpandedItems.splice(index, 1);
+            }
+          });
+          grid.expandedItems = newExpandedItems;
+          items.forEach((item) => grid.$connector.removeFromQueue(item));
+        });
+
+        grid.$connector.removeFromQueue = tryCatchWrapper(function (item) {
+          let itemId = grid.getItemId(item);
+          delete treePageCallbacks[itemId];
+          grid.$connector.removeFromArray(ensureSubCacheQueue, (item) => item.itemkey === itemId);
+          grid.$connector.removeFromArray(parentRequestQueue, (item) => item.parentKey === itemId);
+        });
+
+        grid.$connector.removeFromArray = tryCatchWrapper(function (array, removeTest) {
+          if (array.length) {
+            for (let index = array.length - 1; index--; ) {
+              if (removeTest(array[index])) {
+                array.splice(index, 1);
+              }
+            }
+          }
+        });
+
+        grid.$connector.confirmParent = tryCatchWrapper(function (id, parentKey, levelSize) {
+          if (!treePageCallbacks[parentKey]) {
+            return;
+          }
+          if (cache[parentKey]) {
+            cache[parentKey].size = levelSize;
+          }
+          let outstandingRequests = Object.getOwnPropertyNames(treePageCallbacks[parentKey]);
+          for (let i = 0; i < outstandingRequests.length; i++) {
+            let page = outstandingRequests[i];
+
+            let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
+
+            const callback = treePageCallbacks[parentKey][page];
+            if (
+              (cache[parentKey] && cache[parentKey][page]) ||
+              page < lastRequestedRange[0] ||
+              page > lastRequestedRange[1]
+            ) {
+              delete treePageCallbacks[parentKey][page];
+              let items = cache[parentKey][page] || new Array(levelSize);
+              callback(items, levelSize);
+            } else if (callback && levelSize === 0) {
+              // The parent item has 0 child items => resolve the callback with an empty array
+              delete treePageCallbacks[parentKey][page];
+              callback([], levelSize);
+            }
+          }
+          // Let server know we're done
+          grid.$server.confirmParentUpdate(id, parentKey);
+
+          if (!grid.loading) {
+            grid.__updateVisibleRows();
+          }
+        });
+
+        grid.$connector.confirm = tryCatchWrapper(function (id) {
+          // We're done applying changes from this batch, resolve outstanding
+          // callbacks
+          let outstandingRequests = Object.getOwnPropertyNames(rootPageCallbacks);
+          for (let i = 0; i < outstandingRequests.length; i++) {
+            let page = outstandingRequests[i];
+            let lastRequestedRange = lastRequestedRanges[root] || [0, 0];
+
+            const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
+            // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
+            const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
+            // Resolve if we have data or if we don't expect to get data
+            const callback = rootPageCallbacks[page];
+            if ((cache[root] && cache[root][page]) || page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
+              delete rootPageCallbacks[page];
+
+              if (cache[root][page]) {
+                // Cached data is available, resolve the callback
+                callback(cache[root][page]);
+              } else {
+                // No cached data, resolve the callback with an empty array
+                callback(new Array(grid.pageSize));
+                // Request grid for content update
+                grid.requestContentUpdate();
+              }
+
+              // Makes sure to push all new rows before this stack execution is done so any timeout expiration called after will be applied on a fully updated grid
+              //Resolves https://github.com/vaadin/vaadin-grid-flow/issues/511
+              if (grid._debounceIncreasePool) {
+                grid._debounceIncreasePool.flush();
+              }
+            } else if (callback && grid.size === 0) {
+              // The grid has 0 items => resolve the callback with an empty array
+              delete rootPageCallbacks[page];
+              callback([]);
+            }
+          }
+
+          // Let server know we're done
+          grid.$server.confirmUpdate(id);
+        });
+
+        grid.$connector.ensureHierarchy = tryCatchWrapper(function () {
+          for (let parentKey in cache) {
+            if (parentKey !== root) {
+              delete cache[parentKey];
+            }
+          }
+          deleteObjectContents(lastRequestedRanges);
+
+          grid._cache.itemCaches = {};
+          grid._cache.itemkeyCaches = {};
+
+          updateAllGridRowsInDomBasedOnCache();
+        });
+
+        grid.$connector.setSelectionMode = tryCatchWrapper(function (mode) {
+          if ((typeof mode === 'string' || mode instanceof String) && validSelectionModes.indexOf(mode) >= 0) {
+            selectionMode = mode;
+            selectedKeys = {};
+          } else {
+            throw 'Attempted to set an invalid selection mode';
+          }
+        });
+
+        // TODO: should be removed once https://github.com/vaadin/vaadin-grid/issues/1471 gets implemented
+        grid.$connector.setVerticalScrollingEnabled = tryCatchWrapper(function (enabled) {
+          // There are two scollable containers in grid so apply the changes for both
+          setVerticalScrollingEnabled(grid.$.table, enabled);
+        });
+
+        const setVerticalScrollingEnabled = function (scrollable, enabled) {
+          // Prevent Y axis scrolling with CSS. This will hide the vertical scrollbar.
+          scrollable.style.overflowY = enabled ? '' : 'hidden';
+          // Clean up an existing listener
+          scrollable.removeEventListener('wheel', scrollable.__wheelListener);
+          // Add a wheel event listener with the horizontal scrolling prevention logic
+          !enabled &&
+            scrollable.addEventListener(
+              'wheel',
+              (scrollable.__wheelListener = tryCatchWrapper((e) => {
+                if (e.deltaX) {
+                  // If there was some horizontal delta related to the wheel event, force the vertical
+                  // delta to 0 and let grid process the wheel event normally
+                  Object.defineProperty(e, 'deltaY', { value: 0 });
+                } else {
+                  // If there was verical delta only, skip the grid's wheel event processing to
+                  // enable scrolling the page even if grid isn't scrolled to end
+                  e.stopImmediatePropagation();
+                }
+              }))
+            );
+        };
+
+        const contextMenuListener = function (e) {
+          // For `contextmenu` events, we need to access the source event,
+          // when using open on click we just use the click event itself
+          const sourceEvent = e.detail.sourceEvent || e;
+          const eventContext = grid.getEventContext(sourceEvent);
+          const key = eventContext.item && eventContext.item.key;
+          const colId = eventContext.column && eventContext.column.id;
+          grid.$server.updateContextMenuTargetItem(key, colId);
+        };
+
+        grid.addEventListener(
+          'vaadin-context-menu-before-open',
+          tryCatchWrapper(function (e) {
+            contextMenuListener(grid.$contextMenuConnector.openEvent);
+          })
+        );
+
+        grid.getContextMenuBeforeOpenDetail = tryCatchWrapper(function (event) {
+          // For `contextmenu` events, we need to access the source event,
+          // when using open on click we just use the click event itself
+          const sourceEvent = event.detail.sourceEvent || event;
+          const eventContext = grid.getEventContext(sourceEvent);
+          return {
+            key: (eventContext.item && eventContext.item.key) || ''
+          };
+        });
+
+        grid.addEventListener(
+          'click',
+          tryCatchWrapper((e) => _fireClickEvent(e, 'item-click'))
+        );
+        grid.addEventListener(
+          'dblclick',
+          tryCatchWrapper((e) => _fireClickEvent(e, 'item-double-click'))
+        );
+
+        grid.addEventListener(
+          'column-resize',
+          tryCatchWrapper((e) => {
+            const cols = grid._getColumnsInOrder().filter((col) => !col.hidden);
+
+            cols.forEach((col) => {
+              col.dispatchEvent(new CustomEvent('column-drag-resize'));
+            });
+
+            grid.dispatchEvent(
+              new CustomEvent('column-drag-resize', {
+                detail: {
+                  resizedColumnKey: e.detail.resizedColumn._flowId
+                }
+              })
+            );
+          })
+        );
+
+        grid.addEventListener(
+          'column-reorder',
+          tryCatchWrapper((e) => {
+            const columns = grid._columnTree
+              .slice(0)
+              .pop()
+              .filter((c) => c._flowId)
+              .sort((b, a) => b._order - a._order)
+              .map((c) => c._flowId);
+
+            grid.dispatchEvent(
+              new CustomEvent('column-reorder-all-columns', {
+                detail: { columns }
+              })
+            );
+          })
+        );
+
+        grid.addEventListener(
+          'cell-focus',
+          tryCatchWrapper((e) => {
+            const eventContext = grid.getEventContext(e);
+            const expectedSectionValues = ['header', 'body', 'footer'];
+
+            if (expectedSectionValues.indexOf(eventContext.section) === -1) {
+              return;
+            }
+
+            grid.dispatchEvent(
+              new CustomEvent('grid-cell-focus', {
+                detail: {
+                  itemKey: eventContext.item ? eventContext.item.key : null,
+
+                  internalColumnId: eventContext.column ? eventContext.column._flowId : null,
+
+                  section: eventContext.section
+                }
+              })
+            );
+          })
+        );
+
+        function _fireClickEvent(event, eventName) {
+          const target = event.target;
+          const eventContext = grid.getEventContext(event);
+          const section = eventContext.section;
+
+          if (eventContext.item && !isFocusable(target) && section !== 'details') {
+            event.itemKey = eventContext.item.key;
+            // if you have a details-renderer, getEventContext().column is undefined
+            if (eventContext.column) {
+              event.internalColumnId = eventContext.column._flowId;
+            }
+            grid.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+          }
         }
 
-        grid.dispatchEvent(new CustomEvent('grid-cell-focus', {
-          detail: {
-            itemKey: eventContext.item
-                ? eventContext.item.key
-                : null,
-
-            internalColumnId: eventContext.column
-                ? eventContext.column._flowId
-                : null,
-
-            section: eventContext.section
-          }
-        }));
-      }));
-
-      function _fireClickEvent(event, eventName) {
-        const target = event.target;
-        const eventContext = grid.getEventContext(event);
-        const section = eventContext.section;
-
-        if (eventContext.item && !isFocusable(target) && section !== 'details') {
-          event.itemKey = eventContext.item.key;
-          // if you have a details-renderer, getEventContext().column is undefined
-          if (eventContext.column) {
-            event.internalColumnId = eventContext.column._flowId;
-          }
-          grid.dispatchEvent(new CustomEvent(eventName,
-            { detail: event }));
-        }
-      }
-
-      grid.cellClassNameGenerator = tryCatchWrapper(function(column, rowData) {
+        grid.cellClassNameGenerator = tryCatchWrapper(function (column, rowData) {
           const style = rowData.item.style;
           if (!style) {
             return;
           }
           return (style.row || '') + ' ' + ((column && style[column._flowId]) || '');
-      })
+        });
 
-      grid.dropFilter = tryCatchWrapper(rowData => !rowData.item.dropDisabled);
+        grid.dropFilter = tryCatchWrapper((rowData) => !rowData.item.dropDisabled);
 
-      grid.dragFilter = tryCatchWrapper(rowData => !rowData.item.dragDisabled);
+        grid.dragFilter = tryCatchWrapper((rowData) => !rowData.item.dragDisabled);
 
-      grid.addEventListener('grid-dragstart', tryCatchWrapper(e => {
+        grid.addEventListener(
+          'grid-dragstart',
+          tryCatchWrapper((e) => {
+            if (grid._isSelected(e.detail.draggedItems[0])) {
+              // Dragging selected (possibly multiple) items
+              if (grid.__selectionDragData) {
+                Object.keys(grid.__selectionDragData).forEach((type) => {
+                  e.detail.setDragData(type, grid.__selectionDragData[type]);
+                });
+              } else {
+                (grid.__dragDataTypes || []).forEach((type) => {
+                  e.detail.setDragData(type, e.detail.draggedItems.map((item) => item.dragData[type]).join('\n'));
+                });
+              }
 
-        if (grid._isSelected(e.detail.draggedItems[0])) {
-          // Dragging selected (possibly multiple) items
-          if (grid.__selectionDragData) {
-            Object.keys(grid.__selectionDragData).forEach(type => {
-              e.detail.setDragData(type, grid.__selectionDragData[type]);
-            });
-          } else {
-            (grid.__dragDataTypes || []).forEach(type => {
-              e.detail.setDragData(type, e.detail.draggedItems.map(item => item.dragData[type]).join('\n'));
-            });
-          }
-
-          if (grid.__selectionDraggedItemsCount > 1) {
-            e.detail.setDraggedItemsCount(grid.__selectionDraggedItemsCount);
-          }
-        } else {
-          // Dragging just one (non-selected) item
-          (grid.__dragDataTypes || []).forEach(type => {
-            e.detail.setDragData(type, e.detail.draggedItems[0].dragData[type]);
-          });
-        }
-      }));
-    })(grid)
-  }
+              if (grid.__selectionDraggedItemsCount > 1) {
+                e.detail.setDraggedItemsCount(grid.__selectionDraggedItemsCount);
+              }
+            } else {
+              // Dragging just one (non-selected) item
+              (grid.__dragDataTypes || []).forEach((type) => {
+                e.detail.setDragData(type, e.detail.draggedItems[0].dragData[type]);
+              });
+            }
+          })
+        );
+      })(grid)
+  };
 })();

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -1,52 +1,54 @@
 (function () {
-    const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid Pro', 'vaadin-grid-pro');
-    };
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid Pro', 'vaadin-grid-pro');
+  };
 
-    function isEditedRow(grid, rowData) {
-        return grid.__edited && grid.__edited.model.item.key === rowData.item.key;
-    }
+  function isEditedRow(grid, rowData) {
+    return grid.__edited && grid.__edited.model.item.key === rowData.item.key;
+  }
 
-    window.Vaadin.Flow.gridProConnector = {
-        setEditModeRenderer: (column, component) => tryCatchWrapper(function (column, component) {
-            column.editModeRenderer = tryCatchWrapper(function editModeRenderer(root, _, rowData) {
-                if (!isEditedRow(this._grid, rowData)) {
-                    this._grid._stopEdit();
-                    return;
-                }
+  window.Vaadin.Flow.gridProConnector = {
+    setEditModeRenderer: (column, component) =>
+      tryCatchWrapper(function (column, component) {
+        column.editModeRenderer = tryCatchWrapper(function editModeRenderer(root, _, rowData) {
+          if (!isEditedRow(this._grid, rowData)) {
+            this._grid._stopEdit();
+            return;
+          }
 
-                if (component.parentNode === root) {
-                    return;
-                }
+          if (component.parentNode === root) {
+            return;
+          }
 
-                root.appendChild(component);
-                this._grid._cancelStopEdit();
-                component.focus();
-            });
+          root.appendChild(component);
+          this._grid._cancelStopEdit();
+          component.focus();
+        });
 
-            // Not needed in case of custom editor as value is set on server-side.
-            // Overridden in order to avoid blinking of the cell content.
-            column._setEditorValue = function (editor, value) {};
-            column._getEditorValue = function (editor) {
-                return;
-            };
-        })(column, component),
+        // Not needed in case of custom editor as value is set on server-side.
+        // Overridden in order to avoid blinking of the cell content.
+        column._setEditorValue = function (editor, value) {};
+        column._getEditorValue = function (editor) {
+          return;
+        };
+      })(column, component),
 
-        patchEditModeRenderer: column => tryCatchWrapper(function (column) {
-            column.__editModeRenderer = tryCatchWrapper(function __editModeRenderer(root, column, rowData) {
-                const cell = root.assignedSlot.parentNode;
-                const grid = column._grid;
+    patchEditModeRenderer: (column) =>
+      tryCatchWrapper(function (column) {
+        column.__editModeRenderer = tryCatchWrapper(function __editModeRenderer(root, column, rowData) {
+          const cell = root.assignedSlot.parentNode;
+          const grid = column._grid;
 
-                if (!isEditedRow(grid, rowData)) {
-                    grid._stopEdit();
-                    return;
-                }
+          if (!isEditedRow(grid, rowData)) {
+            grid._stopEdit();
+            return;
+          }
 
-                const tagName = column._getEditorTagName(cell);
-                if (!root.firstElementChild || root.firstElementChild.localName.toLowerCase() !== tagName) {
-                    root.innerHTML = `<${tagName}></${tagName}>`;
-                }
-            });
-        })(column)
-    };
+          const tagName = column._getEditorTagName(cell);
+          if (!root.firstElementChild || root.firstElementChild.localName.toLowerCase() !== tagName) {
+            root.innerHTML = `<${tagName}></${tagName}>`;
+          }
+        });
+      })(column)
+  };
 })();

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/resources/META-INF/resources/frontend/ironListConnector.js
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/src/main/resources/META-INF/resources/frontend/ironListConnector.js
@@ -1,8 +1,8 @@
-import { Debouncer } from "@polymer/polymer/lib/utils/debounce.js";
-import { timeOut } from "@polymer/polymer/lib/utils/async.js";
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
 window.Vaadin.Flow.ironListConnector = {
-  initLazy: function(list) {
+  initLazy: function (list) {
     // Check whether the connector was already initialized for the Iron list
     if (list.$connector) {
       return;
@@ -15,7 +15,7 @@ window.Vaadin.Flow.ironListConnector = {
     list.$connector = {};
     list.$connector.placeholderItem = { __placeholder: true };
 
-    const updateRequestedItem = function() {
+    const updateRequestedItem = function () {
       /*
        * TODO Iron list seems to do a small index adjustment after scrolling
        * has stopped. This causes a redundant request to be sent to make a
@@ -37,12 +37,8 @@ window.Vaadin.Flow.ironListConnector = {
     };
 
     let requestDebounce;
-    const scheduleUpdateRequest = function() {
-      requestDebounce = Debouncer.debounce(
-        requestDebounce,
-        timeOut.after(10),
-        updateRequestedItem
-      );
+    const scheduleUpdateRequest = function () {
+      requestDebounce = Debouncer.debounce(requestDebounce, timeOut.after(10), updateRequestedItem);
     };
 
     /*
@@ -53,7 +49,7 @@ window.Vaadin.Flow.ironListConnector = {
      * empty.
      */
     const originalAssign = list._assignModels;
-    list._assignModels = function() {
+    list._assignModels = function () {
       const tempItems = [];
       const start = list._virtualStart;
       const count = Math.min(list.items.length, list._physicalCount);
@@ -86,7 +82,7 @@ window.Vaadin.Flow.ironListConnector = {
 
     list.items = [];
 
-    list.$connector.set = function(index, items) {
+    list.$connector.set = function (index, items) {
       for (let i = 0; i < items.length; i++) {
         const itemsIndex = index + i;
         list.items[itemsIndex] = items[i];
@@ -95,7 +91,7 @@ window.Vaadin.Flow.ironListConnector = {
       list._render();
     };
 
-    list.$connector.updateData = function(items) {
+    list.$connector.updateData = function (items) {
       // Find the items by key inside the list update them
       const oldItems = list.items;
       const mapByKey = {};
@@ -111,7 +107,7 @@ window.Vaadin.Flow.ironListConnector = {
         const newItem = mapByKey[oldItem.key];
         if (newItem) {
           list.items[i] = newItem;
-          list.notifyPath("items." + i);
+          list.notifyPath('items.' + i);
           leftToUpdate--;
           if (leftToUpdate == 0) {
             break;
@@ -120,46 +116,46 @@ window.Vaadin.Flow.ironListConnector = {
       }
     };
 
-    list.$connector.clear = function(index, length) {
+    list.$connector.clear = function (index, length) {
       for (let i = 0; i < length; i++) {
         const itemsIndex = index + i;
         delete list.items[itemsIndex];
 
         // Most likely a no-op since the affected index isn't in view
-        list.notifyPath("items." + itemsIndex);
+        list.notifyPath('items.' + itemsIndex);
       }
     };
 
-    list.$connector.updateSize = function(newSize) {
+    list.$connector.updateSize = function (newSize) {
       const delta = newSize - list.items.length;
       if (delta > 0) {
         list.items.length = newSize;
 
-        list.notifySplices("items", [
+        list.notifySplices('items', [
           {
             index: newSize - delta,
             removed: [],
             addedCount: delta,
             object: list.items,
-            type: "splice"
+            type: 'splice'
           }
         ]);
       } else if (delta < 0) {
         const removed = list.items.slice(newSize, list.items.length);
         list.items.splice(newSize);
-        list.notifySplices("items", [
+        list.notifySplices('items', [
           {
             index: newSize,
             removed: removed,
             addedCount: 0,
             object: list.items,
-            type: "splice"
+            type: 'splice'
           }
         ]);
       }
     };
 
-    list.$connector.setPlaceholderItem = function(placeholderItem) {
+    list.$connector.setPlaceholderItem = function (placeholderItem) {
       if (!placeholderItem) {
         placeholderItem = {};
       }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -25,7 +25,6 @@
         return;
       }
       menubar.$connector = {
-
         updateButtons: tryCatchWrapper(function () {
           if (!menubar.shadowRoot) {
             // workaround for https://github.com/vaadin/flow/issues/5722
@@ -34,7 +33,7 @@
           }
 
           // Propagate disabled state from items to parent buttons
-          menubar.items.forEach(item => item.disabled = item.component.disabled);
+          menubar.items.forEach((item) => (item.disabled = item.component.disabled));
 
           // Remove hidden items entirely from the array. Just hiding them
           // could cause the overflow button to be rendered without items.
@@ -42,12 +41,12 @@
           //
           // The items-prop needs to be set even when all items are visible
           // to update the disabled state and re-render buttons.
-          menubar.items = menubar.items.filter(item => !item.component.hidden);
+          menubar.items = menubar.items.filter((item) => !item.component.hidden);
 
           // Propagate click events from the menu buttons to the item components
-          menubar._buttons.forEach(button => {
+          menubar._buttons.forEach((button) => {
             if (button.item && button.item.component) {
-              button.addEventListener('click', e => {
+              button.addEventListener('click', (e) => {
                 if (e.composedPath().indexOf(button.item.component) === -1) {
                   button.item.component.click();
                   e.stopPropagation();

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/resources/META-INF/resources/frontend/messageListConnector.js
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/resources/META-INF/resources/frontend/messageListConnector.js
@@ -15,19 +15,27 @@
  */
 
 (function () {
-    const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Message List', 'vaadin-messages');
-    };
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Message List', 'vaadin-messages');
+  };
 
-    window.Vaadin.Flow.messageListConnector = {
-        setItems: (list, items, locale) => tryCatchWrapper(function (list, items, locale) {
-            const formatter = new Intl.DateTimeFormat(locale, {
-                year: 'numeric', month: 'short', day: 'numeric',
-                hour: 'numeric', minute: 'numeric'
-            });
-            list.items = items.map(item => item.time ? Object.assign(item, {
+  window.Vaadin.Flow.messageListConnector = {
+    setItems: (list, items, locale) =>
+      tryCatchWrapper(function (list, items, locale) {
+        const formatter = new Intl.DateTimeFormat(locale, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric'
+        });
+        list.items = items.map((item) =>
+          item.time
+            ? Object.assign(item, {
                 time: formatter.format(new Date(item.time))
-            }) : item);
-        })(list, items, locale)
-    };
+              })
+            : item
+        );
+      })(list, items, locale)
+  };
 })();

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
@@ -1,35 +1,36 @@
 (function () {
-    const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select', 'vaadin-select');
-    };
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select', 'vaadin-select');
+  };
 
-    window.Vaadin.Flow.selectConnector = {
-        initLazy: select => tryCatchWrapper(function (select) {
-            const _findListBoxElement = tryCatchWrapper(function () {
-                for (let i = 0; i < select.childElementCount; i++) {
-                    const child = select.children[i];
-                    if ("VAADIN-LIST-BOX" === child.tagName.toUpperCase()) {
-                        return child;
-                    }
-                }
-            });
-
-            // do not init this connector twice for the given select
-            if (select.$connector) {
-                return;
+  window.Vaadin.Flow.selectConnector = {
+    initLazy: (select) =>
+      tryCatchWrapper(function (select) {
+        const _findListBoxElement = tryCatchWrapper(function () {
+          for (let i = 0; i < select.childElementCount; i++) {
+            const child = select.children[i];
+            if ('VAADIN-LIST-BOX' === child.tagName.toUpperCase()) {
+              return child;
             }
+          }
+        });
 
-            select.$connector = {};
+        // do not init this connector twice for the given select
+        if (select.$connector) {
+          return;
+        }
 
-            select.renderer = tryCatchWrapper(function (root) {
-                const listBox = _findListBoxElement();
-                if (listBox) {
-                    if (root.firstChild) {
-                        root.removeChild(root.firstChild);
-                    }
-                    root.appendChild(listBox);
-                }
-            });
-        })(select)
-    };
+        select.$connector = {};
+
+        select.renderer = tryCatchWrapper(function (root) {
+          const listBox = _findListBoxElement();
+          if (listBox) {
+            if (root.firstChild) {
+              root.removeChild(root.firstChild);
+            }
+            root.appendChild(listBox);
+          }
+        });
+      })(select)
+  };
 })();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -1,252 +1,262 @@
 (function () {
-    const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker', 'vaadin-time-picker');
-    };
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker', 'vaadin-time-picker');
+  };
 
-    // Execute callback when predicate returns true.
-    // Try again later if predicate returns false.
-    function when(predicate, callback, timeout = 0) {
-        if (predicate()) {
-            callback();
-        } else {
-            setTimeout(() => when(predicate, callback, 200), timeout);
-        }
+  // Execute callback when predicate returns true.
+  // Try again later if predicate returns false.
+  function when(predicate, callback, timeout = 0) {
+    if (predicate()) {
+      callback();
+    } else {
+      setTimeout(() => when(predicate, callback, 200), timeout);
     }
+  }
 
-    window.Vaadin.Flow.timepickerConnector = {
-        initLazy: timepicker => tryCatchWrapper(function (timepicker) {
-            // Check whether the connector was already initialized for the timepicker
-            if (timepicker.$connector) {
-                return;
+  window.Vaadin.Flow.timepickerConnector = {
+    initLazy: (timepicker) =>
+      tryCatchWrapper(function (timepicker) {
+        // Check whether the connector was already initialized for the timepicker
+        if (timepicker.$connector) {
+          return;
+        }
+
+        timepicker.$connector = {};
+
+        const getAmPmString = function (locale, testTime) {
+          const testTimeString = testTime.toLocaleTimeString(locale);
+          // AM/PM string is anything from one letter in eastern arabic to standard two letters,
+          // to having space in between, dots ...
+          // cannot disqualify whitespace since some locales use a. m. / p. m.
+          // TODO when more scripts support is added (than Arabic), need to exclude those numbers too
+          const endWithAmPmRegex = /[^\d\u0660-\u0669]+$/g;
+          let amPmString = testTimeString.match(endWithAmPmRegex);
+          if (!amPmString) {
+            // eg. chinese (and some else too) starts with am/pm
+            amPmString = testTimeString.match(/^[^\d\u0660-\u0669]+/g);
+          }
+          if (amPmString) {
+            amPmString = amPmString[0].trim();
+          }
+          return amPmString;
+        };
+        const testPmTime = new Date('August 19, 1975 23:15:30');
+        const testAmTime = new Date('August 19, 1975 05:15:30');
+
+        const getPmString = function (locale) {
+          return getAmPmString(locale, testPmTime);
+        };
+        const getAmString = function (locale) {
+          return getAmPmString(locale, testAmTime);
+        };
+
+        // map from unicode eastern arabic number characters to arabic numbers
+        const arabicDigitMap = {
+          '\\u0660': '0',
+          '\\u0661': '1',
+          '\\u0662': '2',
+          '\\u0663': '3',
+          '\\u0664': '4',
+          '\\u0665': '5',
+          '\\u0666': '6',
+          '\\u0667': '7',
+          '\\u0668': '8',
+          '\\u0669': '9'
+        };
+
+        // parses eastern arabic number characters to arabic numbers (0-9)
+        const anyNumberCharToArabicNumberReplacer = function (charsToReplace) {
+          return charsToReplace.replace(/[\u0660-\u0669]/g, function (char) {
+            const unicode = '\\u0' + char.charCodeAt(0).toString(16);
+            return arabicDigitMap[unicode];
+          });
+        };
+
+        const parseAnyCharsToInt = function (anyNumberChars) {
+          return parseInt(anyNumberCharToArabicNumberReplacer(anyNumberChars));
+        };
+
+        const parseMillisecondCharsToInt = function (millisecondChars) {
+          millisecondChars = anyNumberCharToArabicNumberReplacer(millisecondChars);
+          // digits are either .1 .01 or .001 so need to "shift"
+          if (millisecondChars.length === 1) {
+            millisecondChars += '00';
+          } else if (millisecondChars.length === 2) {
+            millisecondChars += '0';
+          }
+          return parseInt(millisecondChars);
+        };
+
+        // detecting milliseconds from input, expects am/pm removed from end, eg. .0 or .00 or .000
+        const millisecondRegExp = /[[\.][\d\u0660-\u0669]{1,3}$/;
+
+        timepicker.$connector.setLocale = tryCatchWrapper(function (locale) {
+          // capture previous value if any
+          let previousValueObject;
+          if (timepicker.value && timepicker.value !== '') {
+            previousValueObject = timepicker.i18n.parseTime(timepicker.value);
+          }
+
+          try {
+            // Check whether the locale is supported by the browser or not
+            testPmTime.toLocaleTimeString(locale);
+          } catch (e) {
+            locale = 'en-US';
+            // FIXME should do a callback for server to throw an exception ?
+            throw new Error(
+              'vaadin-time-picker: The locale ' +
+                locale +
+                ' is not supported, falling back to default locale setting(en-US).'
+            );
+          }
+
+          // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?
+          const pmString = getPmString(locale);
+          const amString = getAmString(locale);
+
+          // 2. What is the separator ?
+          let localeTimeString = testPmTime.toLocaleTimeString(locale);
+          // since the next regex picks first non-number-whitespace, need to discard possible PM from beginning (eg. chinese locale)
+          if (pmString && localeTimeString.startsWith(pmString)) {
+            localeTimeString = localeTimeString.replace(pmString, '');
+          }
+          const separator = localeTimeString.match(/[^\u0660-\u0669\s\d]/);
+
+          // 3. regexp that allows to find the numbers with optional separator and continuing searching after it
+          const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + separator + ')?', 'g');
+
+          const includeSeconds = function () {
+            return timepicker.step && timepicker.step < 60;
+          };
+
+          const includeMilliSeconds = function () {
+            return timepicker.step && timepicker.step < 1;
+          };
+
+          // the web component expects the correct granularity used for the time string,
+          // thus need to format the time object in correct granularity by passing the format options
+          let cachedStep;
+          let cachedOptions;
+          const getTimeFormatOptions = function () {
+            // calculate the format options if none done cached or step has changed
+            if (!cachedOptions || cachedStep !== timepicker.step) {
+              cachedOptions = {
+                hour: 'numeric',
+                minute: 'numeric',
+                second: includeSeconds() ? 'numeric' : undefined
+              };
+              cachedStep = timepicker.step;
             }
+            return cachedOptions;
+          };
 
-            timepicker.$connector = {};
+          const formatMilliseconds = function (localeTimeString, milliseconds) {
+            if (includeMilliSeconds()) {
+              // might need to inject milliseconds between seconds and AM/PM
+              let cleanedTimeString = localeTimeString;
+              if (localeTimeString.endsWith(amString)) {
+                cleanedTimeString = localeTimeString.replace(' ' + amString, '');
+              } else if (localeTimeString.endsWith(pmString)) {
+                cleanedTimeString = localeTimeString.replace(' ' + pmString, '');
+              }
+              if (milliseconds) {
+                let millisecondsString = milliseconds < 10 ? '0' : '';
+                millisecondsString += milliseconds < 100 ? '0' : '';
+                millisecondsString += milliseconds;
+                cleanedTimeString += '.' + millisecondsString;
+              } else {
+                cleanedTimeString += '.000';
+              }
+              if (localeTimeString.endsWith(amString)) {
+                cleanedTimeString = cleanedTimeString + ' ' + amString;
+              } else if (localeTimeString.endsWith(pmString)) {
+                cleanedTimeString = cleanedTimeString + ' ' + pmString;
+              }
+              return cleanedTimeString;
+            }
+            return localeTimeString;
+          };
 
-            const getAmPmString = function (locale, testTime) {
-                const testTimeString = testTime.toLocaleTimeString(locale);
-                // AM/PM string is anything from one letter in eastern arabic to standard two letters,
-                // to having space in between, dots ...
-                // cannot disqualify whitespace since some locales use a. m. / p. m.
-                // TODO when more scripts support is added (than Arabic), need to exclude those numbers too
-                const endWithAmPmRegex = /[^\d\u0660-\u0669]+$/g;
-                let amPmString = testTimeString.match(endWithAmPmRegex);
-                if (!amPmString) {
-                    // eg. chinese (and some else too) starts with am/pm
-                    amPmString = testTimeString.match(/^[^\d\u0660-\u0669]+/g);
-                }
-                if (amPmString) {
-                    amPmString = amPmString[0].trim();
-                }
-                return amPmString;
-            };
-            const testPmTime = new Date('August 19, 1975 23:15:30');
-            const testAmTime = new Date('August 19, 1975 05:15:30');
+          let cachedTimeString;
+          let cachedTimeObject;
 
-            const getPmString = function (locale) {
-                return getAmPmString(locale, testPmTime);
-
-            };
-            const getAmString = function (locale) {
-                return getAmPmString(locale, testAmTime);
-            };
-
-            // map from unicode eastern arabic number characters to arabic numbers
-            const arabicDigitMap = {
-                '\\u0660': '0',
-                '\\u0661': '1',
-                '\\u0662': '2',
-                '\\u0663': '3',
-                '\\u0664': '4',
-                '\\u0665': '5',
-                '\\u0666': '6',
-                '\\u0667': '7',
-                '\\u0668': '8',
-                '\\u0669': '9'
-            };
-
-            // parses eastern arabic number characters to arabic numbers (0-9)
-            const anyNumberCharToArabicNumberReplacer = function (charsToReplace) {
-                return charsToReplace.replace(/[\u0660-\u0669]/g, function (char) {
-                    const unicode = '\\u0' + char.charCodeAt(0).toString(16);
-                    return arabicDigitMap[unicode];
-                });
-            };
-
-            const parseAnyCharsToInt = function (anyNumberChars) {
-                return parseInt(anyNumberCharToArabicNumberReplacer(anyNumberChars));
-            };
-
-            const parseMillisecondCharsToInt =function (millisecondChars) {
-                millisecondChars = anyNumberCharToArabicNumberReplacer(millisecondChars);
-                // digits are either .1 .01 or .001 so need to "shift"
-                if (millisecondChars.length === 1) {
-                    millisecondChars += "00";
-                } else if (millisecondChars.length === 2) {
-                    millisecondChars += "0";
-                }
-                return parseInt(millisecondChars);
-            };
-
-            // detecting milliseconds from input, expects am/pm removed from end, eg. .0 or .00 or .000
-            const millisecondRegExp = /[[\.][\d\u0660-\u0669]{1,3}$/;
-
-            timepicker.$connector.setLocale = tryCatchWrapper(function (locale) {
-                // capture previous value if any
-                let previousValueObject;
-                if (timepicker.value && timepicker.value !== '') {
-                    previousValueObject = timepicker.i18n.parseTime(timepicker.value);
-                }
-
-                try {
-                    // Check whether the locale is supported by the browser or not
-                    testPmTime.toLocaleTimeString(locale);
-                } catch (e) {
-                    locale = "en-US";
-                    // FIXME should do a callback for server to throw an exception ?
-                    throw new Error("vaadin-time-picker: The locale " + locale + " is not supported, falling back to default locale setting(en-US).");
-                }
-
-                // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?
-                const pmString = getPmString(locale);
-                const amString = getAmString(locale);
-
-                // 2. What is the separator ?
-                let localeTimeString = testPmTime.toLocaleTimeString(locale);
-                // since the next regex picks first non-number-whitespace, need to discard possible PM from beginning (eg. chinese locale)
-                if (pmString && localeTimeString.startsWith(pmString)) {
-                    localeTimeString = localeTimeString.replace(pmString, '');
-                }
-                const separator = localeTimeString.match(/[^\u0660-\u0669\s\d]/);
-
-                // 3. regexp that allows to find the numbers with optional separator and continuing searching after it
-                const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + separator + ')?', 'g');
-
-                const includeSeconds = function () {
-                    return timepicker.step && timepicker.step < 60;
-                };
-
-                const includeMilliSeconds = function () {
-                    return timepicker.step && timepicker.step < 1;
-                };
-
-                // the web component expects the correct granularity used for the time string,
-                // thus need to format the time object in correct granularity by passing the format options
-                let cachedStep;
-                let cachedOptions;
-                const getTimeFormatOptions = function () {
-                    // calculate the format options if none done cached or step has changed
-                    if (!cachedOptions || cachedStep !== timepicker.step) {
-                        cachedOptions = {
-                            hour: "numeric",
-                            minute: "numeric",
-                            second: includeSeconds() ? "numeric" : undefined,
-                        };
-                        cachedStep = timepicker.step;
+          timepicker.i18n = {
+            formatTime: tryCatchWrapper(function (timeObject) {
+              if (timeObject) {
+                let timeToBeFormatted = new Date();
+                timeToBeFormatted.setHours(timeObject.hours);
+                timeToBeFormatted.setMinutes(timeObject.minutes);
+                timeToBeFormatted.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
+                let localeTimeString = timeToBeFormatted.toLocaleTimeString(locale, getTimeFormatOptions());
+                // milliseconds not part of the time format API
+                localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds);
+                return localeTimeString;
+              }
+            }),
+            parseTime: tryCatchWrapper(function (timeString) {
+              if (timeString && timeString === cachedTimeString && cachedTimeObject) {
+                return cachedTimeObject;
+              }
+              if (timeString) {
+                const pm = timeString.search(pmString);
+                const am = timeString.search(amString);
+                let numbersOnlyTimeString = timeString.replace(amString, '').replace(pmString, '').trim();
+                // reset regex to beginning or things can explode when the length of the input changes
+                numbersRegExp.lastIndex = 0;
+                let hours = numbersRegExp.exec(numbersOnlyTimeString);
+                if (hours) {
+                  hours = parseAnyCharsToInt(hours[0].replace(separator, ''));
+                  // handle 12 am -> 0
+                  // do not do anything if am & pm are not used or if those are the same,
+                  // as with locale bg-BG there is always ч. at the end of the time
+                  if (pm !== am) {
+                    if (hours === 12 && am !== -1) {
+                      hours = 0;
+                    } else {
+                      hours += pm !== -1 && hours !== 12 ? 12 : 0;
                     }
-                    return cachedOptions;
-                };
-
-                const formatMilliseconds = function (localeTimeString, milliseconds) {
-                    if (includeMilliSeconds()) {
-                        // might need to inject milliseconds between seconds and AM/PM
-                        let cleanedTimeString = localeTimeString;
-                        if (localeTimeString.endsWith(amString)) {
-                            cleanedTimeString = localeTimeString.replace(" " + amString, '');
-                        } else if (localeTimeString.endsWith(pmString)) {
-                            cleanedTimeString = localeTimeString.replace(" " + pmString, '');
-                        }
-                        if (milliseconds) {
-                            let millisecondsString = milliseconds < 10 ? "0" : "";
-                            millisecondsString += milliseconds < 100 ? "0" : "";
-                            millisecondsString += milliseconds;
-                            cleanedTimeString += "." + millisecondsString;
-                        } else {
-                            cleanedTimeString += ".000";
-                        }
-                        if (localeTimeString.endsWith(amString)) {
-                            cleanedTimeString = cleanedTimeString + " " + amString;
-                        } else if (localeTimeString.endsWith(pmString)) {
-                            cleanedTimeString = cleanedTimeString + " " + pmString;
-                        }
-                        return cleanedTimeString;
-                    }
-                    return localeTimeString;
-                };
-
-                let cachedTimeString;
-                let cachedTimeObject;
-
-                timepicker.i18n = {
-                    formatTime: tryCatchWrapper(function (timeObject) {
-                        if (timeObject) {
-                            let timeToBeFormatted = new Date();
-                            timeToBeFormatted.setHours(timeObject.hours);
-                            timeToBeFormatted.setMinutes(timeObject.minutes);
-                            timeToBeFormatted.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
-                            let localeTimeString = timeToBeFormatted.toLocaleTimeString(locale, getTimeFormatOptions());
-                            // milliseconds not part of the time format API
-                            localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds);
-                            return localeTimeString;
-                        }
-                    }),
-                    parseTime: tryCatchWrapper(function (timeString) {
-                        if (timeString && timeString === cachedTimeString && cachedTimeObject) {
-                            return cachedTimeObject;
-                        }
-                        if (timeString) {
-                            const pm = timeString.search(pmString);
-                            const am = timeString.search(amString);
-                            let numbersOnlyTimeString = timeString.replace(amString, '').replace(pmString, '').trim();
-                            // reset regex to beginning or things can explode when the length of the input changes
-                            numbersRegExp.lastIndex = 0;
-                            let hours = numbersRegExp.exec(numbersOnlyTimeString);
-                            if (hours) {
-                                hours = parseAnyCharsToInt(hours[0].replace(separator, ''));
-                                // handle 12 am -> 0
-                                // do not do anything if am & pm are not used or if those are the same,
-                                // as with locale bg-BG there is always ч. at the end of the time
-                                if (pm !== am) {
-                                    if (hours === 12 && am !== -1) {
-                                        hours = 0;
-                                    } else {
-                                        hours += (pm !== -1 && hours !== 12 ? 12 : 0)
-                                    }
-                                }
-                                const minutes = numbersRegExp.exec(numbersOnlyTimeString);
-                                const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
-                                // reset to end or things can explode
-                                let milliseconds = seconds && includeMilliSeconds() && millisecondRegExp.exec(numbersOnlyTimeString);
-                                // handle case where last numbers are seconds and . is the separator (invalid regexp match)
-                                if (milliseconds && milliseconds['index'] <= seconds['index']) {
-                                    milliseconds = undefined;
-                                }
-                                // hours is a number at this point, others are either arrays or null
-                                // the string in [0] from the arrays includes the separator too
-                                cachedTimeObject = hours !== undefined && {
-                                    hours: hours,
-                                    minutes: minutes ? parseAnyCharsToInt(minutes[0].replace(separator, '')) : 0,
-                                    seconds: seconds ? parseAnyCharsToInt(seconds[0].replace(separator, '')) : 0,
-                                    milliseconds: minutes && seconds && milliseconds ? parseMillisecondCharsToInt(milliseconds[0].replace('.', '')) : 0
-                                };
-                                cachedTimeString = timeString;
-                                return cachedTimeObject;
-                            }
-                            // when nothing is returned, the component shows the invalid state for the input
-                        }
-                    })
-                };
-
-                if (previousValueObject) {
-                    when(() => timepicker.$, () => {
-                        const newValue = timepicker.i18n.formatTime(previousValueObject);
-                        // FIXME works but uses private API, needs fixes in web component
-                        if (timepicker.inputElement.value !== newValue) {
-                            timepicker.inputElement.value = newValue;
-                            timepicker.$.comboBox.value = newValue;
-                        }
-                    });
+                  }
+                  const minutes = numbersRegExp.exec(numbersOnlyTimeString);
+                  const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
+                  // reset to end or things can explode
+                  let milliseconds = seconds && includeMilliSeconds() && millisecondRegExp.exec(numbersOnlyTimeString);
+                  // handle case where last numbers are seconds and . is the separator (invalid regexp match)
+                  if (milliseconds && milliseconds['index'] <= seconds['index']) {
+                    milliseconds = undefined;
+                  }
+                  // hours is a number at this point, others are either arrays or null
+                  // the string in [0] from the arrays includes the separator too
+                  cachedTimeObject = hours !== undefined && {
+                    hours: hours,
+                    minutes: minutes ? parseAnyCharsToInt(minutes[0].replace(separator, '')) : 0,
+                    seconds: seconds ? parseAnyCharsToInt(seconds[0].replace(separator, '')) : 0,
+                    milliseconds:
+                      minutes && seconds && milliseconds
+                        ? parseMillisecondCharsToInt(milliseconds[0].replace('.', ''))
+                        : 0
+                  };
+                  cachedTimeString = timeString;
+                  return cachedTimeObject;
                 }
-            });
-        })(timepicker)
-    };
+                // when nothing is returned, the component shows the invalid state for the input
+              }
+            })
+          };
+
+          if (previousValueObject) {
+            when(
+              () => timepicker.$,
+              () => {
+                const newValue = timepicker.i18n.formatTime(previousValueObject);
+                // FIXME works but uses private API, needs fixes in web component
+                if (timepicker.inputElement.value !== newValue) {
+                  timepicker.inputElement.value = newValue;
+                  timepicker.$.comboBox.value = newValue;
+                }
+              }
+            );
+          }
+        });
+      })(timepicker)
+  };
 })();

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
@@ -40,11 +40,7 @@ window.Vaadin.Flow.virtualListConnector = {
     };
 
     const scheduleUpdateRequest = function () {
-      list.__requestDebounce = Debouncer.debounce(
-        list.__requestDebounce,
-        timeOut.after(50),
-        updateRequestedItem
-      );
+      list.__requestDebounce = Debouncer.debounce(list.__requestDebounce, timeOut.after(50), updateRequestedItem);
     };
 
     requestAnimationFrame(() => updateRequestedItem);
@@ -63,16 +59,16 @@ window.Vaadin.Flow.virtualListConnector = {
         root.__virtualListIndex = model.index;
 
         if (model.item === undefined) {
-          originalRenderer.call(list, root, list, {...model, item: list.$connector.placeholderItem});
+          originalRenderer.call(list, root, list, { ...model, item: list.$connector.placeholderItem });
         } else {
           originalRenderer.call(list, root, list, model);
         }
 
         /*
-        * Check if we need to do anything once things have settled down.
-        * This method is called multiple times in sequence for the same user
-        * action, but we only want to do the check once.
-        */
+         * Check if we need to do anything once things have settled down.
+         * This method is called multiple times in sequence for the same user
+         * action, but we only want to do the check once.
+         */
         scheduleUpdateRequest();
       };
       renderer.__virtualListConnectorPatched = true;
@@ -119,5 +115,5 @@ window.Vaadin.Flow.virtualListConnector = {
       placeholderItem.__placeholder = true;
       list.$connector.placeholderItem = placeholderItem;
     };
-  },
+  }
 };


### PR DESCRIPTION
## Description

This PR is a result of running Prettier on Flow JS connectors. I decided to format connectors on the `22.0` branch as well to support automatic cherry-picks for future fixes.

It is recommended to review the PR with the enabled Hide whitespace to exclude indent changes.

A follow-up to https://github.com/vaadin/flow-components/pull/3036

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
