### PR TITLE
refactor: set data provider related properties on the host element

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringIT.java
@@ -53,6 +53,17 @@ public class MultiSelectComboBoxClientSideFilteringIT
     }
 
     @Test
+    public void inputMatchingFilter_filtersItems() {
+        comboBox.openPopup();
+        comboBox.sendKeys("Item 10");
+
+        List<String> options = comboBox.getOptions();
+        Assert.assertEquals(1, options.size());
+        Assert.assertTrue("Should display Item 10",
+                options.contains("Item 10"));
+    }
+
+    @Test
     public void setNonMatchingFilter_noItems() {
         comboBox.setFilter("Item XYZ");
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -79,7 +79,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], callback);
+              performClientSideFilter(cache[0], params.filter, callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -284,7 +284,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, callback);
+            performClientSideFilter(data, comboBox.filter, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -300,11 +300,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
           let filteredItems = page;
 
-          if (comboBox.filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
+          if (filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -79,7 +79,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], params.filter, callback);
+              performClientSideFilter(cache[0], callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -116,7 +116,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
           if (cache[params.page]) {
             // This may happen after skipping pages by scrolling fast
-            commitPage(params.page, params.filter, callback);
+            commitPage(params.page, callback);
           } else {
             pageCallbacks[params.page] = callback;
             const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
@@ -230,7 +230,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             let page = activePages[i];
 
             if (cache[page]) {
-              commitPage(page, filter, pageCallbacks[page]);
+              commitPage(page, pageCallbacks[page]);
             }
           }
 
@@ -280,11 +280,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           }
         });
 
-        const commitPage = tryCatchWrapper(function (page, filter, callback) {
+        const commitPage = tryCatchWrapper(function (page, callback) {
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, filter, callback);
+            performClientSideFilter(data, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -300,11 +300,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
           let filteredItems = page;
 
-          if (filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
+          if (comboBox.filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -79,7 +79,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], params.filter, callback);
+              performClientSideFilter(cache[0], callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -116,7 +116,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
           if (cache[params.page]) {
             // This may happen after skipping pages by scrolling fast
-            commitPage(params.page, comboBox.filter, callback);
+            commitPage(params.page, callback);
           } else {
             pageCallbacks[params.page] = callback;
             const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
@@ -230,7 +230,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             let page = activePages[i];
 
             if (cache[page]) {
-              commitPage(page, filter, pageCallbacks[page]);
+              commitPage(page, pageCallbacks[page]);
             }
           }
 
@@ -280,11 +280,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           }
         });
 
-        const commitPage = tryCatchWrapper(function (page, filter, callback) {
+        const commitPage = tryCatchWrapper(function (page, callback) {
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, filter, callback);
+            performClientSideFilter(data, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -300,11 +300,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
           let filteredItems = page;
 
-          if (filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
+          if (comboBox.filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -79,7 +79,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], callback);
+              performClientSideFilter(cache[0], params.filter, callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -116,7 +116,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
           if (cache[params.page]) {
             // This may happen after skipping pages by scrolling fast
-            commitPage(params.page, callback);
+            commitPage(params.page, params.filter, callback);
           } else {
             pageCallbacks[params.page] = callback;
             const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
@@ -230,7 +230,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             let page = activePages[i];
 
             if (cache[page]) {
-              commitPage(page, pageCallbacks[page]);
+              commitPage(page, filter, pageCallbacks[page]);
             }
           }
 
@@ -280,11 +280,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           }
         });
 
-        const commitPage = tryCatchWrapper(function (page, callback) {
+        const commitPage = tryCatchWrapper(function (page, filter, callback) {
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, callback);
+            performClientSideFilter(data, filter, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -300,11 +300,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
           let filteredItems = page;
 
-          if (comboBox.filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
+          if (filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -63,20 +63,19 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         })();
 
         const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
-          const dataProviderMixin = getDataProviderMixin();
           // Flush and empty the existing requests
           pages.forEach((page) => {
-            pageCallbacks[page]([], dataProviderMixin.size);
+            pageCallbacks[page]([], comboBox.size);
             delete pageCallbacks[page];
 
             // Empty the comboBox's internal cache without invoking observers by filling
             // the filteredItems array with placeholders (comboBox will request for data when it
             // encounters a placeholder)
-            const pageStart = parseInt(page) * dataProviderMixin.pageSize;
-            const pageEnd = pageStart + dataProviderMixin.pageSize;
-            const end = Math.min(pageEnd, dataProviderMixin.filteredItems.length);
+            const pageStart = parseInt(page) * comboBox.pageSize;
+            const pageEnd = pageStart + comboBox.pageSize;
+            const end = Math.min(pageEnd, comboBox.filteredItems.length);
             for (let i = pageStart; i < end; i++) {
-              dataProviderMixin.filteredItems[i] = placeHolder;
+              comboBox.filteredItems[i] = placeHolder;
             }
           });
         };
@@ -203,11 +202,9 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         });
 
         comboBox.$connector.updateData = tryCatchWrapper(function (items) {
-          const dataProviderMixin = getDataProviderMixin();
-
           const itemsMap = new Map(items.map((item) => [item.key, item]));
 
-          dataProviderMixin.filteredItems = dataProviderMixin.filteredItems.map((item) => {
+          comboBox.filteredItems = comboBox.filteredItems.map((item) => {
             return itemsMap.get(item.key) || item;
           });
         });
@@ -227,9 +224,9 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         });
 
         comboBox.$connector.reset = tryCatchWrapper(function () {
-          const dataProviderMixin = getDataProviderMixin();
           clearPageCallbacks();
           cache = {};
+          const dataProviderMixin = getDataProviderMixin();
           dataProviderMixin.clearCache();
         });
 
@@ -316,11 +313,10 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
         const performClientSideFilter = tryCatchWrapper(function (page, callback) {
-          const dataProviderMixin = getDataProviderMixin();
           let filteredItems = page;
 
-          if (dataProviderMixin.filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, dataProviderMixin.filter));
+          if (comboBox.filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -79,7 +79,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // filter based on comboBox.filter. While later we only filter clientside data.
 
             if (cache[0]) {
-              performClientSideFilter(cache[0], callback);
+              performClientSideFilter(cache[0], params.filter, callback);
               return;
             } else {
               // If client side filter is enabled then we need to first ask all data
@@ -116,7 +116,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
           if (cache[params.page]) {
             // This may happen after skipping pages by scrolling fast
-            commitPage(params.page, callback);
+            commitPage(params.page, comboBox.filter, callback);
           } else {
             pageCallbacks[params.page] = callback;
             const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
@@ -230,7 +230,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             let page = activePages[i];
 
             if (cache[page]) {
-              commitPage(page, pageCallbacks[page]);
+              commitPage(page, filter, pageCallbacks[page]);
             }
           }
 
@@ -280,11 +280,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
           }
         });
 
-        const commitPage = tryCatchWrapper(function (page, callback) {
+        const commitPage = tryCatchWrapper(function (page, filter, callback) {
           let data = cache[page];
 
           if (comboBox._clientSideFilter) {
-            performClientSideFilter(data, callback);
+            performClientSideFilter(data, filter, callback);
           } else {
             // Remove the data if server-side filtering, but keep it for client-side
             // filtering
@@ -300,11 +300,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         // and submitting the filtered items to specified callback.
         // The filter used is the one from combobox, not the lastFilter stored since
         // that may not reflect user's input.
-        const performClientSideFilter = tryCatchWrapper(function (page, callback) {
+        const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
           let filteredItems = page;
 
-          if (comboBox.filter) {
-            filteredItems = page.filter((item) => comboBox.$connector.filter(item, comboBox.filter));
+          if (filter) {
+            filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
           }
 
           callback(filteredItems, filteredItems.length);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -17,17 +17,6 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
 
         comboBox.$connector = {};
 
-        /**
-         * Returns the element that implements the data provider mixin.
-         * For <vaadin-combo-box> that is the element itself.
-         * <vaadin-multi-select-combo-box> wraps a regular combo box internally,
-         * which is returned in this case.
-         * @returns {Node|Element|*}
-         */
-        function getDataProviderMixin() {
-          return comboBox.localName === 'vaadin-multi-select-combo-box' ? comboBox.$.comboBox : comboBox;
-        }
-
         // holds pageIndex -> callback pairs of subsequent indexes (current active range)
         const pageCallbacks = {};
         let cache = {};
@@ -226,8 +215,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         comboBox.$connector.reset = tryCatchWrapper(function () {
           clearPageCallbacks();
           cache = {};
-          const dataProviderMixin = getDataProviderMixin();
-          dataProviderMixin.clearCache();
+          comboBox.clearCache();
         });
 
         comboBox.$connector.confirm = tryCatchWrapper(function (id, filter) {


### PR DESCRIPTION
## Description

Pretty much all the properties related to data provider are available directly on the host combo-box / multi-select-combo-box element so there seems to be no reason for setting them through internal elements bypassing the host element. 

~~The only case when accessing internal elements is reasonable is when calling data provider methods such as `clearCache()`.~~ UPD: The multi-select-combo-box's host element already provides `clearCache()`.

Related to https://github.com/vaadin/web-components/pull/4019#pullrequestreview-1001168796

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
