### PR TITLE
fix: make recalculateColumnnWidths in Grid wait for changes to be applied

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -33,9 +33,9 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         grid1.setAllRowsVisible(true);
         grid1.setItems(ts1, ts2);
 
-        grid1.addColumn(item -> item.a).setAutoWidth(true);
-        grid1.addColumn(item -> item.b).setAutoWidth(true);
-        grid1.addColumn(item -> item.c).setAutoWidth(true);
+        grid1.addColumn(item -> item.a).setAutoWidth(true).setKey("column1");
+        grid1.addColumn(item -> item.b).setAutoWidth(true).setKey("column2");
+        grid1.addColumn(item -> item.c).setAutoWidth(true).setKey("column3");
 
         add(grid1);
 
@@ -48,9 +48,9 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
         grid1.getElement().executeJs(
                 "$0._recalculateColumnWidthOnceLoadingFinished = false");
 
-        Button button = new Button("Add Text");
-        button.setId("change-data-button");
-        button.addClickListener(event -> {
+        Button changeDataButton = new Button("Add Text");
+        changeDataButton.setId("change-data-button");
+        changeDataButton.addClickListener(event -> {
 
             ts2.b = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,"
                     + " sed diam nonumy eirmod tempor invidunt ut labore et dolore"
@@ -68,7 +68,21 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
             grid1.recalculateColumnWidths();
         });
 
-        add(button);
+        Button setCol2InvisibleButton = new Button("Set column 2 invisible");
+        setCol2InvisibleButton.setId("set-column-2-invisible-button");
+        setCol2InvisibleButton.addClickListener(l -> {
+            grid1.getColumnByKey("column2").setVisible(false);
+            grid1.recalculateColumnWidths();
+        });
+
+        Button setCol2VisibleButton = new Button("Set column 2 visible");
+        setCol2VisibleButton.setId("set-column-2-visible-button");
+        setCol2VisibleButton.addClickListener(l -> {
+            grid1.getColumnByKey("column2").setVisible(true);
+            grid1.recalculateColumnWidths();
+        });
+
+        add(changeDataButton, setCol2InvisibleButton, setCol2VisibleButton);
     }
 
     static class ThreeString {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsIT.java
@@ -16,32 +16,39 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
+import java.util.List;
+
 @TestPath("vaadin-grid/recalculate-column-widths")
 public class RecalculateColumnWidthsIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.id("grid"));
+    }
+
     @Test
     public void columnsRecalculateAfterDataChange() {
-        open();
-
-        waitForElementPresent(By.id("grid"));
-
         GridElement grid = $(GridElement.class).id("grid");
-        TestBenchElement button = $(TestBenchElement.class)
+        TestBenchElement changeDataButton = $(TestBenchElement.class)
                 .id("change-data-button");
 
         GridTHTDElement cell = grid.getCell(1, 1);
 
         Integer scrollWidthBefore = cell.getPropertyInteger("scrollWidth");
 
-        button.click();
+        changeDataButton.click();
 
         Integer scrollWidthAfter = cell.getPropertyInteger("scrollWidth");
         Integer offsetWidthAfter = cell.getPropertyInteger("offsetWidth");
@@ -50,5 +57,28 @@ public class RecalculateColumnWidthsIT extends AbstractComponentIT {
                 scrollWidthAfter > scrollWidthBefore);
         Assert.assertTrue("Cell content should not be cut off with ellipsis",
                 offsetWidthAfter <= scrollWidthAfter);
+    }
+
+    @Test
+    public void columnsRecalculateAfterVisibilityChange() {
+        GridElement grid = $(GridElement.class).id("grid");
+        TestBenchElement setCol2InvisibleButton = $(TestBenchElement.class)
+                .id("set-column-2-invisible-button");
+        TestBenchElement setCol2VisibleButton = $(TestBenchElement.class)
+                .id("set-column-2-visible-button");
+
+        List<GridColumnElement> visibleColumnsBefore = grid.getVisibleColumns();
+        Assert.assertEquals(3, visibleColumnsBefore.size());
+
+        int column2SizeBefore = grid.getCell(0, visibleColumnsBefore.get(1))
+                .getSize().getWidth();
+
+        setCol2InvisibleButton.click();
+        setCol2VisibleButton.click();
+
+        List<GridColumnElement> visibleColumnsAfter = grid.getVisibleColumns();
+        Assert.assertEquals(3, visibleColumnsAfter.size());
+        Assert.assertEquals(column2SizeBefore, grid
+                .getCell(0, visibleColumnsAfter.get(1)).getSize().getWidth());
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3842,9 +3842,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         // the client side grid in the beforeClientResponse hook, we need to
         // match this here so that the column width recalculation runs after the
         // data was updated.
-        getElement().getNode().runWhenAttached(ui -> ui.beforeClientResponse(
-                this,
-                ctx -> getElement().callJsFunction("recalculateColumnWidths")));
+        getElement().getNode().runWhenAttached(ui -> {
+            ui.getInternals().getStateTree().collectChanges(ignore -> {
+            });
+            ui.beforeClientResponse(this, ctx -> getElement()
+                    .callJsFunction("recalculateColumnWidths"));
+        });
     }
 
     /**


### PR DESCRIPTION
## Description
When called after toggling visibility, `recalculateColumnWidths` registration is added to the execution list before the visibility change. 

This PR makes sure that the changes that might have happened before the  `recalculateColumnWidths` call to be pushed before registering `recalculateColumnWidths` JS function. This is achieved by calling `collectChanges`.

Fixes #2848 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.