### PR TITLE
refactor: allow setting value as collection

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -333,6 +333,19 @@ public class MultiSelectComboBox<TItem>
         setValue(value);
     }
 
+    /**
+     * Sets the value of the component, which is a set of selected items. As
+     * each item can only be selected once, duplicates in the provided items
+     * will be removed. Passing no items will result in an empty selection.
+     *
+     * @param items
+     *            the new value
+     */
+    public void setValue(Collection<TItem> items) {
+        Set<TItem> value = new LinkedHashSet<>(items);
+        setValue(value);
+    }
+
     @Override
     protected void refreshValue() {
         Set<TItem> value = getValue();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -107,6 +108,24 @@ public class MultiSelectComboBoxTest extends ComboBoxBaseTest {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
         comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
         comboBox.setValue("foo", "foo", "foo");
+
+        Assert.assertEquals(Set.of("foo"), comboBox.getValue());
+    }
+
+    @Test
+    public void setValueAsCollection() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue(List.of("foo", "bar"));
+
+        Assert.assertEquals(Set.of("foo", "bar"), comboBox.getValue());
+    }
+
+    @Test
+    public void setValueAsCollection_removesDuplicates() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems(Arrays.asList("foo", "bar", "baz"));
+        comboBox.setValue(List.of("foo", "foo", "foo"));
 
         Assert.assertEquals(Set.of("foo"), comboBox.getValue());
     }


### PR DESCRIPTION
## Description

Allows setting the value of the `MultiSelectComboBox` as `Collection`. This would be a minor DX improvement when using the component without binder, and initializing the value from a list. This is kind of complementary to the setter using var args added here: https://github.com/vaadin/flow-components/pull/3304
