### PR TITLE
feat: add column to GridContextMenu#dynamicContentHandler

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
@@ -39,7 +39,7 @@ public class DynamicContextMenuGridPage extends Div {
 
         GridContextMenu<Person> contextMenu = grid.addContextMenu();
 
-        contextMenu.setDynamicContentHandler(person -> {
+        contextMenu.setDynamicContentHandler((person, column) -> {
             if (person == null || person.getAge() < 30) {
                 // do not open the context menu
                 return false;
@@ -47,6 +47,7 @@ public class DynamicContextMenuGridPage extends Div {
 
             contextMenu.removeAll();
             contextMenu.addItem(person.getFirstName());
+            contextMenu.addItem(column.getId().get());
             return true;
         });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridIT.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.interactions.Actions;
 public class DynamicContextMenuGridIT extends AbstractComponentIT {
 
     private static final String OVERLAY_TAG = "vaadin-context-menu-overlay";
+    private static final String ITEM_TAG = "vaadin-context-menu-item";
 
     private GridElement grid;
 
@@ -53,7 +54,27 @@ public class DynamicContextMenuGridIT extends AbstractComponentIT {
         verifyOpened();
 
         Assert.assertEquals("Person 40",
-                $(OVERLAY_TAG).first().getAttribute("innerText"));
+                $(ITEM_TAG).first().getAttribute("innerText"));
+
+        $("body").first().click();
+        verifyClosed();
+    }
+
+    @Test
+    public void shouldProvideColumnIdArgument() {
+        grid.getCell(40, 0).contextClick();
+        verifyOpened();
+
+        Assert.assertEquals("Name-Id",
+                $(ITEM_TAG).all().get(1).getAttribute("innerText"));
+
+        $("body").first().click();
+        verifyClosed();
+
+        grid.getCell(40, 1).contextClick();
+        verifyOpened();
+        Assert.assertEquals("Born-Id",
+                $(ITEM_TAG).all().get(1).getAttribute("innerText"));
 
         $("body").first().click();
         verifyClosed();
@@ -74,7 +95,7 @@ public class DynamicContextMenuGridIT extends AbstractComponentIT {
 
         verifyOpened();
         Assert.assertEquals("Person 40",
-                $(OVERLAY_TAG).first().getAttribute("innerText"));
+                $(ITEM_TAG).first().getAttribute("innerText"));
     }
 
     private void verifyOpened() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
@@ -288,7 +288,7 @@ public class GridContextMenu<T> extends
             final T item = grid.getDataCommunicator().getKeyMapper().get(key);
             final Grid.Column<T> column = grid.getColumns().stream()
                     .filter(col -> columnId.equals(col.getId().get()))
-                    .findFirst().get();
+                    .findFirst().orElse(null);
             return getDynamicContentHandler().test(item, column);
         }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1034,20 +1034,11 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             );
         };
 
-        const contextMenuListener = function (e) {
-          // For `contextmenu` events, we need to access the source event,
-          // when using open on click we just use the click event itself
-          const sourceEvent = e.detail.sourceEvent || e;
-          const eventContext = grid.getEventContext(sourceEvent);
-          const key = eventContext.item && eventContext.item.key;
-          const colId = eventContext.column && eventContext.column.id;
-          grid.$server.updateContextMenuTargetItem(key, colId);
-        };
-
         grid.addEventListener(
           'vaadin-context-menu-before-open',
           tryCatchWrapper(function (e) {
-            contextMenuListener(grid.$contextMenuTargetConnector.openEvent);
+            const { key, columnId } = e.detail;
+            grid.$server.updateContextMenuTargetItem(key, columnId);
           })
         );
 
@@ -1056,9 +1047,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           // when using open on click we just use the click event itself
           const sourceEvent = event.detail.sourceEvent || event;
           const eventContext = grid.getEventContext(sourceEvent);
-          return {
-            key: (eventContext.item && eventContext.item.key) || ''
-          };
+          const key = (eventContext.item && eventContext.item.key) || '';
+          const columnId = (eventContext.column && eventContext.column.id) || '';
+          return { key, columnId };
         });
 
         grid.addEventListener(


### PR DESCRIPTION
## Description

WIP, depends on #3385 and needs to be rebased once that PR is merged.

Fixes #1939
Closes #2258

## Clarification

The implementation is based on #425 and is based on `column.id` that we also use in `GridContextMenuOpenedEvent`.

Ideally, to make it aligned with the other Grid events, we should use `column._flowId` instead, e.g. like this:

https://github.com/vaadin/flow-components/blob/30abd294a99e798b59e655f4b833e990ffca2dd6/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnResizeEvent.java#L64-L67

Unfortunately, it's not possible to use `column.getInternalId()` as it's protected and not available in `GridContextMenu`.

## Type of change

- Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
