### PR TITLE
feat: add getters for column header and footer contents

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -50,6 +50,11 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     private String rawHeaderTemplate;
     private boolean sortingIndicators;
 
+    private String headerText;
+    private Component headerComponent;
+    private String footerText;
+    private Component footerComponent;
+
     /**
      * Base constructor with the destination Grid.
      *
@@ -166,19 +171,65 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         return rendering;
     }
 
+    /**
+     * Returns the header text of the column.
+     *
+     * @return the header text
+     */
+    public String getHeaderText() {
+        return headerText;
+    }
+
     protected void setHeaderText(String text) {
-        setHeaderRenderer(TemplateRenderer.of(HtmlUtils.escape(text)));
+        headerText = text;
+        headerComponent = null;
+        setHeaderRenderer(TemplateRenderer
+                .of(text != null ? HtmlUtils.escape(text) : ""));
+    }
+
+    /**
+     * Returns the footer text of the column.
+     *
+     * @return the footer text
+     */
+    public String getFooterText() {
+        return footerText;
     }
 
     protected void setFooterText(String text) {
-        setFooterRenderer(TemplateRenderer.of(HtmlUtils.escape(text)));
+        footerText = text;
+        footerComponent = null;
+        setFooterRenderer(TemplateRenderer
+                .of(text != null ? HtmlUtils.escape(text) : ""));
+    }
+
+    /**
+     * Returns the header component of the column.
+     *
+     * @return the header component
+     */
+    public Component getHeaderComponent() {
+        return headerComponent;
     }
 
     protected void setHeaderComponent(Component component) {
+        headerText = null;
+        headerComponent = component;
         setHeaderRenderer(new ComponentRenderer<>(() -> component));
     }
 
+    /**
+     * Returns the footer component of the column.
+     *
+     * @return the footer component
+     */
+    public Component getFooterComponent() {
+        return footerComponent;
+    }
+
     protected void setFooterComponent(Component component) {
+        footerText = null;
+        footerComponent = component;
         setFooterRenderer(new ComponentRenderer<>(() -> component));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
@@ -65,6 +65,13 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
         }
 
         /**
+         * Gets the text content of this cell.
+         *
+         * @return text content of the cell
+         */
+        public abstract String getText();
+
+        /**
          * Sets the text content of this cell.
          * <p>
          * This will remove a component set with
@@ -74,6 +81,13 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
          *            the text to be shown in this cell
          */
         public abstract void setText(String text);
+
+        /**
+         * Gets the component content of this cell.
+         *
+         * @return component content of the cell
+         */
+        public abstract Component getComponent();
 
         /**
          * Sets the component as the content of this cell.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.List;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.grid.AbstractRow.AbstractCell;
 import com.vaadin.flow.component.grid.FooterRow.FooterCell;
 
 /**
@@ -44,8 +43,18 @@ public class FooterRow extends AbstractRow<FooterCell> {
         }
 
         @Override
+        public String getText() {
+            return getColumn().getFooterText();
+        }
+
+        @Override
         public void setText(String text) {
             getColumn().setFooterText(text);
+        }
+
+        @Override
+        public Component getComponent() {
+            return getColumn().getFooterComponent();
         }
 
         @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.grid.AbstractRow.AbstractCell;
 import com.vaadin.flow.component.grid.FooterRow.FooterCell;
 
 /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.grid.AbstractRow.AbstractCell;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.HeaderRow.HeaderCell;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid.Column;
-import com.vaadin.flow.component.grid.AbstractRow.AbstractCell;
 import com.vaadin.flow.component.grid.HeaderRow.HeaderCell;
 
 /**
@@ -53,8 +52,18 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
         }
 
         @Override
+        public String getText() {
+            return getColumn().getHeaderText();
+        }
+
+        @Override
         public void setText(String text) {
             getColumn().setHeaderText(text);
+        }
+
+        @Override
+        public Component getComponent() {
+            return getColumn().getHeaderComponent();
         }
 
         @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -23,6 +23,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.textfield.TextField;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -102,6 +104,51 @@ public class HeaderFooterTest {
     }
 
     @Test
+    public void getHeaderText() {
+        firstColumn.setHeader("foo");
+
+        Assert.assertEquals("foo", firstColumn.getHeaderText());
+        Assert.assertEquals("foo",
+                grid.getHeaderRows().get(0).getCell(firstColumn).getText());
+    }
+
+    @Test
+    public void getHeaderComponent() {
+        TextField textField = new TextField();
+        firstColumn.setHeader(textField);
+
+        Assert.assertEquals(textField, firstColumn.getHeaderComponent());
+        Assert.assertEquals(textField, grid.getHeaderRows().get(0)
+                .getCell(firstColumn).getComponent());
+    }
+
+    @Test
+    public void setHeaderText_clearsHeaderComponent() {
+        TextField textField = new TextField();
+
+        firstColumn.setHeader(textField);
+        firstColumn.setHeader("foo");
+        Assert.assertNull(firstColumn.getHeaderComponent());
+
+        firstColumn.setHeader(textField);
+        firstColumn.setHeader((String) null);
+        Assert.assertNull(firstColumn.getHeaderComponent());
+    }
+
+    @Test
+    public void setHeaderComponent_clearsHeaderText() {
+        TextField textField = new TextField();
+
+        firstColumn.setHeader("foo");
+        firstColumn.setHeader(textField);
+        Assert.assertNull(firstColumn.getHeaderText());
+
+        firstColumn.setHeader("foo");
+        firstColumn.setHeader((Component) null);
+        Assert.assertNull(firstColumn.getHeaderText());
+    }
+
+    @Test
     public void setFooter_firstFooterRowCreated() {
         firstColumn.setFooter("foo");
         Assert.assertEquals(
@@ -109,6 +156,51 @@ public class HeaderFooterTest {
                 1, grid.getFooterRows().size());
         assertRowWrapsLayer(grid.getFooterRows().get(0),
                 getColumnLayersAndAssertCount(1).get(0));
+    }
+
+    @Test
+    public void getFooterText() {
+        firstColumn.setFooter("foo");
+
+        Assert.assertEquals("foo", firstColumn.getFooterText());
+        Assert.assertEquals("foo",
+                grid.getFooterRows().get(0).getCell(firstColumn).getText());
+    }
+
+    @Test
+    public void getFooterComponent() {
+        TextField textField = new TextField();
+        firstColumn.setFooter(textField);
+
+        Assert.assertEquals(textField, firstColumn.getFooterComponent());
+        Assert.assertEquals(textField, grid.getFooterRows().get(0)
+                .getCell(firstColumn).getComponent());
+    }
+
+    @Test
+    public void setFooterText_clearsFooterComponent() {
+        TextField textField = new TextField();
+
+        firstColumn.setFooter(textField);
+        firstColumn.setFooter("foo");
+        Assert.assertNull(firstColumn.getFooterComponent());
+
+        firstColumn.setFooter(textField);
+        firstColumn.setFooter((String) null);
+        Assert.assertNull(firstColumn.getFooterComponent());
+    }
+
+    @Test
+    public void setFooterComponent_clearsFooterText() {
+        TextField textField = new TextField();
+
+        firstColumn.setFooter("foo");
+        firstColumn.setFooter(textField);
+        Assert.assertNull(firstColumn.getFooterText());
+
+        firstColumn.setFooter("foo");
+        firstColumn.setFooter((Component) null);
+        Assert.assertNull(firstColumn.getFooterText());
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds getters for the text or component content of column header and footer cells.

Closes https://github.com/vaadin/flow-components/issues/1676
Closes https://github.com/vaadin/flow-components/issues/1496

## Type of change

- Feature
