### PR TITLE
feat: add logic to handle client side validation

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasValidation;
+
+/**
+ * A utility class that allows preventing the web component from setting itself
+ * to valid as a result of client-side validation.
+ *
+ * @author Vaadin Ltd
+ */
+public final class ClientValidationUtil {
+
+    private ClientValidationUtil() {
+        // utility class should not be instantiated
+    }
+
+    public static <C extends Component & HasValidation> void preventWebComponentFromSettingItselfToValid(
+            C component) {
+        StringBuilder expression = new StringBuilder(
+                "this._shouldSetInvalid = function (invalid) { return invalid };");
+
+        if (component.isInvalid()) {
+            /*
+             * By default the invalid flag is set to false. Workaround the case
+             * where the client side validation overrides the invalid state
+             * before the `_shouldSetInvalid` method is overridden above.
+             */
+            expression.append("this.invalid = true;");
+        }
+
+        component.getElement().executeJs(expression.toString());
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Mixin interface for subscribing to the client-side `validated` event from a
+ * component.
+ */
+public interface HasClientValidation extends Serializable {
+    /**
+     * Adds a listener for the {@code validated} event fired by the web
+     * component whenever it is validated on the client-side.
+     *
+     * @param listener
+     *            the listener, not null.
+     * @return a {@link Registration} for removing the event listener.
+     */
+    default Registration addClientValidatedEventListener(
+            ComponentEventListener<ClientValidatedEvent> listener) {
+        return ComponentUtil.addListener((Component) this,
+                ClientValidatedEvent.class, listener);
+    }
+
+    /**
+     * An event fired by the web component whenever it is validated on the
+     * client-side.
+     */
+    @DomEvent("validated")
+    public static class ClientValidatedEvent extends ComponentEvent<Component> {
+
+        private final boolean valid;
+
+        /**
+         * Creates a new event using the given source.
+         *
+         * @param source
+         *            the source component.
+         * @param valid
+         *            whether the client-side validation succeeded.
+         */
+        public ClientValidatedEvent(Component source,
+                @EventData("event.detail.valid") boolean valid) {
+            super(source, true);
+            this.valid = valid;
+        }
+
+        /**
+         * Returns true if the client-side validation succeeded and false
+         * otherwise.
+         *
+         * @return whether the client-side validation succeeded.
+         */
+        public Boolean isValid() {
+            return valid;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- add util class to override `shouldSetInvalid` on the web component
- add interface to be implemented by field components to listen to validated events from the web component


## Type of change

- [ ] Bugfix
- [X] Feature
