### PR TITLE
fix: ensure upload i18n is preserved on reattach

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${flow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
         </dependency>
         <dependency>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -48,12 +48,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-html-components-testbench</artifactId>
-            <version>${flow.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
         </dependency>
         <dependency>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadI18nView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadI18nView.java
@@ -20,6 +20,7 @@ package com.vaadin.flow.component.upload.tests;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
 import com.vaadin.flow.router.Route;
@@ -29,6 +30,7 @@ public class UploadI18nView extends Div {
     public UploadI18nView() {
         createFullUploadI18N();
         createPartialUploadI18N();
+        createDetachReattachUpload();
     }
 
     private void createFullUploadI18N() {
@@ -49,6 +51,29 @@ public class UploadI18nView extends Div {
         upload.setI18n(UploadTestsI18N.RUSSIAN_PARTIAL);
 
         add(new H1("Partial I18N"), upload, new Hr());
+    }
+
+    private void createDetachReattachUpload() {
+        MemoryBuffer buffer = new MemoryBuffer();
+        Upload upload = new Upload(buffer);
+        upload.setId("upload-detach-reattach-i18n");
+
+        NativeButton btnToggleAttached = new NativeButton("Toggle attached",
+                e -> {
+                    if (upload.getParent().isPresent()) {
+                        remove(upload);
+                    } else {
+                        add(upload);
+                    }
+                });
+        btnToggleAttached.setId("btn-toggle-attached");
+
+        NativeButton btnSetI18n = new NativeButton("Set i18n", e -> {
+            upload.setI18n(UploadTestsI18N.RUSSIAN_FULL);
+        });
+        btnSetI18n.setId("btn-set-i18n");
+
+        add(new H1("Detach / reattach"), upload, btnToggleAttached, btnSetI18n);
     }
 
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
@@ -17,7 +17,6 @@
 
 package com.vaadin.flow.component.upload.tests;
 
-import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.component.upload.UploadI18N;
 import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.flow.internal.JsonSerializer;
@@ -28,6 +27,7 @@ import elemental.json.JsonType;
 import elemental.json.JsonValue;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import java.util.HashMap;
@@ -117,10 +117,8 @@ public class UploadI18nIT extends AbstractUploadIT {
     public void testDetachReattachI18nIsPreserved() {
         open();
 
-        NativeButtonElement btnSetI18n = $(NativeButtonElement.class)
-                .id("btn-set-i18n");
-        NativeButtonElement btnToggleAttached = $(NativeButtonElement.class)
-                .id("btn-toggle-attached");
+        WebElement btnSetI18n = findElement(By.id("btn-set-i18n"));
+        WebElement btnToggleAttached = findElement(By.id("btn-toggle-attached"));
 
         btnSetI18n.click();
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
@@ -17,6 +17,7 @@
 
 package com.vaadin.flow.component.upload.tests;
 
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.component.upload.UploadI18N;
 import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.flow.internal.JsonSerializer;
@@ -110,6 +111,28 @@ public class UploadI18nIT extends AbstractUploadIT {
 
         assertTranslationMapsHaveSameKeys(fullTranslationMap, translationMap);
         assertTranslationMapHasNoMissingTranslations(translationMap);
+    }
+
+    @Test
+    public void testDetachReattachI18nIsPreserved() {
+        open();
+
+        NativeButtonElement btnSetI18n = $(NativeButtonElement.class)
+                .id("btn-set-i18n");
+        NativeButtonElement btnToggleAttached = $(NativeButtonElement.class)
+                .id("btn-toggle-attached");
+
+        btnSetI18n.click();
+
+        btnToggleAttached.click();
+        btnToggleAttached.click();
+
+        UploadElement upload = $(UploadElement.class)
+                .id("upload-detach-reattach-i18n");
+
+        Assert.assertEquals(
+                UploadTestsI18N.RUSSIAN_FULL.getDropFiles().getOne(),
+                upload.$("*").id("dropLabel").getText());
     }
 
     private void assertTranslationMapsAreEqual(Map<String, String> expected,

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
@@ -118,7 +118,8 @@ public class UploadI18nIT extends AbstractUploadIT {
         open();
 
         WebElement btnSetI18n = findElement(By.id("btn-set-i18n"));
-        WebElement btnToggleAttached = findElement(By.id("btn-toggle-attached"));
+        WebElement btnToggleAttached = findElement(
+                By.id("btn-toggle-attached"));
 
         btnSetI18n.click();
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasSize;
@@ -596,6 +597,16 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
                         + "  addFiles: addFiles,  dropFiles: dropFiles,"
                         + "  uploading: uploading, units: units});",
                 i18nJson);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+
+        // Element state is not persisted across attach/detach
+        if (this.i18n != null) {
+            setI18nWithJS();
+        }
     }
 
     private void deeplyRemoveNullValuesFromJsonObject(JsonObject jsonObject) {


### PR DESCRIPTION
## Description

Fixes #3521
Fixes #1849

Some components that set `i18n` like `AppLayout` and `MenuBar` implement `onAttach` as follows:

https://github.com/vaadin/flow-components/blob/93105314241efb54c4b0e14d38739a2f5bba2564/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java#L122-L129

This logic was missing from `Upload`, so the client side `i18n` property was not updated.

## Type of change

- Bugfix