### PR TITLE
 fix: cleanup orphan sorters after reordering columns

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSortingPage.java
@@ -53,14 +53,15 @@ public class GridViewSortingPage extends LegacyTestView {
                 .thenComparing(
                         (Person person) -> person.getAddress().getNumber());
 
-        grid.addColumn(LitRenderer.<Person> of(
-                "<div>${item.street}, number ${item.number}<br><small>${item.postalCode}</small></div>")
-                .withProperty("street",
-                        person -> person.getAddress().getStreet())
-                .withProperty("number",
-                        person -> person.getAddress().getNumber())
-                .withProperty("postalCode",
-                        person -> person.getAddress().getPostalCode()))
+        Grid.Column<Person> addressColumn = grid
+                .addColumn(LitRenderer.<Person> of(
+                        "<div>${item.street}, number ${item.number}<br><small>${item.postalCode}</small></div>")
+                        .withProperty("street",
+                                person -> person.getAddress().getStreet())
+                        .withProperty("number",
+                                person -> person.getAddress().getNumber())
+                        .withProperty("postalCode",
+                                person -> person.getAddress().getPostalCode()))
                 .setSortProperty("street", "number")
                 .setComparator(addressComparator).setHeader("Address");
 
@@ -110,15 +111,21 @@ public class GridViewSortingPage extends LegacyTestView {
                             .build());
                 });
 
+        NativeButton setColumnOrder = new NativeButton("Set column order",
+                click -> {
+                    grid.setColumnOrder(ageColumn, nameColumn, addressColumn);
+                });
+
         grid.setId("grid-sortable-columns");
         multiSort.setId("grid-multi-sort-toggle");
         invertAllSortings.setId("grid-sortable-columns-invert-sortings");
         resetAllSortings.setId("grid-sortable-columns-reset-sortings");
         toggleFirstColumnAndReset.setId("grid-sortable-columns-toggle-first");
         sortByTwoColumns.setId("grid-sortable-columns-sort-by-two");
+        setColumnOrder.setId("grid-sortable-columns-set-order");
         messageDiv.setId("grid-sortable-columns-message");
         addCard("Sorting", "Grid with sortable columns", grid, multiSort,
                 invertAllSortings, resetAllSortings, toggleFirstColumnAndReset,
-                sortByTwoColumns, messageDiv);
+                sortByTwoColumns, setColumnOrder, messageDiv);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -163,6 +163,29 @@ public class GridViewSortingIT extends AbstractComponentIT {
                 QuerySortOrder.asc("age").thenDesc("firstName").build(), false);
     }
 
+    @Test
+    public void gridWithSorting_columnOrderSetTwice_sorterSizeDoesNotGrow() {
+        GridElement grid = $(GridElement.class).id("grid-sortable-columns");
+        scrollToElement(grid);
+
+        WebElement setColumnOrderButton = findElement(
+                By.id("grid-sortable-columns-set-order"));
+
+        // enable multi sort
+        clickElementWithJs(findElement(By.id("grid-multi-sort-toggle")));
+
+        getCellContent(grid.getHeaderCell(0)).click();
+
+        clickElementWithJs(setColumnOrderButton);
+
+        clickElementWithJs(setColumnOrderButton);
+
+        getCellContent(grid.getHeaderCell(0)).click();
+
+        assertSortMessageEquals(
+                QuerySortOrder.asc("age").thenAsc("firstName").build(), true);
+    }
+
     private void assertSortMessageEquals(List<QuerySortOrder> querySortOrders,
             boolean fromClient) {
         String sortOrdersString = querySortOrders.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -441,10 +441,14 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               try {
                 const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
-                // Sorters for hidden columns are removed from DOM but stored in the web component.
-                // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
-                grid._sorters.forEach((sorter) => {
-                  if (!sorters.includes(sorter)) {
+                grid._sorters.forEach((sorter, idx) => {
+                  if (!sorter.parentNode) {
+                    // When setting column order so that the columns are re-attached but their order
+                    // remains the same, orphan sorters are not being removed, so we need to cleanup.
+                    grid._sorters.splice(idx, 1);
+                  } else if (!sorters.includes(sorter)) {
+                    // Sorters for hidden columns are removed from DOM but stored in the web component.
+                    // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
                     sorters.push(sorter);
                   }
                 });


### PR DESCRIPTION
## Description

This PR fixes the edge case that occurs when you set the same column order twice in a row.
See https://github.com/vaadin/flow-components/issues/2102#issuecomment-1154860141 for an overview of the issue.

In short, when we detach and immediately re-attach columns so that they end up in the DOM order as before, the  `MutationObserver` for children is not triggered, and the `grid._sorters` array is not cleaned properly.

UPD: this PR was originally about not setting the same column order twice, but that would break the valid behavior (restore the correct order on the server after reordering on the client). So I ended up with the connector refactoring instead.

Closes #2102

## Type of change

- Bugfix