### PR TITLE
docs: deprecate legacy IronResizeEvent APIs

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -255,6 +255,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
     }
 
     @DomEvent("iron-resize")
+    @Deprecated
     public static class IronResizeEvent<R extends GeneratedVaadinSplitLayout<R>>
             extends ComponentEvent<R> {
         public IronResizeEvent(R source, boolean fromClient) {
@@ -268,8 +269,11 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     *
+     * @deprecated Since 23.2, this API is deprecated.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Deprecated
     protected Registration addIronResizeListener(
             ComponentEventListener<IronResizeEvent<R>> listener) {
         return addListener(IronResizeEvent.class,


### PR DESCRIPTION
## Description

The `IronResizableBehavior` has been removed from `vaadin-split-layout` in https://github.com/vaadin/web-components/pull/3200.
So this API should be removed as well, as it's not really working anymore. Let's deprecate it for removal in V24.

## Type of change

- Deprecation