### PR TITLE
Revert "refactor: reassign filteredItems instead of mutating them"

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -65,9 +65,6 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
           const dataProviderMixin = getDataProviderMixin();
           // Flush and empty the existing requests
-
-          const filteredItems = [...dataProviderMixin.filteredItems];
-
           pages.forEach((page) => {
             pageCallbacks[page]([], dataProviderMixin.size);
             delete pageCallbacks[page];
@@ -77,13 +74,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             // encounters a placeholder)
             const pageStart = parseInt(page) * dataProviderMixin.pageSize;
             const pageEnd = pageStart + dataProviderMixin.pageSize;
-            const end = Math.min(pageEnd, filteredItems.length);
+            const end = Math.min(pageEnd, dataProviderMixin.filteredItems.length);
             for (let i = pageStart; i < end; i++) {
-              filteredItems[i] = placeHolder;
+              dataProviderMixin.filteredItems[i] = placeHolder;
             }
           });
-
-          dataProviderMixin.filteredItems = filteredItems;
         };
 
         comboBox.dataProvider = function (params, callback) {


### PR DESCRIPTION
## Description

This PR reverts https://github.com/vaadin/flow-components/pull/3327 because it turns out that the use of a mutation way of changing `filteredItems` was intentional and aimed to prevent Polymer from invoking observers.

## Type of change

- [x] Revert

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
