### PR TITLE
fix: ensure the hidden grid sorters are reset

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSortingPage.java
@@ -86,12 +86,23 @@ public class GridViewSortingPage extends LegacyTestView {
 
         NativeButton resetAllSortings = new NativeButton("Reset all sortings",
                 event -> grid.sort(null));
+
+        NativeButton toggleFirstColumnAndReset = new NativeButton(
+                "Toggle first column and reset", event -> {
+                    Grid.Column<Person> firstColumn = grid.getColumns().stream()
+                            .findFirst().get();
+                    firstColumn.setVisible(!firstColumn.isVisible());
+                    grid.sort(null);
+                });
+
         grid.setId("grid-sortable-columns");
         multiSort.setId("grid-multi-sort-toggle");
         invertAllSortings.setId("grid-sortable-columns-invert-sortings");
         resetAllSortings.setId("grid-sortable-columns-reset-sortings");
+        toggleFirstColumnAndReset.setId("grid-sortable-columns-toggle-first");
         messageDiv.setId("grid-sortable-columns-message");
         addCard("Sorting", "Grid with sortable columns", grid, multiSort,
-                invertAllSortings, resetAllSortings, messageDiv);
+                invertAllSortings, resetAllSortings, toggleFirstColumnAndReset,
+                messageDiv);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -128,11 +128,10 @@ public class GridViewSortingIT extends AbstractComponentIT {
         assertSortMessageEquals(QuerySortOrder.asc("firstName").build(), true);
 
         clickElementWithJs(toggleFirstColumnButton);
-        assertSortMessageEquals(QuerySortOrder.desc("firstName").build(),
-                false);
+        assertSortMessageEquals(Collections.emptyList(), false);
 
         clickElementWithJs(toggleFirstColumnButton);
-        assertSortMessageEquals(QuerySortOrder.asc("firstName").build(), false);
+        assertSortMessageEquals(Collections.emptyList(), false);
     }
 
     private void assertSortMessageEquals(List<QuerySortOrder> querySortOrders,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -116,6 +116,25 @@ public class GridViewSortingIT extends AbstractComponentIT {
 
     }
 
+    @Test
+    public void gridWithSorting_toggleColumnVisibilityAndReset() {
+        GridElement grid = $(GridElement.class).id("grid-sortable-columns");
+        scrollToElement(grid);
+
+        WebElement toggleFirstColumnButton = findElement(
+                By.id("grid-sortable-columns-toggle-first"));
+
+        getCellContent(grid.getHeaderCell(0)).click();
+        assertSortMessageEquals(QuerySortOrder.asc("firstName").build(), true);
+
+        clickElementWithJs(toggleFirstColumnButton);
+        assertSortMessageEquals(QuerySortOrder.desc("firstName").build(),
+                false);
+
+        clickElementWithJs(toggleFirstColumnButton);
+        assertSortMessageEquals(QuerySortOrder.asc("firstName").build(), false);
+    }
+
     private void assertSortMessageEquals(List<QuerySortOrder> querySortOrders,
             boolean fromClient) {
         String sortOrdersString = querySortOrders.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -132,6 +132,10 @@ public class GridViewSortingIT extends AbstractComponentIT {
 
         clickElementWithJs(toggleFirstColumnButton);
         assertSortMessageEquals(Collections.emptyList(), false);
+
+        WebElement sorter = grid.getHeaderCell(0).$("vaadin-grid-sorter")
+                .first();
+        Assert.assertEquals(null, sorter.getAttribute("direction"));
     }
 
     private void assertSortMessageEquals(List<QuerySortOrder> querySortOrders,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -441,6 +441,14 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               try {
                 const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
+                // Sorters for hidden columns are removed from DOM but stored in the web component.
+                // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
+                grid._sorters.forEach((sorter) => {
+                  if (!sorters.includes(sorter)) {
+                    sorters.push(sorter);
+                  }
+                });
+
                 sorters.forEach((sorter) => {
                   if (!directions.filter((d) => d.column === sorter.getAttribute('path'))[0]) {
                     sorter.direction = null;


### PR DESCRIPTION
## Description

Current logic for updating sorters in the connector only updates `vaadin-grid-sorter` elements that are added to the DOM.
When the column gets hidden while also calling `grid.sort(null)`, the connector does not update its sorter, because of not checking the actually applied sorters stored in `grid._sorters`. This causes the problem with restoring sort direction.

Fixes #1008

## Type of change

- Bugfix