### PR TITLE
feat: add removeAll functionality for dialog header and footers 

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterPage.java
@@ -44,6 +44,11 @@ public class DialogHeaderFooterPage extends Div {
                 e -> dialog.getHeader().remove(headerContent));
         removeHeaderContent.setId("remove-header-content-button");
 
+        NativeButton removeAllHeaderContents = new NativeButton(
+                "remove all header contents",
+                e -> dialog.getHeader().removeAll());
+        removeAllHeaderContents.setId("remove-all-header-contents-button");
+
         NativeButton addSecondHeaderContent = new NativeButton(
                 "add second header content",
                 e -> dialog.getHeader().add(new Span(ANOTHER_HEADER_CONTENT)));
@@ -59,6 +64,11 @@ public class DialogHeaderFooterPage extends Div {
                 e -> dialog.getFooter().remove(footerContent));
         removeFooterContent.setId("remove-footer-content-button");
 
+        NativeButton removeAllFooterContents = new NativeButton(
+                "remove all footer contents",
+                e -> dialog.getFooter().removeAll());
+        removeAllFooterContents.setId("remove-all-footer-contents-button");
+
         NativeButton addSecondFooterContent = new NativeButton(
                 "add second footer content",
                 e -> dialog.getFooter().add(new Span(ANOTHER_FOOTER_CONTENT)));
@@ -66,7 +76,8 @@ public class DialogHeaderFooterPage extends Div {
 
         Div buttonsContainer = new Div(openDialog, attachDialog, addHeaderTitle,
                 removeHeaderTitle, addHeaderContent, removeHeaderContent,
-                addSecondHeaderContent, addFooterContent, removeFooterContent,
+                removeAllHeaderContents, addSecondHeaderContent,
+                addFooterContent, removeFooterContent, removeAllFooterContents,
                 addSecondFooterContent);
 
         NativeButton moveButtons = new NativeButton("move buttons",

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -589,7 +589,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     }
 
     /**
-     * Class for adding and removing components to the header part of a dialog.
+     * Class for adding and removing components to the footer part of a dialog.
      */
     final public static class DialogFooter extends DialogHeaderFooter {
         private DialogFooter(Dialog dialog) {
@@ -733,7 +733,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         if (ui == null) {
             throw new IllegalStateException("UI instance is not available. "
                     + "It means that you are calling this method "
-                    + "out of a normal workflow where it's always implicitely set. "
+                    + "out of a normal workflow where it's always implicitly set. "
                     + "That may happen if you call the method from the custom thread without "
                     + "'UI::access' or from tests without proper initialization.");
         }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -662,6 +662,16 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         }
 
         /**
+         * Removes all components from the container.
+         */
+        public void removeAll() {
+            root.removeAllChildren();
+            dialog.getElement()
+                    .executeJs("this." + rendererFunction + " = null;");
+            setRendererCreated(false);
+        }
+
+        /**
          * Method called to create the renderer function using
          * {@link #rendererFunction} as the property name.
          */

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -424,6 +424,22 @@ public class DialogTest {
         Assert.assertFalse(thirdContent.getParent().isPresent());
     }
 
+    @Test
+    public void allElementsRemovedFromHeaderOrFooter_elementsShouldNotHaveDialogAsParents() {
+        Dialog dialog = new Dialog();
+        Span content = new Span("content");
+        Span secondContent = new Span("second_content");
+        Span thirdContent = new Span("third_content");
+
+        dialog.getHeader().add(content, secondContent, thirdContent);
+
+        dialog.getHeader().removeAll();
+
+        Assert.assertFalse(content.getParent().isPresent());
+        Assert.assertFalse(secondContent.getParent().isPresent());
+        Assert.assertFalse(thirdContent.getParent().isPresent());
+    }
+
     @Test(expected = NullPointerException.class)
     public void callAddToHeaderOrFooter_withNull_shouldThrowError() {
         Dialog dialog = new Dialog();

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/SlotUtils.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/SlotUtils.java
@@ -54,7 +54,7 @@ public class SlotUtils {
      *            the name of the slot to clear
      */
     public static void clearSlot(HasElement parent, String slot) {
-        getElementsInSlot(parent, slot).collect(Collectors.toList())
+        getElementsInSlot(parent, slot)
                 .forEach(parent.getElement()::removeChild);
     }
 


### PR DESCRIPTION
## Description

For `Dialog`s, removing elements from the `DialogHeader` or `DialogFooter` was done using `DialogHeaderFooter.remove(Component... components)`. For convenience, a `removeAll` method was introduced. An integration test for checking if the elements were removed correctly was added. 

Also, there are 2 refactoring commits: one for typos, and one for removing an extra terminal Stream operation.

Fixes #3334 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
