### PR TITLE
chore: add generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ node_modules
 .driver
 package*json
 pnpm*
+.npmrc
+.pnpmfile.cjs
 error-screenshots
 
 **/frontend/generated


### PR DESCRIPTION
## Description

This adds generated files created when running ITs to `.gitignore`. Example:

```
vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/.npmrc
vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/.pnpmfile.cjs
```

## Type of change

- Internal change