### PR TITLE
chore: add vite.* files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pom.xml.bak
 types.d.ts
 tsconfig.json
 webpack.*
+vite.*
 node_modules
 .driver
 package*json


### PR DESCRIPTION
## Description

I'm using the latest Flow snapshot locally which already has Vite enabled by default and therefore a lot of `vite.*` files are generated each time I compile the project. Added those files to `.gitignore`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
