### PR TITLE
fix: refresh individual items in virtual list

### DIFF
--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListDataProviderRefreshPage.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListDataProviderRefreshPage.java
@@ -1,0 +1,68 @@
+package com.vaadin.flow.component.virtuallist.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.virtuallist.VirtualList;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import com.vaadin.flow.router.Route;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Route("vaadin-virtual-list/data-provider-refresh")
+public class VirtualListDataProviderRefreshPage extends Div {
+
+    public VirtualListDataProviderRefreshPage() {
+        VirtualList<Item> virtualList = new VirtualList<>();
+        List<Item> items = createItems();
+        ListDataProvider<Item> dataProvider = new ListDataProvider<>(items);
+        virtualList.setDataProvider(dataProvider);
+        virtualList.setRenderer(new TextRenderer<>(Item::getName));
+
+        NativeButton updateItemFive = new NativeButton("Update 5th item", e -> {
+            Item item = items.get(4);
+            item.setName(item.getName() + " updated");
+            dataProvider.refreshItem(item);
+        });
+        updateItemFive.setId("update-item-five");
+
+        NativeButton updateAllItems = new NativeButton("Update all items",
+                e -> {
+                    items.forEach(item -> {
+                        item.setName(item.getName() + " updated");
+                    });
+                    dataProvider.refreshAll();
+                });
+        updateAllItems.setId("update-all-items");
+
+        add(virtualList);
+        add(new Div(updateItemFive, updateAllItems));
+    }
+
+    private List<Item> createItems() {
+        final int numberToGenerate = 200;
+        List<Item> items = new ArrayList<>();
+        for (int i = 0; i < numberToGenerate; i++) {
+            items.add(new Item("Item" + (i + 1)));
+        }
+
+        return items;
+    }
+
+    private static class Item {
+        private String name;
+
+        public Item(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListDataProviderRefreshIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListDataProviderRefreshIT.java
@@ -1,0 +1,60 @@
+package com.vaadin.flow.component.virtuallist.tests;
+
+import com.vaadin.flow.component.virtuallist.testbench.VirtualListElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-virtual-list/data-provider-refresh")
+public class VirtualListDataProviderRefreshIT extends AbstractComponentIT {
+    private VirtualListElement virtualList;
+    private TestBenchElement updateItemFive;
+    private TestBenchElement updateAllItems;
+
+    @Before
+    public void init() {
+        open();
+        virtualList = $(VirtualListElement.class).waitForFirst();
+        updateItemFive = $("button").id("update-item-five");
+        updateAllItems = $("button").id("update-all-items");
+    }
+
+    @Test
+    public void refreshItem_itemUpdated() {
+        // Wait for initial renderer
+        virtualList.$("flow-component-renderer").waitForFirst();
+        // Check initial render
+        assertItemText(4, "Item5");
+
+        updateItemFive.click();
+
+        // Check updated render
+        assertItemText(4, "Item5 updated");
+    }
+
+    @Test
+    public void refreshAll_allItemsUpdated() {
+        // Wait for initial renderer
+        virtualList.$("flow-component-renderer").waitForFirst();
+        // Check initial render
+        assertItemText(0, "Item1");
+        assertItemText(7, "Item8");
+        assertItemText(12, "Item13");
+
+        updateAllItems.click();
+
+        // Check updated render
+        assertItemText(0, "Item1 updated");
+        assertItemText(7, "Item8 updated");
+        assertItemText(12, "Item13 updated");
+    }
+
+    private void assertItemText(int itemIndex, String expectedText) {
+        TestBenchElement item = virtualList.$("flow-component-renderer")
+                .get(itemIndex);
+        Assert.assertEquals(expectedText, item.getText());
+    }
+}

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
@@ -97,12 +97,20 @@ window.Vaadin.Flow.virtualListConnector = {
     };
 
     list.$connector.updateData = function (items) {
-      const mapByKey = items.reduce((map, item) => {
+      const updatedItemsMap = items.reduce((map, item) => {
         map[item.key] = item;
         return map;
       }, {});
 
-      list.items = list.items.map((item) => mapByKey[item.key] || item);
+      list.items = list.items.map((item) => {
+        // Items can be undefined if they are outside the viewport
+        if (!item) {
+          return item;
+        }
+        // Replace existing item with updated item,
+        // return existing item as fallback if it was not updated
+        return updatedItemsMap[item.key] || item;
+      });
     };
 
     list.$connector.updateSize = function (newSize) {


### PR DESCRIPTION
## Description

When using a data provider with a size that exceeds the number of items that the virtual list fetches for a viewport, the connector stores `undefined` items as placeholders for items that have not been loaded. When updating individual items in the data provider, the connector iterates over all items, and tries to map updated to existing items - which fails if an existing item is `undefined` because it tries to access its key.
Updated the connector to check if the item is loaded before attempting to map updated to existing item.

Fixes #3487 

## Type of change

- Bugfix