### PR TITLE
test: align the naming of setup methods for ITs

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
@@ -13,6 +13,7 @@
 package com.vaadin.flow.component.charts.tests;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
@@ -33,9 +34,8 @@ public class PieWithLegendEventsIT extends AbstractTBTest {
         return PieWithLegendEvents.class;
     }
 
-    @Override
-    public void setup() throws Exception {
-        super.setup();
+    @Before
+    public void init() {
         lastEvent = $(SpanElement.class).id("lastEvent");
         eventDetails = $(SpanElement.class).id("eventDetails");
     }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -25,10 +25,8 @@ import java.util.stream.Collectors;
 
 public class ServerSideEventsIT extends AbstractTBTest {
 
-    @Override
     @Before
-    public void setup() throws Exception {
-        super.setup();
+    public void init() {
         resetHistory();
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HiddenColumnIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HiddenColumnIT.java
@@ -33,7 +33,7 @@ public class HiddenColumnIT extends AbstractComponentIT {
     private GridElement grid;
 
     @Before
-    public void setUp() {
+    public void init() {
         open();
         grid = $(GridElement.class).first();
         waitUntil(driver -> grid.getRowCount() > 0);

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/OverrideClientValidationIT.java
@@ -39,7 +39,7 @@ public class OverrideClientValidationIT extends AbstractComponentIT {
     private SelectElement selectInGridElement;
 
     @Before
-    public void setUp() {
+    public void init() {
         open();
         basicSelectElement = $(SelectElement.class)
                 .id(OverrideClientValidationPage.ID_BASIC_SELECT);

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/OrientationChangeIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/OrientationChangeIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class OrientationChangeIT extends AbstractComponentIT {
 
     @Before
-    public void setUp() {
+    public void init() {
         open();
     }
 

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -42,7 +42,7 @@ public class SplitterPositionIT extends AbstractComponentIT {
     public static final String ELEMENT_API = "ElementApi";
 
     @Before
-    public void setUp() {
+    public void init() {
         open();
     }
 


### PR DESCRIPTION
## Description

The PR aligns the naming of setup methods in favor of `init()` for ITs based on https://github.com/vaadin/flow-components/pull/3280#discussion_r888740325.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
