### PR TITLE
 Add AbstractGridMultiSelectionModel#getSelectedItemIds

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -163,10 +163,11 @@ public abstract class AbstractGridMultiSelectionModel<T>
 
     /**
      * Returns an unmodifiable view of the selected item ids.
-     *
-     * The returned Set may be a direct view of the internal data structures of this class.
-     * A defensive copy should be made by callers when iterating over this Set and modifying
-     * the selection during iteration to avoid ConcurrentModificationExceptions.
+     * <p>
+     * The returned Set may be a direct view of the internal data structures of
+     * this class. A defensive copy should be made by callers when iterating
+     * over this Set and modifying the selection during iteration to avoid
+     * ConcurrentModificationExceptions.
      */
     protected Set<Object> getSelectedItemIds() {
         return Collections.unmodifiableSet(this.selected.keySet());
@@ -187,11 +188,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (item != null) {
             selected.put(itemId, item);
         }
-        doUpdateSelection(
-                selected,
-                Collections.emptyMap(),
-                false
-        );
+        doUpdateSelection(selected, Collections.emptyMap(), false);
     }
 
     @Override
@@ -204,11 +201,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (item != null) {
             deselected.put(itemId, item);
         }
-        doUpdateSelection(
-                Collections.emptyMap(),
-                deselected,
-                false
-        );
+        doUpdateSelection(Collections.emptyMap(), deselected, false);
         selectionColumn.setSelectAllCheckboxState(false);
     }
 
@@ -217,20 +210,15 @@ public abstract class AbstractGridMultiSelectionModel<T>
         doUpdateSelection(
                 mapItemsById(getGrid().getDataCommunicator().getDataProvider()
                         .fetch(new Query<>()).collect(Collectors.toSet())),
-                Collections.emptyMap(),
-                false
-        );
+                Collections.emptyMap(), false);
         selectionColumn.setSelectAllCheckboxState(true);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);
     }
 
     @Override
     public void deselectAll() {
-        doUpdateSelection(
-                Collections.emptyMap(),
-                new HashMap<>(selected),
-                false
-        );
+        doUpdateSelection(Collections.emptyMap(), new HashMap<>(selected),
+                false);
         selectionColumn.setSelectAllCheckboxState(false);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);
     }
@@ -257,7 +245,9 @@ public abstract class AbstractGridMultiSelectionModel<T>
 
     /**
      * Determines if an object with the given item id is selected or not
-     * @param itemId the item id as returned by {@link DataProvider#getId(Object)}
+     *
+     * @param itemId
+     *            the item id as returned by {@link DataProvider#getId(Object)}
      * @return true if an item with the given id is selected; false otherwise
      */
     protected boolean isSelectedItemId(Object itemId) {
@@ -408,9 +398,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
         }
         doUpdateSelection(
                 mapItemsById(allItemsStream.collect(Collectors.toSet())),
-                Collections.emptyMap(),
-                true
-        );
+                Collections.emptyMap(), true);
         selectionColumn.setSelectAllCheckboxState(true);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);
     }
@@ -458,7 +446,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
             // ignore event if the checkBox was meant to be hidden
             return;
         }
-        doUpdateSelection(Collections.emptyMap(), mapItemsById(getSelectedItems()), true);
+        doUpdateSelection(Collections.emptyMap(),
+                mapItemsById(getSelectedItems()), true);
         selectionColumn.setSelectAllCheckboxState(false);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);
     }
@@ -466,8 +455,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
     private void doUpdateSelection(Map<Object, T> addedItems,
             Map<Object, T> removedItems, boolean userOriginated) {
         Set<Object> selectedIds = getSelectedItemIds();
-        if (selectedIds.containsAll(addedItems.keySet()) && Collections
-                .disjoint(selectedIds, removedItems.keySet())) {
+        if (selectedIds.containsAll(addedItems.keySet())
+                && Collections.disjoint(selectedIds, removedItems.keySet())) {
             return;
         }
         Set<T> oldSelection = getSelectedItems();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -15,7 +15,15 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -159,6 +159,17 @@ public abstract class AbstractGridMultiSelectionModel<T>
                 .unmodifiableSet(new LinkedHashSet<>(selected.values()));
     }
 
+    /**
+     * Returns an unmodifiable view of the selected item ids.
+     *
+     * The returned Set may be a direct view of the internal data structures of this class.
+     * A defensive copy should be made by callers when iterating over this Set and modifying
+     * the selection during iteration to avoid ConcurrentModificationExceptions.
+     */
+    protected Set<Object> getSelectedItemIds() {
+        return Collections.unmodifiableSet(this.selected.keySet());
+    }
+
     @Override
     public Optional<T> getFirstSelectedItem() {
         return selected.values().stream().findFirst();
@@ -215,7 +226,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
 
     @Override
     public boolean isSelected(T item) {
-        return selected.containsKey(getItemId(item));
+        return getSelectedItemIds().contains(getItemId(item));
     }
 
     @Override
@@ -428,9 +439,9 @@ public abstract class AbstractGridMultiSelectionModel<T>
 
     private void doUpdateSelection(Map<Object, T> addedItems,
             Map<Object, T> removedItems, boolean userOriginated) {
-
-        if (selected.keySet().containsAll(addedItems.keySet()) && Collections
-                .disjoint(selected.keySet(), removedItems.keySet())) {
+        Set<Object> selectedIds = getSelectedItemIds();
+        if (selectedIds.containsAll(addedItems.keySet()) && Collections
+                .disjoint(selectedIds, removedItems.keySet())) {
             return;
         }
         Set<T> oldSelection = getSelectedItems();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -168,6 +168,9 @@ public abstract class AbstractGridMultiSelectionModel<T>
      * this class. A defensive copy should be made by callers when iterating
      * over this Set and modifying the selection during iteration to avoid
      * ConcurrentModificationExceptions.
+     *
+     * @return An unmodifiable view of the selected item ids. Updates in the
+     *         selection may or may not be directly reflected in the Set.
      */
     protected Set<Object> getSelectedItemIds() {
         return Collections.unmodifiableSet(this.selected.keySet());

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -68,14 +68,12 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void singleSelect() {
-
         grid.select(item1);
         verifySelection(item1);
     }
 
     @Test
     public void singleSelectItemMultipleTimes() {
-
         grid.select(item1);
         grid.select(item1);
         verifySelection(item1);
@@ -83,7 +81,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void singleSelectItemMultipleTimesAndDeselect() {
-
         grid.select(item1);
         grid.select(item1);
         grid.deselect(item1);
@@ -92,7 +89,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void singleSelectItemAndDeselectMultipleTimes() {
-
         grid.select(item1);
         grid.select(item2);
         grid.deselect(item1);
@@ -102,7 +98,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void singleSelectMultipleItems() {
-
         grid.select(item1);
         grid.select(item2);
         grid.select(item3);
@@ -111,7 +106,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void singleSelectMultipleItemsAndDeselect() {
-
         grid.select(item1);
         grid.select(item2);
         grid.select(item3);
@@ -121,7 +115,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void singleSelectMultipleItemsAndDeselectAll() {
-
         grid.select(item1);
         grid.select(item2);
         grid.select(item3);
@@ -131,14 +124,12 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void multiSelect() {
-
         grid.asMultiSelect().select(item1, item2, item3);
         verifySelection(item1, item2, item3);
     }
 
     @Test
     public void multiSelectItemsMultipleTimes() {
-
         grid.asMultiSelect().select(item1, item2, item3);
         grid.asMultiSelect().select(item1, item2, item3);
         verifySelection(item1, item2, item3);
@@ -146,7 +137,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void multiSelectItemsMultipleTimesAndDeselect() {
-
         grid.asMultiSelect().select(item1, item2, item3);
         grid.asMultiSelect().select(item1, item2, item3);
         grid.asMultiSelect().deselect(item1, item2);
@@ -155,7 +145,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void multiSelectItemsAndDeselectMultipleTimes() {
-
         grid.asMultiSelect().select(item1, item2, item3);
         grid.asMultiSelect().deselect(item1, item2);
         grid.asMultiSelect().deselect(item1, item2);
@@ -164,7 +153,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void multiSelectAndDeselectAll() {
-
         grid.asMultiSelect().select(item1, item2, item3);
         grid.deselectAll();
         verifySelection();
@@ -172,7 +160,6 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Test
     public void multiSelectAndDeselect() {
-
         MultiSelect<Grid<String>, String> multiSelect = grid.asMultiSelect();
         multiSelect.select(item1, item2, item3);
         multiSelect.deselect(item1, item3);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -15,21 +15,14 @@
  */
 package com.vaadin.flow.component.grid;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
-import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
-import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.selection.MultiSelect;
-import com.vaadin.flow.dom.Element;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -118,5 +111,9 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
     private void verifySelection(String... values) {
         Assert.assertEquals(Set.of(values), selectionModel.getSelectedItems());
         Assert.assertEquals(Stream.of(values).map(grid.getDataProvider()::getId).collect(Collectors.toSet()), selectionModel.getSelectedItemIds());
+        for (String value : values) {
+            Assert.assertTrue(selectionModel.isSelected(value));
+            Assert.assertTrue(selectionModel.isSelectedItemId(grid.getDataProvider().getId(value)));
+        }
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -39,9 +39,9 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     @Before
     public void init() {
-        item1 = new String("item1");
-        item2 = new String("item2");
-        item3 = new String("item3");
+        item1 = "item1";
+        item2 = "item2";
+        item3 = "item3";
 
         ListDataProvider<String> dataProvider = new ListDataProvider<>(List.of(item1, item2, item3)) {
             @Override
@@ -74,6 +74,33 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
     }
 
     @Test
+    public void singleSelectItemMultipleTimes() {
+
+        grid.select(item1);
+        grid.select(item1);
+        verifySelection(item1);
+    }
+
+    @Test
+    public void singleSelectItemMultipleTimesAndDeselect() {
+
+        grid.select(item1);
+        grid.select(item1);
+        grid.deselect(item1);
+        verifySelection();
+    }
+
+    @Test
+    public void singleSelectItemAndDeselectMultipleTimes() {
+
+        grid.select(item1);
+        grid.select(item2);
+        grid.deselect(item1);
+        grid.deselect(item1);
+        verifySelection(item2);
+    }
+
+    @Test
     public void singleSelectMultipleItems() {
 
         grid.select(item1);
@@ -93,10 +120,54 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
     }
 
     @Test
+    public void singleSelectMultipleItemsAndDeselectAll() {
+
+        grid.select(item1);
+        grid.select(item2);
+        grid.select(item3);
+        grid.deselectAll();
+        verifySelection();
+    }
+
+    @Test
     public void multiSelect() {
 
         grid.asMultiSelect().select(item1, item2, item3);
         verifySelection(item1, item2, item3);
+    }
+
+    @Test
+    public void multiSelectItemsMultipleTimes() {
+
+        grid.asMultiSelect().select(item1, item2, item3);
+        grid.asMultiSelect().select(item1, item2, item3);
+        verifySelection(item1, item2, item3);
+    }
+
+    @Test
+    public void multiSelectItemsMultipleTimesAndDeselect() {
+
+        grid.asMultiSelect().select(item1, item2, item3);
+        grid.asMultiSelect().select(item1, item2, item3);
+        grid.asMultiSelect().deselect(item1, item2);
+        verifySelection(item3);
+    }
+
+    @Test
+    public void multiSelectItemsAndDeselectMultipleTimes() {
+
+        grid.asMultiSelect().select(item1, item2, item3);
+        grid.asMultiSelect().deselect(item1, item2);
+        grid.asMultiSelect().deselect(item1, item2);
+        verifySelection(item3);
+    }
+
+    @Test
+    public void multiSelectAndDeselectAll() {
+
+        grid.asMultiSelect().select(item1, item2, item3);
+        grid.deselectAll();
+        verifySelection();
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -43,7 +43,8 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
         item2 = "item2";
         item3 = "item3";
 
-        ListDataProvider<String> dataProvider = new ListDataProvider<>(List.of(item1, item2, item3)) {
+        ListDataProvider<String> dataProvider = new ListDataProvider<>(
+                List.of(item1, item2, item3)) {
             @Override
             public Object getId(String item) {
                 return System.identityHashCode(item);
@@ -60,7 +61,8 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
         grid.setItems(dataProvider);
         grid.setSelectionMode(SelectionMode.MULTI);
 
-        selectionModel = ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel());
+        selectionModel = ((AbstractGridMultiSelectionModel<String>) grid
+                .getSelectionModel());
 
         ui = new DataCommunicatorTest.MockUI();
         ui.add(grid);
@@ -168,10 +170,14 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
     private void verifySelection(String... values) {
         Assert.assertEquals(Set.of(values), selectionModel.getSelectedItems());
-        Assert.assertEquals(Stream.of(values).map(grid.getDataProvider()::getId).collect(Collectors.toSet()), selectionModel.getSelectedItemIds());
+        Assert.assertEquals(
+                Stream.of(values).map(grid.getDataProvider()::getId)
+                        .collect(Collectors.toSet()),
+                selectionModel.getSelectedItemIds());
         for (String value : values) {
             Assert.assertTrue(selectionModel.isSelected(value));
-            Assert.assertTrue(selectionModel.isSelectedItemId(grid.getDataProvider().getId(value)));
+            Assert.assertTrue(selectionModel
+                    .isSelectedItemId(grid.getDataProvider().getId(value)));
         }
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.data.selection.MultiSelect;
+import com.vaadin.flow.dom.Element;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AbstractGridMultiSelectionModelSelectedItemsTest {
+
+    private DataCommunicatorTest.MockUI ui;
+    private Grid<String> grid;
+    private String item1;
+    private String item2;
+    private String item3;
+    private AbstractGridMultiSelectionModel<String> selectionModel;
+
+    @Before
+    public void init() {
+        item1 = new String("item1");
+        item2 = new String("item2");
+        item3 = new String("item3");
+
+        ListDataProvider<String> dataProvider = new ListDataProvider<>(List.of(item1, item2, item3)) {
+            @Override
+            public Object getId(String item) {
+                return System.identityHashCode(item);
+            }
+        };
+
+        grid = new Grid<>() {
+            @Override
+            boolean isInActiveRange(String item) {
+                // Updates are sent only for items loaded by client
+                return true;
+            }
+        };
+        grid.setItems(dataProvider);
+        grid.setSelectionMode(SelectionMode.MULTI);
+
+        selectionModel = ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel());
+
+        ui = new DataCommunicatorTest.MockUI();
+        ui.add(grid);
+    }
+
+    @Test
+    public void singleSelect() {
+
+        grid.select(item1);
+        verifySelection(item1);
+    }
+
+    @Test
+    public void singleSelectMultipleItems() {
+
+        grid.select(item1);
+        grid.select(item2);
+        grid.select(item3);
+        verifySelection(item1, item2, item3);
+    }
+
+    @Test
+    public void singleSelectMultipleItemsAndDeselect() {
+
+        grid.select(item1);
+        grid.select(item2);
+        grid.select(item3);
+        grid.deselect(item2);
+        verifySelection(item1, item3);
+    }
+
+    @Test
+    public void multiSelect() {
+
+        grid.asMultiSelect().select(item1, item2, item3);
+        verifySelection(item1, item2, item3);
+    }
+
+    @Test
+    public void multiSelectAndDeselect() {
+
+        MultiSelect<Grid<String>, String> multiSelect = grid.asMultiSelect();
+        multiSelect.select(item1, item2, item3);
+        multiSelect.deselect(item1, item3);
+        verifySelection(item2);
+    }
+
+    private void verifySelection(String... values) {
+        Assert.assertEquals(Set.of(values), selectionModel.getSelectedItems());
+        Assert.assertEquals(Stream.of(values).map(grid.getDataProvider()::getId).collect(Collectors.toSet()), selectionModel.getSelectedItemIds());
+    }
+}


### PR DESCRIPTION
## Description

Add a method, usable by subclasses, that provides access to the internal set of selected item ids.

Fixes #3246

This is a resubmission of #3247 as requested by @yuriy-fix in the last comment there.

## Type of change

* [ ]  Bugfix
* [x]  Refactoring
* [ ]  Feature


## Checklist
* [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
* [x]  I have added a description following the guideline.
* [x]  The issue is created in the corresponding repository and I have referenced it.
* [x]  I have added tests to ensure my change is effective and works as intended.
* [x]  New and existing tests are passing locally with my change.
* [x]  I have performed self-review and corrected misspellings.


#### Additional for `Feature` type of change
* [ ]  Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.