### PR TITLE
fix: restore binary compatibility for theme variant methods

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -295,4 +295,16 @@ public class Avatar extends Component
     public void setColorIndex(Integer colorIndex) {
         getElement().setProperty("colorIndex", colorIndex);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(AvatarVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(AvatarVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -296,13 +296,15 @@ public class Avatar extends Component
         getElement().setProperty("colorIndex", colorIndex);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(AvatarVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(AvatarVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -653,4 +653,16 @@ public class AvatarGroup extends Component implements HasStyle, HasSize,
 
         return null;
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(AvatarGroupVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(AvatarGroupVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -654,13 +654,15 @@ public class AvatarGroup extends Component implements HasStyle, HasSize,
         return null;
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(AvatarGroupVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(AvatarGroupVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupTest.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupTest.java
@@ -19,12 +19,13 @@ package com.vaadin.flow.component.avatar.tests;
 import com.vaadin.flow.component.avatar.AvatarGroup;
 import com.vaadin.flow.component.avatar.AvatarGroup.AvatarGroupItem;
 import com.vaadin.flow.component.avatar.AvatarGroupVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.component.avatar.AvatarVariant;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Set;
 
 public class AvatarGroupTest {
 
@@ -128,15 +129,21 @@ public class AvatarGroupTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new AvatarGroup(), AvatarGroupVariant.LUMO_LARGE);
+        avatarGroup.addThemeVariants(AvatarGroupVariant.LUMO_LARGE);
+
+        Set<String> themeNames = avatarGroup.getThemeNames();
+        Assert.assertTrue(
+                themeNames.contains(AvatarVariant.LUMO_LARGE.getVariantName()));
     }
 
     @Test
-    public void addThemeVariant_removeTheme_doesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new AvatarGroup(), AvatarGroupVariant.LUMO_LARGE);
+    public void addThemeVariant_removeThemeVariant_doesNotContainThemeVariant() {
+        avatarGroup.addThemeVariants(AvatarGroupVariant.LUMO_LARGE);
+        avatarGroup.removeThemeVariants(AvatarGroupVariant.LUMO_LARGE);
+
+        Set<String> themeNames = avatarGroup.getThemeNames();
+        Assert.assertFalse(
+                themeNames.contains(AvatarVariant.LUMO_LARGE.getVariantName()));
     }
 
     @Test

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarTest.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarTest.java
@@ -18,10 +18,11 @@ package com.vaadin.flow.component.avatar.tests;
 
 import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.avatar.AvatarVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Set;
 
 public class AvatarTest {
 
@@ -74,15 +75,21 @@ public class AvatarTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new Avatar(), AvatarVariant.LUMO_LARGE);
+        avatar.addThemeVariants(AvatarVariant.LUMO_LARGE);
+
+        Set<String> themeNames = avatar.getThemeNames();
+        Assert.assertTrue(
+                themeNames.contains(AvatarVariant.LUMO_LARGE.getVariantName()));
     }
 
     @Test
-    public void addThemeVariant_removeTheme_doesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new Avatar(), AvatarVariant.LUMO_LARGE);
+    public void addThemeVariant_removeThemeVariant_doesNotContainThemeVariant() {
+        avatar.addThemeVariants(AvatarVariant.LUMO_LARGE);
+        avatar.removeThemeVariants(AvatarVariant.LUMO_LARGE);
+
+        Set<String> themeNames = avatar.getThemeNames();
+        Assert.assertFalse(
+                themeNames.contains(AvatarVariant.LUMO_LARGE.getVariantName()));
     }
 
     @Test

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -253,13 +253,15 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
         getElement().removeAllChildren();
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(ButtonVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(ButtonVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -253,6 +253,18 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
         getElement().removeAllChildren();
     }
 
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(ButtonVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(ButtonVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
+
     /**
      * Sets the given string as the content of this component.
      *

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
-import com.vaadin.tests.ThemeVariantTestHelper;
 
 public class ButtonTest {
 
@@ -219,15 +218,23 @@ public class ButtonTest {
 
     @Test
     public void addThemeVariant_themeNamesContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new Button(), ButtonVariant.LUMO_SMALL);
+        button = new Button();
+        button.addThemeVariants(ButtonVariant.LUMO_SMALL);
+
+        Set<String> themeNames = button.getThemeNames();
+        Assert.assertTrue(
+                themeNames.contains(ButtonVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new Button(), ButtonVariant.LUMO_SMALL);
+        button = new Button();
+        button.addThemeVariants(ButtonVariant.LUMO_SMALL);
+        button.removeThemeVariants(ButtonVariant.LUMO_SMALL);
+
+        Set<String> themeNames = button.getThemeNames();
+        Assert.assertFalse(
+                themeNames.contains(ButtonVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -333,13 +333,15 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         return null;
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(ComboBoxVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(ComboBoxVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -332,4 +332,16 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     public T getEmptyValue() {
         return null;
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(ComboBoxVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(ComboBoxVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxVariantTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxVariantTest.java
@@ -15,21 +15,30 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ComboBoxVariantTest {
 
     @Test
     public void addThemeVariant_themeNamesContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new ComboBox<String>(), ComboBoxVariant.LUMO_SMALL);
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.addThemeVariants(ComboBoxVariant.LUMO_SMALL);
+
+        ThemeList themeNames = comboBox.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(ComboBoxVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new ComboBox<String>(), ComboBoxVariant.LUMO_SMALL);
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.addThemeVariants(ComboBoxVariant.LUMO_SMALL);
+        comboBox.removeThemeVariants(ComboBoxVariant.LUMO_SMALL);
+
+        ThemeList themeNames = comboBox.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(ComboBoxVariant.LUMO_SMALL.getVariantName()));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -416,13 +416,15 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         FieldValidationUtil.disableClientValidation(this);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -415,4 +415,16 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         super.onAttach(attachEvent);
         FieldValidationUtil.disableClientValidation(this);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -438,4 +438,16 @@ public class BigDecimalField
         super.onAttach(attachEvent);
         FieldValidationUtil.disableClientValidation(this);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -439,13 +439,15 @@ public class BigDecimalField
         FieldValidationUtil.disableClientValidation(this);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -436,13 +436,15 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
         FieldValidationUtil.disableClientValidation(this);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -435,4 +435,16 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
         super.onAttach(attachEvent);
         FieldValidationUtil.disableClientValidation(this);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -480,13 +480,15 @@ public class PasswordField
         FieldValidationUtil.disableClientValidation(this);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -479,4 +479,16 @@ public class PasswordField
         super.onAttach(attachEvent);
         FieldValidationUtil.disableClientValidation(this);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -472,4 +472,16 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         super.onAttach(attachEvent);
         FieldValidationUtil.disableClientValidation(this);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(TextAreaVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(TextAreaVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -473,13 +473,15 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         FieldValidationUtil.disableClientValidation(this);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(TextAreaVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(TextAreaVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -499,4 +499,16 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
         super.onAttach(attachEvent);
         FieldValidationUtil.disableClientValidation(this);
     }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void addThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.addThemeVariants(variants);
+    }
+
+    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    @Override
+    public void removeThemeVariants(TextFieldVariant... variants) {
+        HasThemeVariant.super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -500,13 +500,15 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
         FieldValidationUtil.disableClientValidation(this);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void addThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
-    // Override is only required to keep binary compatibility with other 23.x minor versions, can be removed in a future major
+    // Override is only required to keep binary compatibility with other 23.x
+    // minor versions, can be removed in a future major
     @Override
     public void removeThemeVariants(TextFieldVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -93,15 +93,21 @@ public class BigDecimalFieldTest extends TextFieldTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new BigDecimalField(), TextFieldVariant.LUMO_SMALL);
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new BigDecimalField(), TextFieldVariant.LUMO_SMALL);
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+        field.removeThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     private void assertValueFormatting(BigDecimal bigDecimal,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -18,7 +18,8 @@ package com.vaadin.flow.component.textfield.tests;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -62,15 +63,23 @@ public class EmailFieldTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new EmailField(), TextFieldVariant.LUMO_SMALL);
+        EmailField field = new EmailField();
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new EmailField(), TextFieldVariant.LUMO_SMALL);
+        EmailField field = new EmailField();
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+        field.removeThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -144,15 +144,21 @@ public class IntegerFieldTest extends TextFieldTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new IntegerField(), TextFieldVariant.LUMO_SMALL);
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new IntegerField(), TextFieldVariant.LUMO_SMALL);
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+        field.removeThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     private void assertValidValues(Integer... values) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.component.textfield.tests;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -161,15 +161,21 @@ public class NumberFieldTest extends TextFieldTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new NumberField(), TextFieldVariant.LUMO_SMALL);
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new NumberField(), TextFieldVariant.LUMO_SMALL);
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+        field.removeThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     private void assertValidValues(Double... values) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -18,7 +18,8 @@ package com.vaadin.flow.component.textfield.tests;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -94,15 +95,23 @@ public class PasswordFieldTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new PasswordField(), TextFieldVariant.LUMO_SMALL);
+        PasswordField field = new PasswordField();
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new PasswordField(), TextFieldVariant.LUMO_SMALL);
+        PasswordField field = new PasswordField();
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+        field.removeThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -18,7 +18,8 @@ package com.vaadin.flow.component.textfield.tests;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextAreaVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -105,15 +106,23 @@ public class TextAreaTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new TextArea(), TextAreaVariant.LUMO_SMALL);
+        TextArea textArea = new TextArea();
+        textArea.addThemeVariants(TextAreaVariant.LUMO_SMALL);
+
+        ThemeList themeNames = textArea.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextAreaVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new TextArea(), TextAreaVariant.LUMO_SMALL);
+        TextArea textArea = new TextArea();
+        textArea.addThemeVariants(TextAreaVariant.LUMO_SMALL);
+        textArea.removeThemeVariants(TextAreaVariant.LUMO_SMALL);
+
+        ThemeList themeNames = textArea.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextAreaVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -18,7 +18,8 @@ package com.vaadin.flow.component.textfield.tests;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
-import com.vaadin.tests.ThemeVariantTestHelper;
+import com.vaadin.flow.dom.ThemeList;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -86,15 +87,23 @@ public class TextFieldTest {
 
     @Test
     public void addThemeVariant_themeAttributeContainsThemeVariant() {
-        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
-                new TextField(), TextFieldVariant.LUMO_SMALL);
+        TextField field = new TextField();
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     @Test
     public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
-        ThemeVariantTestHelper
-                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
-                        new TextField(), TextFieldVariant.LUMO_SMALL);
+        TextField field = new TextField();
+        field.addThemeVariants(TextFieldVariant.LUMO_SMALL);
+        field.removeThemeVariants(TextFieldVariant.LUMO_SMALL);
+
+        ThemeList themeNames = field.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
     }
 
     public void assertAutoselectPropertyValueEquals(TextField textField,


### PR DESCRIPTION
## Description

Restore `addThemeVariants` and `removeThemeVariants` methods for those components where they have been removed as part of the refactoring to implement `HasThemeVariant`, in order to restore binary compatibility with previous Vaadin versions. I also had to revert the test changes, as redeclaring the method introduced runtime errors.

This should cover the changes from the following PRs:
- https://github.com/vaadin/flow-components/pull/3205
- https://github.com/vaadin/flow-components/pull/3278
- https://github.com/vaadin/flow-components/pull/3284
- https://github.com/vaadin/flow-components/pull/3310

Fixes: https://github.com/vaadin/flow-components/issues/3423

## Type of change

- Bugfix
