### PR TITLE
chore: fix flaky upload test

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -37,11 +37,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
             <version>1.0</version>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadDropLabelTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadDropLabelTest.java
@@ -3,26 +3,17 @@ package com.vaadin.flow.component.upload.tests;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.upload.Upload;
-import com.vaadin.flow.server.VaadinSession;
 import net.jcip.annotations.NotThreadSafe;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 @NotThreadSafe
 public class UploadDropLabelTest {
-    @Before
-    public void setup() {
-        UI ui = new UI();
-        UI.setCurrent(ui);
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        ui.getInternals().setSession(session);
-    }
-
     // Regression test for:
     // https://github.com/vaadin/flow-components/issues/3053
     @Test
     public void setLabelAndIcon_updateLabel_doesNotThrow() {
+        UI ui = new UI();
+        UI.setCurrent(ui);
         Upload upload = new Upload();
         upload.setDropLabel(new Span("Label"));
         upload.setDropLabelIcon(new Span("Icon"));


### PR DESCRIPTION
## Description

The test introduced with #3052 seems to fail randomly:
- https://teamcity.vaadin.com/viewLog.html?buildId=121901&buildTypeId=VaadinFlowComponents_PullRequestValidation
- https://teamcity.vaadin.com/viewLog.html?buildId=121904&buildTypeId=VaadinFlowComponents_PullRequestValidation

It seems setting the UI in `@Before` is not reliable for a test setup, and that moving the setup into the test itself solves the issue.
