### PR TITLE
chore: exclude shared parent module from run options [skip ci]

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,7 +15,7 @@ jettyrun="jetty:run -Dvaadin.pnpm.enable"
 
 ## List all modules and ask for one to the user
 askModule() {
-  [ -z "$modules" ] && modules=`cat pom.xml | grep 'module>vaadin.*parent</module' | sed -e 's,.*<module>,,g' | sed -e 's,-flow-parent.*,,g' | sort | cat -n -`
+  [ -z "$modules" ] && modules=`cat pom.xml | grep 'module>vaadin.*flow-parent</module' | sed -e 's,.*<module>,,g' | sed -e 's,-flow-parent.*,,g' | sort | cat -n -`
   max=`echo "$modules" | wc -l`
   printf "\nList of Modules\n$modules\nType the number of component:  "
   read module


### PR DESCRIPTION
## Description

Running `./scripts/run.sh`, and selecting option 2 or 3, results in the `vaadin-flow-components-shared-parent` module being listed as option:
```
    18  vaadin-flow-components-shared-parent</module>
```
This change fixes the script to ignore the shared parent module, as it is not runnable.