### PR TITLE
refactor: allow setting value with var args

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -34,6 +34,8 @@ import elemental.json.JsonObject;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -300,6 +302,20 @@ public class MultiSelectComboBox<TItem>
             // actually changed
             super.setValue(value);
         }
+    }
+
+    /**
+     * Sets the value of the component, which is a set of selected items. As
+     * each item can only be selected once, duplicates in the provided items
+     * will be removed. Passing no items will result in an empty selection.
+     *
+     * @param items
+     *            the new value
+     */
+    @SafeVarargs
+    public final void setValue(TItem... items) {
+        Set<TItem> value = new LinkedHashSet<>(List.of(items));
+        setValue(value);
     }
 
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
@@ -67,7 +67,7 @@ public class MultiSelectComboBoxTest extends ComboBoxBaseTest {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
         comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
         comboBox.setValue(Set.of("foo", "bar"));
-        comboBox.setValue(null);
+        comboBox.setValue((Set<String>) null);
 
         // should hold an empty set, rather than null
         Assert.assertEquals(Collections.emptySet(), comboBox.getValue());
@@ -75,6 +75,66 @@ public class MultiSelectComboBoxTest extends ComboBoxBaseTest {
         JsonArray jsonArray = (JsonArray) comboBox.getElement()
                 .getPropertyRaw("selectedItems");
         Assert.assertEquals(0, jsonArray.length());
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void setValue_setSameValue_doesNotTriggerChangeEvent() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue(Set.of("foo", "bar"));
+
+        HasValue.ValueChangeListener valueChangeListenerMock = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        comboBox.addValueChangeListener(valueChangeListenerMock);
+        comboBox.setValue(Set.of("foo", "bar"));
+
+        Mockito.verify(valueChangeListenerMock, Mockito.times(0))
+                .valueChanged(Mockito.any());
+    }
+
+    @Test
+    public void setValueWithVarArgs() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue("foo", "bar");
+
+        Assert.assertEquals(Set.of("foo", "bar"), comboBox.getValue());
+    }
+
+    @Test
+    public void setValueWithVarArgs_removesDuplicates() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue("foo", "foo", "foo");
+
+        Assert.assertEquals(Set.of("foo"), comboBox.getValue());
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void setValueWithVarArgs_setSameValue_doesNotTriggerChangeEvent() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue("foo", "bar");
+
+        HasValue.ValueChangeListener valueChangeListenerMock = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        comboBox.addValueChangeListener(valueChangeListenerMock);
+        comboBox.setValue("foo", "bar");
+
+        Mockito.verify(valueChangeListenerMock, Mockito.times(0))
+                .valueChanged(Mockito.any());
+    }
+
+    @Test()
+    public void setValueWithEmptyVarArgs_emptySelection() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue("foo", "bar");
+        comboBox.setValue();
+
+        Assert.assertEquals(Collections.emptySet(), comboBox.getValue());
     }
 
     @Test


### PR DESCRIPTION
## Description

Allows setting the value / selection of the multi select combo box through a var args parameter. Should wait for #3275 to reuse the multi select model for identifying duplicates in the selection.

Part of https://github.com/vaadin/flow-components/issues/2948
