### PR TITLE
feat!: provide a `setInputValue` method for TB field elements (WIP)

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -33,16 +33,18 @@ public class BigDecimalFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Sets the given value for the slotted {@code input} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code input} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setInputValue(String value) {
         TestBenchElement input = $("input").first();
         input.setProperty("value", value);
         input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -32,11 +32,17 @@ import com.vaadin.testbench.elementsbase.Element;
 public class BigDecimalFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code input} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setInputValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -35,16 +35,18 @@ public class EmailFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Sets the given value for the slotted {@code input} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code input} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setInputValue(String value) {
         TestBenchElement input = $("input").first();
         input.setProperty("value", value);
         input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -34,11 +34,17 @@ import java.util.Collections;
 public class EmailFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code input} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setInputValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -35,16 +35,18 @@ public class IntegerFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Sets the given value for the slotted {@code input} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code input} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setInputValue(String value) {
         TestBenchElement input = $("input").first();
         input.setProperty("value", value);
         input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -34,11 +34,17 @@ import com.vaadin.testbench.elementsbase.Element;
 public class IntegerFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code input} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setInputValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -34,11 +34,17 @@ import java.util.Collections;
 public class NumberFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code input} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setInputValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -35,16 +35,18 @@ public class NumberFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Sets the given value for the slotted {@code input} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code input} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setInputValue(String value) {
         TestBenchElement input = $("input").first();
         input.setProperty("value", value);
         input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -58,16 +58,18 @@ public class PasswordFieldElement extends TestBenchElement
     }
 
     /**
-     * Sets the given value for the slotted {@code input} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code input} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setInputValue(String value) {
         TestBenchElement input = $("input").first();
         input.setProperty("value", value);
         input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -57,11 +57,17 @@ public class PasswordFieldElement extends TestBenchElement
         callFunction("_setPasswordVisible", passwordVisible);
     }
 
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code input} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setInputValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -34,16 +34,19 @@ import java.util.Collections;
 public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
     /**
-     * Sets the given value for the slotted {@code textarea} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code textarea} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setTextareaValue(String value) {
         TestBenchElement textarea = $("textarea").first();
         textarea.setProperty("value", value);
-        textarea.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        textarea.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        textarea.dispatchEvent("input",
+                Collections.singletonMap("bubbles", true));
+        textarea.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -33,11 +33,17 @@ import java.util.Collections;
 @Element("vaadin-text-area")
 public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code textarea} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setTextareaValue(String value) {
+        TestBenchElement textarea = $("textarea").first();
+        textarea.setProperty("value", value);
+        textarea.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        textarea.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -32,11 +32,16 @@ import com.vaadin.testbench.elementsbase.Element;
 public class TextFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
-    @Override
-    public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+    /**
+     * Sets the given value for the slotted {@code input} element and then triggers
+     * {@code input} and {@code change} DOM events.
+     *
+     * @param value the value to set.
+     */
+    public void setInputValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
-
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -33,15 +33,17 @@ public class TextFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Sets the given value for the slotted {@code input} element and then triggers
-     * {@code input} and {@code change} DOM events.
+     * Sets the given value for the slotted {@code input} element and then
+     * triggers {@code input} and {@code change} DOM events.
      *
-     * @param value the value to set.
+     * @param value
+     *            the value to set.
      */
     public void setInputValue(String value) {
         TestBenchElement input = $("input").first();
         input.setProperty("value", value);
         input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a `setInputValue` method for TestBench field elements instead of an override of the `setValue` method. 

The problem with `setValue` is that it is currently overridden in the TB field elements to trigger `change` and `blur` events and it mistakenly triggers those events on the component rather than the input element which results in validation not happening. To fix this, it was decided to introduce a `setInputValue` method specifically for the purpose of emulating user input and remove the override of `setValue` so that it defaults to its original implementation defined by `HasStringValueProperty`.

Also, see https://github.com/vaadin/flow-components/issues/3420#issuecomment-1190086875 explaining an advantage of `setInputValue` over `sendKeys`.

A part of https://github.com/vaadin/flow-components/issues/3420

--- 

**Before:**

- `setValue()` sets the `value` property on the component and then triggers `change` and `blur` events on the component. 

**After:**

- `setValue()` only sets the `value` property on the component.
- `setInputValue()` sets the `value` property on the input element and then triggers `input` and `change` events.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
