### PR TITLE
fix: implement LitRenderer.getValueProviders (#3148) (CP: 23.1)

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.data.renderer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -446,5 +447,16 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         }
         clientCallables.put(functionName, handler);
         return this;
+    }
+
+    /**
+     * Gets the property mapped to {@link ValueProvider}s in this renderer. The
+     * returned map is immutable.
+     *
+     * @return the mapped properties, never <code>null</code>
+     */
+    @Override
+    public Map<String, ValueProvider<SOURCE, ?>> getValueProviders() {
+        return Collections.unmodifiableMap(valueProviders);
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -231,7 +231,9 @@ public class Renderer<SOURCE> implements Serializable {
      * returned map is immutable.
      *
      * @return the mapped properties, never <code>null</code>
+     * @deprecated since Vaadin 23.1
      */
+    @Deprecated
     public Map<String, ValueProvider<SOURCE, ?>> getValueProviders() {
         return valueProviders == null ? Collections.emptyMap()
                 : Collections.unmodifiableMap(valueProviders);

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.data.renderer;
 
 import com.vaadin.flow.component.UI;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,6 +58,18 @@ public class LitRendererTest {
     public void allowAlphaNumericFunctionNames() {
         LitRenderer.of("<div></div>").withFunction("legalName1", item -> {
         });
+    }
+
+    @Test
+    public void supportGettingValueProviders() {
+        LitRenderer<?> renderer = LitRenderer.of("<div></div>")
+                .withProperty("foo", item -> 1).withProperty("bar", item -> 2);
+
+        Assert.assertTrue(
+                renderer.getValueProviders().keySet().contains("foo"));
+        Assert.assertTrue(
+                renderer.getValueProviders().keySet().contains("bar"));
+        Assert.assertTrue(renderer.getValueProviders().size() == 2);
     }
 
 }


### PR DESCRIPTION
Cherry-pick https://github.com/vaadin/flow-components/pull/3148 for V23.1