### PR TITLE
feat: add HasTooltip interface to components

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeature;
@@ -40,7 +41,7 @@ import java.util.stream.Stream;
  * @author Vaadin Ltd
  */
 public class Button extends GeneratedVaadinButton<Button>
-        implements HasSize, HasEnabled {
+        implements HasSize, HasEnabled, HasTooltip {
 
     private Component iconComponent;
     private boolean iconAfterText;

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
@@ -309,6 +310,12 @@ public class ButtonTest {
         button.click();
 
         Assert.assertTrue("Button should be enabled", button.isEnabled());
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        button = new Button();
+        Assert.assertTrue(button instanceof HasTooltip);
     }
 
     private void assertButtonHasThemeAttribute(String theme) {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -12,6 +12,11 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-data</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.PropertyChangeListener;
 
 /**
@@ -35,7 +36,7 @@ import com.vaadin.flow.dom.PropertyChangeListener;
  * @author Vaadin Ltd
  */
 public class Checkbox extends GeneratedVaadinCheckbox<Checkbox, Boolean>
-        implements HasSize, HasLabel {
+        implements HasSize, HasLabel, HasTooltip {
 
     private final Label labelElement;
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupDataView;
 import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupListDataView;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.provider.DataChangeEvent;
@@ -79,7 +80,7 @@ public class CheckboxGroup<T>
         MultiSelect<CheckboxGroup<T>, T>,
         HasListDataView<T, CheckboxGroupListDataView<T>>,
         HasDataView<T, Void, CheckboxGroupDataView<T>>, HasHelper, HasLabel,
-        HasValidator<T> {
+        HasTooltip, HasValidator<T> {
 
     private static final String VALUE = "value";
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupListDataView;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.selection.MultiSelectionEvent;
@@ -536,6 +537,12 @@ public class CheckboxGroupTest {
 
         Assert.assertEquals("Invalid label for checkbox group ", "label",
                 checkboxGroup.getElement().getProperty("label"));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        CheckboxGroup<String> group = new CheckboxGroup<>();
+        Assert.assertTrue(group instanceof HasTooltip);
     }
 
     private CheckboxGroup<Wrapper> getRefreshEventCheckboxGroup(

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
@@ -106,5 +107,11 @@ public class CheckboxUnitTest {
         Checkbox field = Component.from(element, Checkbox.class);
         Assert.assertEquals(Boolean.TRUE,
                 field.getElement().getPropertyRaw("checked"));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Checkbox checkbox = new Checkbox();
+        Assert.assertTrue(checkbox instanceof HasTooltip);
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -78,7 +79,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
         HasHelper, HasTheme, HasLabel, HasClearButton, HasAllowedCharPattern,
         HasDataView<TItem, String, ComboBoxDataView<TItem>>,
         HasListDataView<TItem, ComboBoxListDataView<TItem>>,
-        HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>,
+        HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>, HasTooltip,
         HasValidator<TValue> {
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
@@ -64,6 +65,13 @@ public abstract class ComboBoxBaseTest {
     public void implementsHasAllowedCharPattern() {
         Assert.assertTrue("ComboBox should support allowed char pattern",
                 HasAllowedCharPattern.class.isAssignableFrom(
+                        createComboBox(String.class).getClass()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue("ComboBox should support setting a tooltip",
+                HasTooltip.class.isAssignableFrom(
                         createComboBox(String.class).getClass()));
     }
 

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin Custom Field</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasTooltip;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.AbstractField;
@@ -62,7 +63,7 @@ import com.vaadin.flow.dom.Element;
 @JsModule("@vaadin/custom-field/src/vaadin-custom-field.js")
 public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
         implements HasSize, HasValidation, Focusable<CustomField>, HasHelper,
-        HasLabel, HasTheme, HasStyle {
+        HasLabel, HasTheme, HasStyle, HasTooltip {
 
     /**
      * Default constructor.

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/CustomFieldTest.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/test/java/com/vaadin/flow/component/customfield/CustomFieldTest.java
@@ -7,6 +7,8 @@ import org.mockito.Mockito;
 
 import java.util.function.Consumer;
 
+import com.vaadin.flow.component.shared.HasTooltip;
+
 @SuppressWarnings("unchecked")
 public class CustomFieldTest {
 
@@ -43,4 +45,8 @@ public class CustomFieldTest {
                 .addValueChangeListener(e -> listener.accept(e.getValue()));
     }
 
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(systemUnderTest instanceof HasTooltip);
+    }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
@@ -78,7 +79,7 @@ import elemental.json.JsonType;
 public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         implements HasSize, HasValidation, HasHelper, HasTheme, HasLabel,
         HasClearButton, HasAllowedCharPattern, HasValidator<LocalDate>,
-        HasClientValidation {
+        HasClientValidation, HasTooltip {
 
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
@@ -266,5 +267,11 @@ public class DatePickerTest {
         Assert.assertTrue("DatePicker should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new DatePicker().getClass()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        DatePicker picker = new DatePicker();
+        Assert.assertTrue(picker instanceof HasTooltip);
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.component.timepicker.StepsUtil;
 import com.vaadin.flow.data.binder.HasValidator;
@@ -99,10 +100,11 @@ class DateTimePickerTimePicker
 @NpmPackage(value = "@vaadin/date-time-picker", version = "23.3.0-alpha1")
 @NpmPackage(value = "@vaadin/vaadin-date-time-picker", version = "23.3.0-alpha1")
 @JsModule("@vaadin/date-time-picker/src/vaadin-date-time-picker.js")
-public class DateTimePicker extends
-        AbstractSinglePropertyField<DateTimePicker, LocalDateTime> implements
-        HasStyle, HasSize, HasTheme, HasValidation, Focusable<DateTimePicker>,
-        HasHelper, HasLabel, HasValidator<LocalDateTime>, HasClientValidation {
+public class DateTimePicker
+        extends AbstractSinglePropertyField<DateTimePicker, LocalDateTime>
+        implements HasStyle, HasSize, HasTheme, HasValidation,
+        Focusable<DateTimePicker>, HasHelper, HasLabel,
+        HasValidator<LocalDateTime>, HasClientValidation, HasTooltip {
 
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.datetimepicker;
 
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
@@ -208,5 +209,11 @@ public class DateTimePickerTest {
 
         DateTimePicker field = Component.from(element, DateTimePicker.class);
         Assert.assertEquals(value, field.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        DateTimePicker picker = new DateTimePicker();
+        Assert.assertTrue(picker instanceof HasTooltip);
     }
 }

--- a/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin Details</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.shared.Registration;
@@ -64,7 +65,7 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@vaadin/vaadin-details", version = "23.3.0-alpha1")
 @JsModule("@vaadin/details/src/vaadin-details.js")
 public class Details extends Component
-        implements HasEnabled, HasTheme, HasStyle, HasSize {
+        implements HasEnabled, HasTheme, HasStyle, HasSize, HasTooltip {
 
     private Component summary;
     private final Div contentContainer;

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.component.details;
 
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.shared.HasTooltip;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,5 +34,10 @@ public class DetailsTest {
     public void summaryDefined_getSummaryText_returnsStringDefined() {
         details.setSummaryText("summary");
         Assert.assertEquals("summary", details.getSummaryText());
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(details instanceof HasTooltip);
     }
 }

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin Icons</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.ElementConstants;
 
 /**
@@ -39,7 +40,8 @@ import com.vaadin.flow.dom.ElementConstants;
 @NpmPackage(value = "@vaadin/icon", version = "23.3.0-alpha1")
 @NpmPackage(value = "@vaadin/vaadin-icon", version = "23.3.0-alpha1")
 @JsModule("@vaadin/icon/vaadin-icon.js")
-public class Icon extends Component implements HasStyle, ClickNotifier<Icon> {
+public class Icon extends Component
+        implements HasStyle, ClickNotifier<Icon>, HasTooltip {
 
     private static final String ICON_ATTRIBUTE_NAME = "icon";
     private static final String ICON_COLLECTION_NAME = "vaadin";

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/IconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/IconTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.shared.HasTooltip;
+
+public class IconTest {
+    @Test
+    public void implementsHasTooltip() {
+        Icon icon = new Icon();
+        Assert.assertTrue(icon instanceof HasTooltip);
+    }
+}

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin List Box</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.listbox.dataview.ListBoxDataView;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
@@ -74,7 +75,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
         extends AbstractSinglePropertyField<C, VALUE>
         implements HasItemComponents<ITEM>, HasSize,
         HasListDataView<ITEM, ListBoxListDataView<ITEM>>,
-        HasDataView<ITEM, Void, ListBoxDataView<ITEM>>, HasStyle {
+        HasDataView<ITEM, Void, ListBoxDataView<ITEM>>, HasStyle, HasTooltip {
 
     private final AtomicReference<DataProvider<ITEM, ?>> dataProvider = new AtomicReference<>(
             DataProvider.ofItems());

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.tests.DataProviderListenersTest;
 
@@ -171,6 +172,11 @@ public class ListBoxUnitTest {
                 .checkOldListenersRemovedOnComponentAttachAndDetach(
                         new ListBox<>(), 1, 1, new int[] { 0, 1 },
                         new DataCommunicatorTest.MockUI());
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(listBox instanceof HasTooltip);
     }
 
     private void assertDisabledItem(int index, boolean disabled) {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.MultiSelectListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.selection.MultiSelectionEvent;
@@ -325,6 +326,11 @@ public class MultiSelectListBoxTest {
         listDataView.setIdentifierProvider(CustomItem::getId);
 
         multiSelectListBox.setValue(new CustomItem(null, "First"));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(listBox instanceof HasTooltip);
     }
 
     private void assertValueChangeEvents(Set<Item>... expectedValues) {

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
@@ -12,6 +12,11 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.shared.Registration;
 
@@ -50,7 +51,7 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@vaadin/message-input", version = "23.3.0-alpha1")
 @NpmPackage(value = "@vaadin/vaadin-messages", version = "23.3.0-alpha1")
 public class MessageInput extends Component
-        implements HasSize, HasStyle, HasEnabled {
+        implements HasSize, HasStyle, HasEnabled, HasTooltip {
 
     private MessageInputI18n i18n;
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.messages.MessageInput;
 import com.vaadin.flow.component.messages.MessageInputI18n;
+import com.vaadin.flow.component.shared.HasTooltip;
 
 public class MessageInputTest {
 
@@ -67,5 +68,10 @@ public class MessageInputTest {
                 messageInput, false, "foo");
         ComponentUtil.fireEvent(messageInput, event);
         Assert.assertSame(event, eventRef.get());
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(messageInput instanceof HasTooltip);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin Radio Button</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupDataView;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
 import com.vaadin.flow.data.binder.HasItemComponents;
@@ -72,7 +73,7 @@ public class RadioButtonGroup<T>
         implements HasItemComponents<T>, SingleSelect<RadioButtonGroup<T>, T>,
         HasListDataView<T, RadioButtonGroupListDataView<T>>,
         HasDataView<T, Void, RadioButtonGroupDataView<T>>, HasValidation,
-        HasHelper, HasSize, HasLabel, HasValidator<T> {
+        HasHelper, HasSize, HasLabel, HasTooltip, HasValidator<T> {
 
     private final KeyMapper<T> keyMapper = new KeyMapper<>();
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -456,5 +457,11 @@ public class RadioButtonGroupTest {
                 .checkOldListenersRemovedOnComponentAttachAndDetach(
                         new RadioButtonGroup<>(), 1, 1, new int[] { 0, 1 },
                         new DataCommunicatorTest.MockUI());
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        Assert.assertTrue(group instanceof HasTooltip);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -11,6 +11,11 @@
     <name>Vaadin Select</name>
     <dependencies>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.select.data.SelectDataView;
 import com.vaadin.flow.component.select.data.SelectListDataView;
 import com.vaadin.flow.component.select.generated.GeneratedVaadinSelect;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -76,7 +77,8 @@ import java.util.stream.Stream;
 public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         implements HasItemComponents<T>, HasSize, HasValidation,
         SingleSelect<Select<T>, T>, HasListDataView<T, SelectListDataView<T>>,
-        HasDataView<T, Void, SelectDataView<T>>, HasHelper, HasLabel, HasTheme {
+        HasDataView<T, Void, SelectDataView<T>>, HasHelper, HasLabel, HasTheme,
+        HasTooltip {
 
     public static final String LABEL_ATTRIBUTE = "label";
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.data.SelectListDataView;
 import com.vaadin.flow.component.select.generated.GeneratedVaadinSelect;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
@@ -818,6 +819,11 @@ public class SelectTest {
 
         Assert.assertEquals("Invalid label for select ", "label",
                 select.getElement().getProperty("label"));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(select instanceof HasTooltip);
     }
 
     private void validateItem(int index, String textContent, String label,

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.component.tabs;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasLabel;
+import com.vaadin.flow.component.shared.HasTooltip;
 
 /**
  * This component provides an accessible and customizable tab to be used inside
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.HasLabel;
  * @author Vaadin Ltd.
  */
 public class Tab extends GeneratedVaadinTab<Tab>
-        implements HasComponents, HasLabel {
+        implements HasComponents, HasLabel, HasTooltip {
 
     private static final String FLEX_GROW_CSS_PROPERTY = "flexGrow";
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.tabs.tests;
 
 import org.junit.Test;
 
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.tabs.Tab;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -52,5 +53,10 @@ public class TabTest {
         tab.setFlexGrow(1);
 
         assertThat("flexGrow is invalid", tab.getFlexGrow(), is(1.0));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        assertTrue(tab instanceof HasTooltip);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.KeyNotifier;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.ValidationResult;
@@ -52,7 +53,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
         HasClearButton, HasAllowedCharPattern,
-        HasThemeVariant<TextFieldVariant>, HasValidator<T> {
+        HasThemeVariant<TextFieldVariant>, HasTooltip, HasValidator<T> {
 
     private ValueChangeMode currentMode;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -57,11 +58,12 @@ import com.vaadin.flow.function.SerializableBiFunction;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./vaadin-big-decimal-field.js")
 public class BigDecimalField
-        extends GeneratedVaadinTextField<BigDecimalField, BigDecimal> implements
-        HasSize, HasValidation, HasValueChangeMode, HasPrefixAndSuffix,
-        InputNotifier, KeyNotifier, CompositionNotifier, HasAutocomplete,
-        HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel, HasClearButton,
-        HasThemeVariant<TextFieldVariant>, HasValidator<BigDecimal> {
+        extends GeneratedVaadinTextField<BigDecimalField, BigDecimal>
+        implements HasSize, HasValidation, HasValueChangeMode,
+        HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
+        HasClearButton, HasThemeVariant<TextFieldVariant>, HasTooltip,
+        HasValidator<BigDecimal> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -53,7 +54,7 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
         HasClearButton, HasAllowedCharPattern,
-        HasThemeVariant<TextFieldVariant>, HasValidator<String> {
+        HasThemeVariant<TextFieldVariant>, HasTooltip, HasValidator<String> {
     private static final String EMAIL_PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
             + "@" + "[a-zA-Z0-9-.]+" // domain
             + "\\." + "[a-zA-Z0-9-]{2,}" // tld

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -49,7 +50,7 @@ public class PasswordField
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
         HasClearButton, HasAllowedCharPattern,
-        HasThemeVariant<TextFieldVariant>, HasValidator<String> {
+        HasThemeVariant<TextFieldVariant>, HasTooltip, HasValidator<String> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -48,7 +49,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
         HasClearButton, HasAllowedCharPattern, HasThemeVariant<TextAreaVariant>,
-        HasValidator<String> {
+        HasTooltip, HasValidator<String> {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
@@ -51,7 +52,7 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
         HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper, HasLabel,
         HasClearButton, HasAllowedCharPattern,
-        HasThemeVariant<TextFieldVariant>, HasValidator<String>,
+        HasThemeVariant<TextFieldVariant>, HasTooltip, HasValidator<String>,
         HasClientValidation {
     private ValueChangeMode currentMode;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.flow.dom.ThemeList;
@@ -108,6 +109,11 @@ public class BigDecimalFieldTest extends TextFieldTest {
         ThemeList themeNames = field.getThemeNames();
         Assert.assertFalse(themeNames
                 .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(field instanceof HasTooltip);
     }
 
     private void assertValueFormatting(BigDecimal bigDecimal,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.flow.dom.ThemeList;
@@ -87,5 +88,11 @@ public class EmailFieldTest {
         assertTrue("EmailField should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new EmailField().getClass()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        EmailField field = new EmailField();
+        Assert.assertTrue(field instanceof HasTooltip);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.flow.dom.ThemeList;
@@ -159,6 +160,11 @@ public class IntegerFieldTest extends TextFieldTest {
         ThemeList themeNames = field.getThemeNames();
         Assert.assertFalse(themeNames
                 .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(field instanceof HasTooltip);
     }
 
     private void assertValidValues(Integer... values) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.flow.dom.ThemeList;
@@ -176,6 +177,11 @@ public class NumberFieldTest extends TextFieldTest {
         ThemeList themeNames = field.getThemeNames();
         Assert.assertFalse(themeNames
                 .contains(TextFieldVariant.LUMO_SMALL.getVariantName()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        Assert.assertTrue(field instanceof HasTooltip);
     }
 
     private void assertValidValues(Double... values) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextAreaVariant;
 import com.vaadin.flow.dom.ThemeList;
@@ -130,5 +131,11 @@ public class TextAreaTest {
         assertTrue("TextArea should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new TextArea().getClass()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        TextArea textArea = new TextArea();
+        Assert.assertTrue(textArea instanceof HasTooltip);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.flow.dom.ThemeList;
@@ -119,5 +120,11 @@ public class TextFieldTest {
         assertTrue("TextField should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new TextField().getClass()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        TextField field = new TextField();
+        Assert.assertTrue(field instanceof HasTooltip);
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -65,7 +66,7 @@ import com.vaadin.flow.shared.Registration;
 public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         implements HasSize, HasValidation, HasEnabled, HasHelper, HasLabel,
         HasTheme, HasClearButton, HasAllowedCharPattern,
-        HasValidator<LocalTime>, HasClientValidation {
+        HasValidator<LocalTime>, HasClientValidation, HasTooltip {
 
     private static final SerializableFunction<String, LocalTime> PARSER = valueFromClient -> {
         return valueFromClient == null || valueFromClient.isEmpty() ? null

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
@@ -285,5 +286,11 @@ public class TimePickerTest {
         Assert.assertTrue("TimePicker should support char pattern",
                 HasAllowedCharPattern.class
                         .isAssignableFrom(new TimePicker().getClass()));
+    }
+
+    @Test
+    public void implementsHasTooltip() {
+        TimePicker timePicker = new TimePicker();
+        Assert.assertTrue(timePicker instanceof HasTooltip);
     }
 }


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/3146

Added `HasTooltip` interface to the following components according to the list: https://github.com/vaadin/platform/discussions/3196#discussioncomment-3420595

- [x] Button
- [x] Checkbox
- [x] Checkbox Group
- [x] Combo Box
- [x] Custom Field
- [x] Date Picker
- [x] Date Time Picker
- [x] Details
- [x] Email Field
- [x] Icon
- [x] Integer Field
- [x] List Box
- [x] Message Input
- [x] Multi-Select Combo Box
- [x] Number Field
- [x] Password Field
- [x] Radio Button Group
- [x] Select
- [x] Tab (individual tabs only)
- [x] Text Area
- [x] Text Field
- [x] Time Picker

## Type of change

- Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
