### PR TITLE
chore: change test logic for locked cells

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/LockIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/LockIT.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.spreadsheet.test;
 
+import com.vaadin.flow.component.spreadsheet.testbench.SheetCellElement;
 import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
 
@@ -31,8 +32,10 @@ public class LockIT extends AbstractSpreadsheetIT {
 
         // Assert that a locked cell cannot be edited
         Assert.assertEquals("locked", spreadsheet.getCellAt("B2").getValue());
-        spreadsheet.getCellAt("B2").setValue("new value on locked cell");
-        Assert.assertEquals("locked", spreadsheet.getCellAt("B2").getValue());
+        SheetCellElement lockedCell = spreadsheet.getCellAt("B2");
+        selectCell("B2"); // work around Selenium issue with double-click targeting wrong cell
+        lockedCell.doubleClick();
+        Assert.assertFalse(spreadsheet.getCellValueInput().isDisplayed());
 
         // Assert that an unlocked cell can be edited
         Assert.assertEquals("unlocked", spreadsheet.getCellAt("C3").getValue());

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/LockIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/LockIT.java
@@ -33,7 +33,8 @@ public class LockIT extends AbstractSpreadsheetIT {
         // Assert that a locked cell cannot be edited
         Assert.assertEquals("locked", spreadsheet.getCellAt("B2").getValue());
         SheetCellElement lockedCell = spreadsheet.getCellAt("B2");
-        selectCell("B2"); // work around Selenium issue with double-click targeting wrong cell
+        selectCell("B2"); // work around Selenium issue with double-click
+                          // targeting wrong cell
         lockedCell.doubleClick();
         Assert.assertFalse(spreadsheet.getCellValueInput().isDisplayed());
 


### PR DESCRIPTION
## Description

Fixes `LockIT` to not use `SpreadSheetCellElement.setValue`, which does not work for locked cells, and instead check if double-clicking opens the cell value input.
