### PR TITLE
feat!: use EPSG:4326 as default coordinate system

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DetachAttachPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DetachAttachPage.java
@@ -11,8 +11,7 @@ public class DetachAttachPage extends Div {
         Map map = new Map();
         add(map);
         // Modify viewport, so we can test some non-default values
-        map.getView().setCenter(
-                new Coordinate(2482424.644689998, 8500614.173537256));
+        map.getView().setCenter(new Coordinate(22.3, 60.45));
         map.getView().setZoom(14);
 
         Div newContainer = new Div();

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureEventsPage.java
@@ -35,7 +35,7 @@ public class FeatureEventsPage extends Div {
         map.addLayer(secondFeatureLayer);
 
         MarkerFeature secondMarkerFeature = new MarkerFeature(
-                new Coordinate(2000000, 0));
+                new Coordinate(20, 0));
         secondMarkerFeature.setId("second-marker-feature");
         secondFeatureLayer.addFeature(secondMarkerFeature);
 
@@ -44,7 +44,7 @@ public class FeatureEventsPage extends Div {
         int numOverlappingMarkers = 3;
         for (int i = 0; i < numOverlappingMarkers; i++) {
             MarkerFeature overlappingMarker = new MarkerFeature(
-                    new Coordinate(4000000, 0));
+                    new Coordinate(40, 0));
             overlappingMarker.setId("overlapping-marker-feature-" + (i + 1));
             firstFeatureLayer.addFeature(overlappingMarker);
         }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapEventsPage.java
@@ -31,7 +31,7 @@ public class MapEventsPage extends Div {
         int numOverlappingMarkers = 3;
         for (int i = 0; i < numOverlappingMarkers; i++) {
             MarkerFeature overlappingMarker = new MarkerFeature(
-                    new Coordinate(2000000, 0));
+                    new Coordinate(20, 0));
             overlappingMarker.setId("overlapping-marker-feature-" + (i + 1));
             map.getFeatureLayer().addFeature(overlappingMarker);
         }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MarkerFeaturePage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MarkerFeaturePage.java
@@ -22,8 +22,7 @@ public class MarkerFeaturePage extends Div {
 
         NativeButton addCustomMarkerFeature = new NativeButton(
                 "Add custom marker feature", e -> {
-                    Coordinate coordinate = new Coordinate(1233058.1696443919,
-                            6351912.406929109);
+                    Coordinate coordinate = new Coordinate(11.07675, 49.45203);
                     Icon icon = createCustomIcon();
                     MarkerFeature feature = new MarkerFeature(coordinate, icon);
                     map.getFeatureLayer().addFeature(feature);
@@ -35,8 +34,8 @@ public class MarkerFeaturePage extends Div {
                     if (map.getFeatureLayer().getFeatures().size() > 0) {
                         MarkerFeature feature = (MarkerFeature) map
                                 .getFeatureLayer().getFeatures().get(0);
-                        Coordinate coordinate = new Coordinate(
-                                1233058.1696443919, 6351912.406929109);
+                        Coordinate coordinate = new Coordinate(11.07675,
+                                49.45203);
                         feature.setCoordinates(coordinate);
                     }
                 });

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PreserveOnRefreshPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PreserveOnRefreshPage.java
@@ -20,8 +20,7 @@ public class PreserveOnRefreshPage extends Div {
             // Add custom feature layer (makes 3 layers in total)
             map.addLayer(new FeatureLayer());
             // Modify viewport
-            map.getView().setCenter(
-                    new Coordinate(2482424.644689998, 8500614.173537256));
+            map.getView().setCenter(new Coordinate(22.3, 60.45));
             map.getView().setZoom(14);
         });
         customizeMap.setId("customize-map");

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ViewPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ViewPage.java
@@ -13,14 +13,12 @@ public class ViewPage extends Div {
 
         NativeButton setCenterButton = new NativeButton("Set Center", e -> {
             // here we set center
-            map.getView().setCenter(
-                    new Coordinate(2482424.644689998, 8500614.173537256));
+            map.getView().setCenter(new Coordinate(22.3, 60.45));
         });
         setCenterButton.setId("set-center-button");
 
         NativeButton setZoom = new NativeButton("Set Zoom", e -> {
-            map.getView().setCenter(
-                    new Coordinate(2482424.644689998, 8500614.173537256));
+            map.getView().setCenter(new Coordinate(22.3, 60.45));
             map.getView().setZoom(14);
         });
         setZoom.setId("set-zoom-button");

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/ImageWMSDemo.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/ImageWMSDemo.java
@@ -37,7 +37,7 @@ public class ImageWMSDemo extends Div {
         map.addLayer(imageLayer);
 
         // Move viewport to US
-        map.getView().setCenter(new Coordinate(-10997148, 4569099));
+        map.getView().setCenter(new Coordinate(-98.7890613, 37.9268619));
         map.getView().setZoom(4);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/SamplerView.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/SamplerView.java
@@ -1,8 +1,9 @@
-package com.vaadin.flow.component.map;
+package com.vaadin.flow.component.map.demo;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
 import com.vaadin.flow.component.map.configuration.layer.FeatureLayer;
@@ -15,15 +16,15 @@ import com.vaadin.flow.router.Route;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-@Route("vaadin-map/map-view")
-public class MapView extends Div {
+@Route("vaadin-map/demo/sampler")
+public class SamplerView extends Div {
     Span numMarkers = new Span();
 
-    public MapView() {
+    public SamplerView() {
         Map map = new Map();
 
         MarkerFeature nurembergMarker = new MarkerFeature(
-                new Coordinate(1233058.1696443919, 6351912.406929109));
+                new Coordinate(11.07675, 49.45203));
         map.getFeatureLayer().addFeature(nurembergMarker);
 
         map.addFeatureClickListener(e -> {
@@ -68,15 +69,14 @@ public class MapView extends Div {
                 });
 
         NativeButton showNuremberg = new NativeButton("Show Nuremberg", e -> {
-            map.getView().setCenter(
-                    new Coordinate(1233058.1696443919, 6351912.406929109));
+            map.getView().setCenter(new Coordinate(11.07675, 49.45203));
             map.getView().setZoom(10);
         });
 
         NativeButton showSaintNazaire = new NativeButton("Show Saint Nazaire",
                 e -> {
-                    map.getView().setCenter(new Coordinate(-244780.24508882355,
-                            5986452.183179816));
+                    map.getView()
+                            .setCenter(new Coordinate(-2.1988983, 47.2711907));
                     map.getView().setZoom(15);
                 });
 
@@ -101,10 +101,10 @@ public class MapView extends Div {
 
     private void createRandomMarkers(FeatureLayer layer, int count) {
         for (int i = 0; i < count; i++) {
-            double x = ThreadLocalRandom.current().nextDouble(-20026376.39, // NOSONAR
-                    20026376.39);
-            double y = ThreadLocalRandom.current().nextDouble(-20048966.10, // NOSONAR
-                    20048966.10);
+            double x = ThreadLocalRandom.current().nextDouble(-180, // NOSONAR
+                    180);
+            double y = ThreadLocalRandom.current().nextDouble(-90, // NOSONAR
+                    90);
 
             MarkerFeature markerFeature = new MarkerFeature(
                     new Coordinate(x, y));

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/TileWMSDemo.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/TileWMSDemo.java
@@ -37,7 +37,7 @@ public class TileWMSDemo extends Div {
         map.addLayer(tileLayer);
 
         // Move viewport to US
-        map.getView().setCenter(new Coordinate(-10997148, 4569099));
+        map.getView().setCenter(new Coordinate(-98.7890613, 37.9268619));
         map.getView().setZoom(4);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/XYZSourceDemo.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/XYZSourceDemo.java
@@ -28,8 +28,7 @@ public class XYZSourceDemo extends Div {
         map.setBackgroundLayer(tileLayer);
 
         // Move viewport to Cap Haitien
-        map.getView().setCenter(
-                new Coordinate(-8037267.235274345, 2244621.2004450094));
+        map.getView().setCenter(new Coordinate(-72.2, 19.76));
         map.getView().setZoom(12);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/DetachAttachIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/DetachAttachIT.java
@@ -58,8 +58,8 @@ public class DetachAttachIT extends AbstractComponentIT {
         MapElement.ViewReference view = mapReference.getView();
 
         Assert.assertEquals(2, mapReference.getLayers().getLength());
-        Assert.assertEquals(2482424.644689998, view.getCenter().getX(), 0.0001);
-        Assert.assertEquals(8500614.173537256, view.getCenter().getY(), 0.0001);
+        Assert.assertEquals(22.3, view.getCenter().getX(), 0.0001);
+        Assert.assertEquals(60.45, view.getCenter().getY(), 0.0001);
         Assert.assertEquals(14, view.getZoom(), 0.1);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureEventsIT.java
@@ -38,7 +38,7 @@ public class FeatureEventsIT extends AbstractComponentIT {
         // To prevent double-clicking, wait before we trigger the next event
         waitSeconds(1);
         // Click on second marker
-        map.clickAtCoordinates(2000000, 0);
+        map.clickAtCoordinates(20, 0);
         // Click events are delayed by around 250ms, wait for last event
         waitSeconds(1);
 
@@ -59,7 +59,7 @@ public class FeatureEventsIT extends AbstractComponentIT {
         // To prevent double-clicking, wait before we trigger the next event
         waitSeconds(1);
         // Click on second marker
-        map.clickAtCoordinates(2000000, 0);
+        map.clickAtCoordinates(20, 0);
         // Click events are delayed by around 250ms, wait for last event
         waitSeconds(1);
 
@@ -74,7 +74,7 @@ public class FeatureEventsIT extends AbstractComponentIT {
         addFirstLayerFeatureClickListener.click();
 
         // Click on overlapping markers
-        map.clickAtCoordinates(4000000, 0);
+        map.clickAtCoordinates(40, 0);
         // Click events are delayed by around 250ms, wait for event
         waitSeconds(1);
 

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/MapEventsIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/MapEventsIT.java
@@ -33,8 +33,7 @@ public class MapEventsIT extends AbstractComponentIT {
         MapElement.MapReference mapReference = map.getMapReference();
         MapElement.ViewReference view = mapReference.getView();
         // Simulate user changing the view port of the map
-        view.setCenter(new MapElement.Coordinate(4849385.650796606,
-                5487570.011434158));
+        view.setCenter(new MapElement.Coordinate(43.5627725, 44.1428164));
         view.setZoom(6);
         view.setRotation(5);
 
@@ -44,8 +43,8 @@ public class MapEventsIT extends AbstractComponentIT {
         float rotation = Float.parseFloat(parts[2]);
         float zoom = Float.parseFloat(parts[3]);
 
-        Assert.assertEquals(4849385.650796606, centerX, 0.1);
-        Assert.assertEquals(5487570.011434158, centerY, 0.1);
+        Assert.assertEquals(43.5627725, centerX, 0.1);
+        Assert.assertEquals(44.1428164, centerY, 0.1);
         Assert.assertEquals(5.0, rotation, 0.01);
         Assert.assertEquals(6.0, zoom, 0.01);
     }
@@ -57,8 +56,7 @@ public class MapEventsIT extends AbstractComponentIT {
         MapElement.MapReference mapReference = map.getMapReference();
         MapElement.ViewReference view = mapReference.getView();
         // Simulate user changing the view port of the map
-        view.setCenter(new MapElement.Coordinate(4849385.650796606,
-                5487570.011434158));
+        view.setCenter(new MapElement.Coordinate(43.5627725, 44.1428164));
         view.setZoom(6);
         view.setRotation(5);
 
@@ -68,8 +66,8 @@ public class MapEventsIT extends AbstractComponentIT {
         float rotation = Float.parseFloat(parts[2]);
         float zoom = Float.parseFloat(parts[3]);
 
-        Assert.assertEquals(4849385.650796606, centerX, 0.1);
-        Assert.assertEquals(5487570.011434158, centerY, 0.1);
+        Assert.assertEquals(43.5627725, centerX, 0.1);
+        Assert.assertEquals(44.1428164, centerY, 0.1);
         Assert.assertEquals(5.0, rotation, 0.01);
         Assert.assertEquals(6.0, zoom, 0.01);
     }
@@ -78,7 +76,7 @@ public class MapEventsIT extends AbstractComponentIT {
     public void mapClick_correctCoordinatesAndPosition() {
         addClickListener.click();
 
-        map.clickAtCoordinates(-1956787.9241005122, 1956787.9241005122);
+        map.clickAtCoordinates(-17.578125, 17.308687886770045);
 
         // Click events are delayed, so wait until event data shows up
         waitUntilHasText(eventDataDiv);
@@ -95,15 +93,15 @@ public class MapEventsIT extends AbstractComponentIT {
 
         Assert.assertEquals(100, xPixel, 0.1);
         Assert.assertEquals(100, yPixel, 0.1);
-        Assert.assertEquals(-1956787.9241005122, xCoordinate, 0.00000001);
-        Assert.assertEquals(1956787.9241005122, yCoordinate, 0.00000001);
+        Assert.assertEquals(-17.578125, xCoordinate, 0.00000001);
+        Assert.assertEquals(17.308687886770045, yCoordinate, 0.00000001);
     }
 
     @Test
     public void mapClick_containsAllFeaturesAtLocation() {
         addClickListener.click();
         // Click on location with markers
-        map.clickAtCoordinates(2000000, 0);
+        map.clickAtCoordinates(20, 0);
 
         // Click events are delayed, so wait until event data shows up
         waitUntilHasText(eventDataDiv);

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/MarkerFeatureIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/MarkerFeatureIT.java
@@ -72,8 +72,8 @@ public class MarkerFeatureIT extends AbstractComponentIT {
 
         MapElement.Coordinate coordinates = feature.getGeometry()
                 .getCoordinates();
-        Assert.assertEquals(1233058.1696443919, coordinates.getX(), 0.001);
-        Assert.assertEquals(6351912.406929109, coordinates.getY(), 0.001);
+        Assert.assertEquals(11.07675, coordinates.getX(), 0.001);
+        Assert.assertEquals(49.45203, coordinates.getY(), 0.001);
 
         MapElement.IconReference icon = feature.getStyle().getImage();
         Assert.assertEquals(0.8f, icon.getOpacity(), 0.001);
@@ -96,8 +96,8 @@ public class MarkerFeatureIT extends AbstractComponentIT {
 
         MapElement.Coordinate coordinates = feature.getGeometry()
                 .getCoordinates();
-        Assert.assertEquals(1233058.1696443919, coordinates.getX(), 0.001);
-        Assert.assertEquals(6351912.406929109, coordinates.getY(), 0.001);
+        Assert.assertEquals(11.07675, coordinates.getX(), 0.001);
+        Assert.assertEquals(49.45203, coordinates.getY(), 0.001);
     }
 
     @Test

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/PreserveOnRefreshIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/PreserveOnRefreshIT.java
@@ -37,8 +37,8 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
         MapElement.ViewReference view = mapReference.getView();
 
         Assert.assertEquals(3, mapReference.getLayers().getLength());
-        Assert.assertEquals(2482424.644689998, view.getCenter().getX(), 0.0001);
-        Assert.assertEquals(8500614.173537256, view.getCenter().getY(), 0.0001);
+        Assert.assertEquals(22.3, view.getCenter().getX(), 0.0001);
+        Assert.assertEquals(60.45, view.getCenter().getY(), 0.0001);
         Assert.assertEquals(14, view.getZoom(), 0.1);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ViewIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ViewIT.java
@@ -27,8 +27,8 @@ public class ViewIT extends AbstractComponentIT {
         MapElement.ViewReference view = mapReference.getView();
 
         MapElement.Coordinate center = view.getCenter();
-        Assert.assertEquals(2482424.644689998, center.getX(), 0.0001);
-        Assert.assertEquals(8500614.173537256, center.getY(), 0.0001);
+        Assert.assertEquals(22.3, center.getX(), 0.0001);
+        Assert.assertEquals(60.45, center.getY(), 0.0001);
 
         // Testing setZoom
         TestBenchElement setZoomButton = $("button").id("set-zoom-button");

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -173,12 +173,19 @@ public class Map extends MapBase {
     }
 
     /**
-     * Sets the center of the map's viewport in format specified by projection
-     * set on the view, which defaults to {@code EPSG:3857}
+     * Sets the center of the map's viewport. Coordinates must be specified in
+     * the map's user projection, which by default is {@code EPSG:4326}, also
+     * referred to as GPS coordinates.
      * <p>
      * This is a convenience method that delegates to the map's internal
      * {@link View}. See {@link #getView()} for accessing other properties of
      * the view.
+     * <p>
+     * Note that the user projection is a different concept than the view
+     * projection set in the map's {@link View}. The view projection affects how
+     * map data is interpreted and rendered, while the user projection defines
+     * the coordinate system that all coordinates passed to, or returned from
+     * the public API must be in.
      *
      * @param center
      *            new center of the viewport

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
@@ -19,10 +19,9 @@ package com.vaadin.flow.component.map.configuration;
 import java.util.Objects;
 
 /**
- * Represents map coordinates in a specific projection. Which projection the
- * coordinates are in is not known by the coordinate itself, and developers must
- * ensure themselves to use the same projection between coordinates, the map
- * viewport, and map sources.
+ * Represents map coordinates in a specific projection. Coordinates must be
+ * specified in the map's user projection, which by default is
+ * {@code EPSG:4326}, also referred to as GPS coordinates.
  */
 public class Coordinate {
     private final double x;
@@ -33,11 +32,9 @@ public class Coordinate {
     }
 
     /**
-     * Constructs a new coordinate instance from x and y coordinates. Unless the
-     * map's view uses a custom projection, it is assumed that the coordinates
-     * are in {@code EPSG:3857} / Web Mercator Sphere projection. To create
-     * coordinates from latitude and longitude, see
-     * {@link #fromLonLat(double, double)}.
+     * Constructs a new coordinate instance from x and y coordinates.
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param x
      * @param y

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Extent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Extent.java
@@ -17,9 +17,9 @@ package com.vaadin.flow.component.map.configuration;
  */
 
 /**
- * Defines an area within a map using min/max coordinates. The coordinates are
- * by default in {@code EPSG:3857} / Web Mercator Sphere projection, unless the
- * map's {@link View} uses a custom projection.
+ * Defines an area within a map using min/max coordinates. Coordinates must be
+ * specified in the map's user projection, which by default is
+ * {@code EPSG:4326}, also referred to as GPS coordinates.
  */
 public class Extent {
     private final double minX;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
@@ -43,7 +43,7 @@ public class View extends AbstractConfigurationObject {
     }
 
     /**
-     * Constructs a new view using a custom coordinate projection. A custom
+     * Constructs a new view using a custom coordinate projection. A custom view
      * projection is only necessary when using a map service and corresponding
      * {@link Source} that uses a projection other than {@code EPSG:3857} / Web
      * Mercator Sphere projection.
@@ -74,8 +74,15 @@ public class View extends AbstractConfigurationObject {
     }
 
     /**
-     * Sets the center of the view in format specified by projection set on the
-     * view, which defaults to {@code EPSG:3857}
+     * Sets the center of the map's viewport. Coordinates must be specified in
+     * the map's user projection, which by default is {@code EPSG:4326}, also
+     * referred to as GPS coordinates.
+     * <p>
+     * Note that the user projection is a different concept than the view
+     * projection set in this view. The view projection affects how map data is
+     * interpreted and rendered, while the user projection defines the
+     * coordinate system that all coordinates passed to, or returned from the
+     * public API must be in.
      *
      * @param center
      *            coordinates of the center of the view

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/MarkerFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/MarkerFeature.java
@@ -20,9 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vaadin.flow.component.map.Assets;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Feature;
-import com.vaadin.flow.component.map.configuration.View;
 import com.vaadin.flow.component.map.configuration.geometry.Point;
-import com.vaadin.flow.component.map.configuration.source.Source;
 import com.vaadin.flow.component.map.configuration.style.Icon;
 import com.vaadin.flow.component.map.configuration.style.Style;
 
@@ -82,9 +80,9 @@ public class MarkerFeature extends PointBasedFeature {
 
     /**
      * Creates a new marker feature located at the specified coordinates,
-     * displaying a default marker icon. The coordinates must be in the same
-     * projection as the {@link View#getProjection()} and
-     * {@link Source#getProjection()}.
+     * displaying a default marker icon. Coordinates must be specified in the
+     * map's user projection, which by default is {@code EPSG:4326}, also
+     * referred to as GPS coordinates.
      *
      * @param coordinates
      *            the coordinates that locate the feature
@@ -95,9 +93,9 @@ public class MarkerFeature extends PointBasedFeature {
 
     /**
      * Creates a new marker feature located at the specified coordinates,
-     * displaying the specified custom icon.The coordinates must be in the same
-     * projection as the {@link View#getProjection()} and
-     * {@link Source#getProjection()}.
+     * displaying the specified custom icon. Coordinates must be specified in
+     * the map's user projection, which by default is {@code EPSG:4326}, also
+     * referred to as GPS coordinates.
      * <p>
      * <b>NOTE:</b> Icon instances should be reused between features in order to
      * optimize memory-usage in the client-side component / browser. Creating a

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PointBasedFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PointBasedFeature.java
@@ -22,10 +22,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Feature;
-import com.vaadin.flow.component.map.configuration.View;
 import com.vaadin.flow.component.map.configuration.geometry.Point;
 import com.vaadin.flow.component.map.configuration.geometry.SimpleGeometry;
-import com.vaadin.flow.component.map.configuration.source.Source;
 
 import java.util.Objects;
 
@@ -47,9 +45,9 @@ public abstract class PointBasedFeature extends Feature {
     }
 
     /**
-     * The coordinates that define where the feature is located on the map. The
-     * coordinates must be in the same projection as the
-     * {@link View#getProjection()} and {@link Source#getProjection()}.
+     * The coordinates that define where the feature is located on the map.
+     * Coordinates are returned in the map's user projection, which by default
+     * is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @return the current coordinates
      */
@@ -60,8 +58,8 @@ public abstract class PointBasedFeature extends Feature {
 
     /**
      * Sets the coordinates that define where the feature is located on the map.
-     * The coordinates must be in the same projection as the
-     * {@link View#getProjection()} and {@link Source#getProjection()}.
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the new coordinates

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Point.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Point.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.component.map.configuration.geometry;
 
 import com.vaadin.flow.component.map.configuration.Constants;
 import com.vaadin.flow.component.map.configuration.Coordinate;
-import com.vaadin.flow.component.map.configuration.View;
-import com.vaadin.flow.component.map.configuration.source.Source;
 
 import java.util.Objects;
 
@@ -36,9 +34,9 @@ public class Point extends SimpleGeometry {
     }
 
     /**
-     * Creates a new point geometry located at the specified coordinates.The
-     * coordinates must be in the same projection as the
-     * {@link View#getProjection()} and {@link Source#getProjection()}.
+     * Creates a new point geometry located at the specified coordinates.
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the coordinates that locate the point
@@ -58,9 +56,9 @@ public class Point extends SimpleGeometry {
     }
 
     /**
-     * Sets the coordinates that locate the point. The coordinates must be in
-     * the same projection as the {@link View#getProjection()} and
-     * {@link Source#getProjection()}.
+     * Sets the coordinates that locate the point. Coordinates must be specified
+     * in the map's user projection, which by default is {@code EPSG:4326}, also
+     * referred to as GPS coordinates.
      *
      * @param coordinates
      *            the new coordinates, not null

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapClickEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapClickEvent.java
@@ -76,9 +76,11 @@ public class MapClickEvent extends ComponentEvent<MapBase> {
     }
 
     /**
-     * Gets the coordinate of the click on viewport
+     * Gets the coordinate of the click on viewport. Coordinates are returned in
+     * the map's user projection, which by default is {@code EPSG:4326}, also
+     * referred to as GPS coordinates.
      *
-     * @return coordinate of the click, in the view's projection.
+     * @return coordinate of the click
      */
     public Coordinate getCoordinate() {
         return coordinate;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -1,5 +1,10 @@
+import { setUserProjection as openLayersSetUserProjection } from 'ol/proj';
 import { synchronize } from './synchronization';
 import { createLookup, getLayerForFeature } from './util';
+
+// By default, use EPSG:4326 projection for all coordinates passed to, and return from the public API.
+// Internally coordinates will be converted to the projection used by the map's view.
+openLayersSetUserProjection('EPSG:4326');
 
 (function () {
   function init(mapElement) {

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -38,8 +38,10 @@ public class MapElement extends TestBenchElement {
                 "return arguments[0].configuration.getPixelFromCoordinate([arguments[1], arguments[2]])",
                 this, x, y);
 
-        int clickX = startLeft + pixelCoordinates.get(0).intValue();
-        int clickY = startTop + pixelCoordinates.get(1).intValue();
+        int clickX = startLeft
+                + (int) Math.round(pixelCoordinates.get(0).doubleValue());
+        int clickY = startTop
+                + (int) Math.round(pixelCoordinates.get(1).doubleValue());
         new Actions(getDriver()).moveToElement(this, clickX, clickY).click()
                 .build().perform();
     }


### PR DESCRIPTION
## Description

Changes the default coordinate system / user projection of the Map component to `EPSG:4326`, a.k.a. GPS coordinates. That means that all coordinates passed to, or returned from the public API are assumed to be in this projection. Internally the component will automatically convert coordinates into the configured view projection.

This is a breaking change, and all coordinates that were specified in the previous default (`EPSG:3857`) need to be changed to use `EPSG:4326`. A separate change will allow setting the user projection back to `EPSG:3857`. Also applications that only use `Coordinate.fromLonLat` are going to be covered by another separate change that removes the conversion to `EPSG:3857`, and just creates coordinates in `EPSG:4326` (the new default).

Part of https://github.com/vaadin/platform/issues/3106