### PR TITLE
fix: informative exception thrown if grid row index is out of bounds #3111

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -181,9 +181,15 @@ public class GridElement extends TestBenchElement {
      *
      * @param rowIndex
      *            the row index
+     * @throws IndexOutOfBoundsException
+     *            if no row with given index exists
      * @return the tr element for the row
      */
-    public GridTRElement getRow(int rowIndex) {
+    public GridTRElement getRow(int rowIndex) throws IndexOutOfBoundsException {
+        int rowCount = getRowCount();
+        if (rowIndex < 0 || rowIndex >= rowCount) {
+            throw new IndexOutOfBoundsException("rowIndex: expected to be 0.." + (rowCount - 1) + " but was " + rowIndex);
+        }
         String script = "var grid = arguments[0];"
                 + "var rowIndex = arguments[1];"
                 + "var rowsInDom = grid.$.items.children;"

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -296,7 +296,7 @@ public class TreeGridElement extends GridElement {
     public boolean hasRow(int row) {
         try {
             return getRow(row) != null;
-        } catch (NullPointerException e) {
+        } catch (Exception e) {
             return false;
         }
     }


### PR DESCRIPTION
Calling GridElement.getRow(0) for an empty grid caused a NPE. The issue was also present when calling GridElement.getRow(int index) for any index that was out of the current range of row indexes.

This issue is a TestBench issue, therefore the impact is low.

This change introduces an index validation before trying to get the relevant row. If the input index is not within the current range of grid row indexes, an IndexOutOfBoundsException is thrown with a message that also specifies the expected index range. 
Since GridElement.getRow(int index) now can throw an IndexOutOfBoundsException for invalid index, this change was also reflected onto TreeGridElement.hasRow(int row). The logic in that method depended on the assumption that if there is no row, the method GridElement.getRow(int index) will throw a NPE. With this change, it was changed to Exception in order to account for the new exception.

Fixes #3111