### PR TITLE
refactor: default to null for tooltip position

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.shared;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.WeakHashMap;
 
 import com.vaadin.flow.component.Component;
@@ -221,9 +222,9 @@ public class Tooltip implements Serializable {
      * @return the position
      */
     public TooltipPosition getPosition() {
-        return TooltipPosition.valueOf(tooltipElement
-                .getProperty("position", TooltipPosition.BOTTOM.name())
-                .toUpperCase());
+        var positionString = tooltipElement.getProperty("position");
+        return Arrays.stream(TooltipPosition.values())
+            .filter(p -> p.getPosition().equals(positionString)).findFirst().orElse(null);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -95,7 +95,7 @@ public class TooltipTest {
     @Test
     public void createTooltip_defaultPosition() {
         var tooltip = Tooltip.forComponent(component);
-        Assert.assertEquals(TooltipPosition.BOTTOM, tooltip.getPosition());
+        Assert.assertEquals(null, tooltip.getPosition());
     }
 
     @Test


### PR DESCRIPTION
## Description

Since there already are [component-specific defaults](https://github.com/vaadin/web-components/blob/8326a11bc382d74aed44926c998ac8d3f85d5648/packages/details/src/vaadin-details.js#L154) for the tooltip `position`, it's better to default to `null` in the Flow component `getPosition()` API than trying to keep up with the Web Component defaults.

## Type of change

- Refactor

## Note

- This PR is targeting the `feat/tooltip` branch, not `master`.

