### PR TITLE
fix: make GridElement dispatch selection events

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridSingleSelectionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridSingleSelectionIT.java
@@ -43,12 +43,12 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
 
     @Test
     public void selectFirstItemFromClient_deselectFirstItemFromClient_nothingSelected() {
-        grid.getCell("0").click();
+        grid.select(0);
         Assert.assertEquals("oldValue=null; newValue=0; fromClient=true",
                 selectionLog.getText());
         Assert.assertTrue(grid.getRow(0).isSelected());
 
-        grid.getCell("0").click();
+        grid.deselect(0);
         Assert.assertEquals("oldValue=0; newValue=null; fromClient=true",
                 selectionLog.getText());
         Assert.assertFalse(grid.getRow(0).isSelected());
@@ -61,7 +61,7 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
                 selectionLog.getText());
         Assert.assertTrue(grid.getRow(0).isSelected());
 
-        grid.getCell("1").click();
+        grid.select(1);
         Assert.assertEquals("oldValue=0; newValue=1; fromClient=true",
                 selectionLog.getText());
         Assert.assertFalse(grid.getRow(0).isSelected());
@@ -70,7 +70,7 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
 
     @Test
     public void selectSecondItemFromClient_selectFirstItem_firstItemSelected() {
-        grid.getCell("1").click();
+        grid.select(1);
         Assert.assertEquals("oldValue=null; newValue=1; fromClient=true",
                 selectionLog.getText());
         Assert.assertTrue(grid.getRow(1).isSelected());

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
@@ -57,18 +57,15 @@ public class GridViewSelectionIT extends AbstractComponentIT {
                 messageDiv.getText());
         assertRowsSelected(grid, 0, 5);
 
-        WebElement checkbox = getCellContent(grid.getCell(0, 0));
-        checkbox.click();
-        checkbox = getCellContent(grid.getCell(1, 0));
-        checkbox.click();
+        grid.deselect(0);
+        grid.deselect(1);
         Assert.assertEquals(
                 getSelectionMessage(LegacyTestView.items.subList(1, 5),
                         LegacyTestView.items.subList(2, 5), true),
                 messageDiv.getText());
         assertRowsSelected(grid, 2, 5);
 
-        checkbox = getCellContent(grid.getCell(5, 0));
-        checkbox.click();
+        grid.select(5);
         Assert.assertTrue(isRowSelected(grid, 5));
         clickElementWithJs(selectBtn);
         assertRowsSelected(grid, 0, 6);

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/pom.xml
@@ -16,6 +16,11 @@
             <version>${testbench.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-checkbox-testbench</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.grid.testbench;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -340,9 +341,14 @@ public class GridElement extends TestBenchElement {
      *            the row to select
      */
     void select(GridTRElement row) {
-        if (isMultiselect()) {
-            executeScript("arguments[0].selectItem(arguments[1]._item);", this,
-                    row);
+        GridColumnElement multiSelectColumn = getMultiSelectColumn();
+        if (multiSelectColumn != null) {
+            GridTHTDElement cell = row.getCell(multiSelectColumn);
+            CheckboxElement checkbox = wrapElement(cell.getFirstChildElement(),
+                    getCommandExecutor()).wrap(CheckboxElement.class);
+            if (!checkbox.isChecked()) {
+                checkbox.click();
+            }
         } else {
             setActiveItem(row);
         }
@@ -365,9 +371,14 @@ public class GridElement extends TestBenchElement {
      *            the row to deselect
      */
     void deselect(GridTRElement row) {
-        if (isMultiselect()) {
-            executeScript("arguments[0].deselectItem(arguments[1]._item);",
-                    this, row);
+        GridColumnElement multiSelectColumn = getMultiSelectColumn();
+        if (multiSelectColumn != null) {
+            GridTHTDElement cell = row.getCell(multiSelectColumn);
+            CheckboxElement checkbox = wrapElement(cell.getFirstChildElement(),
+                    getCommandExecutor()).wrap(CheckboxElement.class);
+            if (checkbox.isChecked()) {
+                checkbox.click();
+            }
         } else {
             removeActiveItem(row);
         }
@@ -384,15 +395,17 @@ public class GridElement extends TestBenchElement {
     }
 
     /**
-     * Checks if the grid is in multi select mode.
+     * Get the multi-select column of the grid. Returns null, if the grid is not
+     * in multi-selection mode, or doesn't have a multi-selection column.
      *
-     * @return <code>true</code> if the grid is in multi select mode as defined
-     *         by the Flow grid, <code>false</code> otherwise
+     * @return the multi-select column, or null
      */
-    private boolean isMultiselect() {
-        return (boolean) executeScript(
-                "return arguments[0]._getColumns().filter(function(col) { return typeof col.selectAll != 'undefined';}).length > 0",
+    private GridColumnElement getMultiSelectColumn() {
+        List<Long> columnIds = (List<Long>) executeScript(
+                "return arguments[0]._getColumns().filter(function(col) { return typeof col.selectAll != 'undefined';}).map(function(column) { return column.__generatedTbId;});",
                 this);
+        if (columnIds.isEmpty())
+            return null;
+        return new GridColumnElement(columnIds.get(0), this);
     }
-
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
@@ -131,7 +131,8 @@ public class GridTHTDElement extends TestBenchElement {
     }
 
     /**
-     * Gets the first child element of the slotted `vaadin-grid-cell-content` element
+     * Gets the first child element of the slotted `vaadin-grid-cell-content`
+     * element
      */
     WebElement getFirstChildElement() {
         return (WebElement) executeScript(

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 
 import com.vaadin.testbench.TestBenchElement;
+import org.openqa.selenium.WebElement;
 
 /**
  * A TestBench element representing a <code>&lt;td&gt;</code> or
@@ -126,6 +127,15 @@ public class GridTHTDElement extends TestBenchElement {
     public SearchContext getContext() {
         return (SearchContext) executeScript(
                 "return arguments[0].firstElementChild.assignedNodes()[0];",
+                this);
+    }
+
+    /**
+     * Gets the first child element of the slotted `vaadin-grid-cell-content` element
+     */
+    WebElement getFirstChildElement() {
+        return (WebElement) executeScript(
+                "return arguments[0].firstElementChild.assignedNodes()[0].firstElementChild;",
                 this);
     }
 }


### PR DESCRIPTION
## Description

Fixes `GridElement.select` and `GridElement.deselect` to properly dispatch change events on the server-side. The fix involves changing the implementation to click on the selection checkboxes, which triggers the same logic in the grid connector as it would when a real user interacts with the component.

Ideally we would also change the single-selection logic to use a click instead of setting the active item, but that can be done as a separate change.

Fixes #1598 

## Type of change

- Bugfix
