### PR TITLE
feat: add HasTooltip interface

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * Mixin interface for components that support a tooltip.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasTooltip extends HasElement {
+
+    /**
+     * Sets a tooltip text for the component.
+     *
+     * @param text
+     *            The tooltip text
+     *
+     * @return the tooltip handle
+     */
+    default Tooltip setTooltip(String text) {
+        var tooltip = Tooltip.forHasTooltip(this);
+        tooltip.setText(text);
+        return tooltip;
+    }
+
+    /**
+     * Gets the tooltip text of the component.
+     *
+     * @return The tooltip text
+     */
+    default String getTooltip() {
+        var tooltipElements = SlotUtils.getElementsInSlot(this, "tooltip");
+        return tooltipElements.findFirst()
+                .map(element -> element.getProperty("text")).orElse(null);
+    }
+
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -33,20 +33,21 @@ public interface HasTooltip extends HasElement {
      * @return the tooltip handle
      */
     default Tooltip setTooltip(String text) {
-        var tooltip = Tooltip.forHasTooltip(this);
+        var tooltip = Tooltip.getForElement(getElement());
+        if (tooltip == null) {
+            tooltip = Tooltip.forHasTooltip(this);
+        }
         tooltip.setText(text);
         return tooltip;
     }
 
     /**
-     * Gets the tooltip text of the component.
+     * Gets the tooltip handle of the component or null if no tooltip is set.
      *
-     * @return The tooltip text
+     * @return the tooltip handle
      */
-    default String getTooltip() {
-        var tooltipElements = SlotUtils.getElementsInSlot(this, "tooltip");
-        return tooltipElements.findFirst()
-                .map(element -> element.getProperty("text")).orElse(null);
+    default Tooltip getTooltip() {
+        return Tooltip.getForElement(getElement());
     }
 
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -107,6 +107,24 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * Creates a tooltip to the given {@link HasTooltip} component
+     * and adds the tooltip element to the component's tooltip slot.
+     *
+     * @param hasTooltip
+     *              the component to attach the tooltip to
+     * @return the tooltip handle
+     */
+    static Tooltip forHasTooltip(HasTooltip hasTooltip) {
+        // Clear any existing tooltip
+        SlotUtils.clearSlot(hasTooltip, "tooltip");
+
+        var tooltip = new Tooltip();
+        tooltip.tooltipElement.setAttribute("slot", "tooltip");
+        hasTooltip.getElement().appendChild(tooltip.tooltipElement);
+        return tooltip;
+    }
+
+    /**
      * String used as a tooltip content.
      *
      * @param text

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.shared;
 
 import java.io.Serializable;
+import java.util.WeakHashMap;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -107,6 +108,24 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * Keeps track of elements that have a tooltip. Currently only used for the {@link HasTooltip} APIs.
+     * The other APIs, such as {@link #forElement(Element)} and {@link #forComponent(Component)}, do not use this
+     * because they always return a new {@code Tooltip} instance (support adding multiple tooltips for one target).
+     */
+    private static final WeakHashMap<Element, Tooltip> elementTooltips = new WeakHashMap<>();
+
+    /**
+     * Gets the tooltip handle for the given element.
+     *
+     * @param element
+     *            the element to get the tooltip handle for
+     * @return the tooltip handle
+     */
+    static Tooltip getForElement(Element element) {
+        return elementTooltips.get(element);
+    }
+
+    /**
      * Creates a tooltip to the given {@link HasTooltip} component
      * and adds the tooltip element to the component's tooltip slot.
      *
@@ -121,6 +140,7 @@ public class Tooltip implements Serializable {
         var tooltip = new Tooltip();
         tooltip.tooltipElement.setAttribute("slot", "tooltip");
         hasTooltip.getElement().appendChild(tooltip.tooltipElement);
+        elementTooltips.put(hasTooltip.getElement(), tooltip);
         return tooltip;
     }
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
@@ -30,7 +30,7 @@ public class HasTooltipTest {
     }
 
     @Test
-    public void default_doesNotHaveTooltipText() {
+    public void default_doesNotHaveTooltip() {
         Assert.assertNull(component.getTooltip());
     }
 
@@ -41,9 +41,25 @@ public class HasTooltipTest {
     }
 
     @Test
-    public void setTooltip_hasTooltipText() {
-        component.setTooltip("foo");
-        Assert.assertEquals("foo", component.getTooltip());
+    public void setTooltip_hasTooltip() {
+        var tooltip = component.setTooltip("foo");
+        Assert.assertEquals(tooltip, component.getTooltip());
+    }
+
+    @Test
+    public void setTooltipAgain_hasTooltip() {
+        var tooltip = component.setTooltip("foo");
+        var tooltip2 = component.setTooltip("bar");
+        Assert.assertEquals(tooltip, tooltip2);
+        Assert.assertEquals(component.getTooltip().getText(), "bar");
+    }
+
+    @Test
+    public void setTooltipNull_hasTooltip() {
+        var tooltip = component.setTooltip("foo");
+        var tooltip2 = component.setTooltip(null);
+        Assert.assertEquals(tooltip, tooltip2);
+        Assert.assertEquals(component.getTooltip().getText(), null);
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
@@ -1,0 +1,82 @@
+package com.vaadin.flow.component.shared;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+
+public class HasTooltipTest {
+
+    private TestComponent component;
+    private UI ui;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+        ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test
+    public void default_doesNotHaveTooltipElement() {
+        Assert.assertFalse(getTooltipElement(component).isPresent());
+    }
+
+    @Test
+    public void default_doesNotHaveTooltipText() {
+        Assert.assertNull(component.getTooltip());
+    }
+
+    @Test
+    public void setTooltip_hasTooltipElement() {
+        component.setTooltip("foo");
+        Assert.assertTrue(getTooltipElement(component).isPresent());
+    }
+
+    @Test
+    public void setTooltip_hasTooltipText() {
+        component.setTooltip("foo");
+        Assert.assertEquals("foo", component.getTooltip());
+    }
+
+    @Test
+    public void setTooltip_tooltipHasText() {
+        component.setTooltip("foo");
+        Assert.assertEquals("foo",
+                getTooltipElement(component).get().getProperty("text"));
+    }
+
+    @Test
+    public void setTooltip_tooltipHasSlot() {
+        component.setTooltip("foo");
+        Assert.assertEquals("tooltip",
+                getTooltipElement(component).get().getAttribute("slot"));
+    }
+
+    @Test
+    public void setTooltipAgain_hasOneTooltipElement() {
+        component.setTooltip("foo");
+        component.setTooltip("bar");
+        Assert.assertEquals(1, getTooltipElements(component).count());
+    }
+
+    private Optional<Element> getTooltipElement(HasTooltip component) {
+        return getTooltipElements(component).findFirst();
+    }
+
+    private Stream<Element> getTooltipElements(HasTooltip component) {
+        return component.getElement().getChildren()
+                .filter(child -> child.getTag().equals("vaadin-tooltip"));
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component implements HasTooltip {
+    }
+}


### PR DESCRIPTION
## Description

Adds the `HasTooltip` interface to `vaadin-flow-components-base`. Components implementing the interface will get the following API:
- `Tooltip setTooltip(String text)`
  - Creates a `<vaadin-tooltip slot="tooltip" text="text">` element and adds it inside the target component
  - Returns the `Tooltip` handle that can be used to configure and control the tooltip
- `String getTooltip()`
  - Returns the `text` property that was set using `setTooltip(String text)`

Excluded from this PR (to be submitted separately):
- `HasTooltip` integration to components

## Type of change

- Feature

## Note

- This PR is targeting the `feat/tooltip` branch, not `master`.