### PR TITLE
refactor: pass column ID to before open event detail

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1034,20 +1034,11 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             );
         };
 
-        const contextMenuListener = function (e) {
-          // For `contextmenu` events, we need to access the source event,
-          // when using open on click we just use the click event itself
-          const sourceEvent = e.detail.sourceEvent || e;
-          const eventContext = grid.getEventContext(sourceEvent);
-          const key = eventContext.item && eventContext.item.key;
-          const colId = eventContext.column && eventContext.column.id;
-          grid.$server.updateContextMenuTargetItem(key, colId);
-        };
-
         grid.addEventListener(
           'vaadin-context-menu-before-open',
           tryCatchWrapper(function (e) {
-            contextMenuListener(grid.$contextMenuTargetConnector.openEvent);
+            const { key, columnId } = e.detail;
+            grid.$server.updateContextMenuTargetItem(key, columnId);
           })
         );
 
@@ -1056,9 +1047,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           // when using open on click we just use the click event itself
           const sourceEvent = event.detail.sourceEvent || event;
           const eventContext = grid.getEventContext(sourceEvent);
-          return {
-            key: (eventContext.item && eventContext.item.key) || ''
-          };
+          const key = (eventContext.item && eventContext.item.key) || '';
+          const columnId = (eventContext.column && eventContext.column.id) || '';
+          return { key, columnId };
         });
 
         grid.addEventListener(


### PR DESCRIPTION
## Description

Updated Grid connector to only use `grid.getEventContext()` once before opening context-menu, and get `column.id` there.
This adds `columnId` property to `vaadin-context-menu-before-open` event detail so that we can use it on the server.

https://github.com/vaadin/flow-components/blob/9ceb6c2c80486153c70850d217741d3065cf38fa/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js#L18-L26

Related to #2258

Pre-requisite for #1939

## Type of change

- Refactor