### PR TITLE
docs: deprecate setLabelAsHtml for Checkbox

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -186,7 +186,11 @@ public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
      *
      * @param htmlContent
      *            the label html to set
+     *
+     * @deprecated Since 23.2, this API is deprecated in favor of
+     *             {@link #setLabelComponent(Component)}
      */
+    @Deprecated
     public void setLabelAsHtml(String htmlContent) {
         setLabel("");
         labelElement.getElement().setProperty("innerHTML", htmlContent);


### PR DESCRIPTION
## Description

Related to #1667

The `setLabelAsHtml()` API is not well designed (for example, it does not check for XSS).
As we added `setLabelComponent()` API in 23.1, it makes sense to deprecate this method.

## Type of change

- Deprecation