### PR TITLE
feat: add HasInputValue interface

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasInputValue.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasInputValue.java
@@ -33,8 +33,8 @@ public interface HasInputValue extends HasElement {
      * @return <code>true</code> if the input's value is populated,
      *         <code>false</code> otherwise
      */
-    @Synchronize(property = "__inputValuePopulated", value = "input-value-populated-changed")
+    @Synchronize(property = "_hasInputValue", value = "has-input-value-changed")
     default boolean isInputValuePopulated() {
-        return getElement().getProperty("__inputValuePopulated", false);
+        return getElement().getProperty("_hasInputValue", false);
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasInputValue.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasInputValue.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Synchronize;
+
+/**
+ * Mixin interface for components that has an internal input element. Intended
+ * for internal use.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasInputValue extends HasElement {
+
+    /**
+     * Gets the populated state of the input's value, which is {@code false} by
+     * default.
+     *
+     * @return <code>true</code> if the input's value is populated,
+     *         <code>false</code> otherwise
+     */
+    @Synchronize(property = "__inputValuePopulated", value = "input-value-populated-changed")
+    default boolean isInputValuePopulated() {
+        return getElement().getProperty("__inputValuePopulated", false);
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasInputValue.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasInputValue.java
@@ -34,7 +34,7 @@ public interface HasInputValue extends HasElement {
      *         <code>false</code> otherwise
      */
     @Synchronize(property = "_hasInputValue", value = "has-input-value-changed")
-    default boolean isInputValuePopulated() {
+    default boolean isInputValue() {
         return getElement().getProperty("_hasInputValue", false);
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasInputValueTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasInputValueTest.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HasInputValueTest {
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void initialValue() {
+        Assert.assertFalse(component.isInputValuePopulated());
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasInputValue {
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasInputValueTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasInputValueTest.java
@@ -17,7 +17,7 @@ public class HasInputValueTest {
 
     @Test
     public void initialValue() {
-        Assert.assertFalse(component.isInputValuePopulated());
+        Assert.assertFalse(component.isInputValue());
     }
 
     @Tag("test")


### PR DESCRIPTION
Introduces `HasInputValue` which can be implemented by a component to get the populated state of the internal input's value.

Requires https://github.com/vaadin/web-components/pull/4276