### PR TITLE
feat: define custom coordinate projections

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DefineCustomProjectionPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DefineCustomProjectionPage.java
@@ -10,8 +10,11 @@ public class DefineCustomProjectionPage extends Div {
 
     // WKS for ETRS89 / TM35FIN(E,N) -- Finland
     // Source: https://epsg.io/3067
+    //
+    //@formatter:off
     private static final String EPSG_3067_WKS = ""
-            + "PROJCS[\"ETRS89 / TM35FIN(E,N)\",\n" + "    GEOGCS[\"ETRS89\",\n"
+            + "PROJCS[\"ETRS89 / TM35FIN(E,N)\",\n"
+            + "    GEOGCS[\"ETRS89\",\n"
             + "        DATUM[\"European_Terrestrial_Reference_System_1989\",\n"
             + "            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n"
             + "                AUTHORITY[\"EPSG\",\"7019\"]],\n"
@@ -33,6 +36,7 @@ public class DefineCustomProjectionPage extends Div {
             + "    AXIS[\"Easting\",EAST],\n"
             + "    AXIS[\"Northing\",NORTH],\n"
             + "    AUTHORITY[\"EPSG\",\"3067\"]]";
+    //@formatter:on
 
     public DefineCustomProjectionPage() {
         // Define custom EPSG:3067 projection

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DefineCustomProjectionPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DefineCustomProjectionPage.java
@@ -1,0 +1,63 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.View;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/define-custom-projection")
+public class DefineCustomProjectionPage extends Div {
+
+    // WKS for ETRS89 / TM35FIN(E,N) -- Finland
+    // Source: https://epsg.io/3067
+    private static final String EPSG_3067_WKS = ""
+            + "PROJCS[\"ETRS89 / TM35FIN(E,N)\",\n" + "    GEOGCS[\"ETRS89\",\n"
+            + "        DATUM[\"European_Terrestrial_Reference_System_1989\",\n"
+            + "            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n"
+            + "                AUTHORITY[\"EPSG\",\"7019\"]],\n"
+            + "            TOWGS84[0,0,0,0,0,0,0],\n"
+            + "            AUTHORITY[\"EPSG\",\"6258\"]],\n"
+            + "        PRIMEM[\"Greenwich\",0,\n"
+            + "            AUTHORITY[\"EPSG\",\"8901\"]],\n"
+            + "        UNIT[\"degree\",0.0174532925199433,\n"
+            + "            AUTHORITY[\"EPSG\",\"9122\"]],\n"
+            + "        AUTHORITY[\"EPSG\",\"4258\"]],\n"
+            + "    PROJECTION[\"Transverse_Mercator\"],\n"
+            + "    PARAMETER[\"latitude_of_origin\",0],\n"
+            + "    PARAMETER[\"central_meridian\",27],\n"
+            + "    PARAMETER[\"scale_factor\",0.9996],\n"
+            + "    PARAMETER[\"false_easting\",500000],\n"
+            + "    PARAMETER[\"false_northing\",0],\n"
+            + "    UNIT[\"metre\",1,\n"
+            + "        AUTHORITY[\"EPSG\",\"9001\"]],\n"
+            + "    AXIS[\"Easting\",EAST],\n"
+            + "    AXIS[\"Northing\",NORTH],\n"
+            + "    AUTHORITY[\"EPSG\",\"3067\"]]";
+
+    public DefineCustomProjectionPage() {
+        // Define custom EPSG:3067 projection
+        Map.defineProjection("EPSG:3067", EPSG_3067_WKS);
+        // Use EPSG:3067 as user projection
+        Map.setUserProjection("EPSG:3067");
+
+        Map map = new Map();
+        // Set ID for easier referencing from tests
+        map.getBackgroundLayer().setId("background-layer");
+        // Use EPSG:3067 as view projection
+        map.setView(new View("EPSG:3067"));
+        // Coordinates for Turku in EPSG:3067
+        map.setCenter(new Coordinate(239895.33, 6711153.69));
+        map.setZoom(10);
+
+        Div eventData = new Div();
+        eventData.setId("event-data");
+        map.addViewMoveEndEventListener(event -> {
+            String eventText = event.getCenter().getX() + ";"
+                    + event.getCenter().getY() + ";";
+
+            eventData.setText(eventText);
+        });
+
+        add(map, eventData);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/DefineCustomProjectionIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/DefineCustomProjectionIT.java
@@ -1,0 +1,66 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-map/define-custom-projection")
+public class DefineCustomProjectionIT extends AbstractComponentIT {
+
+    private MapElement map;
+    private TestBenchElement eventDataDiv;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+        eventDataDiv = $(TestBenchElement.class).id("event-data");
+    }
+
+    @Test
+    public void initWithEpsg3067UserProjection_setViewportUsingEpsg3067Coordinates_correctViewport() {
+        // Verify correct viewport by checking that the Turku map tile is
+        // visible
+        // Due to reprojecting the view, the map tile for zoom level 9 is
+        // loaded, rather than for zoom level then as configured in the test
+        // setup
+        // This is the map tile containing Turku for zoom level 9:
+        // https://b.tile.openstreetmap.org/9/287/147.png
+        MapElement.LayerReference layer = map.getMapReference().getLayers()
+                .getLayer("background-layer");
+        MapElement.XyzSourceReference source = layer.getSource().asXyzSource();
+        waitUntilMapTileLoaded(source, 9, 287, 147);
+    }
+
+    @Test
+    public void initWithEpsg3067UserProjection_moveViewportClientSide_receivedEventWithEpsg3067Coordinates() {
+        // Simulate user changing the viewport of the map to Helsinki
+        MapElement.MapReference mapReference = map.getMapReference();
+        MapElement.ViewReference view = mapReference.getView();
+        view.setCenter(new MapElement.Coordinate(385725.63, 6671616.89));
+
+        // Double-check Helsinki map tile is visible
+        // (https://b.tile.openstreetmap.org/9/291/148.png)
+        MapElement.LayerReference layer = map.getMapReference().getLayers()
+                .getLayer("background-layer");
+        MapElement.XyzSourceReference source = layer.getSource().asXyzSource();
+        waitUntilMapTileLoaded(source, 9, 291, 148);
+
+        // Check coordinates received server-side
+        String[] parts = eventDataDiv.getText().split(";");
+        double centerX = Double.parseDouble(parts[0]);
+        double centerY = Double.parseDouble(parts[1]);
+
+        Assert.assertEquals(385725.63, centerX, 0.001);
+        Assert.assertEquals(6671616.89, centerY, 0.001);
+    }
+
+    private void waitUntilMapTileLoaded(MapElement.XyzSourceReference source,
+            int z, int x, int y) {
+        waitUntil(driver -> source.isTileLoaded(z, x, y));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -69,7 +69,8 @@ import java.util.Objects;
  * {@link View}, which is referred to as the view projection. The user
  * projection can be changed using {@link #setUserProjection(String)}. Out of
  * the box, the map component has support for the {@code EPSG:4326} and
- * {@code EPSG:3857} projections.
+ * {@code EPSG:3857} projections. Custom coordinate projections can be defined
+ * using {@link #defineProjection(String, String)}.
  */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "23.2.0-alpha3")
@@ -124,6 +125,38 @@ public class Map extends MapBase {
                 projection);
     }
 
+    /**
+     * Defines a custom coordinate projection that can then be used as user
+     * projection or view projection. Defining a projection requires a name,
+     * which is then used to reference it when setting a user or view
+     * projection, as well as a projection definition in the Well Known Text
+     * (WKS) format. A handy resource for looking up WKS definitions is
+     * <a href="https://epsg.io/">epsg.io</a>, which allows to search for
+     * projections, get coordinates from a map, as well as transform coordinates
+     * between projections.
+     * <p>
+     * This definition is valid for the lifetime of the current {@link UI}. This
+     * method may only be invoked inside of UI threads, and will throw
+     * otherwise. This definition being scoped to the current UI means that it
+     * will stay active when navigating between pages using the Vaadin router,
+     * but not when doing a "hard" location change, or when reloading the page.
+     * As such it is recommended to apply this definition on every page that
+     * displays maps. Note that when using the preserve on refresh feature, a
+     * view's constructor is not called. In that case this definition can be
+     * applied in an attach listener.
+     * <p>
+     * This method should be called before creating any maps that want to make
+     * use of this projection, and before setting it as a custom user
+     * projection.
+     *
+     * @see #setUserProjection(String)
+     * @see View
+     * @param projectionName
+     *            the name of the projection that can be referenced when setting
+     *            a user or view projection
+     * @param wksDefinition
+     *            the Well Known Text (WKS) definition of the projection
+     */
     public static void defineProjection(String projectionName,
             String wksDefinition) {
         UI ui = UI.getCurrent();

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -161,8 +161,11 @@ public class Map extends MapBase {
             String wksDefinition) {
         UI ui = UI.getCurrent();
         if (ui == null || ui.getPage() == null) {
-            throw new IllegalStateException(
-                    "Defining a projection requires a current UI, and a page.");
+            throw new IllegalStateException("UI instance is not available. "
+                    + "It means that you are calling this method "
+                    + "out of a normal workflow where it's always implicitly set. "
+                    + "That may happen if you call the method from the custom thread without "
+                    + "'UI::access' or from tests without proper initialization.");
         }
         UI.getCurrent().getPage().executeJs(
                 "window.Vaadin.Flow.mapConnector.defineProjection($0, $1)",

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -73,6 +73,7 @@ import java.util.Objects;
  */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "23.2.0-alpha3")
+@NpmPackage(value = "proj4", version = "2.8.0")
 @JsModule("@vaadin/map/src/vaadin-map.js")
 @JsModule("./vaadin-map/mapConnector.js")
 public class Map extends MapBase {
@@ -121,6 +122,18 @@ public class Map extends MapBase {
         UI.getCurrent().getPage().executeJs(
                 "window.Vaadin.Flow.mapConnector.setUserProjection($0)",
                 projection);
+    }
+
+    public static void defineProjection(String projectionName,
+            String wksDefinition) {
+        UI ui = UI.getCurrent();
+        if (ui == null || ui.getPage() == null) {
+            throw new IllegalStateException(
+                    "Defining a projection requires a current UI, and a page.");
+        }
+        UI.getCurrent().getPage().executeJs(
+                "window.Vaadin.Flow.mapConnector.defineProjection($0, $1)",
+                projectionName, wksDefinition);
     }
 
     public Map() {

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/mapConnector.js
@@ -1,4 +1,6 @@
 import { setUserProjection as openLayersSetUserProjection } from 'ol/proj';
+import { register as openLayersRegisterProjections } from 'ol/proj/proj4';
+import proj4 from 'proj4';
 import { synchronize } from './synchronization';
 import { createLookup, getLayerForFeature } from './util';
 
@@ -112,8 +114,24 @@ openLayersSetUserProjection('EPSG:4326');
     openLayersSetUserProjection(projection);
   }
 
+  /**
+   * Define a coordinate projection that can be used as view or user projection.
+   * Projection definitions must be provided in the WKT (well known text) format.
+   * Internally the proj4 library is used to define the projection, which is then
+   * integrated with OpenLayers.
+   * @param projection
+   * @param wksDefinition
+   */
+  function defineProjection(projection, wksDefinition) {
+    // Define projection in proj4, and then integrate it with OpenLayers
+    // There should not be any side effects from calling either multiple times
+    proj4.defs(projection, wksDefinition);
+    openLayersRegisterProjections(proj4);
+  }
+
   window.Vaadin.Flow.mapConnector = {
     init,
     setUserProjection,
+    defineProjection
   };
 })();


### PR DESCRIPTION
## Description

Allows to define custom coordinate projections which can then be used as user projection or view projection. The definition is valid for the lifetime of a browser page, the constraints have been documented in the JavaDoc.
The feature uses the `proj4` JS library to allow defining projections in the Well Known Text (WKS) format, which is then integrated with OpenLayers. The library should add around 27kB to production builds, a future change could optimize this further by excluding the default projection definitions that come out of the box with the library. More background on that here: https://github.com/vaadin/platform/issues/3106#issuecomment-1176014836

Part of https://github.com/vaadin/platform/issues/3106
~~Depends on #3454~~