### PR TITLE
chore: remove api key from map sampler

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/SamplerView.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/SamplerView.java
@@ -39,11 +39,11 @@ public class SamplerView extends Div {
                     layer.setVisible(!layer.isVisible());
                 });
 
-        NativeButton useOpenCycleMap = new NativeButton("Use OpenCycleMap",
+        NativeButton useHumanitarianMap = new NativeButton("Use Humanitarian Map",
                 e -> {
                     OSMSource.Options options = new OSMSource.Options();
                     options.setUrl(
-                            "https://{a-c}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=187baf2db9fc454896c700ef9e87f499");
+                            "https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png");
                     OSMSource source = new OSMSource(options);
                     TileLayer layer = new TileLayer();
                     layer.setSource(source);
@@ -87,7 +87,7 @@ public class SamplerView extends Div {
                 });
 
         add(map);
-        add(new Div(toggleLayerVisible, useOpenCycleMap, useOpenStreetMap,
+        add(new Div(toggleLayerVisible, useHumanitarianMap, useOpenStreetMap,
                 addSeaMapLayer, addRandomMarkers, showNuremberg,
                 showSaintNazaire));
 


### PR DESCRIPTION
## Description

Removes a hard-coded API key for a map service that is reported as SonarCloud security issue. Exposing the key was not really an issue, as it is a free key that only allows to load map data, but we can also change the demo to use a different map service that doesn't require a key.
