### PR TITLE
chore: fix generated JavaDoc for i18n object

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -586,25 +586,23 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *               // Translation of the Cancel button text.
      *               cancel: 'Cancel',
      *
-     *               // A function to format given {@code Object} as
-     *               // date string. Object is in the format {@code { day: ..., month: ..., year: ... }}
+     *               // A function to format given Object as date string. Object is in the format { day: ..., month: ..., year: ... }
      *               // Note: The argument month is 0-based. This means that January = 0 and December = 11.
      *               formatDate: d =&gt; {
      *                 // returns a string representation of the given
      *                 // object in 'MM/DD/YYYY' -format
      *               },
      *
-     *               // A function to parse the given text to an {@code Object} in the format {@code { day: ..., month: ..., year: ... }}.
-     *               // Must properly parse (at least) text formatted by {@code formatDate}.
+     *               // A function to parse the given text to an Object in the format { day: ..., month: ..., year: ... }.
+     *               // Must properly parse (at least) text formatted by formatDate.
      *               // Setting the property to null will disable keyboard input feature.
      *               // Note: The argument month is 0-based. This means that January = 0 and December = 11.
      *               parseDate: text =&gt; {
      *                 // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to
-     *                 // an {@code Object} in the format {@code { day: ..., month: ..., year: ... }}.
+     *                 // an Object in the format { day: ..., month: ..., year: ... }.
      *               }
      *
-     *               // A function to format given {@code monthName} and
-     *               // {@code fullYear} integer as calendar title string.
+     *               // A function to format given monthName abd fullYear integer as calendar title string.
      *               formatTitle: (monthName, fullYear) =&gt; {
      *                 return monthName + ' ' + fullYear;
      *               }
@@ -674,25 +672,23 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *               // Translation of the Cancel button text.
      *               cancel: 'Cancel',
      *
-     *               // A function to format given {@code Object} as
-     *               // date string. Object is in the format {@code { day: ..., month: ..., year: ... }}
+     *               // A function to format given Object as date string. Object is in the format { day: ..., month: ..., year: ... }
      *               // Note: The argument month is 0-based. This means that January = 0 and December = 11.
      *               formatDate: d =&gt; {
      *                 // returns a string representation of the given
      *                 // object in 'MM/DD/YYYY' -format
      *               },
      *
-     *               // A function to parse the given text to an {@code Object} in the format {@code { day: ..., month: ..., year: ... }}.
-     *               // Must properly parse (at least) text formatted by {@code formatDate}.
+     *               // A function to parse the given text to an Object in the format { day: ..., month: ..., year: ... }.
+     *               // Must properly parse (at least) text formatted by formatDate.
      *               // Setting the property to null will disable keyboard input feature.
      *               // Note: The argument month is 0-based. This means that January = 0 and December = 11.
      *               parseDate: text =&gt; {
      *                 // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to
-     *                 // an {@code Object} in the format {@code { day: ..., month: ..., year: ... }}.
+     *                 // an Object in the format { day: ..., month: ..., year: ... }.
      *               }
      *
-     *               // A function to format given {@code monthName} and
-     *               // {@code fullYear} integer as calendar title string.
+     *               // A function to format given monthName and fullYear integer as calendar title string.
      *               formatTitle: (monthName, fullYear) =&gt; {
      *                 return monthName + ' ' + fullYear;
      *               }


### PR DESCRIPTION
## Description

Fixed the `@code` usage in `GeneratedVaadinDatePicker` 
This is needed to avoid problems with new versions of `formatter-maven-plugin`, see https://github.com/vaadin/flow-components/pull/3510#issuecomment-1193906770

Note: there is a similar `i18n` description for `GeneratedVaadinTimePicker` which does not use `@code`:

https://github.com/vaadin/flow-components/blob/c932d32aac2652fa20254248043d5fceb3c56da3/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java#L672-L673

## Type of change

- Internal change