### PR TITLE
fix: force render on style changes

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ModifyStylePage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ModifyStylePage.java
@@ -1,0 +1,63 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
+import com.vaadin.flow.component.map.configuration.style.Icon;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/modify-style")
+public class ModifyStylePage extends Div {
+    public ModifyStylePage() {
+        Map map = new Map();
+
+        MarkerFeature marker = new MarkerFeature(new Coordinate(0, 0),
+                createIcon());
+        map.getFeatureLayer().addFeature(marker);
+
+        NativeButton setImage = new NativeButton("Set image", e -> {
+            Icon icon = createIcon();
+            marker.getStyle().setImage(icon);
+        });
+        setImage.setId("set-style-image");
+
+        NativeButton setImageScale = new NativeButton("Set image scale",
+                e -> marker.getStyle().getImage().setScale(5));
+        setImageScale.setId("set-image-scale");
+
+        Span renderCount = new Span("0");
+        renderCount.setId("render-count");
+        // Register event listener for the rendercomplete event, and increase
+        // render count
+        //@formatter:off
+        renderCount.getElement().executeJs(
+                "const map = $0;" +
+                        "map.configuration.on('rendercomplete', () => {" +
+                        "  const nextValue = parseInt(this.textContent) + 1;" +
+                        "  this.textContent = nextValue.toString();" +
+                        "});",
+                map.getElement()
+        );
+        //@formatter:on
+
+        add(map);
+        add(new Div(setImage, setImageScale));
+        add(new Div(new Span("Number of renders: "), renderCount));
+    }
+
+    private Icon createIcon() {
+        Icon.ImageSize pointImageSize = new Icon.ImageSize(
+                Assets.POINT.getWidth(), Assets.POINT.getHeight());
+        Icon.Options iconOptions = new Icon.Options();
+        iconOptions.setSrc(MarkerFeature.POINT_ICON.getSrc());
+        iconOptions.setImg(Assets.POINT.getResource());
+        iconOptions.setImgSize(pointImageSize);
+        iconOptions.setScale(0.25f);
+        iconOptions.setAnchorOrigin(Icon.AnchorOrigin.TOP_LEFT);
+        iconOptions.setAnchor(new Icon.Anchor(0.5f, 0.5f));
+
+        return new Icon(iconOptions);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ModifyStyleIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ModifyStyleIT.java
@@ -1,0 +1,54 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-map/modify-style")
+public class ModifyStyleIT extends AbstractComponentIT {
+
+    MapElement map;
+    TestBenchElement setStyleImage;
+    TestBenchElement setImageScale;
+    TestBenchElement renderCount;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+        setStyleImage = $(TestBenchElement.class).id("set-style-image");
+        setImageScale = $(TestBenchElement.class).id("set-image-scale");
+        renderCount = $(TestBenchElement.class).id("render-count");
+    }
+
+    @Test
+    public void setStyleImage_triggersRender() {
+        // Should start with initial render
+        waitUntilRenderCount(1);
+
+        setStyleImage.click();
+        // Should trigger another render
+        waitUntilRenderCount(2);
+    }
+
+    @Test
+    public void setImageScale_triggersRender() {
+        // Should start with initial render
+        waitUntilRenderCount(1);
+
+        setImageScale.click();
+        // Should trigger another render
+        waitUntilRenderCount(2);
+    }
+
+    private void waitUntilRenderCount(int count) {
+        waitUntil(driver -> getRenderCount() == count);
+    }
+
+    private int getRenderCount() {
+        return Integer.parseInt(renderCount.getText());
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -121,10 +121,6 @@ openLayersSetUserProjection('EPSG:4326');
         mapElement.dispatchEvent(featureClickEvent);
       }
     });
-
-    mapElement.configuration.on('rendercomplete', () => {
-      console.log('###rendercomplete');
-    });
   }
 
   window.Vaadin.Flow.mapConnector = {

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -24,7 +24,7 @@ openLayersSetUserProjection('EPSG:4326');
        */
       synchronize(changedObjects) {
         // Provide synchronization function and the OL instance lookup through context object
-        const context = { synchronize, lookup: this.lookup };
+        const context = { synchronize, lookup: this.lookup, mapElement, connector: mapElement.$connector };
 
         changedObjects.forEach((change) => {
           // The OL map instance already exists and should not be created by the
@@ -34,6 +34,26 @@ openLayersSetUserProjection('EPSG:4326');
           }
 
           synchronize(change, context);
+        });
+      },
+      /**
+       * Forces a render of the OpenLayers map. Some objects in OpenLayers are not observable
+       * and do not trigger change events, for example Style objects or any of their children.
+       * In these cases this method can be called from the synchronization functions of these
+       * objects.
+       * This method will trigger a debounced render of the map by firing a change event from
+       * each layer. We simply render all layers as a sync. function does not know which layer
+       * its synced object is in. Even if the change event is fired from multiple layers, this
+       * only results in a single render of the map.
+       */
+      forceRender() {
+        if (this._forceRenderTimeout) return;
+        this._forceRenderTimeout = setTimeout(() => {
+          this._forceRenderTimeout = null;
+          mapElement.configuration
+            .getLayers()
+            .getArray()
+            .forEach((layer) => layer.changed());
         });
       }
     };
@@ -100,6 +120,10 @@ openLayersSetUserProjection('EPSG:4326');
 
         mapElement.dispatchEvent(featureClickEvent);
       }
+    });
+
+    mapElement.configuration.on('rendercomplete', () => {
+      console.log('###rendercomplete');
     });
   }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/styles.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/styles.js
@@ -8,23 +8,27 @@ import {
   createOptions,
 } from "./util";
 
-export function synchronizeFill(target, source, _context) {
+export function synchronizeFill(target, source, context) {
   if (!target) {
     target = new Fill();
   }
 
   target.setColor(source.color);
 
+  context.connector.forceRender();
+
   return target;
 }
 
-export function synchronizeStroke(target, source, _context) {
+export function synchronizeStroke(target, source, context) {
   if (!target) {
     target = new Stroke();
   }
 
   target.setColor(source.color);
   target.setWidth(source.width);
+
+  context.connector.forceRender();
 
   return target;
 }
@@ -73,6 +77,8 @@ export function synchronizeIcon(target, source, context) {
   }
   synchronizeImageStyle(target, source, context);
 
+  context.connector.forceRender();
+
   return target;
 }
 
@@ -96,6 +102,8 @@ export function synchronizeStyle(target, source, context) {
       ? context.lookup.get(source.stroke)
       : undefined
   );
+
+  context.connector.forceRender();
 
   return target;
 }


### PR DESCRIPTION
## Description

As stated in the OpenLayers [documentation](https://openlayers.org/en/latest/apidoc/module-ol_style_Style-Style.html), changing properties of a style, or one of its children will not automatically trigger a render:
> Any changes made to the style or its children through set*() methods will not take effect until the feature or layer that uses the style is re-rendered.

This change forces an automatic render of all layers when a style or a possible child of a style is changed.

I started working on this because there was a [concern](https://github.com/vaadin/flow-components/issues/2924#issuecomment-1076103409) that we might want to introduce a breaking change to fix this, by making all style classes immutable. However as the issue was fixable by forcing a re-render that should not be necessary.

Fixes https://github.com/vaadin/flow-components/issues/2924

## Type of change

- Bugfix
