### PR TITLE
fix: do not trigger item click listener for prevented click

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.component.grid.it;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
@@ -40,10 +40,10 @@ public class GridViewClickListenersPage extends LegacyTestView {
         grid.addColumn(Person::getFirstName).setHeader("Name");
         grid.addColumn(Person::getAge).setHeader("Age");
         grid.addColumn(new ComponentRenderer<>(person -> {
-            NativeButton button = new NativeButton("Action");
-            button.getElement().executeJs(
+            Span span = new Span("Action");
+            span.getElement().executeJs(
                     "$0.addEventListener('click', e => e.preventDefault())");
-            return button;
+            return span;
         })).setHeader("Action");
 
         // Disable selection: will receive only click events instead

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
@@ -18,7 +18,9 @@ package com.vaadin.flow.component.grid.it;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-grid-it-demo/click-listeners")
@@ -37,6 +39,12 @@ public class GridViewClickListenersPage extends LegacyTestView {
         grid.setItems(getItems());
         grid.addColumn(Person::getFirstName).setHeader("Name");
         grid.addColumn(Person::getAge).setHeader("Age");
+        grid.addColumn(new ComponentRenderer<>(person -> {
+            NativeButton button = new NativeButton("Action");
+            button.getElement().executeJs(
+                    "$0.addEventListener('click', e => e.preventDefault())");
+            return button;
+        })).setHeader("Action");
 
         // Disable selection: will receive only click events instead
         grid.setSelectionMode(SelectionMode.NONE);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
@@ -61,6 +61,23 @@ public class GridViewClickListenersIT extends AbstractComponentIT {
     }
 
     @Test
+    public void itemClickListener_singleClick_preventClickIgnored() {
+        GridElement grid = $(GridElement.class).id("item-click-listener");
+        scrollToElement(grid);
+        waitUntil(driver -> grid.getRowCount() > 0);
+
+        GridTRElement row = grid.getRow(0);
+        GridTHTDElement cell = row.getCell(grid.getColumn("Action"));
+
+        WebElement button = cell.getContext().findElement(By.tagName("button"));
+        button.click();
+
+        WebElement clickInfo = findElement(By.id("clicked-item"));
+
+        Assert.assertEquals("", clickInfo.getText());
+    }
+
+    @Test
     public void itemDoubleClickListener() {
         GridElement grid = $(GridElement.class).id("item-doubleclick-listener");
         scrollToElement(grid);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
@@ -69,8 +69,8 @@ public class GridViewClickListenersIT extends AbstractComponentIT {
         GridTRElement row = grid.getRow(0);
         GridTHTDElement cell = row.getCell(grid.getColumn("Action"));
 
-        WebElement button = cell.getContext().findElement(By.tagName("button"));
-        button.click();
+        WebElement span = cell.getContext().findElement(By.tagName("span"));
+        span.click();
 
         WebElement clickInfo = findElement(By.id("clicked-item"));
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1124,6 +1124,11 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         );
 
         function _fireClickEvent(event, eventName) {
+          // Click event was handled by the component inside grid, do nothing.
+          if (event.defaultPrevented) {
+            return;
+          }
+
           const target = event.target;
           const eventContext = grid.getEventContext(event);
           const section = eventContext.section;


### PR DESCRIPTION
## Description

Fixes #3177

This PR updates item click listener to not fire in case if `event.preventDefault()` was called for the `click` event on the client.
It's especially relevant for the Grid editor because of the following logic that closes the editor:

https://github.com/vaadin/flow-components/blob/6aefadf2db230a0a120c3b25122aea79c9d9d5c2/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java#L67

https://github.com/vaadin/flow-components/blob/6aefadf2db230a0a120c3b25122aea79c9d9d5c2/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java#L199-L205

Clarification about https://github.com/vaadin/flow-components/issues/3177#issuecomment-1125849666: the [`isFocusable` check](https://github.com/vaadin/flow-components/blob/6aefadf2db230a0a120c3b25122aea79c9d9d5c2/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L1131) in the connector prevents click listener from firing on `<input>` element. But the toggle button of `vaadin-select` and `vaadin-combo-box` is not focusable, so it caused click listener to fire.

## Type of change

- Bugfix