### PR TITLE
refactor: move HasPrefixAndSuffix to flow-component-base

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
@@ -25,6 +25,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasPrefixAndSuffix.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasPrefixAndSuffix.java
@@ -19,16 +19,16 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 
 /**
- * Mixin interface for components that have prefix and suffix slots
- * for inserting components.
+ * Mixin interface for components that have prefix and suffix slots for
+ * inserting components.
  *
  * @author Vaadin Ltd
  */
 public interface HasPrefixAndSuffix extends HasElement {
 
     /**
-     * Adds the given component as the prefix of this component, replacing
-     * any existing prefix component.
+     * Adds the given component as the prefix of this component, replacing any
+     * existing prefix component.
      * <p>
      * This is most commonly used to add a simple icon or static text into the
      * component.
@@ -49,8 +49,8 @@ public interface HasPrefixAndSuffix extends HasElement {
     /**
      * Gets the component in the prefix slot of this component.
      *
-     * @return the prefix component of this component, or {@code null} if no prefix
-     *         component has been set
+     * @return the prefix component of this component, or {@code null} if no
+     *         prefix component has been set
      * @see #setPrefixComponent(Component)
      */
     default Component getPrefixComponent() {
@@ -80,8 +80,8 @@ public interface HasPrefixAndSuffix extends HasElement {
     /**
      * Gets the component in the suffix slot of this component.
      *
-     * @return the suffix component of this component, or {@code null} if no suffix
-     *         component has been set
+     * @return the suffix component of this component, or {@code null} if no
+     *         suffix component has been set
      * @see #setPrefixComponent(Component)
      */
     default Component getSuffixComponent() {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasPrefixAndSuffix.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasPrefixAndSuffix.java
@@ -13,14 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.textfield;
+package com.vaadin.flow.component.shared;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
-import com.vaadin.flow.component.shared.SlotUtils;
 
 /**
- * Mixin interface for text-field components that have prefix and suffix slots
+ * Mixin interface for components that have prefix and suffix slots
  * for inserting components.
  *
  * @author Vaadin Ltd
@@ -28,11 +27,11 @@ import com.vaadin.flow.component.shared.SlotUtils;
 public interface HasPrefixAndSuffix extends HasElement {
 
     /**
-     * Adds the given component into this field before the content, replacing
+     * Adds the given component as the prefix of this component, replacing
      * any existing prefix component.
      * <p>
      * This is most commonly used to add a simple icon or static text into the
-     * field.
+     * component.
      *
      * @param component
      *            the component to set, can be {@code null} to remove existing
@@ -48,9 +47,9 @@ public interface HasPrefixAndSuffix extends HasElement {
     }
 
     /**
-     * Gets the component in the prefix slot of this field.
+     * Gets the component in the prefix slot of this component.
      *
-     * @return the prefix component of this field, or {@code null} if no prefix
+     * @return the prefix component of this component, or {@code null} if no prefix
      *         component has been set
      * @see #setPrefixComponent(Component)
      */
@@ -59,11 +58,11 @@ public interface HasPrefixAndSuffix extends HasElement {
     }
 
     /**
-     * Adds the given component into this field after the content, replacing any
+     * Adds the given component as the suffix of this component, replacing any
      * existing suffix component.
      * <p>
      * This is most commonly used to add a simple icon or static text into the
-     * field.
+     * component.
      *
      * @param component
      *            the component to set, can be {@code null} to remove existing
@@ -79,9 +78,9 @@ public interface HasPrefixAndSuffix extends HasElement {
     }
 
     /**
-     * Gets the component in the suffix slot of this field.
+     * Gets the component in the suffix slot of this component.
      *
-     * @return the suffix component of this field, or {@code null} if no suffix
+     * @return the suffix component of this component, or {@code null} if no suffix
      *         component has been set
      * @see #setPrefixComponent(Component)
      */

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/PrefixSuffixTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/PrefixSuffixTest.java
@@ -23,7 +23,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for setting prefix and suffix components for {@link HasPrefixAndSuffix}.
+ * Tests for setting prefix and suffix components for
+ * {@link HasPrefixAndSuffix}.
  */
 public class PrefixSuffixTest {
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/PrefixSuffixTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/PrefixSuffixTest.java
@@ -13,85 +13,90 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.textfield.tests;
+package com.vaadin.flow.component.shared;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.textfield.TextField;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for setting prefix and suffix components for {@link TextField}.
+ * Tests for setting prefix and suffix components for {@link HasPrefixAndSuffix}.
  */
 public class PrefixSuffixTest {
 
     @Test
     public void setPrefix_replacesPrefix() {
-        TextField field = new TextField();
+        TestComponent component = new TestComponent();
         Assert.assertNull("There should be no prefix component by default",
-                field.getPrefixComponent());
+                component.getPrefixComponent());
 
-        setAndAssertPrefix(field, new Span());
-        setAndAssertPrefix(field, new H1());
+        setAndAssertPrefix(component, new Span());
+        setAndAssertPrefix(component, new H1());
     }
 
     @Test
     public void setPrefix_setPrefixNull_prefixRemoved() {
-        TextField field = new TextField();
-        field.setPrefixComponent(new Span());
-        field.setPrefixComponent(null);
+        TestComponent component = new TestComponent();
+        component.setPrefixComponent(new Span());
+        component.setPrefixComponent(null);
 
-        Assert.assertNull(field.getPrefixComponent());
+        Assert.assertNull(component.getPrefixComponent());
         Assert.assertEquals(
                 "Setting prefix component to null should remove all children in the prefix-slot",
-                0, getNumOfChildrenInSlot(field, "prefix"));
+                0, getNumOfChildrenInSlot(component, "prefix"));
     }
 
     @Test
     public void setSuffix_replacesSuffix() {
-        TextField field = new TextField();
+        TestComponent component = new TestComponent();
         Assert.assertNull("There should be no suffix component by default",
-                field.getSuffixComponent());
+                component.getSuffixComponent());
 
-        setAndAssertSuffix(field, new Span());
-        setAndAssertSuffix(field, new H1());
+        setAndAssertSuffix(component, new Span());
+        setAndAssertSuffix(component, new H1());
     }
 
     @Test
     public void setSuffix_setSuffixNull_suffixRemoved() {
-        TextField field = new TextField();
-        field.setSuffixComponent(new Span());
-        field.setSuffixComponent(null);
+        TestComponent component = new TestComponent();
+        component.setSuffixComponent(new Span());
+        component.setSuffixComponent(null);
 
-        Assert.assertNull(field.getSuffixComponent());
+        Assert.assertNull(component.getSuffixComponent());
         Assert.assertEquals(
                 "Setting suffix component to null should remove all children in the suffix-slot",
-                0, getNumOfChildrenInSlot(field, "suffix"));
+                0, getNumOfChildrenInSlot(component, "suffix"));
     }
 
-    private void setAndAssertPrefix(TextField field, Component prefix) {
-        field.setPrefixComponent(prefix);
+    private void setAndAssertPrefix(TestComponent component, Component prefix) {
+        component.setPrefixComponent(prefix);
         Assert.assertEquals(
                 "Setting a prefix component should remove existing prefix components",
-                1, getNumOfChildrenInSlot(field, "prefix"));
+                1, getNumOfChildrenInSlot(component, "prefix"));
         Assert.assertEquals("getPrefixComponent did not return set value",
-                prefix, field.getPrefixComponent());
+                prefix, component.getPrefixComponent());
     }
 
-    private void setAndAssertSuffix(TextField field, Component suffix) {
-        field.setSuffixComponent(suffix);
+    private void setAndAssertSuffix(TestComponent component, Component suffix) {
+        component.setSuffixComponent(suffix);
         Assert.assertEquals(
                 "Setting a suffix component should remove existing suffix components",
-                1, getNumOfChildrenInSlot(field, "suffix"));
+                1, getNumOfChildrenInSlot(component, "suffix"));
         Assert.assertEquals("getSuffixComponent did not return set value",
-                suffix, field.getSuffixComponent());
+                suffix, component.getSuffixComponent());
     }
 
     private int getNumOfChildrenInSlot(Component component, String slot) {
         return (int) component.getElement().getChildren()
                 .filter(child -> slot.equals(child.getAttribute("slot")))
                 .count();
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasPrefixAndSuffix {
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasValidator;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.CompositionNotifier;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;


### PR DESCRIPTION
## Description

Move the `HasPrefixAndSuffix` interface from `vaadin-text-field-flow` to `vaadin-flow-components-base`.
The interface is needed by the `TabSheet` component which also supports adding a prefix and a suffix.

## Type of change

- Refactor

## Note

- This PR is targeting the `feat/tabsheet` branch, not `master`.