### PR TITLE
refactor: fix TextArea not using TextAreaVariant

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -40,7 +40,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
-        HasClearButton, HasThemeVariant<TextFieldVariant> {
+        HasClearButton, HasThemeVariant<TextAreaVariant> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
@@ -15,14 +15,19 @@
  */
 package com.vaadin.flow.component.textfield;
 
+import com.vaadin.flow.component.shared.ThemeVariant;
+
 /**
  * Set of theme variants applicable for {@code vaadin-text-area} component.
  */
-public enum TextAreaVariant {
-    LUMO_SMALL("small"), LUMO_ALIGN_CENTER("align-center"), LUMO_ALIGN_RIGHT(
-            "align-right"), LUMO_HELPER_ABOVE_FIELD(
-                    "helper-above-field"), MATERIAL_ALWAYS_FLOAT_LABEL(
-                            "always-float-label");
+public enum TextAreaVariant implements ThemeVariant {
+    //@formatter:off
+    LUMO_SMALL("small"),
+    LUMO_ALIGN_CENTER("align-center"),
+    LUMO_ALIGN_RIGHT("align-right"),
+    LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
+    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -16,7 +16,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.textfield.TextArea;
-import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.component.textfield.TextAreaVariant;
 import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
@@ -104,13 +104,13 @@ public class TextAreaTest {
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
         ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new TextArea(), TextFieldVariant.LUMO_SMALL);
+                new TextArea(), TextAreaVariant.LUMO_SMALL);
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
         ThemeVariantTestHelper
                 .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new TextArea(), TextFieldVariant.LUMO_SMALL);
+                        new TextArea(), TextAreaVariant.LUMO_SMALL);
     }
 }


### PR DESCRIPTION
## Description

In #3205 we accidentally made `TextArea` use `TextFieldVariant`, this PR fixes that by correctly using `TextAreaVariant`.

Not tagging this as a fix, as the original change has not been released yet.

Part of https://github.com/vaadin/flow-components/issues/2948
