### PR TITLE
fix: only use first column with no multi-sorting

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSortingPage.java
@@ -43,8 +43,10 @@ public class GridViewSortingPage extends LegacyTestView {
         grid.setItems(getItems());
         grid.setSelectionMode(SelectionMode.NONE);
 
-        grid.addColumn(Person::getFirstName, "firstName").setHeader("Name");
-        grid.addColumn(Person::getAge, "age").setHeader("Age");
+        Grid.Column<Person> nameColumn = grid
+                .addColumn(Person::getFirstName, "firstName").setHeader("Name");
+        Grid.Column<Person> ageColumn = grid.addColumn(Person::getAge, "age")
+                .setHeader("Age");
 
         Comparator<Person> addressComparator = Comparator
                 .comparing((Person person) -> person.getAddress().getNumber())
@@ -102,14 +104,21 @@ public class GridViewSortingPage extends LegacyTestView {
                     grid.sort(null);
                 });
 
+        NativeButton sortByTwoColumns = new NativeButton("Sort by 2 columns",
+                event -> {
+                    grid.sort(GridSortOrder.asc(ageColumn).thenDesc(nameColumn)
+                            .build());
+                });
+
         grid.setId("grid-sortable-columns");
         multiSort.setId("grid-multi-sort-toggle");
         invertAllSortings.setId("grid-sortable-columns-invert-sortings");
         resetAllSortings.setId("grid-sortable-columns-reset-sortings");
         toggleFirstColumnAndReset.setId("grid-sortable-columns-toggle-first");
+        sortByTwoColumns.setId("grid-sortable-columns-sort-by-two");
         messageDiv.setId("grid-sortable-columns-message");
         addCard("Sorting", "Grid with sortable columns", grid, multiSort,
                 invertAllSortings, resetAllSortings, toggleFirstColumnAndReset,
-                messageDiv);
+                sortByTwoColumns, messageDiv);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -138,6 +138,31 @@ public class GridViewSortingIT extends AbstractComponentIT {
         Assert.assertEquals(null, sorter.getAttribute("direction"));
     }
 
+    @Test
+    public void gridWithSorting_noMultiSort_secondSortColumnIgnored() {
+        GridElement grid = $(GridElement.class).id("grid-sortable-columns");
+        scrollToElement(grid);
+
+        WebElement sortByTwoColumnsButton = findElement(
+                By.id("grid-sortable-columns-sort-by-two"));
+        WebElement resetButton = findElement(
+                By.id("grid-sortable-columns-reset-sortings"));
+
+        clickElementWithJs(sortByTwoColumnsButton);
+
+        assertSortMessageEquals(QuerySortOrder.asc("age").build(), false);
+
+        clickElementWithJs(resetButton);
+
+        // enable multi sort
+        clickElementWithJs(findElement(By.id("grid-multi-sort-toggle")));
+
+        clickElementWithJs(sortByTwoColumnsButton);
+
+        assertSortMessageEquals(
+                QuerySortOrder.asc("age").thenDesc("firstName").build(), false);
+    }
+
     private void assertSortMessageEquals(List<QuerySortOrder> querySortOrders,
             boolean fromClient) {
         String sortOrdersString = querySortOrders.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3250,6 +3250,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             order = Collections.emptyList();
         }
         if (!isMultiSort() && order.size() > 1) {
+            LoggerFactory.getLogger(Grid.class).warn(
+                    "Multiple sort columns provided but multi-sorting is not enabled.");
             order = order.subList(0, 1);
         }
         setSortOrder(order, false);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3235,6 +3235,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * For Grids with multi-sorting, the index of a given column inside the list
      * defines the sort priority. For example, the column at index 0 of the list
      * is sorted first, then on the index 1, and so on.
+     * <p>
+     * When Grid is not configured to have multi-sorting enabled, all the
+     * columns in the list except the first one are ignored.
      *
      * @param order
      *            the list of sort orders to set on the client, or
@@ -3245,6 +3248,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void sort(List<GridSortOrder<T>> order) {
         if (order == null) {
             order = Collections.emptyList();
+        }
+        if (!isMultiSort() && order.size() > 1) {
+            order = order.subList(0, 1);
         }
         setSortOrder(order, false);
     }


### PR DESCRIPTION
## Description

This PR addresses the bug reported in https://github.com/vaadin/flow-components/issues/3155#issuecomment-1122477130:

> when clicking the button, the grid sorts by multiple columns, even though multi-sort is not enabled. 

Closes #3155

## Type of change

- Bugfix