### PR TITLE
refactor!: make setInputValue simulate real user input

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -22,11 +22,11 @@ import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-date-picker&gt;</code>
@@ -155,18 +155,18 @@ public class DatePickerElement extends TestBenchElement
     }
 
     /**
-     * Opens the overlay, sets the value to the inner input element as a string
-     * and closes the overlay. This simulates the user typing into the input and
-     * triggering an update of the value property.
+     * Emulates the user changing the value. This in practice means clearing
+     * {@code value} of the {@code input} element and then setting the new value
+     * by sending the respective characters + Enter via the Selenium
+     * {@code sendKeys} API.
+     *
+     * @param string
+     *            the value to set
      */
     public void setInputValue(String value) {
-        this.open();
         var input = $("input").first();
-        input.setProperty("value", value);
-        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
-        input.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
-        this.close();
+        input.setProperty("value", "");
+        input.sendKeys(value, Keys.ENTER);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -22,6 +22,7 @@ import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -160,7 +161,12 @@ public class DatePickerElement extends TestBenchElement
      */
     public void setInputValue(String value) {
         this.open();
-        setProperty("_inputValue", value);
+        var input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input",
+                Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
         this.close();
     }
 
@@ -171,7 +177,8 @@ public class DatePickerElement extends TestBenchElement
      * @return
      */
     public String getInputValue() {
-        return getPropertyString("_inputValue");
+        var input = $("input").first();
+        return input.getPropertyString("value");
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -155,18 +155,21 @@ public class DatePickerElement extends TestBenchElement
     }
 
     /**
-     * Emulates the user changing the value. This in practice means clearing
-     * {@code value} of the {@code input} element and then setting the new value
-     * by sending the respective characters + Enter via the Selenium
-     * {@code sendKeys} API.
+     * Simulates the user changing the value via the input element which is in
+     * practice the following sequence of {@code sendKeys}:
+     *
+     * <li>1. {@code Meta} + {@code A} + {@code Backspace} to clear the input
+     * element's old value.
+     * <li>2. Typing the new value.
+     * <li>3. {@code Enter} to commit the new value.
      *
      * @param string
      *            the value to set
      */
     public void setInputValue(String value) {
-        TestBenchElement input = $("input").first();
-        input.setProperty("value", "");
-        input.sendKeys(value, Keys.ENTER);
+        sendKeys(Keys.META, "A");
+        sendKeys(Keys.BACK_SPACE);
+        sendKeys(value, Keys.ENTER);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -164,7 +164,7 @@ public class DatePickerElement extends TestBenchElement
      *            the value to set
      */
     public void setInputValue(String value) {
-        var input = $("input").first();
+        TestBenchElement input = $("input").first();
         input.setProperty("value", "");
         input.sendKeys(value, Keys.ENTER);
     }
@@ -176,7 +176,7 @@ public class DatePickerElement extends TestBenchElement
      * @return
      */
     public String getInputValue() {
-        var input = $("input").first();
+        TestBenchElement input = $("input").first();
         return input.getPropertyString("value");
     }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -163,8 +163,7 @@ public class DatePickerElement extends TestBenchElement
         this.open();
         var input = $("input").first();
         input.setProperty("value", value);
-        input.dispatchEvent("input",
-                Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
         input.dispatchEvent("change",
                 Collections.singletonMap("bubbles", true));
         this.close();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -155,20 +155,16 @@ public class DatePickerElement extends TestBenchElement
     }
 
     /**
-     * Simulates the user changing the value via the input element which is in
-     * practice the following sequence of {@code sendKeys}:
+     * Simulates the user selecting a date via the input element. This
+     * effectively clears the input element with a key shortcut, then types the
+     * given date string and finally presses {@code Enter} to commit the new
+     * date.
      *
-     * <li>1. {@code Meta} + {@code A} + {@code Backspace} to clear the input
-     * element's old value.
-     * <li>2. Typing the new value.
-     * <li>3. {@code Enter} to commit the new value.
-     *
-     * @param string
-     *            the value to set
+     * @param value
+     *            the date string to enter.
      */
     public void setInputValue(String value) {
-        sendKeys(Keys.META, "A");
-        sendKeys(Keys.BACK_SPACE);
+        sendKeys(Keys.chord(Keys.SHIFT, Keys.HOME), Keys.BACK_SPACE);
         sendKeys(value, Keys.ENTER);
     }
 


### PR DESCRIPTION
## Description

This PR changes the `setInputValue` method of `DatePickerElement` to make it simulate real user input by sending the respective characters + <kbd>Enter</kbd> via the Selenium `sendKeys` API. The clearing of the input's value is now done by sending <kbd>Shift</kbd> + <kbd>Home</kbd> and then <kbd>Backspace</kbd> instead of clearing the input's `value` property, see https://github.com/vaadin/flow-components/pull/3576#discussion_r945471738.

In particular, this PR is needed to allow using the method for testing validation behavior on invalid user input – the web component trigger validation on `change` DOM event but not on `_inputValue` property change.

I also removed explicit opening and closing of the overlay as it doesn't seem to be necessary since `DatePicker` already automatically opens on input and closes on <kbd>Enter</kbd>, but let's see if the tests will pass.

> **Warning**
> It is an altering behavior change.

Related to #3420 
Related to #3496 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
