### PR TITLE
feat: add TabSheet with basic features

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -23,11 +23,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-html-components</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.tabs;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * TabSheet consists of a set of tabs and the content area constrolled by them.
+ * The content area displays a component associated with the selected tab.
+ *
+ * @author Vaadin Ltd.
+ */
+@Tag("vaadin-tabsheet")
+// @JsModule("@vaadin/tabsheet/src/vaadin-tabsheet.js")
+// @NpmPackage(value = "@vaadin/vaadin-tabsheet", version = "23.3.0-alpha1")
+// Temporary module used until the package is published to npm
+@JsModule("./tabsheet/vaadin-tabsheet.js")
+public class TabSheet extends Component implements HasStyle, HasSize {
+
+    private Tabs tabs = new Tabs();
+
+    private Map<Tab, Component> tabToContent = new HashMap<>();
+
+    /**
+     * The default constructor.
+     */
+    public TabSheet() {
+        super();
+
+        tabs.getElement().setAttribute("slot", "tabs");
+        getElement().appendChild(tabs.getElement());
+
+        addSelectedChangeListener(e -> updateContent());
+    }
+
+    /**
+     * Adds a tab created from the given tab content and content.
+     *
+     * @param tabContent
+     *            the content of the tab
+     * @param content
+     *            the content related to the tab
+     * @return the created tab
+     */
+    public Tab add(Tab tab, Component content) {
+        Objects.requireNonNull(tab, "The tab to be added cannot be null");
+        Objects.requireNonNull(content,
+                "The content to be added cannot be null");
+        tabs.add(tab);
+
+        // On the client, content is associated with a tab by id
+        var id = "tabsheet-tab-" + UUID.randomUUID().toString();
+        tab.setId(id);
+        content.getElement().setAttribute("tab", id);
+
+        tabToContent.put(tab, content);
+
+        updateContent();
+
+        return tab;
+    }
+
+    /**
+     * Adds a tab created from the given tab content and content.
+     *
+     * @param tabContent
+     *            the content of the tab
+     * @param content
+     *            the content related to the tab
+     * @return the created tab
+     */
+    public Tab add(Component tabContent, Component content) {
+        return add(new Tab(tabContent), content);
+    }
+
+    /**
+     * Adds a tab created from the given text and content.
+     *
+     * @param tabText
+     *            the text of the tab
+     * @param content
+     *            the content related to the tab
+     * @return the created tab
+     */
+    public Tab add(String tabText, Component content) {
+        return add(new Span(tabText), content);
+    }
+
+    /**
+     * Removes a tab.
+     *
+     * @param tab
+     *            the non-null tab to be removed
+     */
+    public void remove(Tab tab) {
+        Objects.requireNonNull(tab, "The tab to be removed cannot be null");
+        var content = tabToContent.remove(tab);
+        content.getElement().removeFromParent();
+        tabs.remove(tab);
+    }
+
+    /**
+     * Removes a tab based on the content
+     *
+     * @param content
+     *            the non-null content related to the tab to be removed
+     */
+    public void remove(Component content) {
+        Objects.requireNonNull(content,
+                "The content of the tab to be removed cannot be null");
+        var tab = tabToContent.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(content))
+                .map(Map.Entry::getKey).findFirst().orElse(null);
+
+        if (tab != null) {
+            remove(tab);
+        }
+    }
+
+    /**
+     * Gets the zero-based index of the currently selected tab.
+     *
+     * @return the zero-based index of the selected tab, or -1 if none of the
+     *         tabs is selected
+     */
+    public int getSelectedIndex() {
+        return tabs.getSelectedIndex();
+    }
+
+    /**
+     * Selects a tab based on its zero-based index.
+     *
+     * @param selectedIndex
+     *            the zero-based index of the selected tab, -1 to unselect all
+     */
+    public void setSelectedIndex(int selectedIndex) {
+        tabs.setSelectedIndex(selectedIndex);
+    }
+
+    /**
+     * Gets the currently selected tab.
+     *
+     * @return the selected tab, or {@code null} if none is selected
+     */
+    public Tab getSelectedTab() {
+        return tabs.getSelectedTab();
+    }
+
+    /**
+     * Selects the given tab.
+     *
+     * @param selectedTab
+     *            the tab to select, {@code null} to unselect all
+     * @throws IllegalArgumentException
+     *             if {@code selectedTab} is not a child of this component
+     */
+    public void setSelectedTab(Tab selectedTab) {
+        tabs.setSelectedTab(selectedTab);
+    }
+
+    /**
+     * Adds a listener for {@link SelectedChangeEvent}.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    public Registration addSelectedChangeListener(
+            ComponentEventListener<SelectedChangeEvent> listener) {
+
+        return tabs.addSelectedChangeListener(event -> {
+            listener.onComponentEvent(new SelectedChangeEvent(TabSheet.this,
+                    event.getPreviousTab(), event.isFromClient(),
+                    event.isInitialSelection()));
+        });
+
+    }
+
+    /**
+     * Marks the content related to the selected tab as enabled and adds it to
+     * the component if it is not already added. All the other content panels
+     * are disabled so they can't be interacted with.
+     */
+    private void updateContent() {
+        for (Map.Entry<Tab, Component> entry : tabToContent.entrySet()) {
+            var tab = entry.getKey();
+            var content = entry.getValue();
+
+            if (tab.equals(tabs.getSelectedTab())) {
+                if (content.getElement().getParent() == null) {
+                    getElement().appendChild(content.getElement());
+                }
+                content.getElement().setEnabled(true);
+            } else {
+                // Can't use setEnabled(false) because it would also mark the
+                // elements as disabled in the DOM. Navigating between tabs
+                // would then briefly show the content as disabled.
+                content.getElement().getNode().setEnabled(false);
+            }
+        }
+    }
+
+    /**
+     * An event to mark that the selected tab has changed.
+     */
+    public static class SelectedChangeEvent extends ComponentEvent<TabSheet> {
+        private final Tab selectedTab;
+        private final Tab previousTab;
+        private final boolean initialSelection;
+
+        /**
+         * Creates a new selected change event.
+         *
+         * @param source
+         *            The tabs that fired the event.
+         * @param previousTab
+         *            The previous selected tab.
+         * @param fromClient
+         *            <code>true</code> for client-side events,
+         *            <code>false</code> otherwise.
+         */
+        public SelectedChangeEvent(TabSheet source, Tab previousTab,
+                boolean fromClient, boolean initialSelection) {
+            super(source, fromClient);
+            this.selectedTab = source.getSelectedTab();
+            this.initialSelection = initialSelection;
+            this.previousTab = previousTab;
+        }
+
+        /**
+         * Get selected tab for this event. Can be {@code null} when autoselect
+         * is set to false.
+         *
+         * @return the selected tab for this event
+         */
+        public Tab getSelectedTab() {
+            return this.selectedTab;
+        }
+
+        /**
+         * Get previous selected tab for this event. Can be {@code null} when
+         * autoselect is set to false.
+         *
+         * @return the selected tab for this event
+         */
+        public Tab getPreviousTab() {
+            return this.previousTab;
+        }
+
+        /**
+         * Checks if this event is initial tabs selection.
+         *
+         * @return <code>true</code> if the event is initial tabs selection,
+         *         <code>false</code> otherwise
+         */
+        public boolean isInitialSelection() {
+            return this.initialSelection;
+        }
+    }
+
+}

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -140,7 +140,7 @@ public class TabSheet extends Component implements HasStyle, HasSize {
         Objects.requireNonNull(content,
                 "The content of the tab to be removed cannot be null");
         var tab = tabToContent.entrySet().stream()
-                .filter(entry -> entry.getValue().equals(content))
+                .filter(entry -> entry.getValue().equals(content.getElement()))
                 .map(Map.Entry::getKey).findFirst().orElse(null);
 
         if (tab != null) {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -40,8 +41,10 @@ import com.vaadin.flow.shared.Registration;
 @Tag("vaadin-tabsheet")
 // @JsModule("@vaadin/tabsheet/src/vaadin-tabsheet.js")
 // @NpmPackage(value = "@vaadin/vaadin-tabsheet", version = "23.3.0-alpha1")
-// Temporary module used until the package is published to npm
+// Temporary module and npm packages used until the package is published to npm
 @JsModule("./tabsheet/vaadin-tabsheet.js")
+@NpmPackage(value = "@vaadin/component-base", version = "23.2.0-beta3")
+@NpmPackage(value = "@vaadin/field-base", version = "23.2.0-beta3")
 public class TabSheet extends Component implements HasStyle, HasSize {
 
     private Tabs tabs = new Tabs();

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -30,10 +30,11 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * TabSheet consists of a set of tabs and the content area constrolled by them.
+ * TabSheet consists of a set of tabs and the content area.
  * The content area displays a component associated with the selected tab.
  *
  * @author Vaadin Ltd.
@@ -49,7 +50,7 @@ public class TabSheet extends Component implements HasStyle, HasSize {
 
     private Tabs tabs = new Tabs();
 
-    private Map<Tab, Component> tabToContent = new HashMap<>();
+    private Map<Tab, Element> tabToContent = new HashMap<>();
 
     /**
      * The default constructor.
@@ -64,13 +65,13 @@ public class TabSheet extends Component implements HasStyle, HasSize {
     }
 
     /**
-     * Adds a tab created from the given tab content and content.
+     * Adds a tab with the given content.
      *
-     * @param tabContent
-     *            the content of the tab
+     * @param tab
+     *            the tab
      * @param content
      *            the content related to the tab
-     * @return the created tab
+     * @return the added tab
      */
     public Tab add(Tab tab, Component content) {
         Objects.requireNonNull(tab, "The tab to be added cannot be null");
@@ -83,7 +84,7 @@ public class TabSheet extends Component implements HasStyle, HasSize {
         tab.setId(id);
         content.getElement().setAttribute("tab", id);
 
-        tabToContent.put(tab, content);
+        tabToContent.put(tab, content.getElement());
 
         updateContent();
 
@@ -125,7 +126,7 @@ public class TabSheet extends Component implements HasStyle, HasSize {
     public void remove(Tab tab) {
         Objects.requireNonNull(tab, "The tab to be removed cannot be null");
         var content = tabToContent.remove(tab);
-        content.getElement().removeFromParent();
+        content.removeFromParent();
         tabs.remove(tab);
     }
 
@@ -212,20 +213,20 @@ public class TabSheet extends Component implements HasStyle, HasSize {
      * are disabled so they can't be interacted with.
      */
     private void updateContent() {
-        for (Map.Entry<Tab, Component> entry : tabToContent.entrySet()) {
+        for (Map.Entry<Tab, Element> entry : tabToContent.entrySet()) {
             var tab = entry.getKey();
             var content = entry.getValue();
 
             if (tab.equals(tabs.getSelectedTab())) {
-                if (content.getElement().getParent() == null) {
-                    getElement().appendChild(content.getElement());
+                if (content.getParent() == null) {
+                    getElement().appendChild(content);
                 }
-                content.getElement().setEnabled(true);
+                content.setEnabled(true);
             } else {
                 // Can't use setEnabled(false) because it would also mark the
                 // elements as disabled in the DOM. Navigating between tabs
                 // would then briefly show the content as disabled.
-                content.getElement().getNode().setEnabled(false);
+                content.getNode().setEnabled(false);
             }
         }
     }
@@ -242,7 +243,7 @@ public class TabSheet extends Component implements HasStyle, HasSize {
          * Creates a new selected change event.
          *
          * @param source
-         *            The tabs that fired the event.
+         *            The TabSheet that fired the event.
          * @param previousTab
          *            The previous selected tab.
          * @param fromClient
@@ -278,9 +279,9 @@ public class TabSheet extends Component implements HasStyle, HasSize {
         }
 
         /**
-         * Checks if this event is initial tabs selection.
+         * Checks if this event is initial TabSheet selection.
          *
-         * @return <code>true</code> if the event is initial tabs selection,
+         * @return <code>true</code> if the event is initial TabSheet selection,
          *         <code>false</code> otherwise
          */
         public boolean isInitialSelection() {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -34,8 +34,8 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * TabSheet consists of a set of tabs and the content area.
- * The content area displays a component associated with the selected tab.
+ * TabSheet consists of a set of tabs and the content area. The content area
+ * displays a component associated with the selected tab.
  *
  * @author Vaadin Ltd.
  */

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -27,8 +27,8 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -110,7 +110,7 @@ public class TabSheet extends Component implements HasStyle, HasSize {
      * @return the created tab
      */
     public Tab add(String tabText, Component content) {
-        return add(new Span(tabText), content);
+        return add(new Text(tabText), content);
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/src/vaadin-tabsheet.d.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * Fired when the `items` property changes.
+ */
+export type TabSheetItemsChangedEvent = CustomEvent<{ value: Tab[] }>;
+
+/**
+ * Fired when the `selected` property changes.
+ */
+export type TabSheetSelectedChangedEvent = CustomEvent<{ value: number }>;
+
+export interface TabSheetCustomEventMap {
+  'items-changed': TabSheetItemsChangedEvent;
+
+  'selected-changed': TabSheetSelectedChangedEvent;
+}
+
+export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEventMap {}
+
+/**
+ * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
+ * into scrollable panels. The panels can be switched between by using tabs.
+ *
+ * ```
+ *  <vaadin-tabsheet>
+ *    <div slot="prefix">Prefix</div>
+ *    <div slot="suffix">Suffix</div>
+ *
+ *    <vaadin-tabs slot="tabs">
+ *      <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+ *      <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+ *      <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+ *    </vaadin-tabs>
+ *
+ *    <div tab="tab-1">Panel 1</div>
+ *    <div tab="tab-2">Panel 2</div>
+ *    <div tab="tab-3">Panel 3</div>
+ *  </vaadin-tabsheet>
+ * ```
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are exposed for styling:
+ *
+ * Part name | Description
+ * --------- | ---------------
+ * `tabs-container`    | The container for the slotted prefix, tabs and suffix
+ * `content`    | The container for the slotted panels
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute         | Description
+ * ------------------|-------------
+ * `loading` | Set when a tab without associated content is selected | :host
+ * `overflow`   | Set to `top`, `bottom`, `start`, `end`, all of them, or none.
+ *
+ * See [Styling Components](hhttps://vaadin.com/docs/latest/components/ds-resources/customization/styling-components) documentation.
+ *
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ */
+declare class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
+  /**
+   * The index of the selected tab.
+   */
+  selected: number | null | undefined;
+
+  /**
+   * The list of `<vaadin-tab>`s from which a selection can be made.
+   * It is populated from the elements passed inside the slotted
+   * `<vaadin-tabs>`, and updated dynamically when adding or removing items.
+   *
+   * Note: unlike `<vaadin-combo-box>`, this property is read-only.
+   */
+  readonly items: Tab[] | undefined;
+
+  addEventListener<K extends keyof TabSheetEventMap>(
+    type: K,
+    listener: (this: TabSheet, ev: TabSheetEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof TabSheetEventMap>(
+    type: K,
+    listener: (this: TabSheet, ev: TabSheetEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-tabsheet': TabSheet;
+  }
+}
+
+export { TabSheet };

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/src/vaadin-tabsheet.js
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/src/vaadin-tabsheet.js
@@ -1,0 +1,277 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/tabs/src/vaadin-tab.js';
+import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import { Tabs } from '@vaadin/tabs/src/vaadin-tabs.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
+ * into scrollable panels. The panels can be switched between by using tabs.
+ *
+ * ```
+ *  <vaadin-tabsheet>
+ *    <div slot="prefix">Prefix</div>
+ *    <div slot="suffix">Suffix</div>
+ *
+ *    <vaadin-tabs slot="tabs">
+ *      <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+ *      <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+ *      <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+ *    </vaadin-tabs>
+ *
+ *    <div tab="tab-1">Panel 1</div>
+ *    <div tab="tab-2">Panel 2</div>
+ *    <div tab="tab-3">Panel 3</div>
+ *  </vaadin-tabsheet>
+ * ```
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are exposed for styling:
+ *
+ * Part name | Description
+ * --------- | ---------------
+ * `tabs-container`    | The container for the slotted prefix, tabs and suffix
+ * `content`    | The container for the slotted panels
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute         | Description
+ * ------------------|-------------
+ * `loading` | Set when a tab without associated content is selected | :host
+ * `overflow`   | Set to `top`, `bottom`, `start`, `end`, all of them, or none.
+ *
+ * See [Styling Components](hhttps://vaadin.com/docs/latest/components/ds-resources/customization/styling-components) documentation.
+ *
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ *
+ * @extends HTMLElement
+ * @mixes ElementMixin
+ * @mixes ThemableMixin
+ * @mixes ControllerMixin
+ * @mises DelegateStateMixin
+ */
+class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
+  static get template() {
+    return html`
+      <style>
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        :host {
+          display: flex;
+          flex-direction: column;
+        }
+
+        [part='tabs-container'] {
+          position: relative;
+          display: flex;
+          align-items: baseline;
+        }
+
+        ::slotted([slot='tabs']) {
+          overflow: hidden;
+          flex: 1;
+        }
+
+        ::slotted([slot='prefix']),
+        ::slotted([slot='suffix']) {
+          flex: none;
+        }
+
+        [part='content'] {
+          position: relative;
+          overflow: auto;
+          flex: 1;
+          box-sizing: border-box;
+        }
+      </style>
+
+      <div part="tabs-container">
+        <slot name="prefix"></slot>
+        <slot name="tabs"></slot>
+        <slot name="suffix"></slot>
+      </div>
+
+      <div part="content">
+        <div part="loader"></div>
+        <slot id="panel-slot"></slot>
+      </div>
+    `;
+  }
+
+  static get is() {
+    return 'vaadin-tabsheet';
+  }
+
+  static get properties() {
+    return {
+      /**
+       * The list of `<vaadin-tab>`s from which a selection can be made.
+       * It is populated from the elements passed inside the slotted
+       * `<vaadin-tabs>`, and updated dynamically when adding or removing items.
+       *
+       * Note: unlike `<vaadin-combo-box>`, this property is read-only.
+       * @type {!Array<!Tab> | undefined}
+       */
+      items: {
+        type: Array,
+        readOnly: true,
+        notify: true,
+      },
+
+      /**
+       * The index of the selected tab.
+       */
+      selected: {
+        value: 0,
+        type: Number,
+        reflectToAttribute: true,
+        notify: true,
+      },
+
+      /**
+       * The slotted <vaadin-tabs> element.
+       */
+      __tabs: {
+        type: Object,
+      },
+
+      /**
+       * The panel elements.
+       */
+      __panels: {
+        type: Array,
+      },
+    };
+  }
+
+  /** @override */
+  static get delegateProps() {
+    return ['selected'];
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    const tabsItemsChangedListener = () => this._setItems(this.__tabs.items);
+
+    const tabsSelectedChangedListener = () => {
+      this.selected = this.__tabs.selected;
+    };
+
+    this.__overflowController = new OverflowController(this, this.shadowRoot.querySelector('[part="content"]'));
+    this.addController(this.__overflowController);
+
+    // Observe the tabs slot for a <vaadin-tabs> element.
+    this._tabsSlotController = new (class extends SlotController {
+      constructor(host) {
+        super(host, 'tabs');
+      }
+
+      initCustomNode(tabs) {
+        if (!(tabs instanceof Tabs)) {
+          throw Error('The "tabs" slot of a <vaadin-tabsheet> must only contain a <vaadin-tabs> element!');
+        }
+        tabs.addEventListener('items-changed', tabsItemsChangedListener);
+        tabs.addEventListener('selected-changed', tabsSelectedChangedListener);
+        this.host.__tabs = tabs;
+        this.host.stateTarget = tabs;
+      }
+
+      teardownNode(tabs) {
+        tabs.removeEventListener('items-changed', tabsItemsChangedListener);
+        tabs.removeEventListener('selected-changed', tabsSelectedChangedListener);
+        this.host._setItems([]);
+        this.host.stateTarget = undefined;
+      }
+    })(this);
+    this.addController(this._tabsSlotController);
+
+    // Observe the panels slot for nodes. Set the assigned element nodes as the __panels array.
+    const panelSlot = this.shadowRoot.querySelector('#panel-slot');
+    this.__panelsObserver = new FlattenedNodesObserver(panelSlot, () => {
+      this.__panels = Array.from(panelSlot.assignedNodes({ flatten: true })).filter(
+        (node) => node.nodeType === Node.ELEMENT_NODE,
+      );
+    });
+  }
+
+  static get observers() {
+    return ['__itemsOrPanelsChanged(items, __panels)', '__selectedTabItemChanged(selected, items, __panels)'];
+  }
+
+  /**
+   * An observer which applies the necessary roles and ARIA attributes
+   * to associate the tab elements with the panels.
+   * @private
+   */
+  __itemsOrPanelsChanged(items, panels) {
+    if (!items || !panels) {
+      return;
+    }
+
+    items.forEach((tabItem) => {
+      const panel = panels.find((panel) => panel.getAttribute('tab') === tabItem.id);
+      if (panel) {
+        panel.role = 'tabpanel';
+        panel.id = panel.id || `tabsheet-panel-${generateUniqueId()}`;
+        panel.setAttribute('aria-labelledby', tabItem.id);
+
+        tabItem.setAttribute('aria-controls', panel.id);
+      }
+    });
+  }
+
+  /**
+   * An observer which toggles the visibility of the panels based on the selected tab.
+   * @private
+   */
+  __selectedTabItemChanged(selected, items, panels) {
+    if (!items || !panels || selected === undefined) {
+      return;
+    }
+
+    const content = this.shadowRoot.querySelector('[part="content"]');
+
+    const selectedTab = items[selected];
+    const selectedTabId = selectedTab ? selectedTab.id : '';
+    const selectedPanel = panels.find((panel) => panel.getAttribute('tab') === selectedTabId);
+
+    // Mark loading state if a selected panel is not found.
+    this.toggleAttribute('loading', !selectedPanel);
+
+    const hasOneVisiblePanel = panels.filter((panel) => !panel.hidden).length === 1;
+
+    if (selectedPanel) {
+      // A selected panel is found, remove the loading state fallback height.
+      content.style.minHeight = '';
+    } else if (hasOneVisiblePanel) {
+      // Make sure the empty content has a fallback height in loading state..
+      content.style.minHeight = `${content.offsetHeight}px`;
+    }
+
+    // Hide all panels and show only the selected panel.
+    panels.forEach((panel) => {
+      panel.hidden = panel !== selectedPanel;
+    });
+  }
+}
+
+customElements.define(TabSheet.is, TabSheet);
+
+export { TabSheet };

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/lumo/vaadin-tabsheet-styles.js
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/lumo/vaadin-tabsheet-styles.js
@@ -1,0 +1,47 @@
+import '@vaadin/vaadin-lumo-styles/color.js';
+import '@vaadin/vaadin-lumo-styles/spacing.js';
+import '@vaadin/vaadin-lumo-styles/typography.js';
+
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const tabsheet = css`
+  :host(:not([theme~='no-border'])) {
+    border: 1px solid var(--lumo-contrast-20pct);
+  }
+
+  ::slotted([slot='tabs']) {
+    box-shadow: initial;
+  }
+
+  /* Needed to align the tabs nicely on the baseline */
+  ::slotted([slot='tabs'])::before {
+    content: '\\2003';
+    width: 0;
+    display: inline-block;
+  }
+
+  [part='tabs-container'] {
+    padding: 0 var(--lumo-space-m);
+    box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
+    font-family: var(--lumo-font-family);
+  }
+
+  [part='content'] {
+    padding: var(--lumo-space-xs) var(--lumo-space-m) var(--lumo-space-s);
+    font-size: var(--lumo-font-size-m);
+    line-height: var(--lumo-line-height-m);
+    font-family: var(--lumo-font-family);
+  }
+
+  :host([loading]) [part='loader'] {
+    margin-left: calc(var(--lumo-icon-size-s) / -2);
+    margin-top: calc(var(--lumo-icon-size-s) / -2);
+    left: 50%;
+    top: 50%;
+    position: absolute;
+  }
+`;
+
+registerStyles('vaadin-tabsheet', [tabsheet], { moduleId: 'lumo-tabsheet' });
+
+export { tabsheet };

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/lumo/vaadin-tabsheet.js
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/lumo/vaadin-tabsheet.js
@@ -1,0 +1,4 @@
+import '@vaadin/tabs/theme/lumo/vaadin-tabs.js';
+import '@vaadin/tabs/theme/lumo/vaadin-tab.js';
+import './vaadin-tabsheet-styles.js';
+import '../../src/vaadin-tabsheet.js';

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/material/vaadin-tabsheet-styles.js
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/material/vaadin-tabsheet-styles.js
@@ -1,0 +1,37 @@
+import '@vaadin/vaadin-material-styles/color.js';
+import '@vaadin/vaadin-material-styles/typography.js';
+import { loader } from '@vaadin/vaadin-material-styles/mixins/loader.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const tabsheet = css`
+  /* Needed to align the tabs nicely on the baseline */
+  ::slotted([slot='tabs'])::before {
+    content: '\\2003';
+    width: 0;
+    display: inline-block;
+  }
+
+  [part='tabs-container'] {
+    border-bottom: 1px solid var(--material-divider-color);
+    font-family: var(--material-font-family);
+  }
+
+  [part='content'] {
+    font-family: var(--material-font-family);
+    padding: 8px 24px 24px;
+  }
+
+  :host([loading]) [part='content'] {
+    overflow: visible;
+  }
+
+  [part~='loader'] {
+    position: absolute;
+    z-index: 1;
+    top: -3px;
+    left: 0;
+    right: 0;
+  }
+`;
+
+registerStyles('vaadin-tabsheet', [tabsheet, loader], { moduleId: 'material-tabsheet' });

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/material/vaadin-tabsheet.js
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/theme/material/vaadin-tabsheet.js
@@ -1,0 +1,4 @@
+import '@vaadin/tabs/theme/material/vaadin-tabs.js';
+import '@vaadin/tabs/theme/material/vaadin-tab.js';
+import './vaadin-tabsheet-styles.js';
+import '../../src/vaadin-tabsheet.js';

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/vaadin-tabsheet.d.ts
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/vaadin-tabsheet.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-tabsheet.js';

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/vaadin-tabsheet.js
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/resources/META-INF/resources/frontend/tabsheet/vaadin-tabsheet.js
@@ -1,0 +1,2 @@
+import './theme/lumo/vaadin-tabsheet.js';
+export * from './src/vaadin-tabsheet.js';

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.tabs.tests;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.TabSheet;
+
+/**
+ * @author Vaadin Ltd.
+ */
+public class TabSheetTest {
+
+    @Test
+    public void tabsheet_tagName() {
+        var tabSheet = new TabSheet();
+        Assert.assertEquals("vaadin-tabsheet", tabSheet.getElement().getTag());
+    }
+
+    @Test
+    public void addTab_assignsTabId() {
+        var tabSheet = new TabSheet();
+        var tab = tabSheet.add("Tab 0", new Span("Content 0"));
+        Assert.assertTrue(tab.getId().isPresent());
+    }
+
+    @Test
+    public void addTab_assignsContentTab() {
+        var tabSheet = new TabSheet();
+        var content = new Span("Content 0");
+        var tab = tabSheet.add("Tab 0", content);
+        Assert.assertEquals(tab.getId().get(),
+                content.getElement().getAttribute("tab"));
+    }
+
+    @Test
+    public void addTab_contentAdded() {
+        var tabSheet = new TabSheet();
+        var content = new Span("Content 0");
+        tabSheet.add("Tab 0", content);
+        Assert.assertTrue(content.getParent().isPresent());
+    }
+
+    @Test
+    public void addSecondTab_contentNotAdded() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", new Span("Content 0"));
+
+        var content1 = new Span("Content 1");
+        tabSheet.add("Tab 1", content1);
+        Assert.assertFalse(content1.getParent().isPresent());
+    }
+
+    @Test
+    public void changeTab_contentAdded() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", new Span("Content 0"));
+
+        var content1 = new Span("Content 1");
+        tabSheet.add("Tab 1", content1);
+        tabSheet.setSelectedIndex(1);
+        Assert.assertTrue(content1.getParent().isPresent());
+    }
+
+    @Test
+    public void addSecondTab_contentDisabled() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", new Span("Content 0"));
+
+        var content1 = new Span("Content 1");
+        tabSheet.add("Tab 1", content1);
+        Assert.assertFalse(content1.isEnabled());
+    }
+
+    @Test
+    public void changeTab_contentEnabled() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", new Span("Content 0"));
+
+        var content1 = new Span("Content 1");
+        tabSheet.add("Tab 1", content1);
+        tabSheet.setSelectedIndex(1);
+        Assert.assertTrue(content1.isEnabled());
+    }
+
+    @Test
+    public void changeTab_oldContentDisabled() {
+        var tabSheet = new TabSheet();
+        var content = new Span("Content 0");
+        tabSheet.add("Tab 0", content);
+
+        tabSheet.add("Tab 1", new Span("Content 1"));
+        tabSheet.setSelectedIndex(1);
+        Assert.assertFalse(content.isEnabled());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addNullTab_throws() {
+        var tabSheet = new TabSheet();
+        tabSheet.add((Tab) null, new Span("Content 0"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addNullContent_throws() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", (Span) null);
+    }
+
+    @Test
+    public void changeTab_selectedChangeEvent() {
+        var tabSheet = new TabSheet();
+        var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
+        var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
+
+        var listenerInvoked = new AtomicBoolean(false);
+        tabSheet.addSelectedChangeListener(event -> {
+            listenerInvoked.set(true);
+            Assert.assertEquals(tabSheet.getSelectedTab(),
+                    event.getSelectedTab());
+            Assert.assertEquals(tabSheet, event.getSource());
+            Assert.assertEquals(tab1, event.getSelectedTab());
+            Assert.assertEquals(tab0, event.getPreviousTab());
+        });
+        tabSheet.setSelectedIndex(1);
+        Assert.assertTrue(listenerInvoked.get());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void removeNullTab_throws() {
+        var tabSheet = new TabSheet();
+        tabSheet.remove((Tab) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void removeNullContent_throws() {
+        var tabSheet = new TabSheet();
+        tabSheet.remove((Span) null);
+    }
+
+    @Test
+    public void removeTab_removesContent() {
+        var tabSheet = new TabSheet();
+        var content = new Span("Content 0");
+        var tab = tabSheet.add("Tab 0", content);
+        tabSheet.remove(tab);
+        Assert.assertFalse(content.getParent().isPresent());
+    }
+
+    @Test
+    public void removeTab_clearsSelection() {
+        var tabSheet = new TabSheet();
+        var content = new Span("Content 0");
+        var tab = tabSheet.add("Tab 0", content);
+        tabSheet.remove(tab);
+        Assert.assertEquals(-1, tabSheet.getSelectedIndex());
+    }
+
+    @Test
+    public void removeTab_selectedChangeEvent() {
+        var tabSheet = new TabSheet();
+        var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
+        var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
+        var listenerInvoked = new AtomicBoolean(false);
+        tabSheet.addSelectedChangeListener(event -> {
+            listenerInvoked.set(true);
+            Assert.assertEquals(tabSheet.getSelectedTab(),
+                    event.getSelectedTab());
+            Assert.assertEquals(tabSheet, event.getSource());
+            Assert.assertEquals(tab1, event.getSelectedTab());
+            Assert.assertEquals(tab0, event.getPreviousTab());
+        });
+        tabSheet.remove(tab0);
+        Assert.assertTrue(listenerInvoked.get());
+    }
+
+    @Test
+    public void removeTab_removesTab() {
+        var tabSheet = new TabSheet();
+        var tab = tabSheet.add("Tab 0", new Span("Content 0"));
+        tabSheet.remove(tab);
+        Assert.assertFalse(tab.getParent().isPresent());
+    }
+
+    @Test
+    public void removeContent_removesTab() {
+        var tabSheet = new TabSheet();
+        var content = new Span("Content 0");
+        var tab = tabSheet.add("Tab 0", content);
+        tabSheet.remove(content);
+        Assert.assertFalse(tab.getParent().isPresent());
+    }
+
+    @Test
+    public void removeNonExistentContent_doesNoteRemoveTab() {
+        var tabSheet = new TabSheet();
+        var tab = tabSheet.add("Tab 0", new Span("Content 0"));
+        tabSheet.remove(new Span("Content 1"));
+        Assert.assertTrue(tab.getParent().isPresent());
+    }
+
+    @Test
+    public void addTab_initialSelection() {
+        var tabSheet = new TabSheet();
+        var tab = tabSheet.add("Tab 0", new Span("Content 0"));
+        Assert.assertEquals(0, tabSheet.getSelectedIndex());
+        Assert.assertEquals(tab, tabSheet.getSelectedTab());
+    }
+
+    @Test
+    public void setSelectedIndex_selection() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", new Span("Content 0"));
+        var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
+        tabSheet.setSelectedIndex(1);
+        Assert.assertEquals(1, tabSheet.getSelectedIndex());
+        Assert.assertEquals(tab1, tabSheet.getSelectedTab());
+    }
+
+    @Test
+    public void setSelectedTab_selection() {
+        var tabSheet = new TabSheet();
+        tabSheet.add("Tab 0", new Span("Content 0"));
+        var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
+        tabSheet.setSelectedTab(tab1);
+        Assert.assertEquals(1, tabSheet.getSelectedIndex());
+        Assert.assertEquals(tab1, tabSheet.getSelectedTab());
+    }
+
+}

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.component.tabs.tests;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.html.Span;
@@ -30,22 +31,26 @@ import com.vaadin.flow.component.tabs.TabSheet;
  */
 public class TabSheetTest {
 
+    private TabSheet tabSheet;
+
+    @Before
+    public void setup() {
+        tabSheet = new TabSheet();
+    }
+
     @Test
     public void tabsheet_tagName() {
-        var tabSheet = new TabSheet();
         Assert.assertEquals("vaadin-tabsheet", tabSheet.getElement().getTag());
     }
 
     @Test
     public void addTab_assignsTabId() {
-        var tabSheet = new TabSheet();
         var tab = tabSheet.add("Tab 0", new Span("Content 0"));
         Assert.assertTrue(tab.getId().isPresent());
     }
 
     @Test
     public void addTab_assignsContentTab() {
-        var tabSheet = new TabSheet();
         var content = new Span("Content 0");
         var tab = tabSheet.add("Tab 0", content);
         Assert.assertEquals(tab.getId().get(),
@@ -54,7 +59,6 @@ public class TabSheetTest {
 
     @Test
     public void addTab_contentAdded() {
-        var tabSheet = new TabSheet();
         var content = new Span("Content 0");
         tabSheet.add("Tab 0", content);
         Assert.assertTrue(content.getParent().isPresent());
@@ -62,7 +66,6 @@ public class TabSheetTest {
 
     @Test
     public void addSecondTab_contentNotAdded() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", new Span("Content 0"));
 
         var content1 = new Span("Content 1");
@@ -72,7 +75,6 @@ public class TabSheetTest {
 
     @Test
     public void changeTab_contentAdded() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", new Span("Content 0"));
 
         var content1 = new Span("Content 1");
@@ -83,7 +85,6 @@ public class TabSheetTest {
 
     @Test
     public void addSecondTab_contentDisabled() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", new Span("Content 0"));
 
         var content1 = new Span("Content 1");
@@ -93,7 +94,6 @@ public class TabSheetTest {
 
     @Test
     public void changeTab_contentEnabled() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", new Span("Content 0"));
 
         var content1 = new Span("Content 1");
@@ -104,7 +104,6 @@ public class TabSheetTest {
 
     @Test
     public void changeTab_oldContentDisabled() {
-        var tabSheet = new TabSheet();
         var content = new Span("Content 0");
         tabSheet.add("Tab 0", content);
 
@@ -115,19 +114,16 @@ public class TabSheetTest {
 
     @Test(expected = NullPointerException.class)
     public void addNullTab_throws() {
-        var tabSheet = new TabSheet();
         tabSheet.add((Tab) null, new Span("Content 0"));
     }
 
     @Test(expected = NullPointerException.class)
     public void addNullContent_throws() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", (Span) null);
     }
 
     @Test
     public void changeTab_selectedChangeEvent() {
-        var tabSheet = new TabSheet();
         var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
 
@@ -146,19 +142,16 @@ public class TabSheetTest {
 
     @Test(expected = NullPointerException.class)
     public void removeNullTab_throws() {
-        var tabSheet = new TabSheet();
         tabSheet.remove((Tab) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void removeNullContent_throws() {
-        var tabSheet = new TabSheet();
         tabSheet.remove((Span) null);
     }
 
     @Test
     public void removeTab_removesContent() {
-        var tabSheet = new TabSheet();
         var content = new Span("Content 0");
         var tab = tabSheet.add("Tab 0", content);
         tabSheet.remove(tab);
@@ -167,7 +160,6 @@ public class TabSheetTest {
 
     @Test
     public void removeTab_clearsSelection() {
-        var tabSheet = new TabSheet();
         var content = new Span("Content 0");
         var tab = tabSheet.add("Tab 0", content);
         tabSheet.remove(tab);
@@ -176,7 +168,6 @@ public class TabSheetTest {
 
     @Test
     public void removeTab_selectedChangeEvent() {
-        var tabSheet = new TabSheet();
         var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
         var listenerInvoked = new AtomicBoolean(false);
@@ -194,7 +185,6 @@ public class TabSheetTest {
 
     @Test
     public void removeTab_removesTab() {
-        var tabSheet = new TabSheet();
         var tab = tabSheet.add("Tab 0", new Span("Content 0"));
         tabSheet.remove(tab);
         Assert.assertFalse(tab.getParent().isPresent());
@@ -202,7 +192,6 @@ public class TabSheetTest {
 
     @Test
     public void removeContent_removesTab() {
-        var tabSheet = new TabSheet();
         var content = new Span("Content 0");
         var tab = tabSheet.add("Tab 0", content);
         tabSheet.remove(content);
@@ -211,7 +200,6 @@ public class TabSheetTest {
 
     @Test
     public void removeNonExistentContent_doesNoteRemoveTab() {
-        var tabSheet = new TabSheet();
         var tab = tabSheet.add("Tab 0", new Span("Content 0"));
         tabSheet.remove(new Span("Content 1"));
         Assert.assertTrue(tab.getParent().isPresent());
@@ -219,7 +207,6 @@ public class TabSheetTest {
 
     @Test
     public void addTab_initialSelection() {
-        var tabSheet = new TabSheet();
         var tab = tabSheet.add("Tab 0", new Span("Content 0"));
         Assert.assertEquals(0, tabSheet.getSelectedIndex());
         Assert.assertEquals(tab, tabSheet.getSelectedTab());
@@ -227,7 +214,6 @@ public class TabSheetTest {
 
     @Test
     public void setSelectedIndex_selection() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
         tabSheet.setSelectedIndex(1);
@@ -237,7 +223,6 @@ public class TabSheetTest {
 
     @Test
     public void setSelectedTab_selection() {
-        var tabSheet = new TabSheet();
         tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
         tabSheet.setSelectedTab(tab1);


### PR DESCRIPTION
## Description

Adds `TabSheet` component with basic features:
- add, remove, selectedTab, selectedIndex APIs
- Selected change listener
- Lazy loading of content (server-to-client)
- Unit tests

Excluded from this PR (to be submitted separately):
- HasTheme & Theme variants
- Prefix & Suffix API
- TestBench Element and ITs

## Type of change

- Feature

## Note

- This PR is targeting the `feat/tabsheet` branch, not `master`.
- The PR includes a temporary copy of the `<vaadin-tabsheet>` web component from https://github.com/vaadin/web-components/tree/feat/tabsheet/packages/tabsheet. Once the package is published to npm, the temporary copy should be removed.