### PR TITLE
fix: delegate sendKeys calls to the input element

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
@@ -74,7 +74,7 @@ public class ValueChangeModeIT extends AbstractComponentIT {
 
     @Test
     public void testValueChangeModesForTextField() throws InterruptedException {
-        testValueChangeModes(textField.$("input").first(), "textfield");
+        testValueChangeModes(textField, "textfield");
     }
 
     @Test
@@ -109,8 +109,7 @@ public class ValueChangeModeIT extends AbstractComponentIT {
     @Test
     public void testValueChangeModesForBigDecimalField()
             throws InterruptedException {
-        testValueChangeModes(bigDecimalField.$("input").first(),
-                "bigdecimalfield");
+        testValueChangeModes(bigDecimalField, "bigdecimalfield");
     }
 
     private void testValueChangeModes(TestBenchElement field,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import org.openqa.selenium.By;
+
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
@@ -44,4 +46,8 @@ public class BigDecimalFieldElement extends TestBenchElement
         TextFieldElementHelper.setValue(input, string);
     }
 
+    @Override
+    public void sendKeys(CharSequence... keysToSend) {
+        findElement(By.tagName("input")).sendKeys(keysToSend);
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import org.openqa.selenium.By;
+
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
@@ -44,4 +46,8 @@ public class TextFieldElement extends TestBenchElement
         TextFieldElementHelper.setValue(input, string);
     }
 
+    @Override
+    public void sendKeys(CharSequence... keysToSend) {
+        findElement(By.tagName("input")).sendKeys(keysToSend);
+    }
 }


### PR DESCRIPTION
## Description

This PR ensures `sendKeys` calls are delegated to the component's slotted input element as calling `sendKeys` directly on the component's host doesn't seem to be reliable.

- [x] TextFieldElement
- [x] BigDecimalFieldElement

Fixes https://github.com/vaadin/flow-components/issues/3502

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
