### PR TITLE
test: align the naming of setup methods for unit tests

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
@@ -24,7 +24,7 @@ public class AppLayoutTest {
     private AppLayout systemUnderTest;
 
     @Before
-    public void setUp() {
+    public void setup() {
         systemUnderTest = new AppLayout();
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxConstructorsTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxConstructorsTest.java
@@ -34,7 +34,7 @@ public class MultiSelectComboBoxConstructorsTest {
 
     @SuppressWarnings("unchecked")
     @Before
-    public void setUp() {
+    public void setup() {
         valueChangeListener = Mockito.mock(HasValue.ValueChangeListener.class);
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/SelectionPreservingKeyMapperTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/SelectionPreservingKeyMapperTest.java
@@ -10,7 +10,7 @@ public class SelectionPreservingKeyMapperTest {
     private ComboBoxDataCommunicator.SelectionPreservingKeyMapper<String> keyMapper;
 
     @Before
-    public void setUp() {
+    public void setup() {
         comboBox = new ComboBox<>();
         comboBox.setItems("1", "2", "3", "4", "5");
         keyMapper = new ComboBoxDataCommunicator.SelectionPreservingKeyMapper<>(

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -55,7 +55,7 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void setup() {
+    public void init() {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         dataProvider = new CustomInMemoryDataProvider<>(items);
         comboBox = getComponent();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -55,7 +55,7 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         dataProvider = new CustomInMemoryDataProvider<>(items);
         comboBox = getComponent();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -40,7 +40,7 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
     private DataCommunicatorTest.MockUI ui;
 
     @Before
-    public void init() {
+    public void setup() {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         component = new ComboBox<>();
         ui = new DataCommunicatorTest.MockUI();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -40,7 +40,7 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
     private DataCommunicatorTest.MockUI ui;
 
     @Before
-    public void setup() {
+    public void init() {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         component = new ComboBox<>();
         ui = new DataCommunicatorTest.MockUI();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTest.java
@@ -28,7 +28,7 @@ public class MenuItemTest {
     private MenuItem item;
 
     @Before
-    public void init() {
+    public void setup() {
         contextMenu = new ContextMenu();
         item = contextMenu.addItem("");
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
@@ -63,7 +63,7 @@ public class MenuManagerTest {
     }
 
     @Before
-    public void setUp() {
+    public void setup() {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent) {
             @Override

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
@@ -38,7 +38,7 @@ public class SubMenuTest {
     private SubMenu subMenu;
 
     @Before
-    public void init() {
+    public void setup() {
         contextMenu = new ContextMenu();
         parentItem = contextMenu.addItem("parent");
         subMenu = parentItem.getSubMenu();

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/CustomFieldTest.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/CustomFieldTest.java
@@ -17,7 +17,7 @@ public class CustomFieldTest {
     private Consumer<Object> consumer;
 
     @Before
-    public void setUp() {
+    public void setup() {
         consumer = Mockito.mock(Consumer.class);
         systemUnderTest = new CustomField<Object>() {
             @Override

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleTest.java
@@ -16,7 +16,7 @@ public class DatePickerLocaleTest {
     private UI ui;
 
     @Before
-    public void setUp() {
+    public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
@@ -15,7 +15,7 @@ public class DateTimePickerLocaleTest {
     private UI ui;
 
     @Before
-    public void setUp() {
+    public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -45,7 +45,7 @@ public class DateTimePickerTest {
     private UI ui;
 
     @Before
-    public void setUp() {
+    public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/HasLabelTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/HasLabelTest.java
@@ -31,7 +31,7 @@ public class HasLabelTest {
     private UI ui;
 
     @Before
-    public void setUp() {
+    public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
     }

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
@@ -10,7 +10,7 @@ public class DetailsTest {
     private Details details;
 
     @Before
-    public void setUp() {
+    public void setup() {
         details = new Details();
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -45,7 +45,7 @@ public class DialogTest {
     private UI ui = new UI();
 
     @Before
-    public void setUp() {
+    public void setup() {
         UI.setCurrent(ui);
 
         VaadinSession session = Mockito.mock(VaadinSession.class);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -39,7 +39,7 @@ public class AbstractGridMultiSelectionModelTest {
     private DataCommunicatorTest.MockUI ui;
 
     @Before
-    public void init() {
+    public void setup() {
         selected = new HashSet<>();
         deselected = new HashSet<>();
         grid = new Grid<String>() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -17,7 +17,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
     private DataCommunicatorTest.MockUI ui;
 
     @Before
-    public void init() {
+    public void setup() {
         treeGrid = new TreeGrid<>();
         // Data provider with only two root items, we don't need any nested
         // items for the test cases (so far)

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridSortingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridSortingTest.java
@@ -103,7 +103,7 @@ public class BeanGridSortingTest {
     private Grid<SortableBean> grid;
 
     @Before
-    public void init() {
+    public void setup() {
         grid = new Grid<>(SortableBean.class);
         grid.setItems(createBeans());
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
@@ -38,7 +38,7 @@ public class BeanGridTest {
     ExtendedGrid<Person> extendedGrid;
 
     @Before
-    public void init() {
+    public void setup() {
         grid = new Grid<>(Person.class);
         extendedGrid = new ExtendedGrid<>(Person.class);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnEditorTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnEditorTest.java
@@ -32,7 +32,7 @@ public class GridColumnEditorTest {
     private Column<Person> nameColumn;
 
     @Before
-    public void init() {
+    public void setup() {
         grid = new Grid<>();
         binder = new Binder<>(Person.class);
         grid.getEditor().setBinder(binder);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
@@ -23,7 +23,7 @@ public class GridColumnOrderTest {
     private Grid.Column<String> fourthColumn;
 
     @Before
-    public void init() {
+    public void setup() {
         grid = new Grid<>();
         firstColumn = grid.addColumn(str -> str).setKey("firstColumn");
         secondColumn = grid.addColumn(str -> str).setKey("secondColumn");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -49,7 +49,7 @@ public class GridColumnTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         grid = new Grid<>();
         firstColumn = grid.addColumn(str -> str);
         secondColumn = grid.addColumn(str -> str);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDelegatesToSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDelegatesToSelectionModelTest.java
@@ -37,7 +37,7 @@ public class GridDelegatesToSelectionModelTest {
     }
 
     @Before
-    public void init() {
+    public void setup() {
         selectionModelMock = Mockito.mock(GridSelectionModel.class);
         grid = new CustomGrid();
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionModelTest.java
@@ -54,7 +54,7 @@ public class GridMultiSelectionModelTest {
     private AtomicInteger events;
 
     @Before
-    public void setUp() {
+    public void setup() {
         grid = new Grid<>();
         selectionModel = (GridMultiSelectionModel<Person>) grid
                 .setSelectionMode(SelectionMode.MULTI);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionWithIdProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionWithIdProviderTest.java
@@ -37,7 +37,7 @@ public class GridMultiSelectionWithIdProviderTest {
 
     @SuppressWarnings("unchecked")
     @Before
-    public void setUp() {
+    public void setup() {
         AARON = new Person(1, "Aaron", "Archer");
         Set<Person> mockPersons = new HashSet<>();
         mockPersons.add(AARON);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridNoSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridNoSelectionModelTest.java
@@ -39,7 +39,7 @@ public class GridNoSelectionModelTest {
     private GridSelectionModel<Person> model;
 
     @Before
-    public void setUp() {
+    public void setup() {
         grid = new Grid<>();
         grid.setItems(PERSON_A, PERSON_B, PERSON_C);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSortingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSortingTest.java
@@ -153,7 +153,7 @@ public class GridSortingTest {
     private TestSortListener<Person> testSortListener;
 
     @Before
-    public void init() {
+    public void setup() {
         testSortListener = new TestSortListener<>();
 
         grid = new Grid<>();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -54,7 +54,7 @@ public class HeaderFooterTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         grid = new Grid<>();
         addColumns();
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorImplTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorImplTest.java
@@ -67,7 +67,7 @@ public class EditorImplTest {
     }
 
     @Before
-    public void setUp() {
+    public void setup() {
         grid = new Grid<>();
         ui = new MockUI();
         ui.getElement().appendChild(grid.getElement());

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorRendererTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorRendererTest.java
@@ -36,7 +36,7 @@ public class EditorRendererTest {
 
     @SuppressWarnings("unchecked")
     @Before
-    public void init() {
+    public void setup() {
         editor = Mockito.mock(Editor.class);
         renderer = Mockito.spy(new EditorRenderer<>(editor, "col"));
         container = new Element("div");

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnConfiguratorTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnConfiguratorTest.java
@@ -22,7 +22,7 @@ public class GridProEditColumnConfiguratorTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         GridPro<Person> grid = new GridPro<>();
         configurator = grid.addEditColumn(value -> value);
         column = (EditColumn<Person>) configurator.getColumn();

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProEditColumnTest.java
@@ -30,7 +30,7 @@ public class GridProEditColumnTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         itemUpdater = (item, newValue) -> {
             Assert.assertNotNull(item);
             Assert.assertNotNull(newValue);

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
@@ -28,7 +28,7 @@ public class GridProTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         grid = createFakeGridPro();
 
         // We should ensure the correct value were passed

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -26,7 +26,7 @@ public class ListBoxUnitTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         listBox = new ListBox<>();
         listBox.setItems(ITEM1, ITEM2);
     }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
@@ -59,7 +59,7 @@ public class MultiSelectListBoxTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void init() {
+    public void setup() {
         listBox = new MultiSelectListBox<>();
 
         foo = new Item("foo");

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTest.java
@@ -29,7 +29,7 @@ public class MenuBarTest {
     private MenuItem item1, item2;
 
     @Before
-    public void init() {
+    public void setup() {
         menuBar = new MenuBar();
         item1 = menuBar.addItem("foo");
         item2 = menuBar.addItem(new Span("bar"));

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -49,7 +49,7 @@ public class NotificationTest {
     private final UI ui = new UI();
 
     @Before
-    public void setUp() {
+    public void setup() {
         UI.setCurrent(ui);
     }
 

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTest.java
@@ -34,7 +34,7 @@ public class NotificationTest {
     private Notification notification;
 
     @Before
-    public void setUp() {
+    public void setup() {
         UI.setCurrent(new UI());
     }
 

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ScrollerTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ScrollerTest.java
@@ -30,7 +30,7 @@ public class ScrollerTest {
     private Scroller scroller;
 
     @Before
-    public void init() {
+    public void setup() {
         scroller = new Scroller();
     }
 

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ThemableLayoutTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ThemableLayoutTest.java
@@ -30,7 +30,7 @@ public class ThemableLayoutTest {
     }
 
     @Before
-    public void setUp() {
+    public void setup() {
         layout = new TestLayout();
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class LitRendererTest {
 
     @Before
-    public void init() {
+    public void setup() {
         UI ui = new UI();
         UI.setCurrent(ui);
     }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -41,7 +41,7 @@ public class SelectTest {
     private Supplier<Select> selectSupplier = () -> select;
 
     @Before
-    public void setUp() {
+    public void setup() {
         select = new Select<>();
     }
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
@@ -37,7 +37,7 @@ public class SelectionEventTest {
     private int eventCount;
 
     @Before
-    public void init() {
+    public void setup() {
         tab1 = new Tab("foo");
         tab2 = new Tab("bar");
         tabs = new Tabs(tab1, tab2);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -33,7 +33,7 @@ public class BigDecimalFieldTest extends TextFieldTest {
     private BigDecimalField field;
 
     @Before
-    public void init() {
+    public void setup() {
         field = new BigDecimalField();
         field.setLocale(Locale.US);
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -32,7 +32,7 @@ public class IntegerFieldTest extends TextFieldTest {
     private IntegerField field;
 
     @Before
-    public void init() {
+    public void setup() {
         field = new IntegerField();
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -35,7 +35,7 @@ public class NumberFieldTest extends TextFieldTest {
     private NumberField field;
 
     @Before
-    public void init() {
+    public void setup() {
         field = new NumberField();
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocaleTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocaleTest.java
@@ -15,7 +15,7 @@ public class TimePickerLocaleTest {
     private UI ui;
 
     @Before
-    public void setUp() {
+    public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
     }


### PR DESCRIPTION
## Description

The PR aligns the naming of setup methods in favor of `setup()` for unit tests based on https://github.com/vaadin/flow-components/pull/3280#discussion_r888740325.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
