### PR TITLE
chore: Set version to karaf maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <jetty.version>9.4.48.v20220622</jetty.version>
         <jetty.http.port>8080</jetty.http.port>
         <jetty.stop.port>9999</jetty.stop.port>
+        <karaf-maven-plugin.version>4.4.0</karaf-maven-plugin.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.failsafe.plugin.version>2.22.2</maven.failsafe.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -101,6 +101,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
+                <version>${karaf-maven-plugin.version}</version>
                 <configuration>
                     <enableGeneration>true</enableGeneration>
                     <includeProjectArtifact>true</includeProjectArtifact>


### PR DESCRIPTION
Version 4.4.1 causes compatibility issues deploy plugin
because of mixed version of wagon artifacts