### PR TITLE
fix: update sorters only if grid is attached

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -28,7 +28,7 @@ public class DetachReattachPage extends Div {
     public DetachReattachPage() {
         Grid<String> grid = new Grid<String>();
         grid.setItems("A", "B", "C");
-        grid.addColumn(x -> x).setHeader("Col");
+        grid.addColumn(x -> x).setHeader("Col").setSortable(true);
 
         grid.setSelectionMode(Grid.SelectionMode.SINGLE);
 
@@ -62,7 +62,13 @@ public class DetachReattachPage extends Div {
         toggleDetailsVisibleOnClick
                 .setId("toggle-details-visible-click-button");
 
+        NativeButton resetSortingButton = new NativeButton("Reset sorting",
+                e -> {
+                    grid.sort(null);
+                });
+        resetSortingButton.setId("reset-sorting-button");
+
         add(btnAttach, btnDetach, btnDisallowDeselect, addItemDetailsButton,
-                toggleDetailsVisibleOnClick, grid);
+                toggleDetailsVisibleOnClick, resetSortingButton, grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
@@ -95,6 +95,25 @@ public class DetachReattachIt extends AbstractComponentIT {
 
     }
 
+    @Test
+    public void detachAndReattach_resetSorting_noErrorIsThrown() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        grid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
+
+        // Detach, reset sorting and re-attach
+        $("button").id("detach-button").click();
+
+        $("button").id("reset-sorting-button").click();
+
+        $("button").id("attach-button").click();
+
+        // Check that there are no new exceptions/errors thrown
+        // after re-attaching the grid when sorting is reset
+        checkLogsForErrors();
+    }
+
     private WebElement getRow(GridElement grid, int row) {
         return grid.$("*").id("items").findElements(By.cssSelector("tr"))
                 .get(row);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3384,8 +3384,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             }
             directions.set(i, direction);
         }
-        getElement().callJsFunction("$connector.setSorterDirections",
-                directions);
+
+        if (getElement().getNode().isAttached()) {
+            getElement().callJsFunction("$connector.setSorterDirections",
+                    directions);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Added a check to ensure calling `grid.sort()` while grid is detached does not throw a JS error upon reattach.

Fixes #1672

## Type of change

- Bugfix