### PR TITLE
Add readonly attribute for radio buttons on radio button group

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -696,6 +696,7 @@ public class RadioButtonGroup<T>
             // Mark non-checked radio buttons in a readonly group as disabled.
             disabled = true;
         }
+        button.getElement().setAttribute("readonly", this.isReadOnly());
 
         button.setEnabled(!disabled);
         button.setDisabled(disabled);


### PR DESCRIPTION
## Description

If the radio button group is readonly, the style of the checked item could not be changed. This change adds an attribute (readonly) to the radio buttons, if the radio button group is readonly. 

Fixes # 3359

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
