### PR TITLE
fix!: make setValue emulate real user input

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -32,11 +32,21 @@ import com.vaadin.testbench.elementsbase.Element;
 public class BigDecimalFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code input} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", string);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
-import java.util.Collections;
-
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
@@ -43,10 +41,7 @@ public class BigDecimalFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement input = $("input").first();
-        input.setProperty("value", string);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(input, string);
     }
 
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -24,8 +24,6 @@ import com.vaadin.testbench.HasStringValueProperty;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
-import java.util.Collections;
-
 /**
  * A TestBench element representing a <code>&lt;vaadin-email-field&gt;</code>
  * element.
@@ -45,10 +43,7 @@ public class EmailFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement input = $("input").first();
-        input.setProperty("value", string);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(input, string);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -34,11 +34,21 @@ import java.util.Collections;
 public class EmailFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code input} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", string);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -34,11 +34,21 @@ import com.vaadin.testbench.elementsbase.Element;
 public class IntegerFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code input} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", string);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.component.textfield.testbench;
 
 import org.openqa.selenium.By;
 
-import java.util.Collections;
-
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
@@ -45,10 +43,7 @@ public class IntegerFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement input = $("input").first();
-        input.setProperty("value", string);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(input, string);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -34,11 +34,21 @@ import java.util.Collections;
 public class NumberFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code input} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", string);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -24,8 +24,6 @@ import com.vaadin.testbench.HasStringValueProperty;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
-import java.util.Collections;
-
 /**
  * A TestBench element representing a <code>&lt;vaadin-number-field&gt;</code>
  * element.
@@ -45,10 +43,7 @@ public class NumberFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement input = $("input").first();
-        input.setProperty("value", string);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(input, string);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.component.textfield.testbench;
 
 import org.openqa.selenium.By;
 
-import java.util.Collections;
-
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
@@ -68,10 +66,7 @@ public class PasswordFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement input = $("input").first();
-        input.setProperty("value", string);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(input, string);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -57,11 +57,21 @@ public class PasswordFieldElement extends TestBenchElement
         callFunction("_setPasswordVisible", passwordVisible);
     }
 
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code input} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", string);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -24,8 +24,6 @@ import com.vaadin.testbench.HasStringValueProperty;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
-import java.util.Collections;
-
 /**
  * A TestBench element representing a <code>&lt;vaadin-text-area&gt;</code>
  * element.
@@ -44,11 +42,7 @@ public class TextAreaElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement textarea = $("textarea").first();
-        textarea.setProperty("value", string);
-        textarea.dispatchEvent("input",
-                Collections.singletonMap("bubbles", true));
-        textarea.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(textarea, string);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -33,11 +33,22 @@ import java.util.Collections;
 @Element("vaadin-text-area")
 public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code textarea} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement textarea = $("textarea").first();
+        textarea.setProperty("value", string);
+        textarea.dispatchEvent("input",
+                Collections.singletonMap("bubbles", true));
+        textarea.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
-import java.util.Collections;
-
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
@@ -43,10 +41,7 @@ public class TextFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         TestBenchElement input = $("input").first();
-        input.setProperty("value", string);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
+        TextFieldElementHelper.setValue(input, string);
     }
 
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -32,11 +32,21 @@ import com.vaadin.testbench.elementsbase.Element;
 public class TextFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
+    /**
+     * Emulates the user changing the value, which in practice means setting
+     * {@code value} of the {@code input} element to the given value and then
+     * triggering {@code input} and {@code change} DOM events.
+     *
+     * @param string
+     *            the value to set
+     */
     @Override
     public void setValue(String string) {
-        HasStringValueProperty.super.setValue(string);
-        dispatchEvent("change", Collections.singletonMap("bubbles", true));
-        dispatchEvent("blur");
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", string);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
     }
 
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.testbench;
+
+import java.util.Collections;
+
+import com.vaadin.testbench.TestBenchElement;
+
+class TextFieldElementHelper {
+    static void setValue(TestBenchElement element, String value) {
+        element.setProperty("value", value);
+        element.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        element.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
@@ -7,7 +7,8 @@ import com.vaadin.testbench.TestBenchElement;
 class TextFieldElementHelper {
     static void setValue(TestBenchElement element, String value) {
         element.setProperty("value", value);
-        element.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        element.dispatchEvent("input",
+                Collections.singletonMap("bubbles", true));
         element.dispatchEvent("change",
                 Collections.singletonMap("bubbles", true));
     }


### PR DESCRIPTION
## Description

This PR changes the `setValue` method for field components to make it emulate real user input firing `input` and `change` DOM events rather than just setting the `value` property on the host element. This is needed to allow using this method for testing validation behavior on invalid user input – the web components trigger validation on `change` DOM event but not all and not always on `value` property change.

Also, see https://github.com/vaadin/flow-components/issues/3420#issuecomment-1190086875 explaining why using `sendKeys` is not an option for `setValue`.

> **Warning**
> It is an altering behavior change.

Fixes #3420 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
