### PR TITLE
docs: deprecate setPreventInvalidInput API

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -256,7 +256,10 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     /**
      * Whether the component should block user input that does not match the
      * configured pattern
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     public boolean isPreventInvalidInput() {
         return getElement().getProperty("preventInvalidInput", false);
     }
@@ -264,7 +267,11 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     /**
      * Sets whether the component should block user input that does not match
      * the configured pattern
+     *
+     * @deprecated Since 23.2, this API is deprecated in favor of
+     * {@code setAllowedCharPattern(charPattern)}
      */
+    @Deprecated
     public void setPreventInvalidInput(boolean preventInvalidInput) {
         getElement().setProperty("preventInvalidInput", preventInvalidInput);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -269,7 +269,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * the configured pattern
      *
      * @deprecated Since 23.2, this API is deprecated in favor of
-     * {@code setAllowedCharPattern(charPattern)}
+     *             {@code setAllowedCharPattern(charPattern)}
      */
     @Deprecated
     public void setPreventInvalidInput(boolean preventInvalidInput) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -269,7 +269,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * the configured pattern
      *
      * @deprecated Since 23.2, this API is deprecated in favor of
-     *             {@code setAllowedCharPattern(charPattern)}
+     *             {@link #setAllowedCharPattern(String)}
      */
     @Deprecated
     public void setPreventInvalidInput(boolean preventInvalidInput) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -309,11 +309,19 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
      * conflicts with the given {@code pattern}.
      *
      * @return the {@code preventInvalidInput} property from the webcomponent
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     public boolean isPreventInvalidInput() {
         return isPreventInvalidInputBoolean();
     }
 
+    /**
+     * @deprecated Since 23.2, this API is deprecated in favor of
+     * {@code setAllowedCharPattern(charPattern)}
+     */
+    @Deprecated
     @Override
     public void setPreventInvalidInput(boolean preventInvalidInput) {
         super.setPreventInvalidInput(preventInvalidInput);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -319,7 +319,7 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     *             {@code setAllowedCharPattern(charPattern)}
+     *             {@link #setAllowedCharPattern(String)}
      */
     @Deprecated
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -319,7 +319,7 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     * {@code setAllowedCharPattern(charPattern)}
+     *             {@code setAllowedCharPattern(charPattern)}
      */
     @Deprecated
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -674,7 +674,10 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * </p>
      *
      * @return the {@code preventInvalidInput} property from the webcomponent
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     protected boolean isPreventInvalidInputBoolean() {
         return getElement().getProperty("preventInvalidInput", false);
     }
@@ -690,7 +693,10 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @param preventInvalidInput
      *            the boolean value to set
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     protected void setPreventInvalidInput(boolean preventInvalidInput) {
         getElement().setProperty("preventInvalidInput", preventInvalidInput);
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -699,7 +699,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code preventInvalidInput} property from the webcomponent
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     protected boolean isPreventInvalidInputBoolean() {
         return getElement().getProperty("preventInvalidInput", false);
     }
@@ -716,7 +719,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param preventInvalidInput
      *            the boolean value to set
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     protected void setPreventInvalidInput(boolean preventInvalidInput) {
         getElement().setProperty("preventInvalidInput", preventInvalidInput);
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -340,7 +340,7 @@ public class PasswordField
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     *             {@code setAllowedCharPattern(charPattern)}
+     *             {@link #setAllowedCharPattern(String)}
      */
     @Deprecated
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -330,11 +330,19 @@ public class PasswordField
      * conflicts with the given {@code pattern}.
      *
      * @return the {@code preventInvalidInput} property from the webcomponent
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     public boolean isPreventInvalidInput() {
         return isPreventInvalidInputBoolean();
     }
 
+    /**
+     * @deprecated Since 23.2, this API is deprecated in favor of
+     * {@code setAllowedCharPattern(charPattern)}
+     */
+    @Deprecated
     @Override
     public void setPreventInvalidInput(boolean preventInvalidInput) {
         super.setPreventInvalidInput(preventInvalidInput);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -340,7 +340,7 @@ public class PasswordField
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     * {@code setAllowedCharPattern(charPattern)}
+     *             {@code setAllowedCharPattern(charPattern)}
      */
     @Deprecated
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -382,7 +382,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     *             {@code setAllowedCharPattern(charPattern)}
+     *             {@link #setAllowedCharPattern(String)}
      */
     @Override
     public void setPreventInvalidInput(boolean preventInvalidInput) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -382,7 +382,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     * {@code setAllowedCharPattern(charPattern)}
+     *             {@code setAllowedCharPattern(charPattern)}
      */
     @Override
     public void setPreventInvalidInput(boolean preventInvalidInput) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -372,11 +372,18 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
      * conflicts with the given {@code pattern}.
      *
      * @return the {@code preventInvalidInput} property from the webcomponent
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     public boolean isPreventInvalidInput() {
         return isPreventInvalidInputBoolean();
     }
 
+    /**
+     * @deprecated Since 23.2, this API is deprecated in favor of
+     * {@code setAllowedCharPattern(charPattern)}
+     */
     @Override
     public void setPreventInvalidInput(boolean preventInvalidInput) {
         super.setPreventInvalidInput(preventInvalidInput);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -391,7 +391,7 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     * {@code setAllowedCharPattern(charPattern)}
+     *             {@code setAllowedCharPattern(charPattern)}
      */
     @Deprecated
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -391,7 +391,7 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
 
     /**
      * @deprecated Since 23.2, this API is deprecated in favor of
-     *             {@code setAllowedCharPattern(charPattern)}
+     *             {@link #setAllowedCharPattern(String)}
      */
     @Deprecated
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -381,11 +381,19 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
      * conflicts with the given {@code pattern}.
      *
      * @return the {@code preventInvalidInput} property from the webcomponent
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
+    @Deprecated
     public boolean isPreventInvalidInput() {
         return isPreventInvalidInputBoolean();
     }
 
+    /**
+     * @deprecated Since 23.2, this API is deprecated in favor of
+     * {@code setAllowedCharPattern(charPattern)}
+     */
+    @Deprecated
     @Override
     public void setPreventInvalidInput(boolean preventInvalidInput) {
         super.setPreventInvalidInput(preventInvalidInput);


### PR DESCRIPTION
## Description

This PR deprecates the `setPreventInvalidInpit()` API in favor of the newly added `setAllowedCharPattern()`.

Note: in `NumberField`, corresponding methods were already deprecated as not supported by web component.

Closes https://github.com/vaadin/web-components/issues/3837

## Type of change

-  Docs