### PR TITLE
feat: add setTooltipEnabled() to Avatar

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -295,6 +295,28 @@ public class Avatar extends Component
         getElement().setProperty("colorIndex", colorIndex);
     }
 
+    /**
+     * Gets the enabled state of the avatar tooltip, which is {@code false} by
+     * default.
+     *
+     * @return <code>true</code> if the tooltip is shown on hover or focus,
+     *         <code>false</code> otherwise
+     */
+    public boolean isTooltipEnabled() {
+        return getElement().getProperty("withTooltip", false);
+    }
+
+    /**
+     * Sets the enabled of the avatar tooltip.
+     *
+     * @param tooltipEnabled
+     *            <code>true</code> to show the tooltip on hover or focus,
+     *            <code>false</code> to not show it
+     */
+    public void setTooltipEnabled(boolean tooltipEnabled) {
+        getElement().setProperty("withTooltip", tooltipEnabled);
+    }
+
     // Override is only required to keep binary compatibility with other 23.x
     // minor versions, can be removed in a future major
     @Override

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarTest.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarTest.java
@@ -101,4 +101,16 @@ public class AvatarTest {
         Assert.assertEquals(i18n, avatar.getI18n());
     }
 
+    @Test
+    public void setTooltipEnabled_isTooltipEnabled() {
+        avatar.setTooltipEnabled(true);
+        Assert.assertEquals(avatar.isTooltipEnabled(), true);
+        Assert.assertTrue(
+                avatar.getElement().getProperty("withTooltip", false));
+
+        avatar.setTooltipEnabled(false);
+        Assert.assertEquals(avatar.isTooltipEnabled(), false);
+        Assert.assertFalse(
+                avatar.getElement().getProperty("withTooltip", false));
+    }
 }


### PR DESCRIPTION
## Description

Added `setTooltipEnabled()` to change `withTooltip` property on the `vaadin-avatar`.

Note, the `Avatar` is not supposed to implement `HasTooltip` because its tooltip is always pre-configured to show the name, the abbreviation, or the "anonymous" string in case when neither of those is set by the user.

## Type of change

- Feature