### PR TITLE
refactor: move legacy import to deprecated file

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.dom.ElementConstants;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.1.0-beta4")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/icons", version = "23.1.0-beta4")
-@NpmPackage(value = "@vaadin/vaadin-icons", version = "23.1.0-beta4")
 @JsModule("@vaadin/icons/vaadin-iconset.js")
 @NpmPackage(value = "@vaadin/icon", version = "23.1.0-beta4")
 @NpmPackage(value = "@vaadin/vaadin-icon", version = "23.1.0-beta4")

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/IronIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/IronIcon.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.dom.ElementConstants;
  */
 @Tag("iron-icon")
 @NpmPackage(value = "@polymer/iron-icon", version = "3.0.1")
+@NpmPackage(value = "@vaadin/vaadin-icons", version = "23.1.0-beta4")
 @JsModule("@polymer/iron-icon/iron-icon.js")
 @Deprecated
 public class IronIcon extends Component


### PR DESCRIPTION
## Description

The `Icon` component has already been updated to use `vaadin-icon` but it still imports the legacy iconset.
Moved the corresponding import to the deprecated `IronIcon` - to be removed in the next major.

## Type of change

- Refactor