### PR TITLE
fix: make AbstractGridSingleSelectionModel.isSelected use data provider identity

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModel.java
@@ -60,7 +60,7 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
 
     @Override
     public void selectFromClient(T item) {
-        if (Objects.equals(getItemId(item), getItemId(selectedItem))) {
+        if (isSelected(item)) {
             return;
         }
         doSelect(item, true);
@@ -68,7 +68,7 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
 
     @Override
     public void select(T item) {
-        if (Objects.equals(getItemId(item), getItemId(selectedItem))) {
+        if (isSelected(item)) {
             return;
         }
         doSelect(item, false);
@@ -91,6 +91,11 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
         if (isSelected(item)) {
             select(null);
         }
+    }
+
+    @Override
+    public boolean isSelected(T item) {
+        return Objects.equals(getItemId(item), getItemId(selectedItem));
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModelTest.java
@@ -91,9 +91,22 @@ public class AbstractGridSingleSelectionModelTest {
         Assert.assertEquals(0, selectionModel.getSelectedItems().size());
     }
 
+    @Test
+    public void isSelected_usesDataProviderIdentify() {
+        grid.setItems(dataProviderWithIdentityProvider);
+        GridSelectionModel<TestEntity> selectionModel = grid
+                .getSelectionModel();
+        // Select item
+        selectionModel.select(new TestEntity(1, "joseph"));
+        // Item with same ID, but different hash code should be reported as
+        // selected
+        Assert.assertTrue(
+                selectionModel.isSelected(new TestEntity(1, "Joseph")));
+    }
+
     public static class TestEntity {
-        private final int id;
-        private final String name;
+        private int id;
+        private String name;
 
         public TestEntity(int id, String name) {
             this.id = id;
@@ -104,8 +117,16 @@ public class AbstractGridSingleSelectionModelTest {
             return id;
         }
 
+        public void setId(int id) {
+            this.id = id;
+        }
+
         public String getName() {
             return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
 
         // equals and hashCode are intentionally implemented differently from


### PR DESCRIPTION
## Description

Override `isSelected` in `AbstractGridSingleSelectionModel` to use a custom implementation that uses the data provider identity for comparing the selected item.

This is kind of a follow-up of https://github.com/vaadin/flow-components/pull/2357, where we only covered the `select` and `selectFromClient` methods. Targeting the same versions that contain the previous fix.

Fixes #3384

## Type of change

- Bugfix