### PR TITLE
chore: update mergeITs to use default scope to util dep

### DIFF
--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -43,7 +43,11 @@ function addDependency(arr, groupId, artifactId, version, scope, exclusions) {
       artifactId: [artifactId]
     }
     version && (obj.version = [version]);
-    scope && (obj.scope = [scope]);
+    // some components like TP are using this dependency under default scope instead of test scope
+    if (artifactId !== "vaadin-flow-components-test-util"){
+      scope && (obj.scope = [scope]);
+    }
+
     exclusions && (obj.exclusions = exclusions);
     arr.push(obj);
   }


### PR DESCRIPTION
since fcbac5ea043e120fee5dde23eaae2cb23a7c4c8a, `vaadin-flow-components-test-util` is needed under default scope instead of the original test scope. 