### PR TITLE
refactor: Use KeyMapper by default to generate unique keys (#3251) (CP: 14.8)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1370,8 +1370,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 .getUniqueKeyProperty();
         if (uniqueKeyPropertyName != null
                 && !jsonObject.hasKey(uniqueKeyPropertyName)) {
-            jsonObject.put(uniqueKeyPropertyName,
-                    getUniqueKeyProvider().apply(item));
+            jsonObject.put(uniqueKeyPropertyName, getUniqueKey(item));
         }
     }
 
@@ -4073,5 +4072,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     public NestedNullBehavior getNestedNullBehavior() {
         return nestedNullBehavior;
+    }
+
+    private String getUniqueKey(T item) {
+        return Optional.ofNullable(getUniqueKeyProvider())
+                .map(provider -> provider.apply(item))
+                .orElse(getDataCommunicator().getKeyMapper().key(item));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -18,13 +18,9 @@ package com.vaadin.flow.component.treegrid;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -141,13 +137,6 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
-    private final AtomicLong uniqueKeyCounter = new AtomicLong(0);
-    private final Map<Object, Long> objectUniqueKeyMap = new HashMap<>();
-
-    ValueProvider<T, String> defaultUniqueKeyProvider = item -> String.valueOf(
-            objectUniqueKeyMap.computeIfAbsent(getDataProvider().getId(item),
-                    key -> uniqueKeyCounter.getAndIncrement()));
-
     private Registration dataProviderRegistration;
 
     /**
@@ -241,17 +230,6 @@ public class TreeGrid<T> extends Grid<T>
         setUniqueKeyProvider(uniqueKeyProvider);
 
         getDataProvider().refreshAll();
-    }
-
-    /**
-     * Gets value provider for unique key in row's generated JSON.
-     *
-     * @return ValueProvider for unique key for row
-     */
-    @Override
-    protected ValueProvider<T, String> getUniqueKeyProvider() {
-        return Optional.ofNullable(super.getUniqueKeyProvider())
-                .orElse(defaultUniqueKeyProvider);
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of #3251

Solved a minor conflict in `Grid` and updated `TreeGridTest` to use a custom `MockUI` (added as part of a previous PR), as `DataCommunicator.MockUI` does not exist in 14.8.