### PR TITLE
fix: add max-height with scrollable area to item filter

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/spreadsheet-styles-valo.css
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/spreadsheet-styles-valo.css
@@ -988,6 +988,8 @@
         display: flex;
         flex-direction: column;
         gap: 4px;
+        max-height: 275px;
+        overflow-y: auto;
       }
 
       #spreadsheet-overlays .spreadsheet-filter-table-content {


### PR DESCRIPTION
## Description

Add a max height with scrollable area to item filter content to avoid it growing to fit all its content, which can be a problem for table with lots of filter options.

The value of max height is the same of how it is defined on the FW8 version. The difference is that it was setting the value to height instead of max height.

### Before

![Screenshot 2022-07-01 at 12 09 04](https://user-images.githubusercontent.com/262432/176864003-a81cf50f-a532-44f7-b885-a68b41cae874.png)

### After

![Screenshot 2022-07-01 at 12 08 46](https://user-images.githubusercontent.com/262432/176864022-a40a834a-062c-44df-88b2-5d18ee3eb5b2.png)

Fixes #3416 

## Type of change

- [x] Bugfix
- [ ] Feature
