### PR TITLE
test: move basic tests to DatePickerIT

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerValidationPage.java
@@ -34,7 +34,6 @@ public class DatePickerValidationPage extends Div {
 
     public DatePickerValidationPage() {
         initView();
-        createPickerInsideDiv();
         createPickerTestLocales();
         createPickerWithValueAndLocaleFromServerSide();
         createPickerWithMaxAndMinValues();
@@ -80,31 +79,11 @@ public class DatePickerValidationPage extends Div {
         add(button);
         add(label, value);
 
-        button = new NativeButton("Open DatePicker");
-        button.setId("open");
-        button.addClickListener(event -> datePicker.open());
-        add(button);
-
         NativeButton localeChange = new NativeButton("Locale change button");
         localeChange.addClickListener(
                 event -> datePicker.setLocale(new Locale("i", "i", "i")));
         localeChange.setId("change-locale");
         add(localeChange);
-    }
-
-    private void createPickerInsideDiv() {
-        Div parent = new Div();
-        DatePicker datePicker = new DatePicker();
-        datePicker.setId("picker-inside-div");
-
-        parent.add(datePicker);
-        parent.setEnabled(false);
-
-        NativeButton button = new NativeButton("set Div Enabled");
-        button.setId("set-enabled");
-        button.addClickListener(event -> parent.setEnabled(true));
-
-        add(parent, button);
     }
 
     private void createPickerTestLocales() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
@@ -248,7 +248,8 @@ public class DatePickerViewDemoPage extends Div {
         enableParent.setId("enable-parent");
         enableParent.addClickListener(event -> parent.setEnabled(true));
 
-        addCard("DatePicker inside a disabled parent div", parent, enableParent);
+        addCard("DatePicker inside a disabled parent div", parent,
+                enableParent);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
@@ -44,6 +44,7 @@ public class DatePickerViewDemoPage extends Div {
         createWithClearButton();
         createStartAndEndDatePickers();
         createLocaleChangeDatePicker();
+        createDatePickerInsideDisabledParent();
         addCard("Additional code used in the demo",
                 new Label("These methods are used in the demo."));
     }
@@ -57,7 +58,12 @@ public class DatePickerViewDemoPage extends Div {
                 event -> updateMessage(message, datePicker));
 
         datePicker.setId("simple-picker");
-        addCard("Simple date picker", datePicker, message);
+
+        NativeButton open = new NativeButton("Open");
+        open.setId("open-simple-picker");
+        open.addClickListener(event -> datePicker.open());
+
+        addCard("Simple date picker", datePicker, open, message);
     }
 
     private void createMinAndMaxDatePicker() {
@@ -228,6 +234,21 @@ public class DatePickerViewDemoPage extends Div {
         datePicker.setId("locale-change-picker");
         addCard("Date picker with customize locales", datePicker, locale1,
                 locale2, locale3, message);
+    }
+
+    private void createDatePickerInsideDisabledParent() {
+        Div parent = new Div();
+        DatePicker datePicker = new DatePicker();
+        datePicker.setId("picker-inside-disabled-parent");
+
+        parent.add(datePicker);
+        parent.setEnabled(false);
+
+        NativeButton enableParent = new NativeButton("Enable parent");
+        enableParent.setId("enable-parent");
+        enableParent.addClickListener(event -> parent.setEnabled(true));
+
+        addCard("DatePicker inside a disabled parent div", parent, enableParent);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -49,6 +49,12 @@ public class DatePickerIT extends AbstractComponentIT {
     }
 
     @Test
+    public void openSimpleDatePickerFromServer_overlayVisible() {
+        scrollIntoViewAndClick(findElement(By.id("open-simple-picker")));
+        waitForElementVisible(By.tagName("vaadin-date-picker-overlay"));
+    }
+
+    @Test
     public void selectDateOnSimpleDatePicker() {
         WebElement picker = layout.findElement(By.id("simple-picker"));
         WebElement message = layout.findElement(By.id("simple-picker-message"));
@@ -316,5 +322,22 @@ public class DatePickerIT extends AbstractComponentIT {
 
         $("button").id("Locale-US").click();
         Assert.assertEquals("3/8/20", localePicker.getInputValue());
+    }
+
+    @Test
+    public void datePickerInsideDisabledParent_pickerIsDisabled() {
+        WebElement picker = findElement(By.id("picker-inside-disabled-parent"));
+        Assert.assertFalse(
+                "The date picker should be disabled, when the parent component is disabled.",
+                picker.isEnabled());
+    }
+
+    @Test
+    public void datePickerInsideDisabledParent_enableParent_pickerIsEnabled() {
+        WebElement picker = findElement(By.id("picker-inside-disabled-parent"));
+        findElement(By.id("enable-parent")).click();
+        Assert.assertTrue(
+                "The date picker should be enabled after parent component is enabled.",
+                picker.isEnabled());
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
@@ -42,7 +42,6 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
     private WebElement field;
     private WebElement invalidate;
     private WebElement validate;
-    private WebElement open;
 
     @Before
     public void init() {
@@ -52,7 +51,6 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
         field = findElement(By.id("field"));
         invalidate = findElement(By.id("invalidate"));
         validate = findElement(By.id("validate"));
-        open = findElement(By.id("open"));
     }
 
     @Test
@@ -99,12 +97,6 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void openFromServer_overlayVisible() {
-        scrollIntoViewAndClick(open);
-        waitForElementVisible(By.tagName("vaadin-date-picker-overlay"));
-    }
-
-    @Test
     public void invalidLocale() {
         String logList = getLogEntries(Level.WARNING).toString();
         Assert.assertFalse(logList.contains(
@@ -124,19 +116,6 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
                 true,
                 executeScript("return arguments[0].value === '12/26/2018'",
                         displayText));
-    }
-
-    @Test
-    public void disabledDatePicker() {
-        WebElement disabledPicker = findElement(By.id("picker-inside-div"));
-        Assert.assertFalse(
-                "The date picker should be disabled, when the parent component is disabled.",
-                disabledPicker.isEnabled());
-
-        findElement(By.id("set-enabled")).click();
-        Assert.assertTrue(
-                "The date picker should be enabled after parent component is enabled.",
-                disabledPicker.isEnabled());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR moves some basic tests from `DatePickerValidationPageIT` to `DatePickerIT` because they are not related to validation.

Related to https://github.com/vaadin/flow-components/pull/3496

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
