### PR TITLE
chore: bring ComboBoxElement#clear() method back

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxClearPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxClearPage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2012 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-combo-box/clear")
+public class ComboBoxClearPage extends VerticalLayout {
+
+    public ComboBoxClearPage() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems("One", "Two", "Three", "Four", "Five", "Six", "Seven",
+                "Eight", "Nine", "Ten");
+        comboBox.setValue("Eight");
+        add(comboBox);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxClearIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxClearIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2012 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-combo-box/clear")
+public class ComboBoxClearIT extends AbstractComboBoxIT {
+
+    private ComboBoxElement box;
+
+    @Test
+    public void comboBoxClear() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+        box = $(ComboBoxElement.class).first();
+        Assert.assertEquals(box.getSelectedText(),"Eight");
+        box.clear();
+        Assert.assertTrue(box.getSelectedText().isEmpty());
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/ComboBoxElement.java
@@ -31,6 +31,36 @@ import com.vaadin.testbench.elementsbase.Element;
 public class ComboBoxElement extends TestBenchElement
         implements HasLabel, HasSelectByText, HasHelper {
 
+    /**
+     * Clears the value of the combobox.
+     */
+    @Override
+    public void clear() {
+        setValue(null);
+    }
+
+    /**
+     * Sets the property "value" as a string.
+     * <p>
+     *
+     * @param value
+     *            the value to set
+     */
+    protected void setValue(String value) {
+        setProperty("value", value);
+    }
+
+    /**
+     * Gets the property "value" as a string.
+     * <p>
+     *
+     * @return the value of the combobox or an empty string if no value is
+     *         selected
+     */
+    protected String getValue() {
+        return getPropertyString("value");
+    }
+
     @Override
     public void selectByText(String text) {
         setFilter(text);


### PR DESCRIPTION
For some reason the fix has been dropped since 14.7. This was in 14.5 and 14.6.

See: https://github.com/vaadin/flow-components/pull/757