### PR TITLE
feat: add Tooltip handle

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
@@ -25,6 +25,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+  </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableRunnable;
+
+/**
+ * A handle that can be used to configure and control tooltips.
+ *
+ * @author Vaadin Ltd
+ */
+public class Tooltip {
+
+    /**
+     * The {@code <vaadin-tooltip>} element controlled by this tooltip instance.
+     */
+    private final Element tooltipElement = new Element("vaadin-tooltip");
+
+    /**
+     * Tooltip position in relation to the target element.
+     */
+    public enum TooltipPosition {
+        TOP_START("top-start"), TOP("top"), TOP_END("top-end"), BOTTOM_START(
+                "bottom-start"), BOTTOM("bottom"), BOTTOM_END(
+                        "bottom-end"), START_TOP("start-top"), START(
+                                "start"), START_BOTTOM("start-bottom"), END_TOP(
+                                        "end-top"), END("end"), END_BOTTOM(
+                                                "end-bottom");
+
+        private final String position;
+
+        TooltipPosition(String position) {
+            this.position = position;
+        }
+
+        public String getPosition() {
+            return position;
+        }
+    }
+
+    /**
+     * Creates a tooltip for the given element.
+     *
+     * @param element
+     *            the element to attach the tooltip to
+     * @return the tooltip handle
+     */
+    public static Tooltip forElement(Element element) {
+        // Create a new Tooltip handle instance
+        var tooltip = new Tooltip();
+
+        // The host under which the <vaadin-tooltip> element is auto-attached
+        var tooltipHost = UI.getCurrent().getElement();
+
+        // Handle target attach
+        SerializableRunnable onTargetAttach = () -> {
+            tooltipHost.appendChild(tooltip.tooltipElement);
+            tooltip.tooltipElement.executeJs("this.target = $0;", element);
+        };
+        element.addAttachListener(e -> onTargetAttach.run());
+        if (element.getNode().isAttached()) {
+            onTargetAttach.run();
+        }
+
+        // Handle target detach
+        element.addDetachListener(
+                e -> tooltip.tooltipElement.removeFromParent());
+
+        return tooltip;
+    }
+
+    /**
+     * Creates a tooltip to the given {@code Component}.
+     *
+     * @param component
+     *            the component to attach the tooltip to
+     * @return the tooltip handle
+     */
+    public static Tooltip forComponent(Component component) {
+        return forElement(component.getElement());
+    }
+
+    /**
+     * String used as a tooltip content.
+     *
+     * @param text
+     *            the text to set
+     */
+    public void setText(String text) {
+        tooltipElement.setProperty("text", text);
+    }
+
+    /**
+     * String used as a tooltip content.
+     *
+     * @return the text
+     */
+    public String getText() {
+        return tooltipElement.getProperty("text");
+    }
+
+    /**
+     * The delay in milliseconds before the tooltip is opened on hover, when not
+     * in manual mode. On focus, the tooltip is opened immediately.
+     *
+     * @param delay
+     *            the delay in milliseconds
+     */
+    public void setDelay(int delay) {
+        tooltipElement.setProperty("delay", delay);
+    }
+
+    /**
+     * The delay in milliseconds before the tooltip is opened on hover, when not
+     * in manual mode. On focus, the tooltip is opened immediately.
+     *
+     * @return the delay in milliseconds
+     */
+    public int getDelay() {
+        return tooltipElement.getProperty("delay", 0);
+    }
+
+    /**
+     * The delay in milliseconds before the tooltip is closed on losing hover,
+     * when not in manual mode. On blur, the tooltip is closed immediately.
+     *
+     * @param hideDelay
+     *            the delay in milliseconds
+     */
+    public void setHideDelay(int hideDelay) {
+        tooltipElement.setProperty("hideDelay", hideDelay);
+    }
+
+    /**
+     * The delay in milliseconds before the tooltip is closed on losing hover,
+     * when not in manual mode. On blur, the tooltip is closed immediately.
+     *
+     * @return the delay in milliseconds
+     */
+    public int getHideDelay() {
+        return tooltipElement.getProperty("hideDelay", 0);
+    }
+
+    /**
+     * Position of the tooltip with respect to its target.
+     *
+     * @param position
+     *            the position to set
+     */
+    public void setPosition(TooltipPosition position) {
+        tooltipElement.setProperty("position", position.getPosition());
+    }
+
+    /**
+     * Position of the tooltip with respect to its target.
+     *
+     * @return the position
+     */
+    public TooltipPosition getPosition() {
+        return TooltipPosition.valueOf(tooltipElement
+                .getProperty("position", TooltipPosition.BOTTOM.name())
+                .toUpperCase());
+    }
+
+    /**
+     * When true, the tooltip is controlled programmatically instead of reacting
+     * to focus and mouse events.
+     *
+     * @param manual
+     *            true to enable manual mode
+     */
+    public void setManual(boolean manual) {
+        tooltipElement.setProperty("manual", manual);
+    }
+
+    /**
+     * When true, the tooltip is controlled programmatically instead of reacting
+     * to focus and mouse events.
+     *
+     * @return true if manual mode is enabled
+     */
+    public boolean isManual() {
+        return tooltipElement.getProperty("manual", false);
+    }
+
+    /**
+     * When true, the tooltip is opened programmatically. Only works if `manual`
+     * is set to `true`.
+     *
+     * @param opened
+     *            true to open the tooltip
+     */
+    public void setOpened(boolean opened) {
+        tooltipElement.setProperty("opened", opened);
+    }
+
+    /**
+     * When true, the tooltip is opened programmatically. Only works if `manual`
+     * is set to `true`.
+     *
+     * @return true if the tooltip is opened
+     */
+    public boolean isOpened() {
+        return tooltipElement.getProperty("opened", false);
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.shared;
 
+import java.io.Serializable;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
@@ -25,7 +27,7 @@ import com.vaadin.flow.function.SerializableRunnable;
  *
  * @author Vaadin Ltd
  */
-public class Tooltip {
+public class Tooltip implements Serializable {
 
     /**
      * The {@code <vaadin-tooltip>} element controlled by this tooltip instance.

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -38,12 +38,20 @@ public class Tooltip implements Serializable {
      * Tooltip position in relation to the target element.
      */
     public enum TooltipPosition {
-        TOP_START("top-start"), TOP("top"), TOP_END("top-end"), BOTTOM_START(
-                "bottom-start"), BOTTOM("bottom"), BOTTOM_END(
-                        "bottom-end"), START_TOP("start-top"), START(
-                                "start"), START_BOTTOM("start-bottom"), END_TOP(
-                                        "end-top"), END("end"), END_BOTTOM(
-                                                "end-bottom");
+        //@formatter:off
+        TOP_START("top-start"),
+        TOP("top"),
+        TOP_END("top-end"),
+        BOTTOM_START("bottom-start"),
+        BOTTOM("bottom"),
+        BOTTOM_END("bottom-end"),
+        START_TOP("start-top"),
+        START("start"),
+        START_BOTTOM("start-bottom"),
+        END_TOP("end-top"),
+        END("end"),
+        END_BOTTOM("end-bottom");
+        //@formatter:off
 
         private final String position;
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -1,0 +1,131 @@
+package com.vaadin.flow.component.shared;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
+import com.vaadin.flow.dom.Element;
+
+public class TooltipTest {
+
+    private TestComponent component;
+    private UI ui;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+        ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test
+    public void createTooltip_tooltipNotAttached() {
+        Tooltip.forComponent(component);
+        Assert.assertFalse(getTooltipElement().isPresent());
+    }
+
+    @Test
+    public void createTooltip_addComponent_tooltipAttached() {
+        Tooltip.forComponent(component);
+        ui.add(component);
+        Assert.assertTrue(getTooltipElement().isPresent());
+    }
+
+    @Test
+    public void addComponent_createTooltip_tooltipAttached() {
+        ui.add(component);
+        Tooltip.forComponent(component);
+        Assert.assertTrue(getTooltipElement().isPresent());
+    }
+
+    @Test
+    public void createTooltip_removeComponent_tooltipNotAttached() {
+        Tooltip.forComponent(component);
+        ui.add(component);
+        ui.remove(component);
+        Assert.assertFalse(getTooltipElement().isPresent());
+    }
+
+    @Test
+    public void createTooltip_setText() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setText("foo");
+        ui.add(component);
+        Assert.assertEquals("foo",
+                getTooltipElement().get().getProperty("text"));
+        Assert.assertEquals("foo", tooltip.getText());
+    }
+
+    @Test
+    public void createTooltip_setDelay() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setDelay(1000);
+        ui.add(component);
+        Assert.assertEquals(1000,
+                getTooltipElement().get().getProperty("delay", 0));
+        Assert.assertEquals(1000, tooltip.getDelay());
+    }
+
+    @Test
+    public void createTooltip_setHideDelay() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setHideDelay(1000);
+        ui.add(component);
+        Assert.assertEquals(1000,
+                getTooltipElement().get().getProperty("hideDelay", 0));
+        Assert.assertEquals(1000, tooltip.getHideDelay());
+    }
+
+    @Test
+    public void createTooltip_setPosition() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setPosition(TooltipPosition.END);
+        ui.add(component);
+        Assert.assertEquals("end",
+                getTooltipElement().get().getProperty("position"));
+        Assert.assertEquals(TooltipPosition.END, tooltip.getPosition());
+    }
+
+    @Test
+    public void createTooltip_defaultPosition() {
+        var tooltip = Tooltip.forComponent(component);
+        Assert.assertEquals(TooltipPosition.BOTTOM, tooltip.getPosition());
+    }
+
+    @Test
+    public void createTooltip_setManual() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setManual(true);
+        ui.add(component);
+        Assert.assertEquals(true,
+                getTooltipElement().get().getProperty("manual", false));
+        Assert.assertEquals(true, tooltip.isManual());
+    }
+
+    @Test
+    public void createTooltip_setOpened() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setOpened(true);
+        ui.add(component);
+        Assert.assertEquals(true,
+                getTooltipElement().get().getProperty("opened", false));
+        Assert.assertEquals(true, tooltip.isOpened());
+    }
+
+    private Optional<Element> getTooltipElement() {
+        return ui.getElement().getChildren()
+                .filter(child -> child.getTag().equals("vaadin-tooltip"))
+                .findFirst();
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasClearButton {
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -125,7 +125,6 @@ public class TooltipTest {
     }
 
     @Tag("test")
-    private static class TestComponent extends Component
-            implements HasClearButton {
+    private static class TestComponent extends Component {
     }
 }


### PR DESCRIPTION
## Description

Adds `Tooltip` handle with basic features:
- `var handle = Tooltip.forComponent(component)` (also for `Element`)
  - Creates a handle that controls a `<vaadin-tooltip>` instance that gets automatically attached/detached under `<body>` when the target component gets attached/detached.
- API for configuring the tooltip
- API for opening/closing the tooltip manually
- Unit tests

Excluded from this PR (to be submitted separately):
- `HasTooltip` interface and integration to components
- `TooltipGenerator` API for `Grid`
- TestBench Element and ITs

## Type of change

- Feature

## Note

- This PR is targeting the `feat/tooltip` branch, not `master`.