### PR TITLE
refactor: extract common interface for theme variants

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/HasThemeVariant.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/HasThemeVariant.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Mixin interface that allows adding and removing typed theme variants to /
+ * from a component
+ *
+ * @param <TVariantEnum>
+ *            The specific theme variant enum type
+ */
+public interface HasThemeVariant<TVariantEnum extends ThemeVariant>
+        extends HasTheme {
+    /**
+     * Adds theme variants to the component.
+     *
+     * @param variants
+     *            theme variants to add
+     */
+    @SuppressWarnings("unchecked")
+    default void addThemeVariants(TVariantEnum... variants) {
+        getThemeNames()
+                .addAll(Stream.of(variants).map(TVariantEnum::getVariantName)
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Removes theme variants from the component.
+     *
+     * @param variants
+     *            theme variants to remove
+     */
+    @SuppressWarnings("unchecked")
+    default void removeThemeVariants(TVariantEnum... variants) {
+        getThemeNames()
+                .removeAll(Stream.of(variants).map(TVariantEnum::getVariantName)
+                        .collect(Collectors.toList()));
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/ThemeVariant.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/ThemeVariant.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component;
+
+import java.io.Serializable;
+
+/**
+ * Base definition for a typed theme variant enum of a component
+ */
+public interface ThemeVariant extends Serializable {
+    /**
+     * Returns the string value of the specific theme variant
+     */
+    String getVariantName();
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/HasThemeVariantTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/HasThemeVariantTest.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.component;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class HasThemeVariantTest {
+    @Test
+    public void addThemeVariant_themeNamesContainsThemeVariant() {
+        TestComponent component = new TestComponent();
+        component.addThemeVariants(TestComponentVariant.TEST_VARIANT);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        TestComponent component = new TestComponent();
+        component.addThemeVariants(TestComponentVariant.TEST_VARIANT);
+        component.removeThemeVariants(TestComponentVariant.TEST_VARIANT);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+    }
+
+    private enum TestComponentVariant implements ThemeVariant {
+        TEST_VARIANT("test");
+
+        private final String variant;
+
+        TestComponentVariant(String variant) {
+            this.variant = variant;
+        }
+
+        /**
+         * Gets the variant name.
+         *
+         * @return variant name
+         */
+        public String getVariantName() {
+            return variant;
+        }
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasThemeVariant<TestComponentVariant> {
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
@@ -20,5 +20,11 @@
       <artifactId>flow-test-util</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-flow-components-base</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/ThemeVariantTestHelper.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/ThemeVariantTestHelper.java
@@ -1,0 +1,28 @@
+package com.vaadin.tests;
+
+import com.vaadin.flow.component.HasThemeVariant;
+import com.vaadin.flow.component.ThemeVariant;
+import org.junit.Assert;
+
+import java.util.Set;
+
+public class ThemeVariantTestHelper {
+    @SuppressWarnings("unchecked")
+    public static <TVariantEnum extends ThemeVariant> void addThemeVariant_themeNamesContainsThemeVariant(
+            HasThemeVariant<TVariantEnum> component, TVariantEnum testValue) {
+        component.addThemeVariants(testValue);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertTrue(themeNames.contains(testValue.getVariantName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <TVariantEnum extends ThemeVariant> void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+            HasThemeVariant<TVariantEnum> component, TVariantEnum testValue) {
+        component.addThemeVariants(testValue);
+        component.removeThemeVariants(testValue);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertFalse(themeNames.contains(testValue.getVariantName()));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasThemeVariant;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -39,10 +40,11 @@ import com.vaadin.flow.function.SerializableFunction;
  * @author Vaadin Ltd.
  */
 public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T extends Number>
-        extends GeneratedVaadinNumberField<C, T> implements HasSize,
-        HasValidation, HasValueChangeMode, HasPrefixAndSuffix, InputNotifier,
-        KeyNotifier, CompositionNotifier, HasAutocomplete, HasAutocapitalize,
-        HasAutocorrect, HasHelper, HasLabel, HasClearButton {
+        extends GeneratedVaadinNumberField<C, T>
+        implements HasSize, HasValidation, HasValueChangeMode,
+        HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
+        HasClearButton, HasThemeVariant<TextFieldVariant> {
 
     private ValueChangeMode currentMode;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasThemeVariant;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -54,10 +55,11 @@ import com.vaadin.flow.function.SerializableBiFunction;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./vaadin-big-decimal-field.js")
 public class BigDecimalField
-        extends GeneratedVaadinTextField<BigDecimalField, BigDecimal> implements
-        HasSize, HasValidation, HasValueChangeMode, HasPrefixAndSuffix,
-        InputNotifier, KeyNotifier, CompositionNotifier, HasAutocomplete,
-        HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel, HasClearButton {
+        extends GeneratedVaadinTextField<BigDecimalField, BigDecimal>
+        implements HasSize, HasValidation, HasValueChangeMode,
+        HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
+        HasClearButton, HasThemeVariant<TextFieldVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasThemeVariant;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -45,7 +46,7 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton {
+        HasClearButton, HasThemeVariant<TextFieldVariant> {
     private static final String EMAIL_PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
             + "@" + "[a-zA-Z0-9-.]+" // domain
             + "\\." + "[a-zA-Z0-9-]{2,}" // tld

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -149,31 +149,7 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/text-area/src/vaadin-text-area.js")
 public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<R, T>, T>
         extends AbstractSinglePropertyField<R, T>
-        implements HasStyle, Focusable<R>, HasTheme {
-
-    /**
-     * Adds theme variants to the component.
-     *
-     * @param variants
-     *            theme variants to add
-     */
-    public void addThemeVariants(TextAreaVariant... variants) {
-        getThemeNames()
-                .addAll(Stream.of(variants).map(TextAreaVariant::getVariantName)
-                        .collect(Collectors.toList()));
-    }
-
-    /**
-     * Removes theme variants from the component.
-     *
-     * @param variants
-     *            theme variants to remove
-     */
-    public void removeThemeVariants(TextAreaVariant... variants) {
-        getThemeNames().removeAll(
-                Stream.of(variants).map(TextAreaVariant::getVariantName)
-                        .collect(Collectors.toList()));
-    }
+        implements HasStyle, Focusable<R> {
 
     /**
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -173,31 +173,7 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/text-field/src/vaadin-text-field.js")
 public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextField<R, T>, T>
         extends AbstractSinglePropertyField<R, T>
-        implements HasStyle, Focusable<R>, HasTheme {
-
-    /**
-     * Adds theme variants to the component.
-     *
-     * @param variants
-     *            theme variants to add
-     */
-    public void addThemeVariants(TextFieldVariant... variants) {
-        getThemeNames().addAll(
-                Stream.of(variants).map(TextFieldVariant::getVariantName)
-                        .collect(Collectors.toList()));
-    }
-
-    /**
-     * Removes theme variants from the component.
-     *
-     * @param variants
-     *            theme variants to remove
-     */
-    public void removeThemeVariants(TextFieldVariant... variants) {
-        getThemeNames().removeAll(
-                Stream.of(variants).map(TextFieldVariant::getVariantName)
-                        .collect(Collectors.toList()));
-    }
+        implements HasStyle, Focusable<R> {
 
     /**
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasThemeVariant;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -37,10 +38,11 @@ import com.vaadin.flow.data.value.ValueChangeMode;
  * @author Vaadin Ltd.
  */
 public class PasswordField
-        extends GeneratedVaadinPasswordField<PasswordField, String> implements
-        HasSize, HasValidation, HasValueChangeMode, HasPrefixAndSuffix,
-        InputNotifier, KeyNotifier, CompositionNotifier, HasAutocomplete,
-        HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel, HasClearButton {
+        extends GeneratedVaadinPasswordField<PasswordField, String>
+        implements HasSize, HasValidation, HasValueChangeMode,
+        HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
+        HasClearButton, HasThemeVariant<TextFieldVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasThemeVariant;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -39,7 +40,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton {
+        HasClearButton, HasThemeVariant<TextFieldVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasThemeVariant;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -38,7 +39,7 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton {
+        HasClearButton, HasThemeVariant<TextFieldVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
@@ -15,14 +15,20 @@
  */
 package com.vaadin.flow.component.textfield;
 
+import com.vaadin.flow.component.ThemeVariant;
+
 /**
- * Set of theme variants applicable for {@code vaadin-text-field} component.
+ * Set of theme variants applicable for the {@link TextField} component, as well
+ * as other components based on it.
  */
-public enum TextFieldVariant {
-    LUMO_SMALL("small"), LUMO_ALIGN_CENTER("align-center"), LUMO_ALIGN_RIGHT(
-            "align-right"), LUMO_HELPER_ABOVE_FIELD(
-                    "helper-above-field"), MATERIAL_ALWAYS_FLOAT_LABEL(
-                            "always-float-label");
+public enum TextFieldVariant implements ThemeVariant {
+    //@formatter:off
+    LUMO_SMALL("small"),
+    LUMO_ALIGN_CENTER("align-center"),
+    LUMO_ALIGN_RIGHT("align-right"),
+    LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
+    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNull;
 import java.math.BigDecimal;
 import java.util.Locale;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,6 +90,19 @@ public class BigDecimalFieldTest extends TextFieldTest {
         ComponentFromTest
                 .elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue(
                         BigDecimal.TEN.toString(), BigDecimalField.class);
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new BigDecimalField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new BigDecimalField(), TextFieldVariant.LUMO_SMALL);
     }
 
     private void assertValueFormatting(BigDecimal bigDecimal,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -55,5 +57,18 @@ public class EmailFieldTest {
         ComponentFromTest
                 .elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue(
                         "foo@example.com", EmailField.class);
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new EmailField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new EmailField(), TextFieldVariant.LUMO_SMALL);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -139,6 +141,19 @@ public class IntegerFieldTest extends TextFieldTest {
         ComponentFromTest
                 .elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue(1,
                         IntegerField.class);
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new IntegerField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new IntegerField(), TextFieldVariant.LUMO_SMALL);
     }
 
     private void assertValidValues(Integer... values) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,6 +157,19 @@ public class NumberFieldTest extends TextFieldTest {
         ComponentFromTest
                 .elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue(
                         1.1d, NumberField.class);
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new NumberField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new NumberField(), TextFieldVariant.LUMO_SMALL);
     }
 
     private void assertValidValues(Double... values) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -87,5 +89,18 @@ public class PasswordFieldTest {
         assertEquals(value, passwordField.isAutoselect());
         assertEquals(passwordField.isAutoselect(),
                 passwordField.getElement().getProperty("autoselect", value));
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new PasswordField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new PasswordField(), TextFieldVariant.LUMO_SMALL);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -98,5 +100,18 @@ public class TextAreaTest {
         assertEquals(value, textArea.isAutoselect());
         assertEquals(textArea.isAutoselect(),
                 textArea.getElement().getProperty("autoselect", value));
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new TextArea(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new TextArea(), TextFieldVariant.LUMO_SMALL);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -79,6 +81,19 @@ public class TextFieldTest {
         ComponentFromTest
                 .elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue(
                         "foo", TextField.class);
+    }
+
+    @Test
+    public void addThemeVariant_themeAttributeContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new TextField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new TextField(), TextFieldVariant.LUMO_SMALL);
     }
 
     public void assertAutoselectPropertyValueEquals(TextField textField,


### PR DESCRIPTION
## Description

Extracts a `HasThemeVariant<TVariantEnum>` interface that can be mixed into component classes to add / remove typed theme variants. The intention is to replace all the duplicated `addThemeVariants` / `removeThemeVariants` methods with this interface. For now only the text field related components make use of this interface, other components will be adapted in sub-sequent refactorings.

Part of https://github.com/vaadin/flow-components/issues/2948

## Type of change

- Refactor
