### PR TITLE
refactor: don't use Polymer API in the combo-box connector

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -204,17 +204,19 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
         comboBox.$connector.updateData = tryCatchWrapper(function (items) {
           const dataProviderMixin = getDataProviderMixin();
-          // IE11 doesn't work with the transpiled version of the forEach.
-          for (let i = 0; i < items.length; i++) {
-            let item = items[i];
 
-            for (let j = 0; j < dataProviderMixin.filteredItems.length; j++) {
-              if (dataProviderMixin.filteredItems[j].key === item.key) {
-                dataProviderMixin.set('filteredItems.' + j, item);
-                break;
-              }
+          const itemsMap = items.reduce((map, item) => {
+            map.set(item.key, item);
+            return map;
+          }, new Map());
+
+          dataProviderMixin.filteredItems = dataProviderMixin.filteredItems.map((item) => {
+            if (itemsMap.has(item.key)) {
+              return itemsMap.get(item.key);
             }
-          }
+
+            return item;
+          });
         });
 
         comboBox.$connector.updateSize = tryCatchWrapper(function (newSize) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -205,7 +205,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         comboBox.$connector.updateData = tryCatchWrapper(function (items) {
           const dataProviderMixin = getDataProviderMixin();
 
-          const itemsMap = new Map(items.map(item => [item.key, item]));
+          const itemsMap = new Map(items.map((item) => [item.key, item]));
 
           dataProviderMixin.filteredItems = dataProviderMixin.filteredItems.map((item) => {
             if (itemsMap.has(item.key)) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -208,11 +208,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           const itemsMap = new Map(items.map((item) => [item.key, item]));
 
           dataProviderMixin.filteredItems = dataProviderMixin.filteredItems.map((item) => {
-            if (itemsMap.has(item.key)) {
-              return itemsMap.get(item.key);
-            }
-
-            return item;
+            return itemsMap.get(item.key) || item;
           });
         });
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -205,10 +205,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         comboBox.$connector.updateData = tryCatchWrapper(function (items) {
           const dataProviderMixin = getDataProviderMixin();
 
-          const itemsMap = items.reduce((map, item) => {
-            map.set(item.key, item);
-            return map;
-          }, new Map());
+          const itemsMap = new Map(items.map(item => [item.key, item]));
 
           dataProviderMixin.filteredItems = dataProviderMixin.filteredItems.map((item) => {
             if (itemsMap.has(item.key)) {


### PR DESCRIPTION
## Description

The PR removes the use of Polymer API from the combo-box connector as a follow-up to https://github.com/vaadin/web-components/pull/4008

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
