### PR TITLE
feat: add prefix and suffix to TabSheet

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin Tabs</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasPrefixAndSuffix;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
 
@@ -46,7 +47,8 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("./tabsheet/vaadin-tabsheet.js")
 @NpmPackage(value = "@vaadin/component-base", version = "23.2.0-beta3")
 @NpmPackage(value = "@vaadin/field-base", version = "23.2.0-beta3")
-public class TabSheet extends Component implements HasStyle, HasSize {
+public class TabSheet extends Component
+        implements HasStyle, HasSize, HasPrefixAndSuffix {
 
     private Tabs tabs = new Tabs();
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -230,4 +230,18 @@ public class TabSheetTest {
         Assert.assertEquals(tab1, tabSheet.getSelectedTab());
     }
 
+    @Test
+    public void setPrefix_hasPrefix() {
+        var prefix = new Span("prefix");
+        tabSheet.setPrefixComponent(prefix);
+        Assert.assertEquals(prefix, tabSheet.getPrefixComponent());
+    }
+
+    @Test
+    public void setSuffix_hasSuffix() {
+        var suffix = new Span("suffix");
+        tabSheet.setSuffixComponent(suffix);
+        Assert.assertEquals(suffix, tabSheet.getSuffixComponent());
+    }
+
 }


### PR DESCRIPTION
## Description

Add prefix and suffix support to `TabSheet`

## Type of change

- Feature

## Note

- This PR is targeting the `feat/tabsheet` branch, not `master`.