### PR TITLE
test: move locale tests to DatePickerLocaleIT

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -20,7 +20,6 @@ public class DatePickerLocalePage extends Div {
     public DatePickerLocalePage() {
         createDatePicker();
         createDatePickerWithGermanLocale();
-
         createDatePickerWithValue();
         createDatePickerWithValueAndFrenchLocale();
         createDatePickerWithValueAndPolishLocale();
@@ -39,7 +38,7 @@ public class DatePickerLocalePage extends Div {
     }
 
     private void createDatePickerWithGermanLocale() {
-        DatePicker datePicker = new DatePicker(may3rd, Locale.GERMAN);
+        DatePicker datePicker = new DatePicker(null, Locale.GERMAN);
         datePicker.setId("picker-with-german-locale");
         addCard("DatePicker with German locale", datePicker);
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -15,25 +15,18 @@ public class DatePickerLocalePage extends Div {
     private final LocalDate april23rd = LocalDate.of(2018, Month.APRIL, 23);
 
     public DatePickerLocalePage() {
-        DatePicker datePicker = new DatePicker(april23rd, Locale.CHINA);
-        datePicker.setId("locale-picker-server-with-value");
-
-        NativeButton locale = new NativeButton("Locale: UK");
-        locale.setId("uk-locale");
-
-        locale.addClickListener(e -> datePicker.setLocale(Locale.UK));
+        createDatePicker();
+        createDatePickerWithValue();
 
         DatePicker frenchLocale = new DatePicker();
         frenchLocale.setId("french-locale-date-picker");
-
         frenchLocale.setLocale(Locale.FRANCE);
         frenchLocale.setValue(may3rd);
 
         DatePicker german = new DatePicker();
         german.setLocale(Locale.GERMAN);
         german.setId("german-locale-date-picker");
-
-        add(datePicker, locale, frenchLocale, german);
+        add(frenchLocale, german);
 
         DatePicker polandDatePicker = new DatePicker(may3rd,
                 new Locale("pl", "PL"));
@@ -43,7 +36,48 @@ public class DatePickerLocalePage extends Div {
         DatePicker korean = new DatePicker(may3rd, new Locale("ko", "KR"));
         korean.setId("korean-locale-date-picker");
         add(korean);
+    }
 
+    private void createDatePicker() {
+        DatePicker datePicker = new DatePicker();
+        datePicker.setId("picker");
+
+        NativeButton ukLocale = new NativeButton("Locale: UK");
+        ukLocale.setId("picker-set-uk-locale");
+        ukLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
+
+        NativeButton plLocale = new NativeButton("Locale: Poland");
+        ukLocale.setId("picker-set-pl-locale");
+        ukLocale.addClickListener(
+                e -> datePicker.setLocale(new Locale("pl", "PL")));
+
+        NativeButton svLocale = new NativeButton("Locale: Sweden");
+        ukLocale.setId("picker-set-sv-locale");
+        ukLocale.addClickListener(
+                e -> datePicker.setLocale(new Locale("sv", "SE")));
+
+        add(datePicker, ukLocale, plLocale, svLocale);
+    }
+
+    private void createDatePickerWithValue() {
+        DatePicker datePicker = new DatePicker(april23rd);
+        datePicker.setId("picker-with-value");
+
+        NativeButton ukLocale = new NativeButton("Locale: UK");
+        ukLocale.setId("picker-with-value-set-uk-locale");
+        ukLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
+
+        NativeButton plLocale = new NativeButton("Locale: Poland");
+        ukLocale.setId("picker-with-value-set-pl-locale");
+        ukLocale.addClickListener(
+                e -> datePicker.setLocale(new Locale("pl", "PL")));
+
+        NativeButton svLocale = new NativeButton("Locale: Sweden");
+        ukLocale.setId("picker-with-value-set-sv-locale");
+        ukLocale.addClickListener(
+                e -> datePicker.setLocale(new Locale("sv", "SE")));
+
+        add(datePicker, ukLocale, plLocale, svLocale);
     }
 
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -15,12 +15,12 @@ import com.vaadin.flow.router.Route;
 public class DatePickerLocalePage extends Div {
 
     private final LocalDate may3rd = LocalDate.of(2018, Month.MAY, 3);
-    private final LocalDate april23rd = LocalDate.of(2018, Month.APRIL, 23);
 
     public DatePickerLocalePage() {
         createDatePicker();
         createDatePickerWithGermanLocale();
         createDatePickerWithValue();
+        createDatePickerWithValueAndChinaLocale();
         createDatePickerWithValueAndFrenchLocale();
         createDatePickerWithValueAndPolishLocale();
         createDatePickerWithValueAndKoreanLocale();
@@ -44,7 +44,7 @@ public class DatePickerLocalePage extends Div {
     }
 
     private void createDatePickerWithValue() {
-        DatePicker datePicker = new DatePicker(april23rd);
+        DatePicker datePicker = new DatePicker(may3rd);
         datePicker.setId("picker-with-value");
 
         NativeButton ukLocale = new NativeButton("Locale: UK");
@@ -70,6 +70,12 @@ public class DatePickerLocalePage extends Div {
         DatePicker datePicker = new DatePicker(may3rd, new Locale("ko", "KR"));
         datePicker.setId("picker-with-value-and-korean-locale");
         addCard("DatePicker with value and Korean locale", datePicker);
+    }
+
+    private void createDatePickerWithValueAndChinaLocale() {
+        DatePicker datePicker = new DatePicker(may3rd, Locale.CHINA);
+        datePicker.setId("picker-with-value-and-china-locale");
+        addCard("DatePicker with value and China locale", datePicker);
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -30,11 +30,16 @@ public class DatePickerLocalePage extends Div {
         DatePicker datePicker = new DatePicker();
         datePicker.setId("picker");
 
-        NativeButton ukLocale = new NativeButton("Locale: UK");
-        ukLocale.setId("picker-set-uk-locale");
-        ukLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
+        NativeButton setUKLocale = new NativeButton("Set UK locale");
+        setUKLocale.setId("picker-set-uk-locale");
+        setUKLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
 
-        addCard("DatePicker", datePicker, ukLocale);
+        NativeButton setInvalidLocale = new NativeButton("Set invalid locale");
+        setInvalidLocale.addClickListener(
+                event -> datePicker.setLocale(new Locale("i", "i", "i")));
+        setInvalidLocale.setId("picker-set-invalid-locale");
+
+        addCard("DatePicker", datePicker, setUKLocale, setInvalidLocale);
     }
 
     private void createDatePickerWithGermanLocale() {
@@ -47,11 +52,11 @@ public class DatePickerLocalePage extends Div {
         DatePicker datePicker = new DatePicker(may3rd);
         datePicker.setId("picker-with-value");
 
-        NativeButton ukLocale = new NativeButton("Locale: UK");
-        ukLocale.setId("picker-with-value-set-uk-locale");
-        ukLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
+        NativeButton setUKLocale = new NativeButton("Set UK locale");
+        setUKLocale.setId("picker-with-value-set-uk-locale");
+        setUKLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
 
-        addCard("DatePicker with value", datePicker, ukLocale);
+        addCard("DatePicker with value", datePicker, setUKLocale);
     }
 
     private void createDatePickerWithValueAndFrenchLocale() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -4,8 +4,11 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.util.Locale;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-date-picker/date-picker-locale")
@@ -16,26 +19,12 @@ public class DatePickerLocalePage extends Div {
 
     public DatePickerLocalePage() {
         createDatePicker();
+        createDatePickerWithGermanLocale();
+
         createDatePickerWithValue();
-
-        DatePicker frenchLocale = new DatePicker();
-        frenchLocale.setId("french-locale-date-picker");
-        frenchLocale.setLocale(Locale.FRANCE);
-        frenchLocale.setValue(may3rd);
-
-        DatePicker german = new DatePicker();
-        german.setLocale(Locale.GERMAN);
-        german.setId("german-locale-date-picker");
-        add(frenchLocale, german);
-
-        DatePicker polandDatePicker = new DatePicker(may3rd,
-                new Locale("pl", "PL"));
-        polandDatePicker.setId("polish-locale-date-picker");
-        add(polandDatePicker);
-
-        DatePicker korean = new DatePicker(may3rd, new Locale("ko", "KR"));
-        korean.setId("korean-locale-date-picker");
-        add(korean);
+        createDatePickerWithValueAndFrenchLocale();
+        createDatePickerWithValueAndPolishLocale();
+        createDatePickerWithValueAndKoreanLocale();
     }
 
     private void createDatePicker() {
@@ -46,17 +35,13 @@ public class DatePickerLocalePage extends Div {
         ukLocale.setId("picker-set-uk-locale");
         ukLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
 
-        NativeButton plLocale = new NativeButton("Locale: Poland");
-        ukLocale.setId("picker-set-pl-locale");
-        ukLocale.addClickListener(
-                e -> datePicker.setLocale(new Locale("pl", "PL")));
+        addCard("DatePicker", datePicker, ukLocale);
+    }
 
-        NativeButton svLocale = new NativeButton("Locale: Sweden");
-        ukLocale.setId("picker-set-sv-locale");
-        ukLocale.addClickListener(
-                e -> datePicker.setLocale(new Locale("sv", "SE")));
-
-        add(datePicker, ukLocale, plLocale, svLocale);
+    private void createDatePickerWithGermanLocale() {
+        DatePicker datePicker = new DatePicker(may3rd, Locale.GERMAN);
+        datePicker.setId("picker-with-german-locale");
+        addCard("DatePicker with German locale", datePicker);
     }
 
     private void createDatePickerWithValue() {
@@ -67,17 +52,33 @@ public class DatePickerLocalePage extends Div {
         ukLocale.setId("picker-with-value-set-uk-locale");
         ukLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
 
-        NativeButton plLocale = new NativeButton("Locale: Poland");
-        ukLocale.setId("picker-with-value-set-pl-locale");
-        ukLocale.addClickListener(
-                e -> datePicker.setLocale(new Locale("pl", "PL")));
+        addCard("DatePicker with value", datePicker, ukLocale);
+    }
 
-        NativeButton svLocale = new NativeButton("Locale: Sweden");
-        ukLocale.setId("picker-with-value-set-sv-locale");
-        ukLocale.addClickListener(
-                e -> datePicker.setLocale(new Locale("sv", "SE")));
+    private void createDatePickerWithValueAndFrenchLocale() {
+        DatePicker datePicker = new DatePicker(may3rd, Locale.FRENCH);
+        datePicker.setId("picker-with-value-and-french-locale");
+        addCard("DatePicker with value and French locale", datePicker);
+    }
 
-        add(datePicker, ukLocale, plLocale, svLocale);
+    private void createDatePickerWithValueAndPolishLocale() {
+        DatePicker datePicker = new DatePicker(may3rd, new Locale("pl", "PL"));
+        datePicker.setId("picker-with-value-and-polish-locale");
+        addCard("DatePicker with value and Polish locale", datePicker);
+    }
+
+    private void createDatePickerWithValueAndKoreanLocale() {
+        DatePicker datePicker = new DatePicker(may3rd, new Locale("ko", "KR"));
+        datePicker.setId("picker-with-value-and-korean-locale");
+        addCard("DatePicker with value and Korean locale", datePicker);
+    }
+
+    private void addCard(String title, Component... components) {
+        VerticalLayout layout = new VerticalLayout();
+        layout.setMargin(true);
+        layout.add(new H2(title));
+        layout.add(components);
+        add(layout);
     }
 
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerValidationPage.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import java.util.Locale;
-
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
@@ -74,11 +72,5 @@ public class DatePickerValidationPage extends Div {
         });
         add(button);
         add(label, value);
-
-        NativeButton localeChange = new NativeButton("Locale change button");
-        localeChange.addClickListener(
-                event -> datePicker.setLocale(new Locale("i", "i", "i")));
-        localeChange.setId("change-locale");
-        add(localeChange);
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerValidationPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import java.time.LocalDate;
 import java.util.Locale;
 
 import com.vaadin.flow.component.html.Div;
@@ -34,8 +33,6 @@ public class DatePickerValidationPage extends Div {
 
     public DatePickerValidationPage() {
         initView();
-        createPickerTestLocales();
-        createPickerWithValueAndLocaleFromServerSide();
     }
 
     private void initView() {
@@ -83,38 +80,5 @@ public class DatePickerValidationPage extends Div {
                 event -> datePicker.setLocale(new Locale("i", "i", "i")));
         localeChange.setId("change-locale");
         add(localeChange);
-    }
-
-    private void createPickerTestLocales() {
-        DatePicker datePicker = new DatePicker();
-        datePicker.setId("locale-picker");
-        NativeButton locale1 = new NativeButton("Locale: Poland");
-        NativeButton locale2 = new NativeButton("Locale: Sweden");
-
-        locale1.setId("polish-locale");
-        locale2.setId("swedish-locale");
-        locale1.addClickListener(
-                e -> datePicker.setLocale(new Locale("pl", "PL")));
-        locale2.addClickListener(
-                e -> datePicker.setLocale(new Locale("sv", "SE")));
-
-        add(datePicker, locale1, locale2);
-    }
-
-    private void createPickerWithValueAndLocaleFromServerSide() {
-        DatePicker datePicker = new DatePicker(LocalDate.of(2018, 5, 23));
-
-        datePicker.setId("locale-picker-server");
-        NativeButton locale1 = new NativeButton("Locale: Poland");
-        NativeButton locale2 = new NativeButton("Locale: Sweden");
-
-        locale1.setId("polish-locale-server");
-        locale2.setId("swedish-locale-server");
-        locale1.addClickListener(
-                e -> datePicker.setLocale(new Locale("pl", "PL")));
-        locale2.addClickListener(
-                e -> datePicker.setLocale(new Locale("sv", "SE")));
-
-        add(datePicker, locale1, locale2);
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -21,24 +21,72 @@ import com.vaadin.flow.testutil.TestPath;
 public class DatePickerLocaleIT extends AbstractComponentIT {
 
     @Test
-    public void testPickerWithValueAndLocaleFromServerSideDifferentCtor() {
+    public void datePickerWithValueAndLocaleFromServerSide_assertDisplayedValue() {
         open();
 
+        Assert.assertEquals("03/05/2018", $(DatePickerElement.class)
+                .id("french-locale-date-picker").getInputValue());
+
+        Assert.assertEquals("2018. 5. 3.", $(DatePickerElement.class)
+                .id("korean-locale-date-picker").getInputValue());
+
+        Assert.assertEquals("3.05.2018", $(DatePickerElement.class)
+                .id("polish-locale-date-picker").getInputValue());
+
         DatePickerElement localePicker = $(DatePickerElement.class)
-                .id("locale-picker-server-with-value");
-        WebElement displayText = localePicker.findElement(By.tagName("input"));
+                .id("german-locale-date-picker");
+        localePicker.setDate(LocalDate.of(1985, 1, 10));
+        findElement(By.tagName("body")).click();
 
-        Assert.assertEquals("Wrong initial date in field.", "2018/4/23",
-                executeScript("return arguments[0].value", displayText));
+        Assert.assertTrue("No new warnings should have appeared in the logs",
+                getWarningEntries().isEmpty());
 
-        findElement(By.id("uk-locale")).click();
-        Assert.assertEquals("Didn't have expected UK locale date.",
-                "23/04/2018",
-                executeScript("return arguments[0].value", displayText));
+        Assert.assertEquals("10.1.1985", localePicker.getInputValue());
 
-        assertText($(DatePickerElement.class).id("french-locale-date-picker"),
-                "03/05/2018");
+        assertNoWarnings();
 
+    }
+
+    @Test
+    public void datePicker_setDifferentLocales_assertDisplayedValue() {
+        open();
+
+        DatePickerElement picker = $(DatePickerElement.class).id("picker");
+
+        picker.setDate(LocalDate.of(2018, 4, 23));
+
+        $("button").id("picker-set-uk-locale").click();
+        Assert.assertEquals("23/04/2018", picker.getInputValue());
+
+        $("button").id("picker-set-pl-locale").click();
+        Assert.assertEquals("23.04.2018", picker.getInputValue());
+
+        $("button").id("picker-set-sv-locale").click();
+        Assert.assertEquals("2018-04-23", picker.getInputValue());
+
+        assertNoWarnings();
+    }
+
+    @Test
+    public void datePickerWithValue_setDifferentLocales_assertDisplayedValue() {
+        open();
+
+        DatePickerElement picker = $(DatePickerElement.class)
+                .id("picker-with-value");
+
+        $("button").id("picker-set-uk-locale").click();
+        Assert.assertEquals("23/04/2018", picker.getInputValue());
+
+        $("button").id("picker-set-pl-locale").click();
+        Assert.assertEquals("23.04.2018", picker.getInputValue());
+
+        $("button").id("picker-set-sv-locale").click();
+        Assert.assertEquals("2018-04-23", picker.getInputValue());
+
+        assertNoWarnings();
+    }
+
+    private void assertNoWarnings() {
         for (LogEntry logEntry : getWarningEntries()) {
             Assert.assertThat(
                     "Expected only [Deprecation] warnings in the logs",
@@ -47,31 +95,6 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
             Assert.assertThat(logEntry.getMessage(),
                     CoreMatchers.containsString("deprecated"));
         }
-
-        localePicker = $(DatePickerElement.class)
-                .id("german-locale-date-picker");
-        localePicker.setDate(LocalDate.of(1985, 1, 10));
-        findElement(By.tagName("body")).click();
-
-        Assert.assertTrue("No new warnings should have appeared in the logs",
-                getWarningEntries().isEmpty());
-
-        assertText(localePicker, "10.1.1985");
-
-        assertText($(DatePickerElement.class).id("korean-locale-date-picker"),
-                "2018. 5. 3.");
-
-        assertText($(DatePickerElement.class).id("polish-locale-date-picker"),
-                "3.05.2018");
-
-    }
-
-    private void assertText(DatePickerElement datePickerElement,
-            String expected) {
-        WebElement displayText = datePickerElement
-                .findElement(By.tagName("input"));
-        Assert.assertEquals("Didn't have expected locale date.", expected,
-                executeScript("return arguments[0].value", displayText));
     }
 
     private List<LogEntry> getWarningEntries() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -77,6 +77,27 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     }
 
     @Test
+    public void datePicker_setInvalidLocale_warningIsShown() {
+        assertNoWarnings();
+
+        $("button").id("picker-set-invalid-locale").click();
+        waitUntil(driver -> getWarningEntries().size() > 0);
+
+        List<LogEntry> warnings = getWarningEntries();
+        Assert.assertEquals(1, warnings.size());
+        Assert.assertEquals("The locale is not supported, using default locale setting(en-US).", warnings.get(0).getMessage());
+    }
+
+    @Test
+    public void datePicker_setInvalidLocale_defaultUSLocaleIsUsed() {
+        DatePickerElement picker = $(DatePickerElement.class).id("picker");
+
+        picker.setDate(LocalDate.of(2018, Month.MAY, 3));
+        Assert.assertEquals("Should display the value using the default US date format",
+                "03/05/2018", picker.getInputValue());
+    }
+
+    @Test
     public void datePickerWithValue_setLocale_assertDisplayedValue() {
         DatePickerElement picker = $(DatePickerElement.class)
                 .id("picker-with-value");

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -81,20 +81,21 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         assertNoWarnings();
 
         $("button").id("picker-set-invalid-locale").click();
-        waitUntil(driver -> getWarningEntries().size() > 0);
 
-        List<LogEntry> warnings = getWarningEntries();
-        Assert.assertEquals(1, warnings.size());
-        Assert.assertEquals("The locale is not supported, using default locale setting(en-US).", warnings.get(0).getMessage());
+        waitUntil(driver -> getWarningEntries().toString().contains(
+                "The locale is not supported, using default locale setting(en-US)."));
     }
 
     @Test
     public void datePicker_setInvalidLocale_defaultUSLocaleIsUsed() {
         DatePickerElement picker = $(DatePickerElement.class).id("picker");
 
+        $("button").id("picker-set-invalid-locale").click();
         picker.setDate(LocalDate.of(2018, Month.MAY, 3));
-        Assert.assertEquals("Should display the value using the default US date format",
-                "03/05/2018", picker.getInputValue());
+
+        Assert.assertEquals(
+                "Should display the value using the default US date format",
+                "5/3/2018", picker.getInputValue());
     }
 
     @Test

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -5,11 +5,10 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 
@@ -20,98 +19,80 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("vaadin-date-picker/date-picker-locale")
 public class DatePickerLocaleIT extends AbstractComponentIT {
 
+    @Before
+    public void init() {
+        open();
+    }
+
     @Test
     public void datePickerWithValueAndLocale_assertDisplayedValue() {
-        open();
-
         DatePickerElement frenchLocalePicker = $(DatePickerElement.class)
                 .id("picker-with-value-and-french-locale");
-        Assert.assertEquals("Should display the correct value when using French locale",
+        Assert.assertEquals("Should display the value using French date format",
                 "03/05/2018", frenchLocalePicker.getInputValue());
 
         DatePickerElement koreanLocalePicker = $(DatePickerElement.class)
                 .id("picker-with-value-and-korean-locale");
-        Assert.assertEquals(
-                "Should display the correct value when using Korean locale",
+        Assert.assertEquals("Should display the value using Korean date format",
                 "2018. 5. 3.", koreanLocalePicker.getInputValue());
 
         DatePickerElement polishLocalePicker = $(DatePickerElement.class)
                 .id("picker-with-value-and-polish-locale");
-        Assert.assertEquals(
-                "Should display the correct value when using Polish locale",
+        Assert.assertEquals("Should display the value using Polish date format",
                 "3.05.2018", polishLocalePicker.getInputValue());
 
-        for (LogEntry logEntry : getWarningEntries()) {
-            Assert.assertThat(
-                    "Expected only [Deprecation] warnings in the logs",
-                    logEntry.getMessage(), CoreMatchers.containsString(
-                            "'lit-element' module entrypoint is deprecated."));
-            Assert.assertThat(logEntry.getMessage(),
-                    CoreMatchers.containsString("deprecated"));
-        }
+        assertNoWarnings();
     }
 
     @Test
-    public void datePicker_setDate_setLocale_assertDisplayedValue() {
-        open();
+    public void datePickerWithValueAndLocale_blur_assertDisplayedValue() {
+        DatePickerElement picker = $(DatePickerElement.class)
+                .id("picker-with-value-and-polish-locale");
+        // trigger the validation on the from clientside
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals("Should display the value using Polish date format",
+                "3.05.2018", picker.getInputValue());
 
+        checkLogsForErrors();
+
+        assertNoWarnings();
+    }
+
+    @Test
+    public void datePicker_setValue_setLocale_assertDisplayedValue() {
         DatePickerElement picker = $(DatePickerElement.class).id("picker");
-        picker.setDate(LocalDate.of(2018, 4, 23));
 
+        picker.setDate(LocalDate.of(2018, 4, 23));
         $("button").id("picker-set-uk-locale").click();
-        Assert.assertEquals("23/04/2018", picker.getInputValue());
+        Assert.assertEquals("Should display the value using UK date format",
+                "23/04/2018", picker.getInputValue());
+
+        assertNoWarnings();
     }
 
     @Test
     public void datePickerWithValue_setLocale_assertDisplayedValue() {
-        open();
-
         DatePickerElement picker = $(DatePickerElement.class)
                 .id("picker-with-value");
 
         $("button").id("picker-with-value-set-uk-locale").click();
-        Assert.assertEquals("23/04/2018", picker.getInputValue());
+        Assert.assertEquals("Should display the value using UK date format",
+                "23/04/2018", picker.getInputValue());
+
+        assertNoWarnings();
     }
 
     @Test
-    public void datePickerWithValueAndLocale_clickInside_clickOutside_assertNoErrors() {
-        open();
-
-        checkLogsForErrors();
-        WebElement picker = findElement(
-                By.id("picker-with-value-and-polish-locale"));
-        // trigger the validation on the from clientside
-        picker.click();
-        executeScript("document.body.click()");
-
-        checkLogsForErrors();
-    }
-
-    @Test
-    public void datePickerWithLocale_setDate_clickOutside_assertNoWarnings() {
-        open();
-
+    public void datePickerWithLocale_setInputValue_blur_assertDisplayedValue() {
         DatePickerElement picker = $(DatePickerElement.class)
                 .id("picker-with-german-locale");
 
-        picker.setDate(LocalDate.of(1985, 1, 10));
-        findElement(By.tagName("body")).click();
+        picker.setInputValue("23.4.2018");
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals("Should display the value using German date format",
+                "23.4.2018", picker.getInputValue());
 
-        Assert.assertTrue("No new warnings should have appeared in the logs",
-                getWarningEntries().isEmpty());
-
-        Assert.assertEquals("10.1.1985", picker.getInputValue());
-    }
-
-    private void assertNoWarnings() {
-        for (LogEntry logEntry : getWarningEntries()) {
-            Assert.assertThat(
-                    "Expected only [Deprecation] warnings in the logs",
-                    logEntry.getMessage(), CoreMatchers.containsString(
-                            "'lit-element' module entrypoint is deprecated."));
-            Assert.assertThat(logEntry.getMessage(),
-                    CoreMatchers.containsString("deprecated"));
-        }
+        assertNoWarnings();
     }
 
     private List<LogEntry> getWarningEntries() {
@@ -119,6 +100,16 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         return logs.getAll().stream()
                 .filter(log -> log.getLevel().equals(Level.WARNING))
                 .filter(log -> !log.getMessage().contains("iron-icon"))
+                .filter(log -> !log.getMessage().contains("deprecated"))
+                .filter(log -> !log.getMessage().contains("Lit is in dev mode"))
                 .collect(Collectors.toList());
+    }
+
+    private void assertNoWarnings() {
+        for (LogEntry logEntry : getWarningEntries()) {
+            throw new AssertionError(String.format(
+                    "Received a warning in browser log console, message: %s",
+                    logEntry));
+        }
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -26,6 +27,11 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
     @Test
     public void datePickerWithValueAndLocale_assertDisplayedValue() {
+        DatePickerElement chinaLocalePicker = $(DatePickerElement.class)
+                .id("picker-with-value-and-china-locale");
+        Assert.assertEquals("Should display the value using China date format",
+                "2018/5/3", chinaLocalePicker.getInputValue());
+
         DatePickerElement frenchLocalePicker = $(DatePickerElement.class)
                 .id("picker-with-value-and-french-locale");
         Assert.assertEquals("Should display the value using French date format",
@@ -62,10 +68,10 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     public void datePicker_setValue_setLocale_assertDisplayedValue() {
         DatePickerElement picker = $(DatePickerElement.class).id("picker");
 
-        picker.setDate(LocalDate.of(2018, 4, 23));
+        picker.setDate(LocalDate.of(2018, Month.MAY, 3));
         $("button").id("picker-set-uk-locale").click();
         Assert.assertEquals("Should display the value using UK date format",
-                "23/04/2018", picker.getInputValue());
+                "03/05/2018", picker.getInputValue());
 
         assertNoWarnings();
     }
@@ -77,7 +83,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
         $("button").id("picker-with-value-set-uk-locale").click();
         Assert.assertEquals("Should display the value using UK date format",
-                "23/04/2018", picker.getInputValue());
+                "03/05/2018", picker.getInputValue());
 
         assertNoWarnings();
     }
@@ -87,10 +93,10 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         DatePickerElement picker = $(DatePickerElement.class)
                 .id("picker-with-german-locale");
 
-        picker.setInputValue("23.4.2018");
+        picker.setInputValue("3.5.2018");
         picker.sendKeys(Keys.TAB);
         Assert.assertEquals("Should display the value using German date format",
-                "23.4.2018", picker.getInputValue());
+                "3.5.2018", picker.getInputValue());
 
         assertNoWarnings();
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -21,69 +21,86 @@ import com.vaadin.flow.testutil.TestPath;
 public class DatePickerLocaleIT extends AbstractComponentIT {
 
     @Test
-    public void datePickerWithValueAndLocaleFromServerSide_assertDisplayedValue() {
+    public void datePickerWithValueAndLocale_assertDisplayedValue() {
         open();
 
-        Assert.assertEquals("03/05/2018", $(DatePickerElement.class)
-                .id("french-locale-date-picker").getInputValue());
+        DatePickerElement frenchLocalePicker = $(DatePickerElement.class)
+                .id("picker-with-value-and-french-locale");
+        Assert.assertEquals("Should display the correct value when using French locale",
+                "03/05/2018", frenchLocalePicker.getInputValue());
 
-        Assert.assertEquals("2018. 5. 3.", $(DatePickerElement.class)
-                .id("korean-locale-date-picker").getInputValue());
+        DatePickerElement koreanLocalePicker = $(DatePickerElement.class)
+                .id("picker-with-value-and-korean-locale");
+        Assert.assertEquals(
+                "Should display the correct value when using Korean locale",
+                "2018. 5. 3.", koreanLocalePicker.getInputValue());
 
-        Assert.assertEquals("3.05.2018", $(DatePickerElement.class)
-                .id("polish-locale-date-picker").getInputValue());
+        DatePickerElement polishLocalePicker = $(DatePickerElement.class)
+                .id("picker-with-value-and-polish-locale");
+        Assert.assertEquals(
+                "Should display the correct value when using Polish locale",
+                "3.05.2018", polishLocalePicker.getInputValue());
 
-        DatePickerElement localePicker = $(DatePickerElement.class)
-                .id("german-locale-date-picker");
-        localePicker.setDate(LocalDate.of(1985, 1, 10));
-        findElement(By.tagName("body")).click();
-
-        Assert.assertTrue("No new warnings should have appeared in the logs",
-                getWarningEntries().isEmpty());
-
-        Assert.assertEquals("10.1.1985", localePicker.getInputValue());
-
-        assertNoWarnings();
-
+        for (LogEntry logEntry : getWarningEntries()) {
+            Assert.assertThat(
+                    "Expected only [Deprecation] warnings in the logs",
+                    logEntry.getMessage(), CoreMatchers.containsString(
+                            "'lit-element' module entrypoint is deprecated."));
+            Assert.assertThat(logEntry.getMessage(),
+                    CoreMatchers.containsString("deprecated"));
+        }
     }
 
     @Test
-    public void datePicker_setDifferentLocales_assertDisplayedValue() {
+    public void datePicker_setDate_setLocale_assertDisplayedValue() {
         open();
 
         DatePickerElement picker = $(DatePickerElement.class).id("picker");
-
         picker.setDate(LocalDate.of(2018, 4, 23));
 
         $("button").id("picker-set-uk-locale").click();
         Assert.assertEquals("23/04/2018", picker.getInputValue());
-
-        $("button").id("picker-set-pl-locale").click();
-        Assert.assertEquals("23.04.2018", picker.getInputValue());
-
-        $("button").id("picker-set-sv-locale").click();
-        Assert.assertEquals("2018-04-23", picker.getInputValue());
-
-        assertNoWarnings();
     }
 
     @Test
-    public void datePickerWithValue_setDifferentLocales_assertDisplayedValue() {
+    public void datePickerWithValue_setLocale_assertDisplayedValue() {
         open();
 
         DatePickerElement picker = $(DatePickerElement.class)
                 .id("picker-with-value");
 
-        $("button").id("picker-set-uk-locale").click();
+        $("button").id("picker-with-value-set-uk-locale").click();
         Assert.assertEquals("23/04/2018", picker.getInputValue());
+    }
 
-        $("button").id("picker-set-pl-locale").click();
-        Assert.assertEquals("23.04.2018", picker.getInputValue());
+    @Test
+    public void datePickerWithValueAndLocale_clickInside_clickOutside_assertNoErrors() {
+        open();
 
-        $("button").id("picker-set-sv-locale").click();
-        Assert.assertEquals("2018-04-23", picker.getInputValue());
+        checkLogsForErrors();
+        WebElement picker = findElement(
+                By.id("picker-with-value-and-polish-locale"));
+        // trigger the validation on the from clientside
+        picker.click();
+        executeScript("document.body.click()");
 
-        assertNoWarnings();
+        checkLogsForErrors();
+    }
+
+    @Test
+    public void datePickerWithLocale_setDate_clickOutside_assertNoWarnings() {
+        open();
+
+        DatePickerElement picker = $(DatePickerElement.class)
+                .id("picker-with-german-locale");
+
+        picker.setDate(LocalDate.of(1985, 1, 10));
+        findElement(By.tagName("body")).click();
+
+        Assert.assertTrue("No new warnings should have appeared in the logs",
+                getWarningEntries().isEmpty());
+
+        Assert.assertEquals("10.1.1985", picker.getInputValue());
     }
 
     private void assertNoWarnings() {
@@ -103,19 +120,5 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 .filter(log -> log.getLevel().equals(Level.WARNING))
                 .filter(log -> !log.getMessage().contains("iron-icon"))
                 .collect(Collectors.toList());
-    }
-
-    @Test
-    public void polishLocaleTest() {
-        open();
-
-        checkLogsForErrors();
-        WebElement polishPicker = findElement(
-                By.id("polish-locale-date-picker"));
-        // trigger the validation on the from clientside
-        polishPicker.click();
-        executeScript("document.body.click()");
-
-        checkLogsForErrors();
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import java.util.logging.Level;
 import java.util.stream.IntStream;
 
 import com.google.common.base.Strings;
@@ -92,28 +91,6 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
         scrollIntoViewAndClick(invalidate);
         setValue("1/1/2018");
         assertValid();
-    }
-
-    @Test
-    public void invalidLocale() {
-        String logList = getLogEntries(Level.WARNING).toString();
-        Assert.assertFalse(logList.contains(
-                "The locale is not supported, using default locale setting(en-US)."));
-
-        WebElement changeLocale = findElement(By.id("change-locale"));
-        scrollIntoViewAndClick(changeLocale);
-
-        waitUntil(driver -> getLogEntries(Level.WARNING).toString().contains(
-                "The locale is not supported, using default locale setting(en-US)."));
-        WebElement picker = findElement(By.id("field"));
-        WebElement displayText = picker.findElement(By.tagName("input"));
-
-        executeScript("arguments[0].value = '2018-12-26'", picker);
-        Assert.assertEquals(
-                "DatePicker should use default locale(en-US) format, MM/DD/YYYY",
-                true,
-                executeScript("return arguments[0].value === '12/26/2018'",
-                        displayText));
     }
 
     private void assertInvalid() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
@@ -15,12 +15,10 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import java.time.LocalDate;
 import java.util.logging.Level;
 import java.util.stream.IntStream;
 
 import com.google.common.base.Strings;
-import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -115,43 +113,6 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
                 "DatePicker should use default locale(en-US) format, MM/DD/YYYY",
                 true,
                 executeScript("return arguments[0].value === '12/26/2018'",
-                        displayText));
-    }
-
-    @Test
-    public void testDifferentLocales() {
-        WebElement localePicker = findElement(By.id("locale-picker"));
-        WebElement displayText = localePicker.findElement(By.tagName("input"));
-        findElement(By.id("polish-locale")).click();
-
-        executeScript("arguments[0].value = '2018-03-26'", localePicker);
-        Assert.assertEquals("Polish Locale is using DD.MM.YYYY format ", true,
-                executeScript("return arguments[0].value === '26.03.2018'",
-                        displayText));
-
-        findElement(By.id("swedish-locale")).click();
-        executeScript("arguments[0].value = '2018-03-25'", localePicker);
-        Assert.assertEquals("Swedish Locale is using YYYY-MM-DD format ", true,
-                executeScript("return arguments[0].value === '2018-03-25'",
-                        displayText));
-    }
-
-    @Test
-    public void testPickerWithValueAndLocaleFromServerSide() {
-        WebElement localePicker = findElement(By.id("locale-picker-server"));
-        WebElement displayText = localePicker.findElement(By.tagName("input"));
-
-        Assert.assertEquals("Initial date is 5/23/2018", true, executeScript(
-                "return arguments[0].value === '5/23/2018'", displayText));
-
-        findElement(By.id("polish-locale-server")).click();
-        Assert.assertEquals("Polish locale date is 23.05.2018", true,
-                executeScript("return arguments[0].value === '23.05.2018'",
-                        displayText));
-
-        findElement(By.id("swedish-locale-server")).click();
-        Assert.assertEquals("Swedish locale date is 2018-05-23", true,
-                executeScript("return arguments[0].value === '2018-05-23'",
                         displayText));
     }
 


### PR DESCRIPTION
## Description

This PR moves locale tests from `DatePickerValidationPageIT` to `DatePickerLocaleIT` because it is a more appropriate place for them.

Related to https://github.com/vaadin/flow-components/pull/3496

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
