### PR TITLE
feat: set projection for coordinates used in public API

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ChangeUserProjectionPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ChangeUserProjectionPage.java
@@ -1,0 +1,30 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/change-user-projection")
+public class ChangeUserProjectionPage extends Div {
+    public ChangeUserProjectionPage() {
+        Map.setUserProjection("EPSG:3857");
+
+        Map map = new Map();
+        // Set ID for easier referencing from tests
+        map.getBackgroundLayer().setId("background-layer");
+        // Coordinates for Turku in EPSG:3857
+        map.setCenter(new Coordinate(2482424.644689998, 8500614.173537256));
+        map.setZoom(10);
+
+        Div eventData = new Div();
+        eventData.setId("event-data");
+        map.addViewMoveEndEventListener(event -> {
+            String eventText = event.getCenter().getX() + ";"
+                    + event.getCenter().getY() + ";";
+
+            eventData.setText(eventText);
+        });
+
+        add(map, eventData);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ChangeUserProjectionIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ChangeUserProjectionIT.java
@@ -23,11 +23,14 @@ public class ChangeUserProjectionIT extends AbstractComponentIT {
 
     @Test
     public void initWithEpsg3857UserProjection_setViewportUsingEpsg3857Coordinates_correctViewport() {
-        // Verify correct viewport by checking that the Turku map tile for the configured zoom level is visible
-        // This is the map tile containing Turku for zoom level 10: https://c.tile.openstreetmap.org/10/575/294.png
-        MapElement.LayerReference layer = map.getMapReference().getLayers().getLayer("background-layer");
+        // Verify correct viewport by checking that the Turku map tile for the
+        // configured zoom level is visible
+        // This is the map tile containing Turku for zoom level 10:
+        // https://c.tile.openstreetmap.org/10/575/294.png
+        MapElement.LayerReference layer = map.getMapReference().getLayers()
+                .getLayer("background-layer");
         MapElement.XyzSourceReference source = layer.getSource().asXyzSource();
-        waitUntilMapTileLoaded(source,10, 575, 294);
+        waitUntilMapTileLoaded(source, 10, 575, 294);
     }
 
     @Test
@@ -35,10 +38,13 @@ public class ChangeUserProjectionIT extends AbstractComponentIT {
         // Simulate user changing the viewport of the map to Berlin
         MapElement.MapReference mapReference = map.getMapReference();
         MapElement.ViewReference view = mapReference.getView();
-        view.setCenter(new MapElement.Coordinate(1491592.169957, 6893740.925498));
+        view.setCenter(
+                new MapElement.Coordinate(1491592.169957, 6893740.925498));
 
-        // Double-check Berlin map tile is visible (https://a.tile.openstreetmap.org/10/550/335.png)
-        MapElement.LayerReference layer = map.getMapReference().getLayers().getLayer("background-layer");
+        // Double-check Berlin map tile is visible
+        // (https://a.tile.openstreetmap.org/10/550/335.png)
+        MapElement.LayerReference layer = map.getMapReference().getLayers()
+                .getLayer("background-layer");
         MapElement.XyzSourceReference source = layer.getSource().asXyzSource();
         waitUntilMapTileLoaded(source, 10, 550, 335);
 
@@ -51,7 +57,8 @@ public class ChangeUserProjectionIT extends AbstractComponentIT {
         Assert.assertEquals(6893740.925498, centerY, 0.001);
     }
 
-    private void waitUntilMapTileLoaded(MapElement.XyzSourceReference source, int z, int x, int y) {
+    private void waitUntilMapTileLoaded(MapElement.XyzSourceReference source,
+            int z, int x, int y) {
         waitUntil(driver -> source.isTileLoaded(z, x, y));
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ChangeUserProjectionIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ChangeUserProjectionIT.java
@@ -1,0 +1,57 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-map/change-user-projection")
+public class ChangeUserProjectionIT extends AbstractComponentIT {
+
+    private MapElement map;
+    private TestBenchElement eventDataDiv;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+        eventDataDiv = $(TestBenchElement.class).id("event-data");
+    }
+
+    @Test
+    public void initWithEpsg3857UserProjection_setViewportUsingEpsg3857Coordinates_correctViewport() {
+        // Verify correct viewport by checking that the Turku map tile for the configured zoom level is visible
+        // This is the map tile containing Turku for zoom level 10: https://c.tile.openstreetmap.org/10/575/294.png
+        MapElement.LayerReference layer = map.getMapReference().getLayers().getLayer("background-layer");
+        MapElement.XyzSourceReference source = layer.getSource().asXyzSource();
+        waitUntilMapTileLoaded(source,10, 575, 294);
+    }
+
+    @Test
+    public void initWithEpsg3857UserProjection_moveViewportClientSide_receivedEventWithEpsg3857Coordinates() {
+        // Simulate user changing the viewport of the map to Berlin
+        MapElement.MapReference mapReference = map.getMapReference();
+        MapElement.ViewReference view = mapReference.getView();
+        view.setCenter(new MapElement.Coordinate(1491592.169957, 6893740.925498));
+
+        // Double-check Berlin map tile is visible (https://a.tile.openstreetmap.org/10/550/335.png)
+        MapElement.LayerReference layer = map.getMapReference().getLayers().getLayer("background-layer");
+        MapElement.XyzSourceReference source = layer.getSource().asXyzSource();
+        waitUntilMapTileLoaded(source, 10, 550, 335);
+
+        // Check coordinates received server-side
+        String[] parts = eventDataDiv.getText().split(";");
+        double centerX = Double.parseDouble(parts[0]);
+        double centerY = Double.parseDouble(parts[1]);
+
+        Assert.assertEquals(1491592.169957, centerX, 0.001);
+        Assert.assertEquals(6893740.925498, centerY, 0.001);
+    }
+
+    private void waitUntilMapTileLoaded(MapElement.XyzSourceReference source, int z, int x, int y) {
+        waitUntil(driver -> source.isTileLoaded(z, x, y));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -112,8 +112,11 @@ public class Map extends MapBase {
     public static void setUserProjection(String projection) {
         UI ui = UI.getCurrent();
         if (ui == null || ui.getPage() == null) {
-            throw new IllegalStateException(
-                    "Setting a user projection requires a current UI, and a page.");
+            throw new IllegalStateException("UI instance is not available. "
+                    + "It means that you are calling this method "
+                    + "out of a normal workflow where it's always implicitly set. "
+                    + "That may happen if you call the method from the custom thread without "
+                    + "'UI::access' or from tests without proper initialization.");
         }
         UI.getCurrent().getPage().executeJs(
                 "window.Vaadin.Flow.mapConnector.setUserProjection($0)",

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.map;
  */
 
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.map.configuration.Configuration;
@@ -69,6 +70,39 @@ public class Map extends MapBase {
 
     private Layer backgroundLayer;
     private final FeatureLayer featureLayer;
+
+    /**
+     * Sets the projection (or coordinate system) to use for all coordinates.
+     * That means that all coordinates passed to, or returned from the public
+     * API, must be in this projection. Internally the coordinates will be
+     * converted into the projection that is used by the map's {@link View}.
+     * <p>
+     * By default, the user projection is set to {@code EPSG:4326}, also known
+     * as latitude / longitude, or GPS coordinates.
+     * <p>
+     * This setting affects all maps in the current {@link UI}, currently it is
+     * not possible to configure this per map instance. This method may only be
+     * invoked inside of UI threads, and will throw otherwise.
+     * <p>
+     * This method should be called before creating any maps. Changing this
+     * setting does not affect existing maps, specifically the component does
+     * not convert coordinates configured in an existing map into the new
+     * projection. Instead, existing maps should be recreated after changing
+     * this setting.
+     *
+     * @param projection
+     *            the user projection to use for all public facing API
+     */
+    public static void setUserProjection(String projection) {
+        UI ui = UI.getCurrent();
+        if (ui == null || ui.getPage() == null) {
+            throw new IllegalStateException(
+                    "Setting a user projection requires a current UI, and a page.");
+        }
+        UI.getCurrent().getPage().executeJs(
+                "window.Vaadin.Flow.mapConnector.setUserProjection($0)",
+                projection);
+    }
 
     public Map() {
         super();

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -91,7 +91,14 @@ public class Map extends MapBase {
      * <p>
      * This setting affects all maps in the current {@link UI}, currently it is
      * not possible to configure this per map instance. This method may only be
-     * invoked inside of UI threads, and will throw otherwise.
+     * invoked inside of UI threads, and will throw otherwise. This setting
+     * being scoped to the current UI means that it will stay active when
+     * navigating between pages using the Vaadin router, but not when doing a
+     * "hard" location change, or when reloading the page. As such it is
+     * recommended to apply this setting on every page that displays maps. Note
+     * that when using the preserve on refresh feature, a view's constructor is
+     * not called. In that case this setting can be applied in an attach
+     * listener.
      * <p>
      * This method should be called before creating any maps. Changing this
      * setting does not affect existing maps, specifically the component does

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -61,6 +61,15 @@ import java.util.Objects;
  * The viewport of the map is controlled through a {@link View}, which allows
  * setting the center, zoom level and rotation. The map's view can be accessed
  * through {@link Map#getView()}.
+ * <p>
+ * The default projection, or coordinate system, for all coordinates passed to,
+ * or returned from the public API is {@code EPSG:4326}, also referred to as GPS
+ * coordinates. This is called the user projection. Internally the component
+ * converts all coordinates into the projection that is used by the map's
+ * {@link View}, which is referred to as the view projection. The user
+ * projection can be changed using {@link #setUserProjection(String)}. Out of
+ * the box, the map component has support for the {@code EPSG:4326} and
+ * {@code EPSG:3857} projections.
  */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "23.2.0-alpha3")
@@ -209,7 +218,9 @@ public class Map extends MapBase {
     /**
      * Sets the center of the map's viewport. Coordinates must be specified in
      * the map's user projection, which by default is {@code EPSG:4326}, also
-     * referred to as GPS coordinates.
+     * referred to as GPS coordinates. If the user projection has been changed
+     * using {@link Map#setUserProjection(String)}, then coordinates must be
+     * specified in that projection instead.
      * <p>
      * This is a convenience method that delegates to the map's internal
      * {@link View}. See {@link #getView()} for accessing other properties of

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
@@ -16,12 +16,16 @@ package com.vaadin.flow.component.map.configuration;
  * #L%
  */
 
+import com.vaadin.flow.component.map.Map;
+
 import java.util.Objects;
 
 /**
  * Represents map coordinates in a specific projection. Coordinates must be
  * specified in the map's user projection, which by default is
- * {@code EPSG:4326}, also referred to as GPS coordinates.
+ * {@code EPSG:4326}, also referred to as GPS coordinates. If the user
+ * projection has been changed using {@link Map#setUserProjection(String)}, then
+ * coordinates must be specified in that projection instead.
  */
 public class Coordinate {
     private final double x;
@@ -34,7 +38,10 @@ public class Coordinate {
     /**
      * Constructs a new coordinate instance from x and y coordinates.
      * Coordinates must be specified in the map's user projection, which by
-     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates. If the
+     * user projection has been changed using
+     * {@link Map#setUserProjection(String)}, then coordinates must be specified
+     * in that projection instead.
      *
      * @param x
      * @param y

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Extent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Extent.java
@@ -16,10 +16,14 @@ package com.vaadin.flow.component.map.configuration;
  * #L%
  */
 
+import com.vaadin.flow.component.map.Map;
+
 /**
  * Defines an area within a map using min/max coordinates. Coordinates must be
  * specified in the map's user projection, which by default is
- * {@code EPSG:4326}, also referred to as GPS coordinates.
+ * {@code EPSG:4326}, also referred to as GPS coordinates. If the user
+ * projection has been changed using {@link Map#setUserProjection(String)}, then
+ * coordinates must be specified in that projection instead.
  */
 public class Extent {
     private final double minX;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.map.configuration;
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.source.Source;
 
 import java.util.Objects;
@@ -76,7 +77,9 @@ public class View extends AbstractConfigurationObject {
     /**
      * Sets the center of the map's viewport. Coordinates must be specified in
      * the map's user projection, which by default is {@code EPSG:4326}, also
-     * referred to as GPS coordinates.
+     * referred to as GPS coordinates. If the user projection has been changed
+     * using {@link Map#setUserProjection(String)}, then coordinates must be
+     * specified in that projection instead.
      * <p>
      * Note that the user projection is a different concept than the view
      * projection set in this view. The view projection affects how map data is

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/MarkerFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/MarkerFeature.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.map.configuration.feature;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vaadin.flow.component.map.Assets;
+import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Feature;
 import com.vaadin.flow.component.map.configuration.geometry.Point;
@@ -82,7 +83,9 @@ public class MarkerFeature extends PointBasedFeature {
      * Creates a new marker feature located at the specified coordinates,
      * displaying a default marker icon. Coordinates must be specified in the
      * map's user projection, which by default is {@code EPSG:4326}, also
-     * referred to as GPS coordinates.
+     * referred to as GPS coordinates. If the user projection has been changed
+     * using {@link Map#setUserProjection(String)}, then coordinates must be
+     * specified in that projection instead.
      *
      * @param coordinates
      *            the coordinates that locate the feature
@@ -95,7 +98,9 @@ public class MarkerFeature extends PointBasedFeature {
      * Creates a new marker feature located at the specified coordinates,
      * displaying the specified custom icon. Coordinates must be specified in
      * the map's user projection, which by default is {@code EPSG:4326}, also
-     * referred to as GPS coordinates.
+     * referred to as GPS coordinates. If the user projection has been changed
+     * using {@link Map#setUserProjection(String)}, then coordinates must be
+     * specified in that projection instead.
      * <p>
      * <b>NOTE:</b> Icon instances should be reused between features in order to
      * optimize memory-usage in the client-side component / browser. Creating a

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PointBasedFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PointBasedFeature.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Feature;
 import com.vaadin.flow.component.map.configuration.geometry.Point;
@@ -47,7 +48,9 @@ public abstract class PointBasedFeature extends Feature {
     /**
      * The coordinates that define where the feature is located on the map.
      * Coordinates are returned in the map's user projection, which by default
-     * is {@code EPSG:4326}, also referred to as GPS coordinates.
+     * is {@code EPSG:4326}, also referred to as GPS coordinates. If the user
+     * projection has been changed using {@link Map#setUserProjection(String)},
+     * then coordinates must be specified in that projection instead.
      *
      * @return the current coordinates
      */
@@ -59,7 +62,10 @@ public abstract class PointBasedFeature extends Feature {
     /**
      * Sets the coordinates that define where the feature is located on the map.
      * Coordinates must be specified in the map's user projection, which by
-     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates. If the
+     * user projection has been changed using
+     * {@link Map#setUserProjection(String)}, then coordinates must be specified
+     * in that projection instead.
      *
      * @param coordinates
      *            the new coordinates

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Point.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Point.java
@@ -16,6 +16,7 @@ package com.vaadin.flow.component.map.configuration.geometry;
  * #L%
  */
 
+import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Constants;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 
@@ -58,7 +59,9 @@ public class Point extends SimpleGeometry {
     /**
      * Sets the coordinates that locate the point. Coordinates must be specified
      * in the map's user projection, which by default is {@code EPSG:4326}, also
-     * referred to as GPS coordinates.
+     * referred to as GPS coordinates. If the user projection has been changed
+     * using {@link Map#setUserProjection(String)}, then coordinates must be
+     * specified in that projection instead.
      *
      * @param coordinates
      *            the new coordinates, not null

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapClickEvent.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/events/MapClickEvent.java
@@ -78,7 +78,9 @@ public class MapClickEvent extends ComponentEvent<MapBase> {
     /**
      * Gets the coordinate of the click on viewport. Coordinates are returned in
      * the map's user projection, which by default is {@code EPSG:4326}, also
-     * referred to as GPS coordinates.
+     * referred to as GPS coordinates. If the user projection has been changed
+     * using {@link Map#setUserProjection(String)}, then coordinates must be
+     * specified in that projection instead.
      *
      * @return coordinate of the click
      */

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -103,7 +103,17 @@ openLayersSetUserProjection('EPSG:4326');
     });
   }
 
+  /**
+   * Set a custom user projection for all coordinates passing through the public API.
+   * Internally coordinates will be converted to the projection used by the map's view.
+   * @param projection
+   */
+  function setUserProjection(projection) {
+    openLayersSetUserProjection(projection);
+  }
+
   window.Vaadin.Flow.mapConnector = {
-    init
+    init,
+    setUserProjection,
   };
 })();

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -329,6 +329,11 @@ public class MapElement extends TestBenchElement {
                 String expression) {
             super(executor, expression);
         }
+
+        public boolean isTileLoaded(int z, int x, int y) {
+            String tileKey = String.format("%s/%s/%s", z, x, y);
+            return getBoolean("tileCache.containsKey('%s')", tileKey);
+        }
     }
 
     public static class TileWmsSourceReference extends UrlTileSourceReference {


### PR DESCRIPTION
## Description

Allows to set a different user projection for all coordinates passed to, or received from the public API. This allows to use coordinates in a projection other than `EPSG:4326`, which is the default user projection. Currently the feature is limited to `EPSG:4326` and `EPSG:3857` projections, a separate PR will add support for defining custom projection. The user projection applies to all maps in a browser page, it is not possible to configure this setting for individual maps.

For testing, [epsg.io](https://epsg.io/) is a handy website for looking up projections, and converting coordinates.

Part of https://github.com/vaadin/platform/issues/3106