### PR TITLE
fix: remove the block that resets tree grid connector (CP: 3514)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/LazyLoadingTreeGridRefreshAllPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/LazyLoadingTreeGridRefreshAllPage.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.AbstractHierarchicalDataProvider;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+@Route("vaadin-grid/lazy-loading-treegrid-refreshall")
+public class LazyLoadingTreeGridRefreshAllPage extends Div {
+
+    private TreeGrid<String> treeGrid = new TreeGrid<>();
+
+    private IntegerField childCount = new IntegerField("Child count");
+
+    private Button refreshAll = new Button("Refresh all",
+            e -> treeGrid.getDataProvider().refreshAll());
+
+    public LazyLoadingTreeGridRefreshAllPage() {
+        childCount.setId("child-count");
+        childCount.setValue(500);
+        refreshAll.setId("refresh-all");
+        add(childCount, refreshAll);
+
+        treeGrid.setDataProvider(new LazyLoadingProvider());
+        treeGrid.addHierarchyColumn(ValueProvider.identity()).setHeader("Name");
+        add(treeGrid);
+    }
+
+    private class LazyLoadingProvider
+            extends AbstractHierarchicalDataProvider<String, Void> {
+
+        @Override
+        public int getChildCount(HierarchicalQuery<String, Void> query) {
+            return childCount.getValue();
+        }
+
+        @Override
+        public Stream<String> fetchChildren(
+                HierarchicalQuery<String, Void> query) {
+            int limit = query.getLimit();
+            int offset = query.getOffset();
+            return IntStream.range(offset, offset + limit)
+                    .mapToObj(index -> "Item " + index);
+        }
+
+        @Override
+        public boolean hasChildren(String item) {
+            return false;
+        }
+
+        @Override
+        public boolean isInMemory() {
+            return true;
+        }
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/LazyLoadingTreeGridRefreshAllIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/LazyLoadingTreeGridRefreshAllIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+@TestPath("vaadin-grid/lazy-loading-treegrid-refreshall")
+public class LazyLoadingTreeGridRefreshAllIT extends AbstractTreeGridIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void setChildCountAndRefreshAll_resultIsNotEmpty() {
+        TreeGridElement treeGrid = $(TreeGridElement.class).get(0);
+
+        // The row index should be larger than 100 in order to replicate the
+        // issue.
+        treeGrid.scrollToRow(120);
+
+        // The count should be smaller than 100 in order to replicate the issue.
+        IntegerFieldElement childCount = $(IntegerFieldElement.class)
+                .id("child-count");
+        childCount.setValue("5");
+
+        ButtonElement refreshAll = $(ButtonElement.class).id("refresh-all");
+        refreshAll.click();
+
+        Assert.assertTrue(treeGrid.getRowCount() > 0);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -142,8 +142,6 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
-    private Registration dataProviderRegistration;
-
     /**
      * Creates a new {@code TreeGrid} without support for creating columns based
      * on property names. Use an alternative constructor, such as
@@ -281,18 +279,6 @@ public class TreeGrid<T> extends Grid<T>
     @Override
     public void setDataProvider(
             HierarchicalDataProvider<T, ?> hierarchicalDataProvider) {
-        if (dataProviderRegistration != null) {
-            dataProviderRegistration.remove();
-        }
-        dataProviderRegistration = hierarchicalDataProvider
-                .addDataProviderListener(e -> {
-                    if (!(e instanceof DataChangeEvent.DataRefreshEvent)) {
-                        // refreshAll was called
-                        getElement().executeJs(
-                                "$0.$connector && $0.$connector.reset()",
-                                getElement());
-                    }
-                });
         super.setDataProvider(hierarchicalDataProvider);
     }
 


### PR DESCRIPTION
## Description

Backporting [3514](https://github.com/vaadin/flow-components/pull/3514) to v22.

Fixes #3434

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.