### PR TITLE
feat: add HasAllowedCharPattern interface to field components

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -73,7 +74,7 @@ import java.util.stream.Stream;
 public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, TItem, TValue>, TItem, TValue>
         extends AbstractSinglePropertyField<TComponent, TValue>
         implements HasStyle, Focusable<TComponent>, HasSize, HasValidation,
-        HasHelper, HasTheme, HasLabel, HasClearButton,
+        HasHelper, HasTheme, HasLabel, HasClearButton, HasAllowedCharPattern,
         HasDataView<TItem, String, ComboBoxDataView<TItem>>,
         HasListDataView<TItem, ComboBoxListDataView<TItem>>,
         HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>> {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.combobox;
 
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasLabel;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
@@ -48,15 +49,21 @@ public abstract class ComboBoxBaseTest {
 
     @Test
     public void implementsFocusable() {
-        Assert.assertTrue("MultSelectComboBox should be focusable",
-                Focusable.class.isAssignableFrom(
-                        createComboBox(String.class).getClass()));
+        Assert.assertTrue("ComboBox should be focusable", Focusable.class
+                .isAssignableFrom(createComboBox(String.class).getClass()));
     }
 
     @Test
     public void implementsHasLabel() {
-        Assert.assertTrue("MultSelectComboBox should be focusable",
+        Assert.assertTrue("ComboBox should support setting a label",
                 HasLabel.class.isAssignableFrom(
+                        createComboBox(String.class).getClass()));
+    }
+
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("ComboBox should support allowed char pattern",
+                HasAllowedCharPattern.class.isAssignableFrom(
                         createComboBox(String.class).getClass()));
     }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -64,7 +65,7 @@ import elemental.json.JsonType;
 @NpmPackage(value = "date-fns", version = "2.28.0")
 public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         implements HasSize, HasValidation, HasHelper, HasTheme, HasLabel,
-        HasClearButton {
+        HasClearButton, HasAllowedCharPattern {
 
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
@@ -260,4 +261,10 @@ public class DatePickerTest {
         germanDatePicker.setI18n(datePickerI18n);
     }
 
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("DatePicker should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new DatePicker().getClass()));
+    }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasAllowedCharPattern.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasAllowedCharPattern.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * Mixin interface for field components that support setting allowed char
+ * pattern to prevent user from entering invalid characters when typing or
+ * pasting text.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasAllowedCharPattern extends HasElement {
+
+    /**
+     * A regular expression that the user input is checked against. The allowed
+     * pattern must matches a single character, not the sequence of characters.
+     *
+     * @return the {@code allowedCharPattern} property
+     */
+    default String getAllowedCharPattern() {
+        return getElement().getProperty("allowedCharPattern", "");
+    }
+
+    /**
+     * Sets a regular expression for the user input to pass on the client-side.
+     * The allowed char pattern must be a valid JavaScript Regular Expression
+     * that matches a single character, not the sequence of characters.
+     * <p>
+     * For example, to allow entering only numbers and slash character, use
+     * {@code setAllowedCharPattern("[0-9/]")}`.
+     * </p>
+     *
+     * @param allowedCharPattern
+     *            the String pattern to set
+     */
+    default void setAllowedCharPattern(String pattern) {
+        getElement().setProperty("allowedCharPattern",
+                pattern == null ? "" : pattern);
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasAllowedCharPatternTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasAllowedCharPatternTest.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component.shared;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+public class HasAllowedCharPatternTest {
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void initialValue() {
+        Assert.assertEquals(component.getAllowedCharPattern(), "");
+    }
+
+    @Test
+    public void changeValue() {
+        component.setAllowedCharPattern("[-+\\d]");
+        Assert.assertEquals(
+                component.getElement().getProperty("allowedCharPattern"),
+                "[-+\\d]");
+
+        component.setAllowedCharPattern(null);
+        Assert.assertEquals(
+                component.getElement().getProperty("allowedCharPattern"), "");
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasAllowedCharPattern {
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -205,8 +205,8 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
         clickElementWithJs("set-french-locale");
         Assert.assertEquals(
                 "BigDecimalField with French locale has unexpected pattern for "
-                        + "invalid input prevention (the _enabledCharPattern property)",
-                "[\\d-+,]", field.getPropertyString("_enabledCharPattern"));
+                        + "invalid input prevention (the allowedCharPattern property)",
+                "[\\d-+,]", field.getPropertyString("allowedCharPattern"));
     }
 
     // Always checking the count of fired events to make sure it doesn't fire

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -40,11 +41,11 @@ import com.vaadin.flow.function.SerializableFunction;
  * @author Vaadin Ltd.
  */
 public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T extends Number>
-        extends GeneratedVaadinNumberField<C, T>
-        implements HasSize, HasValidation, HasValueChangeMode,
-        HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton, HasThemeVariant<TextFieldVariant> {
+        extends GeneratedVaadinNumberField<C, T> implements HasSize,
+        HasValidation, HasValueChangeMode, HasPrefixAndSuffix, InputNotifier,
+        KeyNotifier, CompositionNotifier, HasAutocomplete, HasAutocapitalize,
+        HasAutocorrect, HasHelper, HasLabel, HasClearButton,
+        HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
 
     private ValueChangeMode currentMode;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -46,7 +47,8 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton, HasThemeVariant<TextFieldVariant> {
+        HasClearButton, HasAllowedCharPattern,
+        HasThemeVariant<TextFieldVariant> {
     private static final String EMAIL_PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
             + "@" + "[a-zA-Z0-9-.]+" // domain
             + "\\." + "[a-zA-Z0-9-]{2,}" // tld

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -38,11 +39,11 @@ import com.vaadin.flow.data.value.ValueChangeMode;
  * @author Vaadin Ltd.
  */
 public class PasswordField
-        extends GeneratedVaadinPasswordField<PasswordField, String>
-        implements HasSize, HasValidation, HasValueChangeMode,
-        HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton, HasThemeVariant<TextFieldVariant> {
+        extends GeneratedVaadinPasswordField<PasswordField, String> implements
+        HasSize, HasValidation, HasValueChangeMode, HasPrefixAndSuffix,
+        InputNotifier, KeyNotifier, CompositionNotifier, HasAutocomplete,
+        HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel, HasClearButton,
+        HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -40,7 +41,8 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton, HasThemeVariant<TextAreaVariant> {
+        HasClearButton, HasAllowedCharPattern,
+        HasThemeVariant<TextAreaVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -39,7 +40,8 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton, HasThemeVariant<TextFieldVariant> {
+        HasClearButton, HasAllowedCharPattern,
+        HasThemeVariant<TextFieldVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
@@ -62,7 +62,7 @@
       }
 
       __decimalSeparatorChanged(separator, oldSeparator) {
-        this._enabledCharPattern = '[\\d-+' + separator + ']';
+        this.allowedCharPattern = '[\\d-+' + separator + ']';
 
         if (this.value && oldSeparator) {
           this.value = this.value.split(oldSeparator).join(separator);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.tests.ThemeVariantTestHelper;
@@ -69,5 +70,12 @@ public class EmailFieldTest {
         ThemeVariantTestHelper
                 .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
                         new EmailField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("EmailField should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new EmailField().getClass()));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link EmailField}.
@@ -74,7 +75,7 @@ public class EmailFieldTest {
 
     @Test
     public void implementsHasAllowedCharPattern() {
-        Assert.assertTrue("EmailField should support char pattern",
+        assertTrue("EmailField should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new EmailField().getClass()));
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.tests.ThemeVariantTestHelper;
@@ -204,5 +205,12 @@ public class NumberFieldTest extends TextFieldTest {
         final NumberField numberField = new NumberField();
         numberField.setValue(value);
         assertEquals(expected, numberField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("NumberField should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new NumberField().getClass()));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.tests.ThemeVariantTestHelper;
@@ -101,5 +102,12 @@ public class PasswordFieldTest {
         ThemeVariantTestHelper
                 .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
                         new PasswordField(), TextFieldVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("PasswordField should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new PasswordField().getClass()));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link PasswordField}.
@@ -106,7 +107,7 @@ public class PasswordFieldTest {
 
     @Test
     public void implementsHasAllowedCharPattern() {
-        Assert.assertTrue("PasswordField should support char pattern",
+        assertTrue("PasswordField should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new PasswordField().getClass()));
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextAreaVariant;
 import com.vaadin.tests.ThemeVariantTestHelper;
@@ -112,5 +113,12 @@ public class TextAreaTest {
         ThemeVariantTestHelper
                 .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
                         new TextArea(), TextAreaVariant.LUMO_SMALL);
+    }
+
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("TextArea should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new TextArea().getClass()));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link TextArea}.
@@ -117,7 +118,7 @@ public class TextAreaTest {
 
     @Test
     public void implementsHasAllowedCharPattern() {
-        Assert.assertTrue("TextArea should support char pattern",
+        assertTrue("TextArea should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new TextArea().getClass()));
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.tests.ThemeVariantTestHelper;
@@ -103,4 +104,10 @@ public class TextFieldTest {
                 textField.getElement().getProperty("autoselect", value));
     }
 
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("TextField should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new TextField().getClass()));
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link TextField}.
@@ -106,7 +107,7 @@ public class TextFieldTest {
 
     @Test
     public void implementsHasAllowedCharPattern() {
-        Assert.assertTrue("TextField should support char pattern",
+        assertTrue("TextField should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new TextField().getClass()));
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -51,7 +52,7 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("./vaadin-time-picker/timepickerConnector.js")
 public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         implements HasSize, HasValidation, HasEnabled, HasHelper, HasLabel,
-        HasTheme, HasClearButton {
+        HasTheme, HasClearButton, HasAllowedCharPattern {
 
     private static final SerializableFunction<String, LocalTime> PARSER = valueFromClient -> {
         return valueFromClient == null || valueFromClient.isEmpty() ? null

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
@@ -277,5 +278,12 @@ public class TimePickerTest {
         assertTrue(timePicker.getElement().getProperty(PROP_AUTO_OPEN_DISABLED,
                 false));
         assertFalse(timePicker.isAutoOpen());
+    }
+
+    @Test
+    public void implementsHasAllowedCharPattern() {
+        Assert.assertTrue("TimePicker should support char pattern",
+                HasAllowedCharPattern.class
+                        .isAssignableFrom(new TimePicker().getClass()));
     }
 }


### PR DESCRIPTION
## Description

Added support for `allowedCharPattern` to the following components:

- `ComboBox`
- `DatePicker`
- `EmailField`
- `NumberField`
- `PasswordField`
- `TextArea`
- `TextField`
- `TimePicker`

Note: this does not include `BigDecimalField` as it has a hardcoded pattern.

Part of https://github.com/vaadin/platform/issues/2963
Depends on https://github.com/vaadin/web-components/pull/3937

## Type of change

- Feature