### PR TITLE
fix: ignore empty values in resize arrays

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -539,6 +539,10 @@ public abstract class AbstractSpreadsheetIT extends AbstractParallelTest {
         });
     }
 
+    protected void checkLogsForErrors() {
+        checkLogsForErrors(msg -> false);
+    }
+
     protected List<LogEntry> getLogEntries(Level level) {
         // https://github.com/vaadin/testbench/issues/1233
         getCommandExecutor().waitForVaadin();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ResizeIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ResizeIT.java
@@ -31,6 +31,8 @@ public class ResizeIT extends AbstractSpreadsheetIT {
         double newWidth = getSize(getCellStyle("C1", "width"));
 
         assertInRange(2.5 * originalWidth, newWidth, 3.5 * originalWidth);
+
+        checkLogsForErrors();
     }
 
     @Test
@@ -50,6 +52,8 @@ public class ResizeIT extends AbstractSpreadsheetIT {
         double newHeight = getSize(getCellStyle("A3", "height"));
 
         assertInRange(2.3 * originalHeight, newHeight, 3.5 * originalHeight);
+
+        checkLogsForErrors();
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetEventListener.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetEventListener.java
@@ -34,10 +34,6 @@ public class SpreadsheetEventListener
         return o == null ? null : o.getBoolean(pos);
     }
 
-    private double toNumber(JsonValue v) {
-        return (v instanceof JsonNumber) ? ((JsonNumber) v).asNumber() : 0;
-    }
-
     private HashMap<Integer, Float> toMapFloat(JsonArray o, int pos) {
         HashMap<Integer, Float> m = new HashMap<>();
         if (o == null) {
@@ -45,7 +41,10 @@ public class SpreadsheetEventListener
         }
         JsonArray jso = o.getArray(pos);
         for (int i = 0; i < jso.length(); i++) {
-            m.put(i, (float) toNumber(jso.get(i)));
+            JsonValue value = jso.get(i);
+            if (value instanceof JsonNumber) {
+                m.put(i, (float) value.asNumber());
+            }
         }
         return m;
     }
@@ -57,7 +56,10 @@ public class SpreadsheetEventListener
         }
         JsonArray jso = o.getArray(pos);
         for (int i = 0; i < jso.length(); i++) {
-            m.put(i, (int) toNumber(jso.get(i)));
+            JsonValue value = jso.get(i);
+            if (value instanceof JsonNumber) {
+                m.put(i, (int) value.asNumber());
+            }
         }
         return m;
     }


### PR DESCRIPTION
Fixes #3329 

Fixes an issue in `toMapInt`/`toMapFloat` helpers where empty / `null` values got accidentally translated as `0`. This caused exceptions with column and row resize events.

before:
```js
// Given array of values
[,,100]

->

// Resulting Map
{
 0: 0,
 1: 0,
 2: 100
}
```

after:
```js
// Given array of values
[,,100]

->

// Resulting Map
{
 2: 100
}
```
