### PR TITLE
fix: prevent adding overlay to UI when forwarding happens in beforeEnter

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/OverlayForwardingSourcePage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/OverlayForwardingSourcePage.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.confirmdialog.tests;
+
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-confirm-dialog/overlay-remains-in-dom-after-detach-view")
+public class OverlayForwardingSourcePage extends ConfirmDialog
+        implements BeforeEnterObserver {
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        event.forwardTo(OverlayForwardingTargetPage.class);
+    }
+
+    public OverlayForwardingSourcePage() {
+        setOpened(true);
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/OverlayForwardingTargetPage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/OverlayForwardingTargetPage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.confirmdialog.tests;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-confirm-dialog/forwarding-target")
+public class OverlayForwardingTargetPage extends Div {
+    public OverlayForwardingTargetPage() {
+        setId("forwarded-view");
+        add(new Text("Forwarded"));
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/OverlayForwardingIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/OverlayForwardingIT.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.component.confirmdialog.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-confirm-dialog/overlay-remains-in-dom-after-detach-view")
+public class OverlayForwardingIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void forwardPageInBeforeEnter_newPageDoesNotContainVaadinConfirmDialogOverlay() {
+        waitForElementPresent(By.id("forwarded-view"));
+        Assert.assertFalse(
+                isElementPresent(By.tagName("vaadin-confirm-dialog-overlay")));
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.internal.StateTree;
+import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -97,6 +99,8 @@ public class ConfirmDialog extends Component
 
     private String height;
     private String width;
+
+    private Registration afterProgrammaticNavigationListenerRegistration;
 
     /**
      * Sets the width of the component content area.
@@ -664,14 +668,26 @@ public class ConfirmDialog extends Component
 
     private void ensureAttached() {
         UI ui = getCurrentUI();
-        ui.beforeClientResponse(ui, context -> {
-            if (getElement().getNode().getParent() == null) {
-                ui.addToModalComponent(this);
-                autoAddedToTheUi = true;
-                updateWidth();
-                updateHeight();
-                ui.setChildComponentModal(this, true);
-            }
-        });
+        StateTree.ExecutionRegistration addToUiRegistration = ui
+                .beforeClientResponse(ui, context -> {
+                    if (getElement().getNode().getParent() == null) {
+                        ui.addToModalComponent(this);
+                        autoAddedToTheUi = true;
+                        updateWidth();
+                        updateHeight();
+                        ui.setChildComponentModal(this, true);
+                    }
+                });
+        if (ui.getSession() != null) {
+            afterProgrammaticNavigationListenerRegistration = ui
+                    .addAfterNavigationListener(event -> {
+                        if (event.getLocationChangeEvent()
+                                .getTrigger() == NavigationTrigger.PROGRAMMATIC) {
+                            addToUiRegistration.remove();
+                            afterProgrammaticNavigationListenerRegistration
+                                    .remove();
+                        }
+                    });
+        }
     }
 }

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -677,6 +677,10 @@ public class ConfirmDialog extends Component
                         updateHeight();
                         ui.setChildComponentModal(this, true);
                     }
+                    if (afterProgrammaticNavigationListenerRegistration != null) {
+                        afterProgrammaticNavigationListenerRegistration
+                                .remove();
+                    }
                 });
         if (ui.getSession() != null) {
             afterProgrammaticNavigationListenerRegistration = ui

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/OverlayForwardingSourcePage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/OverlayForwardingSourcePage.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-dialog/overlay-remains-in-dom-after-detach-view")
+public class OverlayForwardingSourcePage extends Dialog
+        implements BeforeEnterObserver {
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        event.forwardTo(OverlayForwardingTargetPage.class);
+    }
+
+    public OverlayForwardingSourcePage() {
+        setOpened(true);
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/OverlayForwardingTargetPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/OverlayForwardingTargetPage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-dialog/forwarding-target")
+public class OverlayForwardingTargetPage extends Div {
+    public OverlayForwardingTargetPage() {
+        setId("forwarded-view");
+        add(new Text("Forwarded"));
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/OverlayForwardingIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/OverlayForwardingIT.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-dialog/overlay-remains-in-dom-after-detach-view")
+public class OverlayForwardingIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void forwardPageInBeforeEnter_newPageDoesNotContainVaadinDialogOverlay() {
+        waitForElementPresent(By.id("forwarded-view"));
+        Assert.assertFalse(
+                isElementPresent(By.tagName("vaadin-dialog-overlay")));
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -755,6 +755,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                         ui.setChildComponentModal(this, isModal());
                         autoAddedToTheUi = true;
                     }
+                    if (afterProgrammaticNavigationListenerRegistration != null) {
+                        afterProgrammaticNavigationListenerRegistration
+                                .remove();
+                    }
                 });
         if (ui.getSession() != null) {
             afterProgrammaticNavigationListenerRegistration = ui

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -39,6 +39,8 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.internal.StateTree;
+import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -85,6 +87,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     private String maxHeight;
     private DialogHeader dialogHeader;
     private DialogFooter dialogFooter;
+
+    private Registration afterProgrammaticNavigationListenerRegistration;
 
     /**
      * Creates an empty dialog.
@@ -744,13 +748,25 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     private void ensureAttached() {
         UI ui = getCurrentUI();
-        ui.beforeClientResponse(ui, context -> {
-            if (getElement().getNode().getParent() == null) {
-                ui.addToModalComponent(this);
-                ui.setChildComponentModal(this, isModal());
-                autoAddedToTheUi = true;
-            }
-        });
+        StateTree.ExecutionRegistration addToUiRegistration = ui
+                .beforeClientResponse(ui, context -> {
+                    if (getElement().getNode().getParent() == null) {
+                        ui.addToModalComponent(this);
+                        ui.setChildComponentModal(this, isModal());
+                        autoAddedToTheUi = true;
+                    }
+                });
+        if (ui.getSession() != null) {
+            afterProgrammaticNavigationListenerRegistration = ui
+                    .addAfterNavigationListener(event -> {
+                        if (event.getLocationChangeEvent()
+                                .getTrigger() == NavigationTrigger.PROGRAMMATIC) {
+                            addToUiRegistration.remove();
+                            afterProgrammaticNavigationListenerRegistration
+                                    .remove();
+                        }
+                    });
+        }
     }
 
     private void ensureOnCloseConfigured() {

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/main/java/com/vaadin/flow/component/login/tests/OverlayForwardingSourcePage.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/main/java/com/vaadin/flow/component/login/tests/OverlayForwardingSourcePage.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.login.tests;
+
+import com.vaadin.flow.component.login.LoginOverlay;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-login/overlay-remains-in-dom-after-detach-view")
+public class OverlayForwardingSourcePage extends LoginOverlay
+        implements BeforeEnterObserver {
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        event.forwardTo(OverlayForwardingTargetPage.class);
+    }
+
+    public OverlayForwardingSourcePage() {
+        setOpened(true);
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/main/java/com/vaadin/flow/component/login/tests/OverlayForwardingTargetPage.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/main/java/com/vaadin/flow/component/login/tests/OverlayForwardingTargetPage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.login.tests;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-login/forwarding-target")
+public class OverlayForwardingTargetPage extends Div {
+    public OverlayForwardingTargetPage() {
+        setId("forwarded-view");
+        add(new Text("Forwarded"));
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayForwardingIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayForwardingIT.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.component.login.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-login/overlay-remains-in-dom-after-detach-view")
+public class OverlayForwardingIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void forwardPageInBeforeEnter_newPageDoesNotContainVaadinLoginOverlay() {
+        waitForElementPresent(By.id("forwarded-view"));
+        Assert.assertFalse(
+                isElementPresent(By.tagName("vaadin-login-overlay")));
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
@@ -131,6 +131,10 @@ public class LoginOverlay extends AbstractLogin implements HasStyle {
                     .beforeClientResponse(ui, context -> {
                         ui.addToModalComponent(this);
                         autoAddedToTheUi = true;
+                        if (afterProgrammaticNavigationListenerRegistration != null) {
+                            afterProgrammaticNavigationListenerRegistration
+                                    .remove();
+                        }
                     });
             if (ui.getSession() != null) {
                 afterProgrammaticNavigationListenerRegistration = ui

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
@@ -29,6 +29,9 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.internal.StateTree;
+import com.vaadin.flow.router.NavigationTrigger;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * Server-side component for the {@code <vaadin-login-overlay>} component.
@@ -54,6 +57,8 @@ public class LoginOverlay extends AbstractLogin implements HasStyle {
     private Component title;
 
     private boolean autoAddedToTheUi;
+
+    private Registration afterProgrammaticNavigationListenerRegistration;
 
     public LoginOverlay() {
         initEnsureDetachListener();
@@ -122,10 +127,22 @@ public class LoginOverlay extends AbstractLogin implements HasStyle {
     private void ensureAttached() {
         if (getElement().getNode().getParent() == null) {
             UI ui = getCurrentUI();
-            ui.beforeClientResponse(ui, context -> {
-                ui.addToModalComponent(this);
-                autoAddedToTheUi = true;
-            });
+            StateTree.ExecutionRegistration addToUiRegistration = ui
+                    .beforeClientResponse(ui, context -> {
+                        ui.addToModalComponent(this);
+                        autoAddedToTheUi = true;
+                    });
+            if (ui.getSession() != null) {
+                afterProgrammaticNavigationListenerRegistration = ui
+                        .addAfterNavigationListener(event -> {
+                            if (event.getLocationChangeEvent()
+                                    .getTrigger() == NavigationTrigger.PROGRAMMATIC) {
+                                addToUiRegistration.remove();
+                                afterProgrammaticNavigationListenerRegistration
+                                        .remove();
+                            }
+                        });
+            }
         }
     }
 

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/ContainerForwardingSourcePage.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/ContainerForwardingSourcePage.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.notification.tests;
+
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-notification/container-remains-in-dom-after-detach-view")
+public class ContainerForwardingSourcePage extends Notification
+        implements BeforeEnterObserver {
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        event.forwardTo(ContainerForwardingTargetPage.class);
+    }
+
+    public ContainerForwardingSourcePage() {
+        setOpened(true);
+    }
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/ContainerForwardingTargetPage.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/ContainerForwardingTargetPage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.notification.tests;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-notification/forwarding-target")
+public class ContainerForwardingTargetPage extends Div {
+    public ContainerForwardingTargetPage() {
+        setId("forwarded-view");
+        add(new Text("Forwarded"));
+    }
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/ContainerForwardingIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/ContainerForwardingIT.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.component.notification.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-notification/container-remains-in-dom-after-detach-view")
+public class ContainerForwardingIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void forwardPageInBeforeEnter_newPageDoesNotContainVaadinNotificationContainer() {
+        waitForElementPresent(By.id("forwarded-view"));
+        Assert.assertFalse(
+                isElementPresent(By.tagName("vaadin-notification-container")));
+    }
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -456,6 +456,10 @@ public class Notification extends GeneratedVaadinNotification<Notification>
                         ui.addToModalComponent(this);
                         autoAddedToTheUi = true;
                     }
+                    if (afterProgrammaticNavigationListenerRegistration != null) {
+                        afterProgrammaticNavigationListenerRegistration
+                                .remove();
+                    }
                 });
         if (ui.getSession() != null) {
             afterProgrammaticNavigationListenerRegistration = ui


### PR DESCRIPTION
## Description

The issue was caused by registrations regarding adding the component to UI persisting even after a forwarding/rerouting happens in `beforeEnter`.

This PR introduces an `AfterNavigationListener` for programmatic navigation events. Whenever such an event occurs, the listener removes the previously added registration regarding adding the component to UI.

Applies to ConfirmDialog, Dialog, LoginOverlay, and Notification.

Fixes #3414

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.