### PR TITLE
fix: resolve empty load request after data provider refresh (#3444) (CP: 23.1)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/RefreshEmptyLazyDataProviderPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/RefreshEmptyLazyDataProviderPage.java
@@ -1,0 +1,36 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.provider.AbstractBackEndDataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.router.Route;
+
+import java.util.stream.Stream;
+
+@Route("vaadin-combo-box/refresh-empty-lazy-data-provider")
+public class RefreshEmptyLazyDataProviderPage extends Div {
+    public RefreshEmptyLazyDataProviderPage() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems(new AbstractBackEndDataProvider<>() {
+            @Override
+            protected Stream<String> fetchFromBackEnd(
+                    Query<String, String> query) {
+                return Stream.of();
+            }
+
+            @Override
+            protected int sizeInBackEnd(Query<String, String> query) {
+                return 0;
+            }
+        });
+
+        NativeButton refreshDataProvider = new NativeButton("Refresh", e -> {
+            comboBox.getDataProvider().refreshAll();
+        });
+        refreshDataProvider.setId("refresh-data-provider");
+
+        add(comboBox, refreshDataProvider);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/RefreshEmptyLazyDataProviderIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/RefreshEmptyLazyDataProviderIT.java
@@ -1,0 +1,40 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-combo-box/refresh-empty-lazy-data-provider")
+public class RefreshEmptyLazyDataProviderIT extends AbstractComponentIT {
+    private ComboBoxElement comboBox;
+    private TestBenchElement refreshDataProvider;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $(ComboBoxElement.class).waitForFirst();
+        refreshDataProvider = $("button").id("refresh-data-provider");
+    }
+
+    // Regression test for:
+    // https://github.com/vaadin/flow-components/issues/3432
+    @Test
+    public void open_close_refreshDataProvider_open_overlayIsHiddenAndLoadingStateIsCleared() {
+        comboBox.openPopup();
+        comboBox.closePopup();
+
+        refreshDataProvider.click();
+        comboBox.openPopup();
+
+        // Verify the overlay is closed
+        // When there are no items to display then the overlay is hidden, but
+        // the opened state of the combo box is still true, so we can't check
+        // the opened state. Instead, we test that there is no overlay element.
+        Assert.assertFalse($("vaadin-combo-box-overlay").exists());
+        Assert.assertFalse(comboBox.getPropertyBoolean("loading"));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -1701,6 +1701,19 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
     @ClientCallable
     private void setRequestedRange(int start, int length, String filter) {
+        // If the filter is null, which indicates that the combo box was closed
+        // before, then reset the data communicator to force sending an update
+        // to the client connector. This covers an edge-case when using an empty
+        // lazy data provider and refreshing it before opening the combo box
+        // again. In that case the data provider thinks that the client should
+        // already be up-to-date from the refresh, as in both cases, refresh and
+        // empty data provider, the effective requested size is zero, which
+        // results in it not sending an update. However, the client needs to
+        // receive an update in order to clear the loading state from opening
+        // the combo box.
+        if (lastFilter == null) {
+            dataCommunicator.reset();
+        }
         dataCommunicator.setRequestedRange(start, length);
         filterSlot.accept(filter);
         updateSelectedKey();


### PR DESCRIPTION
Cherry-pick of: #3444
Fixes: #3432

(cherry picked from commit b8ff071135aab4bd494342fee1ab68f868a178d5)

