### PR TITLE
refactor: add multi select combo box integration tests

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/frontend/src/multi-select-combo-box-lit-wrapper.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/frontend/src/multi-select-combo-box-lit-wrapper.ts
@@ -1,0 +1,28 @@
+/*
+  ~ Copyright 2000-2022 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  */
+import {html, TemplateResult, LitElement} from "lit";
+import {customElement} from "lit/decorators.js";
+
+@customElement("multi-select-combo-box-lit-wrapper")
+export class MultiSelectComboBoxLitWrapper extends LitElement {
+    protected render(): TemplateResult {
+        return html`
+            <div>
+                <vaadin-multi-select-combo-box id="combo-box"></vaadin-multi-select-combo-box>
+            </div>
+        `;
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/frontend/src/multi-select-combo-box-polymer-wrapper.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/frontend/src/multi-select-combo-box-polymer-wrapper.js
@@ -1,0 +1,31 @@
+/*
+  ~ Copyright 2000-2022 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  */
+
+import {PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {html} from '@polymer/polymer/lib/utils/html-tag.js';
+
+class MultiSelectComboBoxPolymerWrapper extends PolymerElement {
+  static get template() {
+    return html`
+        <vaadin-multi-select-combo-box id="combo-box"></vaadin-multi-select-combo-box>
+    `;
+  }
+
+  static get is() {
+      return 'multi-select-combo-box-polymer-wrapper'
+  }
+}
+customElements.define(MultiSelectComboBoxPolymerWrapper.is, MultiSelectComboBoxPolymerWrapper);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringPage.java
@@ -8,14 +8,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@Route("vaadin-multi-select-combo-box/server-side-filtering")
-public class MultiSelectComboBoxServerSideFilteringPage extends Div {
-    public MultiSelectComboBoxServerSideFilteringPage() {
+@Route("vaadin-multi-select-combo-box/client-side-filtering")
+public class MultiSelectComboBoxClientSideFilteringPage extends Div {
+    public MultiSelectComboBoxClientSideFilteringPage() {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
-        // By generating more items than the default page size of 50 we
-        // automatically enable server-side filtering
-        List<String> items = IntStream.range(0, 100)
+        // By generating less items than the default page size of 50 we
+        // automatically enable client-side filtering
+        List<String> items = IntStream.range(0, 10)
                 .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
         comboBox.setItems(items);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitWrapperPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitWrapperPage.java
@@ -1,0 +1,34 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.template.Id;
+import com.vaadin.flow.router.Route;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Route("vaadin-multi-select-combo-box/lit-wrapper")
+public class MultiSelectComboBoxLitWrapperPage extends Div {
+    public MultiSelectComboBoxLitWrapperPage() {
+        add(new MultiSelectComboBoxLitWrapper());
+    }
+
+    @JsModule("./src/multi-select-combo-box-lit-wrapper.ts")
+    @Tag("multi-select-combo-box-lit-wrapper")
+    public static class MultiSelectComboBoxLitWrapper extends LitTemplate {
+        @Id("combo-box")
+        private MultiSelectComboBox<String> comboBox;
+
+        public MultiSelectComboBoxLitWrapper() {
+            List<String> items = IntStream.range(0, 100)
+                    .mapToObj(i -> "Item " + (i + 1))
+                    .collect(Collectors.toList());
+            comboBox.setItems(items);
+        }
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPolymerWrapperPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPolymerWrapperPage.java
@@ -1,0 +1,36 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.component.template.Id;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Route("vaadin-multi-select-combo-box/polymer-wrapper")
+public class MultiSelectComboBoxPolymerWrapperPage extends Div {
+    public MultiSelectComboBoxPolymerWrapperPage() {
+        add(new MultiSelectComboBoxPolymerWrapper());
+    }
+
+    @JsModule("./src/multi-select-combo-box-polymer-wrapper.js")
+    @Tag("multi-select-combo-box-polymer-wrapper")
+    public static class MultiSelectComboBoxPolymerWrapper
+            extends PolymerTemplate<TemplateModel> {
+        @Id("combo-box")
+        private MultiSelectComboBox<String> comboBox;
+
+        public MultiSelectComboBoxPolymerWrapper() {
+            List<String> items = IntStream.range(0, 100)
+                    .mapToObj(i -> "Item " + (i + 1))
+                    .collect(Collectors.toList());
+            comboBox.setItems(items);
+        }
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxRefreshValuePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxRefreshValuePage.java
@@ -1,0 +1,59 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Route("vaadin-multi-select-combo-box/refresh-value")
+public class MultiSelectComboBoxRefreshValuePage extends Div {
+    public MultiSelectComboBoxRefreshValuePage() {
+        MultiSelectComboBox<TestBean> comboBox = new MultiSelectComboBox<>(
+                "Items");
+        List<TestBean> items = IntStream.range(0, 100)
+                .mapToObj(i -> new TestBean("Item " + (i + 1)))
+                .collect(Collectors.toList());
+        comboBox.setItems(items);
+        comboBox.setItemLabelGenerator(TestBean::getName);
+        // Make component wider, so that we can fit multiple chips
+        comboBox.setWidth("500px");
+
+        NativeButton changeItemLabelGenerator = new NativeButton(
+                "Change item label generator", e -> {
+                    comboBox.setItemLabelGenerator(
+                            item -> "Custom " + item.getName());
+                });
+        changeItemLabelGenerator.setId("change-item-label-generator");
+
+        NativeButton changeItemData = new NativeButton("Change item data",
+                e -> {
+                    items.forEach(
+                            item -> item.setName("Updated " + item.getName()));
+                    comboBox.getDataProvider().refreshAll();
+                });
+        changeItemData.setId("change-item-data");
+
+        add(comboBox);
+        add(new Div(changeItemLabelGenerator, changeItemData));
+    }
+
+    private static class TestBean {
+        private String name;
+
+        public TestBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringPage.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Route("vaadin-multi-select-combo-box/server-side-filtering")
+public class MultiSelectComboBoxServerSideFilteringPage extends Div {
+    public MultiSelectComboBoxServerSideFilteringPage() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
+                "Items");
+        List<String> items = IntStream.range(0, 100)
+                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+        comboBox.setItems(items);
+
+        add(comboBox);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangePage.java
@@ -1,0 +1,47 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Route("vaadin-multi-select-combo-box/value-change")
+public class MultiSelectComboBoxValueChangePage extends Div {
+    public MultiSelectComboBoxValueChangePage() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
+                "Items");
+        List<String> items = IntStream.range(0, 100)
+                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+        comboBox.setItems(items);
+        // Make component wider, so that we can fit multiple chips
+        comboBox.setWidth("500px");
+
+        NativeButton setServerSideValue = new NativeButton(
+                "Set value server-side", e -> {
+                    comboBox.setValue(Set.of("Item 1", "Item 2"));
+                });
+        setServerSideValue.setId("set-server-side-value");
+
+        Span eventValue = new Span();
+        eventValue.setId("event-value");
+        Span eventOrigin = new Span();
+        eventOrigin.setId("event-origin");
+        comboBox.addValueChangeListener(e -> {
+            String combinedValues = String.join(",", e.getValue());
+
+            eventValue.setText(combinedValues);
+            eventOrigin.setText(e.isFromClient() ? "client" : "server");
+        });
+
+        add(comboBox);
+        add(new Div(setServerSideValue));
+        add(new Div(new Span("Event value: "), eventValue));
+        add(new Div(new Span("Event origin: "), eventOrigin));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangePage.java
@@ -28,6 +28,12 @@ public class MultiSelectComboBoxValueChangePage extends Div {
                 });
         setServerSideValue.setId("set-server-side-value");
 
+        NativeButton clearServerSideValue = new NativeButton(
+                "Clear value server-side", e -> {
+                    comboBox.clear();
+                });
+        clearServerSideValue.setId("clear-server-side-value");
+
         Span eventValue = new Span();
         eventValue.setId("event-value");
         Span eventOrigin = new Span();
@@ -40,7 +46,7 @@ public class MultiSelectComboBoxValueChangePage extends Div {
         });
 
         add(comboBox);
-        add(new Div(setServerSideValue));
+        add(new Div(setServerSideValue, clearServerSideValue));
         add(new Div(new Span("Event value: "), eventValue));
         add(new Div(new Span("Event origin: "), eventOrigin));
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxVirtualChildPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxVirtualChildPage.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-multi-select-combo-box/virtual-child")
+public class MultiSelectComboBoxVirtualChildPage extends Div {
+    public MultiSelectComboBoxVirtualChildPage() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+
+        // Add the component as a virtual child, which will initialize the
+        // connector, but does not add the element to the DOM, and does not
+        // finalize the Polymer element.
+        // This covers scenarios like adding the component to an unopened
+        // dialog, or rendering it with a Polymer or Lit template.
+        getElement().appendVirtualChild(comboBox.getElement());
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringIT.java
@@ -21,6 +21,15 @@ public class MultiSelectComboBoxClientSideFilteringIT
     }
 
     @Test
+    public void openPopup_showsAllItems() {
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(10, options.size());
+    }
+
+    @Test
     public void setFilter_noErrors() {
         comboBox.setFilter("Item 10");
         checkLogsForErrors();
@@ -49,5 +58,14 @@ public class MultiSelectComboBoxClientSideFilteringIT
 
         List<String> options = comboBox.getOptions();
         Assert.assertEquals(0, options.size());
+    }
+
+    @Test
+    public void setFilter_clearFilter_showsAllItems() {
+        comboBox.setFilter("Item 10");
+        comboBox.setFilter("");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(10, options.size());
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringIT.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+@TestPath("vaadin-multi-select-combo-box/client-side-filtering")
+public class MultiSelectComboBoxClientSideFilteringIT
+        extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
+    }
+
+    @Test
+    public void setFilter_noErrors() {
+        comboBox.setFilter("Item 10");
+        checkLogsForErrors();
+    }
+
+    @Test
+    public void setFilter_closePopup_noErrors() {
+        comboBox.setFilter("Item 10");
+        comboBox.closePopup();
+        checkLogsForErrors();
+    }
+
+    @Test
+    public void setMatchingFilter_filtersItems() {
+        comboBox.setFilter("Item 10");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(1, options.size());
+        Assert.assertTrue("Should display Item 10",
+                options.contains("Item 10"));
+    }
+
+    @Test
+    public void setNonMatchingFilter_noItems() {
+        comboBox.setFilter("Item XYZ");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(0, options.size());
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitWrapperIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitWrapperIT.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+@TestPath("vaadin-multi-select-combo-box/lit-wrapper")
+public class MultiSelectComboBoxLitWrapperIT extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+
+    @Before
+    public void init() {
+        open();
+        TestBenchElement litWrapper = $("multi-select-combo-box-lit-wrapper")
+                .waitForFirst();
+        comboBox = litWrapper.$(MultiSelectComboBoxElement.class).first();
+    }
+
+    @Test
+    public void addWithLitTemplate_noErrors() {
+        checkLogsForErrors();
+    }
+
+    // Basic smoke test to verify that connector works correctly
+    @Test
+    public void openPopup_showsAllItems() {
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(100, options.size());
+        Assert.assertTrue(
+                options.containsAll(Set.of("Item 1", "Item 10", "Item 20")));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPolymerWrapperIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPolymerWrapperIT.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+@TestPath("vaadin-multi-select-combo-box/polymer-wrapper")
+public class MultiSelectComboBoxPolymerWrapperIT extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+
+    @Before
+    public void init() {
+        open();
+        TestBenchElement polymerWrapper = $(
+                "multi-select-combo-box-polymer-wrapper").waitForFirst();
+        comboBox = polymerWrapper.$(MultiSelectComboBoxElement.class).first();
+    }
+
+    @Test
+    public void addWithPolymerTemplate_noErrors() {
+        checkLogsForErrors();
+    }
+
+    // Basic smoke test to verify that connector works correctly
+    @Test
+    public void openPopup_showsAllItems() {
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(100, options.size());
+        Assert.assertTrue(
+                options.containsAll(Set.of("Item 1", "Item 10", "Item 20")));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxRefreshValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxRefreshValueIT.java
@@ -1,0 +1,57 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+@TestPath("vaadin-multi-select-combo-box/refresh-value")
+public class MultiSelectComboBoxRefreshValueIT extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+    private TestBenchElement changeItemLabelGenerator;
+    private TestBenchElement changeItemData;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
+        changeItemLabelGenerator = $("button")
+                .id("change-item-label-generator");
+        changeItemData = $("button").id("change-item-data");
+    }
+
+    @Test
+    public void selectItems_changeItemLabelGenerator_valueUpdated() {
+        comboBox.selectByText("Item 1");
+        comboBox.selectByText("Item 10");
+        changeItemLabelGenerator.click();
+
+        assertSelectedItems(Set.of("Custom Item 1", "Custom Item 10"));
+    }
+
+    @Test
+    @Ignore("https://github.com/vaadin/flow-components/issues/3239")
+    public void selectItems_changeItemData_valueUpdated() {
+        comboBox.selectByText("Item 1");
+        comboBox.selectByText("Item 10");
+        changeItemData.click();
+
+        assertSelectedItems(Set.of("Updated Item 1", "Updated Item 10"));
+    }
+
+    private void assertSelectedItems(Set<String> items) {
+        List<String> selectedTexts = comboBox.getSelectedTexts();
+        Assert.assertEquals("Number of selected items does not match",
+                items.size(), selectedTexts.size());
+        items.forEach(item -> Assert.assertTrue(
+                "Selection does not include item: " + item,
+                selectedTexts.contains(item)));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringIT.java
@@ -21,6 +21,15 @@ public class MultiSelectComboBoxServerSideFilteringIT
     }
 
     @Test
+    public void openPopup_showsAllItems() {
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(100, options.size());
+    }
+
+    @Test
     public void setFilter_noErrors() {
         comboBox.setFilter("Item 10");
         checkLogsForErrors();
@@ -51,5 +60,14 @@ public class MultiSelectComboBoxServerSideFilteringIT
 
         List<String> options = comboBox.getOptions();
         Assert.assertEquals(0, options.size());
+    }
+
+    @Test
+    public void setFilter_clearFilter_showsAllItems() {
+        comboBox.setFilter("Item 10");
+        comboBox.setFilter("");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(100, options.size());
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringIT.java
@@ -1,0 +1,55 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+@TestPath("vaadin-multi-select-combo-box/server-side-filtering")
+public class MultiSelectComboBoxServerSideFilteringIT
+        extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
+    }
+
+    @Test
+    public void setFilter_noErrors() {
+        comboBox.setFilter("Item 10");
+        checkLogsForErrors();
+    }
+
+    @Test
+    public void setFilter_closePopup_noErrors() {
+        comboBox.setFilter("Item 10");
+        comboBox.closePopup();
+        checkLogsForErrors();
+    }
+
+    @Test
+    public void setMatchingFilter_filtersItems() {
+        comboBox.setFilter("Item 10");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(2, options.size());
+        Assert.assertTrue("Should display Item 10",
+                options.contains("Item 10"));
+        Assert.assertTrue("Should display Item 100",
+                options.contains("Item 100"));
+    }
+
+    @Test
+    public void setNonMatchingFilter_noItems() {
+        comboBox.setFilter("Item XYZ");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(0, options.size());
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerValueChangeIT.java
@@ -1,0 +1,111 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@TestPath("vaadin-multi-select-combo-box/value-change")
+public class MultiSelectComboBoxServerValueChangeIT
+        extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+    private TestBenchElement setServerSideValue;
+    private TestBenchElement eventValue;
+    private TestBenchElement eventOrigin;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
+        setServerSideValue = $("button").id("set-server-side-value");
+        eventValue = $("span").id("event-value");
+        eventOrigin = $("span").id("event-origin");
+    }
+
+    @Test
+    public void inputValue_valueUpdated() {
+        comboBox.openPopup();
+        comboBox.sendKeys("Item 1");
+        comboBox.waitForLoadingFinished();
+        comboBox.sendKeys(Keys.ENTER);
+        comboBox.sendKeys("Item 10");
+        comboBox.waitForLoadingFinished();
+        comboBox.sendKeys(Keys.ENTER);
+
+        assertVisibleChips(Set.of("Item 1", "Item 10"));
+        assertValueChange(Set.of("Item 1", "Item 10"), "client");
+    }
+
+    @Test
+    public void inputValue_removeValue_valueUpdated() {
+        comboBox.openPopup();
+        comboBox.sendKeys("Item 1");
+        comboBox.waitForLoadingFinished();
+        comboBox.sendKeys(Keys.ENTER);
+        // Popup needs to be closed in order to remove chips with backspace
+        comboBox.closePopup();
+        // Select the chip
+        comboBox.sendKeys(Keys.BACK_SPACE);
+        // Delete the chip
+        comboBox.sendKeys(Keys.BACK_SPACE);
+
+        assertVisibleChips(Collections.emptySet());
+        assertValueChange(Collections.emptySet(), "client");
+    }
+
+    @Test
+    public void selectItemsFromPopup_valueUpdated() {
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+        // Select "Item 1"
+        comboBox.sendKeys(Keys.DOWN, Keys.ENTER);
+
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+        // Select "Item 3"
+        comboBox.sendKeys(Keys.DOWN, Keys.DOWN, Keys.ENTER);
+
+        assertVisibleChips(Set.of("Item 1", "Item 3"));
+        assertValueChange(Set.of("Item 1", "Item 3"), "client");
+    }
+
+    @Test
+    public void setServerSideValue_valueUpdated() {
+        setServerSideValue.click();
+
+        assertVisibleChips(Set.of("Item 1", "Item 2"));
+        assertValueChange(Set.of("Item 1", "Item 2"), "server");
+    }
+
+    private void assertVisibleChips(Set<String> items) {
+        List<String> chips = comboBox.getVisibleChips();
+        Assert.assertEquals("Number of selected items does not match",
+                items.size(), chips.size());
+        items.forEach(item -> Assert.assertTrue(
+                "Chips do not include item: " + item, chips.contains(item)));
+    }
+
+    private void assertValueChange(Set<String> items, String origin) {
+        String eventValuesText = eventValue.getText();
+        List<String> eventValues = eventValuesText.isEmpty()
+                ? Collections.emptyList()
+                : Arrays.asList(eventValuesText.split(","));
+
+        Assert.assertEquals("Number of selected items does not match",
+                items.size(), eventValues.size());
+        items.forEach(item -> Assert.assertTrue(
+                "Event value does not include item: " + item,
+                eventValues.contains(item)));
+        Assert.assertEquals("Event should have originated from: " + origin,
+                origin, eventOrigin.getText());
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerValueChangeIT.java
@@ -33,13 +33,8 @@ public class MultiSelectComboBoxServerValueChangeIT
 
     @Test
     public void inputValue_valueUpdated() {
-        comboBox.openPopup();
-        comboBox.sendKeys("Item 1");
-        comboBox.waitForLoadingFinished();
-        comboBox.sendKeys(Keys.ENTER);
-        comboBox.sendKeys("Item 10");
-        comboBox.waitForLoadingFinished();
-        comboBox.sendKeys(Keys.ENTER);
+        comboBox.selectByText("Item 1");
+        comboBox.selectByText("Item 10");
 
         assertVisibleChips(Set.of("Item 1", "Item 10"));
         assertValueChange(Set.of("Item 1", "Item 10"), "client");
@@ -47,10 +42,7 @@ public class MultiSelectComboBoxServerValueChangeIT
 
     @Test
     public void inputValue_removeValue_valueUpdated() {
-        comboBox.openPopup();
-        comboBox.sendKeys("Item 1");
-        comboBox.waitForLoadingFinished();
-        comboBox.sendKeys(Keys.ENTER);
+        comboBox.selectByText("Item 1");
         // Popup needs to be closed in order to remove chips with backspace
         comboBox.closePopup();
         // Select the chip
@@ -71,7 +63,7 @@ public class MultiSelectComboBoxServerValueChangeIT
 
         comboBox.openPopup();
         comboBox.waitForLoadingFinished();
-        // Select "Item 3"
+        // Select "Item 3", starting from preselected "Item 1"
         comboBox.sendKeys(Keys.DOWN, Keys.DOWN, Keys.ENTER);
 
         assertVisibleChips(Set.of("Item 1", "Item 3"));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
@@ -18,6 +18,7 @@ import java.util.Set;
 public class MultiSelectComboBoxValueChangeIT extends AbstractComponentIT {
     private MultiSelectComboBoxElement comboBox;
     private TestBenchElement setServerSideValue;
+    private TestBenchElement clearServerSideValue;
     private TestBenchElement eventValue;
     private TestBenchElement eventOrigin;
 
@@ -26,6 +27,7 @@ public class MultiSelectComboBoxValueChangeIT extends AbstractComponentIT {
         open();
         comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
         setServerSideValue = $("button").id("set-server-side-value");
+        clearServerSideValue = $("button").id("clear-server-side-value");
         eventValue = $("span").id("event-value");
         eventOrigin = $("span").id("event-origin");
     }
@@ -72,6 +74,16 @@ public class MultiSelectComboBoxValueChangeIT extends AbstractComponentIT {
 
         assertSelectedItems(Set.of("Item 1", "Item 2"));
         assertValueChange(Set.of("Item 1", "Item 2"), "server");
+    }
+
+    @Test
+    public void selectItems_clearValueServerSide_valueCleared() {
+        comboBox.selectByText("Item 1");
+        comboBox.selectByText("Item 10");
+        clearServerSideValue.click();
+
+        assertSelectedItems(Collections.emptySet());
+        assertValueChange(Collections.emptySet(), "server");
     }
 
     private void assertSelectedItems(Set<String> items) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
@@ -15,8 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 @TestPath("vaadin-multi-select-combo-box/value-change")
-public class MultiSelectComboBoxValueChangeIT
-        extends AbstractComponentIT {
+public class MultiSelectComboBoxValueChangeIT extends AbstractComponentIT {
     private MultiSelectComboBoxElement comboBox;
     private TestBenchElement setServerSideValue;
     private TestBenchElement eventValue;
@@ -32,30 +31,27 @@ public class MultiSelectComboBoxValueChangeIT
     }
 
     @Test
-    public void inputValue_valueUpdated() {
+    public void selectItem_valueUpdated() {
         comboBox.selectByText("Item 1");
         comboBox.selectByText("Item 10");
 
-        assertVisibleChips(Set.of("Item 1", "Item 10"));
+        assertSelectedItems(Set.of("Item 1", "Item 10"));
         assertValueChange(Set.of("Item 1", "Item 10"), "client");
     }
 
     @Test
-    public void inputValue_removeValue_valueUpdated() {
+    public void selectItem_deselectItem_valueUpdated() {
         comboBox.selectByText("Item 1");
-        // Popup needs to be closed in order to remove chips with backspace
-        comboBox.closePopup();
-        // Select the chip
-        comboBox.sendKeys(Keys.BACK_SPACE);
-        // Delete the chip
-        comboBox.sendKeys(Keys.BACK_SPACE);
+        assertSelectedItems(Set.of("Item 1"));
+        assertValueChange(Set.of("Item 1"), "client");
 
-        assertVisibleChips(Collections.emptySet());
+        comboBox.deselectByText("Item 1");
+        assertSelectedItems(Collections.emptySet());
         assertValueChange(Collections.emptySet(), "client");
     }
 
     @Test
-    public void selectItemsFromPopup_valueUpdated() {
+    public void selectItemsWithKeyboardNavigation_valueUpdated() {
         comboBox.openPopup();
         comboBox.waitForLoadingFinished();
         // Select "Item 1"
@@ -66,7 +62,7 @@ public class MultiSelectComboBoxValueChangeIT
         // Select "Item 3", starting from preselected "Item 1"
         comboBox.sendKeys(Keys.DOWN, Keys.DOWN, Keys.ENTER);
 
-        assertVisibleChips(Set.of("Item 1", "Item 3"));
+        assertSelectedItems(Set.of("Item 1", "Item 3"));
         assertValueChange(Set.of("Item 1", "Item 3"), "client");
     }
 
@@ -74,16 +70,17 @@ public class MultiSelectComboBoxValueChangeIT
     public void setServerSideValue_valueUpdated() {
         setServerSideValue.click();
 
-        assertVisibleChips(Set.of("Item 1", "Item 2"));
+        assertSelectedItems(Set.of("Item 1", "Item 2"));
         assertValueChange(Set.of("Item 1", "Item 2"), "server");
     }
 
-    private void assertVisibleChips(Set<String> items) {
-        List<String> chips = comboBox.getVisibleChips();
+    private void assertSelectedItems(Set<String> items) {
+        List<String> selectedTexts = comboBox.getSelectedTexts();
         Assert.assertEquals("Number of selected items does not match",
-                items.size(), chips.size());
+                items.size(), selectedTexts.size());
         items.forEach(item -> Assert.assertTrue(
-                "Chips do not include item: " + item, chips.contains(item)));
+                "Selection does not include item: " + item,
+                selectedTexts.contains(item)));
     }
 
     private void assertValueChange(Set<String> items, String origin) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 @TestPath("vaadin-multi-select-combo-box/value-change")
-public class MultiSelectComboBoxServerValueChangeIT
+public class MultiSelectComboBoxValueChangeIT
         extends AbstractComponentIT {
     private MultiSelectComboBoxElement comboBox;
     private TestBenchElement setServerSideValue;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxVirtualChildIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxVirtualChildIT.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-multi-select-combo-box/virtual-child")
+public class MultiSelectComboBoxVirtualChildIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void addAsVirtualChild_noErrors() {
+        // Verify that the connector initializes successfully even though the
+        // element is not attached to the DOM, and Polymer has not finalized the
+        // element yet
+        checkLogsForErrors();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -17,11 +17,16 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
         comboBox.$connector = {};
 
-        // <vaadin-multi-select-combo-box> wraps a regular combo box internally,
-        // to reuse logic between both components we need to identify the
-        // element that implements the data provider mixin
-        const dataProviderMixin =
-          comboBox.localName === 'vaadin-multi-select-combo-box' ? comboBox.$.comboBox : comboBox;
+        /**
+         * Returns the element that implements the data provider mixin.
+         * For <vaadin-combo-box> that is the element itself.
+         * <vaadin-multi-select-combo-box> wraps a regular combo box internally,
+         * which is returned in this case.
+         * @returns {Node|Element|*}
+         */
+        function getDataProviderMixin() {
+          return comboBox.localName === 'vaadin-multi-select-combo-box' ? comboBox.$.comboBox : comboBox;
+        }
 
         // holds pageIndex -> callback pairs of subsequent indexes (current active range)
         const pageCallbacks = {};
@@ -58,6 +63,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         })();
 
         const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
+          const dataProviderMixin = getDataProviderMixin();
           // Flush and empty the existing requests
           pages.forEach((page) => {
             pageCallbacks[page]([], dataProviderMixin.size);
@@ -197,6 +203,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         });
 
         comboBox.$connector.updateData = tryCatchWrapper(function (items) {
+          const dataProviderMixin = getDataProviderMixin();
           // IE11 doesn't work with the transpiled version of the forEach.
           for (let i = 0; i < items.length; i++) {
             let item = items[i];
@@ -225,6 +232,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         });
 
         comboBox.$connector.reset = tryCatchWrapper(function () {
+          const dataProviderMixin = getDataProviderMixin();
           clearPageCallbacks();
           cache = {};
           dataProviderMixin.clearCache();
@@ -313,6 +321,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
         const performClientSideFilter = tryCatchWrapper(function (page, callback) {
+          const dataProviderMixin = getDataProviderMixin();
           let filteredItems = page;
 
           if (dataProviderMixin.filter) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -85,7 +85,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], params.filter, callback);
+              performClientSideFilter(cache[0], callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -296,7 +296,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, comboBox.filter, callback);
+            performClientSideFilter(data, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -312,11 +312,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
           let filteredItems = page;
 
-          if (filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
+          if (dataProviderMixin.filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, dataProviderMixin.filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -85,7 +85,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], callback);
+              performClientSideFilter(cache[0], params.filter, callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -166,7 +166,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
         comboBox.$connector.filter = tryCatchWrapper(function (item, filter) {
           filter = filter ? filter.toString().toLowerCase() : '';
-          return comboBox._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;
+          return comboBox._getItemLabel(item, comboBox.itemLabelPath).toString().toLowerCase().indexOf(filter) > -1;
         });
 
         comboBox.$connector.set = tryCatchWrapper(function (index, items, filter) {
@@ -296,7 +296,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, callback);
+            performClientSideFilter(data, comboBox.filter, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -312,11 +312,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
           let filteredItems = page;
 
-          if (comboBox.filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
+          if (filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -201,9 +201,9 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           for (let i = 0; i < items.length; i++) {
             let item = items[i];
 
-            for (let j = 0; j < comboBox.filteredItems.length; j++) {
-              if (comboBox.filteredItems[j].key === item.key) {
-                comboBox.set('filteredItems.' + j, item);
+            for (let j = 0; j < dataProviderMixin.filteredItems.length; j++) {
+              if (dataProviderMixin.filteredItems[j].key === item.key) {
+                dataProviderMixin.set('filteredItems.' + j, item);
                 break;
               }
             }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -17,6 +17,12 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
         comboBox.$connector = {};
 
+        // <vaadin-multi-select-combo-box> wraps a regular combo box internally,
+        // to reuse logic between both components we need to identify the
+        // element that implements the data provider mixin
+        const dataProviderMixin =
+          comboBox.localName === 'vaadin-multi-select-combo-box' ? comboBox.$.comboBox : comboBox;
+
         // holds pageIndex -> callback pairs of subsequent indexes (current active range)
         const pageCallbacks = {};
         let cache = {};
@@ -54,17 +60,17 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
           // Flush and empty the existing requests
           pages.forEach((page) => {
-            pageCallbacks[page]([], comboBox.size);
+            pageCallbacks[page]([], dataProviderMixin.size);
             delete pageCallbacks[page];
 
             // Empty the comboBox's internal cache without invoking observers by filling
             // the filteredItems array with placeholders (comboBox will request for data when it
             // encounters a placeholder)
-            const pageStart = parseInt(page) * comboBox.pageSize;
-            const pageEnd = pageStart + comboBox.pageSize;
-            const end = Math.min(pageEnd, comboBox.filteredItems.length);
+            const pageStart = parseInt(page) * dataProviderMixin.pageSize;
+            const pageEnd = pageStart + dataProviderMixin.pageSize;
+            const end = Math.min(pageEnd, dataProviderMixin.filteredItems.length);
             for (let i = pageStart; i < end; i++) {
-              comboBox.filteredItems[i] = placeHolder;
+              dataProviderMixin.filteredItems[i] = placeHolder;
             }
           });
         };
@@ -221,7 +227,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         comboBox.$connector.reset = tryCatchWrapper(function () {
           clearPageCallbacks();
           cache = {};
-          comboBox.clearCache();
+          dataProviderMixin.clearCache();
         });
 
         comboBox.$connector.confirm = tryCatchWrapper(function (id, filter) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
@@ -81,8 +81,7 @@ public class MultiSelectComboBoxElement extends TestBenchElement
     public void setFilter(String filter) {
         openPopup();
         setProperty("filter", filter);
-        waitUntil(
-                driver -> !getInternalComboBox().getPropertyBoolean("loading"));
+        waitForLoadingFinished();
     }
 
     /**
@@ -92,6 +91,14 @@ public class MultiSelectComboBoxElement extends TestBenchElement
      */
     public String getFilter() {
         return getPropertyString("filter");
+    }
+
+    /**
+     * Waits until the combo box has finished loading items to show in the popup
+     */
+    public void waitForLoadingFinished() {
+        waitUntil(
+                driver -> !getInternalComboBox().getPropertyBoolean("loading"));
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
@@ -22,6 +22,7 @@ import com.vaadin.testbench.elementsbase.Element;
 import org.openqa.selenium.By;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A TestBench element representing a
@@ -70,6 +71,26 @@ public class MultiSelectComboBoxElement extends TestBenchElement
         return (List<String>) executeScript("const comboBox=arguments[0];"
                 + "return comboBox.filteredItems.map(function(item) { return comboBox._getItemLabel(item);});",
                 getInternalComboBox());
+    }
+
+    /**
+     * Gets the labels of the currently displayed chips. The multi select combo
+     * box will display one chip per selected item. The displayed label is
+     * determined by the item label generator of the component.
+     * <p>
+     * Note that multiple chips may be combined into an overflow chip if not all
+     * chips fit into the element. Increase the width of the component to ensure
+     * that all chips are visible.
+     *
+     * @return the labels of the currently displayed chips
+     */
+    public List<String> getVisibleChips() {
+        List<TestBenchElement> chips = $("vaadin-multi-select-combo-box-chip")
+                .all();
+        return chips.stream()
+                // skip overflow chip
+                .skip(1).map(TestBenchElement::getText)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
@@ -67,9 +67,8 @@ public class MultiSelectComboBoxElement extends TestBenchElement
     @SuppressWarnings("unchecked")
     public List<String> getOptions() {
         openPopup();
-        return (List<String>) executeScript(
-                "const dataProviderMixin=arguments[0];"
-                        + "return dataProviderMixin.filteredItems.map(function(item) { return dataProviderMixin._getItemLabel(item);});",
+        return (List<String>) executeScript("const comboBox=arguments[0];"
+                + "return comboBox.filteredItems.map(function(item) { return comboBox._getItemLabel(item);});",
                 getInternalComboBox());
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.testbench;
+
+import com.vaadin.testbench.HasHelper;
+import com.vaadin.testbench.HasLabel;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+import org.openqa.selenium.By;
+
+import java.util.List;
+
+/**
+ * A TestBench element representing a
+ * <code>&lt;vaadin-multi-select-combo-box&gt;</code> element.
+ */
+@Element("vaadin-multi-select-combo-box")
+public class MultiSelectComboBoxElement extends TestBenchElement
+        implements HasLabel, HasHelper {
+
+    public String getInputElementValue() {
+        return this.getPropertyString("_inputElementValue");
+    }
+
+    /**
+     * Opens the popup with options, if it is not already open.
+     */
+    public void openPopup() {
+        setProperty("opened", true);
+    }
+
+    /**
+     * Close the popup with options, if it is open.
+     */
+    public void closePopup() {
+        setProperty("opened", false);
+    }
+
+    /**
+     * Checks whether the popup with options is open.
+     *
+     * @return <code>true</code> if the popup is open, <code>false</code>
+     *         otherwiseF
+     */
+    public boolean isPopupOpen() {
+        return getPropertyBoolean("opened");
+    }
+
+    /**
+     * Gets a list of all available options.
+     *
+     * @return a list of the options (visible text)
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> getOptions() {
+        openPopup();
+        return (List<String>) executeScript(
+                "const dataProviderMixin=arguments[0];"
+                        + "return dataProviderMixin.filteredItems.map(function(item) { return dataProviderMixin._getItemLabel(item);});",
+                getInternalComboBox());
+    }
+
+    /**
+     * Sets the filter for the options in the popup.
+     *
+     * @param filter
+     *            the filter to use for filtering options
+     */
+    public void setFilter(String filter) {
+        openPopup();
+        setProperty("filter", filter);
+        waitUntil(
+                driver -> !getInternalComboBox().getPropertyBoolean("loading"));
+    }
+
+    /**
+     * Gets the filter for the options in the popup.
+     *
+     * @return the filter to use for filtering options
+     */
+    public String getFilter() {
+        return getPropertyString("filter");
+    }
+
+    /**
+     * Gets whether dropdown will open automatically or not.
+     *
+     * @return @{code true} if enabled, {@code false} otherwise
+     */
+    public boolean isAutoOpen() {
+        return !getPropertyBoolean("autoOpenDisabled");
+    }
+
+    @Override
+    public void sendKeys(CharSequence... keysToSend) {
+        findElement(By.tagName("input")).sendKeys(keysToSend);
+    }
+
+    private TestBenchElement getInternalComboBox() {
+        return $("vaadin-multi-select-combo-box-internal").first();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
@@ -20,6 +20,7 @@ import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -91,6 +92,27 @@ public class MultiSelectComboBoxElement extends TestBenchElement
                 // skip overflow chip
                 .skip(1).map(TestBenchElement::getText)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Attempts to select an item from the popup by matching the label. Throws
+     * an {@link IllegalArgumentException} if the popup does not contain the
+     * item.
+     *
+     * @param label
+     *            The label of the item to select from the popup
+     */
+    public void selectByText(String label) {
+        openPopup();
+        sendKeys(label);
+        waitForLoadingFinished();
+        List<String> options = getOptions();
+        if (!options.contains(label)) {
+            throw new IllegalArgumentException(String.format(
+                    "Item with the label '%s' not found in the popup", label));
+        }
+        sendKeys(Keys.ENTER);
+        closePopup();
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a `MultiSelectComboBoxElement` TestBench element, and integration tests for the `MultiSelectComboBox`. The tests are mostly intended to cover the differences compared to the regular combo box component regarding value handling and the client-side connector.
The PR also introduces some necessary changes to the connector in order to support both components. The new multi select combo box filtering ITs are supposed to cover that change.

Part of https://github.com/vaadin/platform/issues/2961
