### PR TITLE
refactor!: make selectByText clear input's value by sending keys

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -204,10 +204,10 @@ public class TimePickerElement extends TestBenchElement
     }
 
     /**
-     * Simulates the user selecting a time via the input element.
-     * This effectively clears the input element with a key shortcut,
-     * then types the given time string and finally presses {@code Enter}
-     * to commit the new time.
+     * Simulates the user selecting a time via the input element. This
+     * effectively clears the input element with a key shortcut, then types the
+     * given time string and finally presses {@code Enter} to commit the new
+     * time.
      *
      * @param timeInput
      *            the time string to enter, not {@code null}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -218,7 +218,7 @@ public class TimePickerElement extends TestBenchElement
     @Override
     public void selectByText(String timeInput) {
         Objects.requireNonNull(timeInput, "null input not accepted");
-        sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.BACK_SPACE);
+        sendKeys(Keys.HOME, Keys.chord(Keys.SHIFT, Keys.END), Keys.BACK_SPACE);
         sendKeys(timeInput, Keys.ENTER);
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -207,8 +207,8 @@ public class TimePickerElement extends TestBenchElement
      * Simulates the user selecting a time via the input element which is in
      * practice the following sequence of {@code sendKeys}:
      *
-     * <li>1. {@code Meta} + {@code A} + {@code Backspace} to possibly clear
-     * the input element's old value.
+     * <li>1. {@code Meta} + {@code a} + {@code Backspace} to possibly clear the
+     * input element's old value.
      * <li>2. Typing the given time string.
      * <li>3. {@code Enter} to commit the new time.
      *
@@ -218,7 +218,7 @@ public class TimePickerElement extends TestBenchElement
     @Override
     public void selectByText(String timeInput) {
         Objects.requireNonNull(timeInput, "null input not accepted");
-        sendKeys(Keys.chord(Keys.META, "a"), Keys.BACK_SPACE);
+        sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.BACK_SPACE);
         sendKeys(timeInput, Keys.ENTER);
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.timepicker.testbench;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import com.vaadin.testbench.HasHelper;
@@ -206,8 +207,8 @@ public class TimePickerElement extends TestBenchElement
      * Simulates the user selecting a time via the input element which is in
      * practice the following sequence of {@code sendKeys}:
      *
-     * <li>1. {@code Meta} + {@code A} + {@code Backspace} to clear the input
-     * element's old value.
+     * <li>1. {@code Meta} + {@code A} + {@code Backspace} to possibly clear
+     * the input element's old value.
      * <li>2. Typing the given time string.
      * <li>3. {@code Enter} to commit the new time.
      *
@@ -217,8 +218,7 @@ public class TimePickerElement extends TestBenchElement
     @Override
     public void selectByText(String timeInput) {
         Objects.requireNonNull(timeInput, "null input not accepted");
-        sendKeys(Keys.META, "A");
-        sendKeys(Keys.BACK_SPACE);
+        sendKeys(Keys.chord(Keys.META, "a"), Keys.BACK_SPACE);
         sendKeys(timeInput, Keys.ENTER);
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -204,13 +204,10 @@ public class TimePickerElement extends TestBenchElement
     }
 
     /**
-     * Simulates the user selecting a time via the input element which is in
-     * practice the following sequence of {@code sendKeys}:
-     *
-     * <li>1. {@code Meta} + {@code a} + {@code Backspace} to possibly clear the
-     * input element's old value.
-     * <li>2. Typing the given time string.
-     * <li>3. {@code Enter} to commit the new time.
+     * Simulates the user selecting a time via the input element.
+     * This effectively clears the input element with a key shortcut,
+     * then types the given time string and finally presses {@code Enter}
+     * to commit the new time.
      *
      * @param timeInput
      *            the time string to enter, not {@code null}
@@ -218,7 +215,7 @@ public class TimePickerElement extends TestBenchElement
     @Override
     public void selectByText(String timeInput) {
         Objects.requireNonNull(timeInput, "null input not accepted");
-        sendKeys(Keys.HOME, Keys.chord(Keys.SHIFT, Keys.END), Keys.BACK_SPACE);
+        sendKeys(Keys.chord(Keys.SHIFT, Keys.HOME), Keys.BACK_SPACE);
         sendKeys(timeInput, Keys.ENTER);
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -203,18 +203,23 @@ public class TimePickerElement extends TestBenchElement
     }
 
     /**
-     * Enter the given time input to the text field.
+     * Simulates the user selecting a time via the input element which is in
+     * practice the following sequence of {@code sendKeys}:
+     *
+     * <li>1. {@code Meta} + {@code A} + {@code Backspace} to clear the input
+     * element's old value.
+     * <li>2. Typing the given time string.
+     * <li>3. {@code Enter} to commit the new time.
      *
      * @param timeInput
-     *            the time input to enter, not {@code null}
+     *            the time string to enter, not {@code null}
      */
     @Override
     public void selectByText(String timeInput) {
         Objects.requireNonNull(timeInput, "null input not accepted");
-
-        TestBenchElement timePickerInputElement = getTimePickerInputElement();
-        executeScript("arguments[0].value = ''", timePickerInputElement);
-        timePickerInputElement.sendKeys(timeInput + Keys.RETURN);
+        sendKeys(Keys.META, "A");
+        sendKeys(Keys.BACK_SPACE);
+        sendKeys(timeInput, Keys.ENTER);
     }
 
     @Override


### PR DESCRIPTION
## Description

The previous implementation used to clear the input element's `value` property which could result in missing the `input` event when `selectByText` is called with an empty string. This PR instead makes `selectByText` clear the value by sending <kbd>Shift</kbd> + <kbd>Home</kbd> (Select All) and then <kbd>Backspace</kbd> which doesn't have that drawback.

This is needed to allow using the `selectByText` method for testing validation in https://github.com/vaadin/flow-components/pull/3515.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
