### PR TITLE
fix: Force rendering the icon after a change

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/MarkerFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/MarkerFeature.java
@@ -149,5 +149,8 @@ public class MarkerFeature extends PointBasedFeature {
     public void setIcon(Icon icon) {
         Objects.requireNonNull(icon);
         getStyle().setImage(icon);
+
+        // force rerendering of the map by re-syncing the geometry (coordinates)
+        deepMarkAsDirty();
     }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->

## Description

A marker is not rendered after an icon change until the map is rerendered, e.g. by a map move or adding another marker.
Rerendering from the client side can't be achived thus a rerendering must be started from the server. Marking all childs of the FeatureMarker as dirty leads to such a rerendering.

Fixes #2924

## Type of change

- [x ] Bugfix
- [ ] Feature

## Checklist

- [x ] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x ] I have added a description following the guideline.
- [x ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [1 ] New and existing tests are passing locally with my change.
- [ x] I have performed self-review and corrected misspellings.

1 I can't run the IT tests locally even without any changes -> Gave up trying to create a chromedriver instance
 
#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
