### PR TITLE
Add AbstractGridMultiSelectionModel#getSelectedItemIds

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -159,6 +159,17 @@ public abstract class AbstractGridMultiSelectionModel<T>
                 .unmodifiableSet(new LinkedHashSet<>(selected.values()));
     }
 
+    /**
+     * Returns an unmodifiable view of the selected item ids.
+     *
+     * The returned Set may be a direct view of the internal data structures of this class.
+     * A defensive copy should be made by callers when iterating over this Set and modifying
+     * the selection during iteration to avoid ConcurrentModificationExceptions.
+     */
+    protected final Set<T> getSelectedItems() {
+        return Collections.unmodifiableSet(this.selected.keySet());
+    }
+
     @Override
     public Optional<T> getFirstSelectedItem() {
         return selected.values().stream().findFirst();


### PR DESCRIPTION
## Description

Add a method, usable by subclasses, that provides access to the internal set of selected item ids.

Fixes #3246

## Type of change

- [ ] Bugfix
- [x] Refactoring
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
