### PR TITLE
chore: fix test package in TimePicker testing class

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerVariantTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerVariantTest.java
@@ -13,13 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.timepicker;
+package com.vaadin.flow.component.timepicker.tests;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.component.timepicker.TimePickerVariant;
 
 public class TimePickerVariantTest {
 


### PR DESCRIPTION
The package naming doesn't reflect the folder structure.
Fix the package name and add import for TimePicker classes.

