### PR TITLE
feat: add setDefaultMultiSortPriority to Grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityPage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.Grid.MultiSortPriority;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/default-multi-sort-priority")
+public class DefaultMultiSortPriorityPage extends Div {
+
+    public DefaultMultiSortPriorityPage() {
+        Grid<Person> grid = new Grid<>();
+        grid.setMultiSort(true);
+        grid.setId("multi-sort-priority-grid");
+        grid.setItems(new Person("Bob", 20), new Person("Ann", 30),
+                new Person("Ann", 25));
+
+        Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
+                .setHeader(new Span("Name"))
+                .setComparator(Person::getFirstName);
+
+        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                .setHeader("Age").setComparator(Person::getAge);
+
+        NativeButton addGrid = new NativeButton("Add grid", e -> {
+            add(grid);
+        });
+        addGrid.setId("btn-add-grid");
+
+        NativeButton setMultiSortPriorityAppend = new NativeButton(
+                "Set multi-sort: append", e -> {
+                    Grid.setDefaultMultiSortPriority(MultiSortPriority.APPEND);
+                });
+        setMultiSortPriorityAppend.setId("btn-set-msp-append");
+
+        add(addGrid, setMultiSortPriorityAppend);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityPage.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.stream.Collectors;
-
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.Grid.MultiSortPriority;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityPage.java
@@ -28,30 +28,30 @@ import com.vaadin.flow.router.Route;
 public class DefaultMultiSortPriorityPage extends Div {
 
     public DefaultMultiSortPriorityPage() {
-        Grid<Person> grid = new Grid<>();
-        grid.setMultiSort(true);
-        grid.setId("multi-sort-priority-grid");
-        grid.setItems(new Person("Bob", 20), new Person("Ann", 30),
-                new Person("Ann", 25));
-
-        Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
-                .setHeader(new Span("Name"))
-                .setComparator(Person::getFirstName);
-
-        Column<Person> ageColumn = grid.addColumn(Person::getAge)
-                .setHeader("Age").setComparator(Person::getAge);
-
-        NativeButton addGrid = new NativeButton("Add grid", e -> {
-            add(grid);
-        });
-        addGrid.setId("btn-add-grid");
-
-        NativeButton setMultiSortPriorityAppend = new NativeButton(
-                "Set multi-sort: append", e -> {
+        NativeButton setThenAdd = new NativeButton("Set priority then add",
+                e -> {
                     Grid.setDefaultMultiSortPriority(MultiSortPriority.APPEND);
-                });
-        setMultiSortPriorityAppend.setId("btn-set-msp-append");
 
-        add(addGrid, setMultiSortPriorityAppend);
+                    Grid<Person> grid = new Grid<>();
+                    grid.setMultiSort(true);
+                    grid.setId("multi-sort-priority-grid");
+                    grid.setItems(new Person("Bob", 20), new Person("Ann", 30),
+                            new Person("Ann", 25));
+
+                    Column<Person> nameColumn = grid
+                            .addColumn(Person::getFirstName)
+                            .setHeader(new Span("Name"))
+                            .setComparator(Person::getFirstName);
+
+                    Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                            .setHeader("Age").setComparator(Person::getAge);
+
+                    add(grid);
+
+                    // Restore initial state
+                    Grid.setDefaultMultiSortPriority(MultiSortPriority.PREPEND);
+                });
+        setThenAdd.setId("btn-set-add");
+        add(setThenAdd);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityIT.java
@@ -36,8 +36,7 @@ public class DefaultMultiSortPriorityIT extends AbstractComponentIT {
 
     @Test
     public void setDefaultMultiSortPriority_addGrid_priorityIsUsed() {
-        findElement(By.id("btn-set-msp-append")).click();
-        findElement(By.id("btn-add-grid")).click();
+        findElement(By.id("btn-set-add")).click();
 
         GridElement grid = $(GridElement.class).id("multi-sort-priority-grid");
 
@@ -56,30 +55,6 @@ public class DefaultMultiSortPriorityIT extends AbstractComponentIT {
 
         Assert.assertEquals("Bob", grid.getCell(2, 0).getText());
         Assert.assertEquals("20", grid.getCell(2, 1).getText());
-    }
-
-    @Test
-    public void addGrid_setDefaultMultiSortPriority_priorityIsIgnored() {
-        findElement(By.id("btn-add-grid")).click();
-        findElement(By.id("btn-set-msp-append")).click();
-
-        GridElement grid = $(GridElement.class).id("multi-sort-priority-grid");
-
-        // Sort by Name column
-        getCellContent(grid.getHeaderCell(0)).click();
-
-        // Sort by Age column
-        getCellContent(grid.getHeaderCell(1)).click();
-
-        // "Prepend" priority
-        Assert.assertEquals("Bob", grid.getCell(0, 0).getText());
-        Assert.assertEquals("20", grid.getCell(0, 1).getText());
-
-        Assert.assertEquals("Ann", grid.getCell(1, 0).getText());
-        Assert.assertEquals("25", grid.getCell(1, 1).getText());
-
-        Assert.assertEquals("Ann", grid.getCell(2, 0).getText());
-        Assert.assertEquals("30", grid.getCell(2, 1).getText());
     }
 
     private WebElement getCellContent(GridTHTDElement cell) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/default-multi-sort-priority")
+public class DefaultMultiSortPriorityIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void setDefaultMultiSortPriority_addGrid_priorityIsUsed() {
+        findElement(By.id("btn-set-msp-append")).click();
+        findElement(By.id("btn-add-grid")).click();
+
+        GridElement grid = $(GridElement.class).id("multi-sort-priority-grid");
+
+        // Sort by Name column
+        getCellContent(grid.getHeaderCell(0)).click();
+
+        // Sort by Age column
+        getCellContent(grid.getHeaderCell(1)).click();
+
+        // "Append" priority
+        Assert.assertEquals("Ann", grid.getCell(0, 0).getText());
+        Assert.assertEquals("25", grid.getCell(0, 1).getText());
+
+        Assert.assertEquals("Ann", grid.getCell(1, 0).getText());
+        Assert.assertEquals("30", grid.getCell(1, 1).getText());
+
+        Assert.assertEquals("Bob", grid.getCell(2, 0).getText());
+        Assert.assertEquals("20", grid.getCell(2, 1).getText());
+    }
+
+    @Test
+    public void addGrid_setDefaultMultiSortPriority_priorityIsIgnored() {
+        findElement(By.id("btn-add-grid")).click();
+        findElement(By.id("btn-set-msp-append")).click();
+
+        GridElement grid = $(GridElement.class).id("multi-sort-priority-grid");
+
+        // Sort by Name column
+        getCellContent(grid.getHeaderCell(0)).click();
+
+        // Sort by Age column
+        getCellContent(grid.getHeaderCell(1)).click();
+
+        // "Prepend" priority
+        Assert.assertEquals("Bob", grid.getCell(0, 0).getText());
+        Assert.assertEquals("20", grid.getCell(0, 1).getText());
+
+        Assert.assertEquals("Ann", grid.getCell(1, 0).getText());
+        Assert.assertEquals("25", grid.getCell(1, 1).getText());
+
+        Assert.assertEquals("Ann", grid.getCell(2, 0).getText());
+        Assert.assertEquals("30", grid.getCell(2, 1).getText());
+    }
+
+    private WebElement getCellContent(GridTHTDElement cell) {
+        return (WebElement) executeScript(
+                "return arguments[0].firstElementChild.assignedNodes()[0].firstElementChild;",
+                cell);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DefaultMultiSortPriorityIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -50,6 +50,7 @@ import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dnd.DragSource;
@@ -413,6 +414,40 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * behavior of the component.
          */
         PREPEND
+    }
+
+    /**
+     * Sets the default multi-sort priority to use for all Grid instances.
+     * <p>
+     * This method should be called before creating any Grid instances. Changing
+     * this setting does not affect the default for existing Grids. Use
+     * {@link Grid#setMultiSort(boolean, MultiSortPriority)} to provide a custom
+     * multi-sort priority overriding the default priority for a single Grid.
+     * <p>
+     * This method may only be invoked inside of UI threads, and will throw
+     * otherwise. This setting being scoped to the current UI means that it will
+     * stay active when navigating between pages using the Vaadin router, but
+     * not when doing a "hard" location change, or when reloading the page. As
+     * such it is recommended to apply this setting on every page that displays
+     * a Grid. Note that when using the preserve on refresh feature, a view's
+     * constructor is not called. In that case this setting can be applied in an
+     * attach listener.
+     *
+     * @param priority
+     *            the multi-sort priority to be used by all grid instances
+     */
+    public static void setDefaultMultiSortPriority(MultiSortPriority priority) {
+        UI ui = UI.getCurrent();
+        if (ui == null || ui.getPage() == null) {
+            throw new IllegalStateException("UI instance is not available. "
+                    + "It means that you are calling this method "
+                    + "out of a normal workflow where it's always implicitly set. "
+                    + "That may happen if you call the method from the custom thread without "
+                    + "'UI::access' or from tests without proper initialization.");
+        }
+        UI.getCurrent().getPage().executeJs(
+                "window.Vaadin.Flow.gridConnector.setDefaultMultiSortPriority($0)",
+                priority == MultiSortPriority.APPEND ? "append" : "prepend");
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -50,7 +50,6 @@ import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dnd.DragSource;
@@ -423,32 +422,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * this setting does not affect the default for existing Grids. Use
      * {@link Grid#setMultiSort(boolean, MultiSortPriority)} to provide a custom
      * multi-sort priority overriding the default priority for a single Grid.
-     * <p>
-     * This method may only be invoked inside of UI threads, and will throw
-     * otherwise. This setting being scoped to the current UI means that it will
-     * stay active when navigating between pages using the Vaadin router, but
-     * not when doing a "hard" location change, or when reloading the page. As
-     * such it is recommended to apply this setting on every page that displays
-     * a Grid. Note that when using the preserve on refresh feature, a view's
-     * constructor is not called. In that case this setting can be applied in an
-     * attach listener.
      *
      * @param priority
      *            the multi-sort priority to be used by all grid instances
      */
     public static void setDefaultMultiSortPriority(MultiSortPriority priority) {
-        UI ui = UI.getCurrent();
-        if (ui == null || ui.getPage() == null) {
-            throw new IllegalStateException("UI instance is not available. "
-                    + "It means that you are calling this method "
-                    + "out of a normal workflow where it's always implicitly set. "
-                    + "That may happen if you call the method from the custom thread without "
-                    + "'UI::access' or from tests without proper initialization.");
-        }
-        UI.getCurrent().getPage().executeJs(
-                "window.Vaadin.Flow.gridConnector.setDefaultMultiSortPriority($0)",
-                priority == MultiSortPriority.APPEND ? "append" : "prepend");
+        defaultMultiSortPriority = priority;
     }
+
+    private static MultiSortPriority defaultMultiSortPriority = MultiSortPriority.PREPEND;
 
     /**
      * Server-side component for the {@code <vaadin-grid-column>} element.
@@ -1504,6 +1486,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         addDragStartListener(this::onDragStart);
         addDragEndListener(this::onDragEnd);
 
+        updateMultiSortPriority(defaultMultiSortPriority);
         getElement().setAttribute("suppress-template-warning", true);
     }
 
@@ -3187,6 +3170,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 "Multi-sort priority must not be null");
         setMultiSort(multiSort);
 
+        if (priority != defaultMultiSortPriority) {
+            updateMultiSortPriority(priority);
+        }
+    }
+
+    private void updateMultiSortPriority(MultiSortPriority priority) {
         getElement().setAttribute("multi-sort-priority",
                 priority == MultiSortPriority.APPEND ? "append" : "prepend");
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3169,10 +3169,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         Objects.requireNonNull(priority,
                 "Multi-sort priority must not be null");
         setMultiSort(multiSort);
-
-        if (priority != defaultMultiSortPriority) {
-            updateMultiSortPriority(priority);
-        }
+        updateMultiSortPriority(priority);
     }
 
     private void updateMultiSortPriority(MultiSortPriority priority) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1,6 +1,7 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
+import { setDefaultMultiSortPriorityAppend } from '@vaadin/grid/src/vaadin-grid-sort-mixin.js';
 import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
@@ -8,6 +9,10 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
   const tryCatchWrapper = function (callback) {
     return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid');
   };
+
+  function setDefaultMultiSortPriority(priority) {
+    setDefaultMultiSortPriorityAppend(priority === 'append');
+  }
 
   let isItemCacheInitialized = false;
 
@@ -1180,6 +1185,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           })
         );
-      })(grid)
+      })(grid),
+    setDefaultMultiSortPriority
   };
 })();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1,7 +1,6 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
-import { setDefaultMultiSortPriorityAppend } from '@vaadin/grid/src/vaadin-grid-sort-mixin.js';
 import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
@@ -9,10 +8,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
   const tryCatchWrapper = function (callback) {
     return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid');
   };
-
-  function setDefaultMultiSortPriority(priority) {
-    setDefaultMultiSortPriorityAppend(priority === 'append');
-  }
 
   let isItemCacheInitialized = false;
 
@@ -1185,7 +1180,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           })
         );
-      })(grid),
-    setDefaultMultiSortPriority
+      })(grid)
   };
 })();


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/platform/issues/3052

Added a static method to configure default multi-sort priority as proposed in https://github.com/vaadin/platform/issues/3052#issuecomment-1202325061
See https://github.com/vaadin/web-components/pull/4305 where the web component API for this was added.

## Type of change

- Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
