### PR TITLE
chore: fix invalid null check

### DIFF
--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -31,7 +31,7 @@ async function computeModules() {
   } else {
     // Read modules from the parent pom.xml
     const parentJs = await xml2js.parseStringPromise(fs.readFileSync(`pom.xml`, 'utf8'));
-    modules = parentJs.project.modules[0].module.filter(m => !/shared/.test(m)).filter(m => !/demo-helpers/.test(m));
+    modules = parentJs.project.modules[0].module.filter(m => !/shared-parent/.test(m)).filter(m => !/demo-helpers/.test(m));
   }
 }
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractParallelTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractParallelTest.java
@@ -75,14 +75,13 @@ public abstract class AbstractParallelTest extends ParallelTest {
     }
 
     protected String getDeploymentPath(Class<?> viewClass) {
-
+        if (viewClass == null) {
+            return "/";
+        }
         com.vaadin.flow.router.Route[] ann = viewClass
                 .getAnnotationsByType(com.vaadin.flow.router.Route.class);
         if (ann.length > 0) {
             return "/" + ann[0].value();
-        }
-        if (viewClass == null) {
-            return "/";
         }
 
         final Package aPackage = viewClass.getPackage();


### PR DESCRIPTION
## Description

Fixes an invalid null check in `AbstractParallelTest`. Solves this SonarCloud issue: https://sonarcloud.io/project/issues?resolved=false&types=BUG&pullRequest=3080&id=vaadin_flow-components&open=AYBrG-WEv9hxt65QaWaS

