### PR TITLE
fix: implement LitRenderer.getValueProviders

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.data.renderer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -446,5 +447,16 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         }
         clientCallables.put(functionName, handler);
         return this;
+    }
+
+    /**
+     * Gets the property mapped to {@link ValueProvider}s in this renderer. The
+     * returned map is immutable.
+     *
+     * @return the mapped properties, never <code>null</code>
+     */
+    @Override
+    public Map<String, ValueProvider<SOURCE, ?>> getValueProviders() {
+        return Collections.unmodifiableMap(valueProviders);
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -231,7 +231,9 @@ public class Renderer<SOURCE> implements Serializable {
      * returned map is immutable.
      *
      * @return the mapped properties, never <code>null</code>
+     * @deprecated since Vaadin 23.1
      */
+    @Deprecated
     public Map<String, ValueProvider<SOURCE, ?>> getValueProviders() {
         return valueProviders == null ? Collections.emptyMap()
                 : Collections.unmodifiableMap(valueProviders);

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.data.renderer;
 
 import com.vaadin.flow.component.UI;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,6 +58,15 @@ public class LitRendererTest {
     public void allowAlphaNumericFunctionNames() {
         LitRenderer.of("<div></div>").withFunction("legalName1", item -> {
         });
+    }
+
+    @Test
+    public void supportGettingValueProviders() {
+        LitRenderer<?> renderer = LitRenderer.of("<div></div>").withProperty("foo", item -> 1).withProperty("bar", item -> 2);
+
+        Assert.assertTrue(renderer.getValueProviders().keySet().contains("foo"));
+        Assert.assertTrue(renderer.getValueProviders().keySet().contains("bar"));
+        Assert.assertTrue(renderer.getValueProviders().size() == 2);
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -62,10 +62,13 @@ public class LitRendererTest {
 
     @Test
     public void supportGettingValueProviders() {
-        LitRenderer<?> renderer = LitRenderer.of("<div></div>").withProperty("foo", item -> 1).withProperty("bar", item -> 2);
+        LitRenderer<?> renderer = LitRenderer.of("<div></div>")
+                .withProperty("foo", item -> 1).withProperty("bar", item -> 2);
 
-        Assert.assertTrue(renderer.getValueProviders().keySet().contains("foo"));
-        Assert.assertTrue(renderer.getValueProviders().keySet().contains("bar"));
+        Assert.assertTrue(
+                renderer.getValueProviders().keySet().contains("foo"));
+        Assert.assertTrue(
+                renderer.getValueProviders().keySet().contains("bar"));
         Assert.assertTrue(renderer.getValueProviders().size() == 2);
     }
 


### PR DESCRIPTION
Fixes #3086 

The PR also deprecates the method in `Renderer` because value providers are not something each type of a `Renderer` necessarily has/uses (for example `ComponentRenderer`).

This PR also doesn't fix the bug mentioned in [one of the comments](https://github.com/vaadin/flow-components/issues/3086#issuecomment-1116984857) on the issue (`Grid.addColumn(renderer)` doesn't automatically generate comparators for the value providers defined for the renderer). There's actually an [old issue](https://github.com/vaadin/flow-components/issues/1233) for it already and it should be resolved separately.