### PR TITLE
fix: ensure grid sorters in hidden columns are reset (#3250) (CP: 23.0)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridView.java
@@ -768,14 +768,24 @@ public class GridView extends DemoView {
 
         NativeButton resetAllSortings = new NativeButton("Reset all sortings",
                 event -> grid.sort(null));
+
+        NativeButton toggleFirstColumnAndReset = new NativeButton(
+                "Toggle first column and reset", event -> {
+                    Grid.Column<Person> firstColumn = grid.getColumns().stream()
+                            .findFirst().get();
+                    firstColumn.setVisible(!firstColumn.isVisible());
+                    grid.sort(null);
+                });
         // end-source-example
         grid.setId("grid-sortable-columns");
         multiSort.setId("grid-multi-sort-toggle");
         invertAllSortings.setId("grid-sortable-columns-invert-sortings");
         resetAllSortings.setId("grid-sortable-columns-reset-sortings");
+        toggleFirstColumnAndReset.setId("grid-sortable-columns-toggle-first");
         messageDiv.setId("grid-sortable-columns-message");
         addCard("Sorting", "Grid with sortable columns", grid, multiSort,
-                invertAllSortings, resetAllSortings, messageDiv);
+                invertAllSortings, resetAllSortings, toggleFirstColumnAndReset,
+                messageDiv);
     }
 
     private void createBeanGrid() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -504,6 +504,29 @@ public class GridViewIT extends GridViewBase {
 
     }
 
+    @Test
+    public void gridWithSorting_toggleColumnVisibilityAndReset() {
+        openTabAndCheckForErrors("sorting");
+        GridElement grid = $(GridElement.class).id("grid-sortable-columns");
+        scrollToElement(grid);
+
+        WebElement toggleFirstColumnButton = findElement(
+                By.id("grid-sortable-columns-toggle-first"));
+
+        getCellContent(grid.getHeaderCell(0)).click();
+        assertSortMessageEquals(QuerySortOrder.asc("firstName").build(), true);
+
+        clickElementWithJs(toggleFirstColumnButton);
+        assertSortMessageEquals(Collections.emptyList(), false);
+
+        clickElementWithJs(toggleFirstColumnButton);
+        assertSortMessageEquals(Collections.emptyList(), false);
+
+        WebElement sorter = grid.getHeaderCell(0).$("vaadin-grid-sorter")
+                .first();
+        Assert.assertEquals(null, sorter.getAttribute("direction"));
+    }
+
     private void assertSortMessageEquals(List<QuerySortOrder> querySortOrders,
             boolean fromClient) {
         String sortOrdersString = querySortOrders.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -434,6 +434,14 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               try {
                 const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
+                // Sorters for hidden columns are removed from DOM but stored in the web component.
+                // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
+                grid._sorters.forEach((sorter) => {
+                  if (!sorters.includes(sorter)) {
+                    sorters.push(sorter);
+                  }
+                });
+
                 sorters.forEach((sorter) => {
                   if (!directions.filter((d) => d.column === sorter.getAttribute('path'))[0]) {
                     sorter.direction = null;


### PR DESCRIPTION
## Description

Manual cherry-pick of #3250 to `23.0` branch with the IT moved to the old demo view.

## Type of change

- Cherry-pick