### PR TITLE
refactor: Use KeyMapper by default to generate unique keys (#3251) (CP: 23.1)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1448,8 +1448,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 .getUniqueKeyProperty();
         if (uniqueKeyPropertyName != null
                 && !jsonObject.hasKey(uniqueKeyPropertyName)) {
-            jsonObject.put(uniqueKeyPropertyName,
-                    getUniqueKeyProvider().apply(item));
+            jsonObject.put(uniqueKeyPropertyName, getUniqueKey(item));
         }
     }
 
@@ -4428,5 +4427,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             }
             return result;
         };
+    }
+
+    private String getUniqueKey(T item) {
+        return Optional.ofNullable(getUniqueKeyProvider())
+                .map(provider -> provider.apply(item))
+                .orElse(getDataCommunicator().getKeyMapper().key(item));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -18,13 +18,9 @@ package com.vaadin.flow.component.treegrid;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -216,13 +212,6 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
-    private final AtomicLong uniqueKeyCounter = new AtomicLong(0);
-    private final Map<Object, Long> objectUniqueKeyMap = new HashMap<>();
-
-    ValueProvider<T, String> defaultUniqueKeyProvider = item -> String.valueOf(
-            objectUniqueKeyMap.computeIfAbsent(getDataProvider().getId(item),
-                    key -> uniqueKeyCounter.getAndIncrement()));
-
     private Registration dataProviderRegistration;
 
     /**
@@ -316,17 +305,6 @@ public class TreeGrid<T> extends Grid<T>
         setUniqueKeyProvider(uniqueKeyProvider);
 
         getDataProvider().refreshAll();
-    }
-
-    /**
-     * Gets value provider for unique key in row's generated JSON.
-     *
-     * @return ValueProvider for unique key for row
-     */
-    @Override
-    protected ValueProvider<T, String> getUniqueKeyProvider() {
-        return Optional.ofNullable(super.getUniqueKeyProvider())
-                .orElse(defaultUniqueKeyProvider);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
@@ -17,45 +17,83 @@
 package com.vaadin.flow.component.grid;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.treegrid.TreeGrid;
-import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 
 public class TreeGridTest {
 
-    @Test
-    public void defaultUniqueKeyProvider_usesIncrementalLongId() {
-        Item item1 = new Item("sensitive data 1");
-        Item item2 = new Item("sensitive data 2");
+    private DataCommunicatorTest.MockUI ui;
+    private TreeGrid<Item> treeGrid;
 
-        UniqueKeyTreeGrid grid = new UniqueKeyTreeGrid();
-        String key1 = grid.getUniqueKeyProvider().apply(item1);
-        Assert.assertEquals("0", key1);
+    @Before
+    public void init() {
+        Item item1 = new Item("key 1");
+        Item item2 = new Item("key 2");
+        treeGrid = new TreeGrid<>();
+        TreeData<Item> treeData = new TreeData<>();
+        treeData.addItem(null, item1);
+        treeData.addItem(null, item2);
+        HierarchicalDataProvider<Item, ?> treeDataProvider = new TreeDataProvider<>(
+                treeData);
+        treeGrid.setDataProvider(treeDataProvider);
 
-        String key2 = grid.getUniqueKeyProvider().apply(item2);
-        Assert.assertEquals("1", key2);
-
-        key1 = grid.getUniqueKeyProvider().apply(item1);
-        Assert.assertEquals("0", key1);
+        ui = new DataCommunicatorTest.MockUI();
+        ui.add(treeGrid);
     }
 
-    private static class UniqueKeyTreeGrid extends TreeGrid<Item> {
-        @Override
-        public ValueProvider<Item, String> getUniqueKeyProvider() {
-            return super.getUniqueKeyProvider();
-        }
+    @Test
+    public void uniqueKeyProviderNotSet_usesKeyMapper() {
+        fakeClientCommunication();
+
+        Assert.assertNotNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("1"));
+        Assert.assertNotNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("2"));
+        Assert.assertNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("3"));
+    }
+
+    @Test
+    public void uniqueKeyProviderSet_usesUniqueKeyProvider() {
+        treeGrid.setUniqueKeyProvider(Item::toString);
+        fakeClientCommunication();
+
+        Assert.assertNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("1"));
+        Assert.assertNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("2"));
+        Assert.assertNotNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("key 1"));
+        Assert.assertNotNull(
+                treeGrid.getDataCommunicator().getKeyMapper().get("key 2"));
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
     }
 
     private static class Item {
-        private final String sensitiveData;
+        private final String key;
 
-        public Item(String sensitiveData) {
-            this.sensitiveData = sensitiveData;
+        public Item(String key) {
+            this.key = key;
         }
 
-        public String getSensitiveData() {
-            return sensitiveData;
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public String toString() {
+            return key;
         }
     }
 


### PR DESCRIPTION
Cherry-pick of #3251 

(cherry picked from commit c5f9e8470a2115ed7d4e707a19511cc65602abe0)

Depends on https://github.com/vaadin/flow/pull/13883 to be cherry-picked, and released for 23.1, as well as all other target versions (23.0, 22.0, 14.8).