### PR TITLE
feat: make setTooltip(null) remove existing tooltip

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -34,6 +34,10 @@ public interface HasTooltip extends HasElement {
      */
     default Tooltip setTooltip(String text) {
         var tooltip = Tooltip.getForElement(getElement());
+        if (text == null && tooltip != null) {
+            Tooltip.removeForHasTooltip(this);
+            return null;
+        }
         if (tooltip == null) {
             tooltip = Tooltip.forHasTooltip(this);
         }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -150,6 +150,22 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * Removes the tooltip from the given {@link HasTooltip} component
+     * and clears the component's tooltip slot.
+     *
+     * @param hasTooltip
+     *            the element to get the tooltip handle for
+     */
+    static void removeForHasTooltip(HasTooltip hasTooltip) {
+        var tooltip = getForElement(hasTooltip.getElement());
+        if (tooltip != null) {
+            tooltip.tooltipElement.executeJs("this.target = null;");
+            SlotUtils.clearSlot(hasTooltip, "tooltip");
+            elementTooltips.remove(hasTooltip.getElement());
+        }
+    }
+
+    /**
      * String used as a tooltip content.
      *
      * @param text

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
@@ -55,11 +55,11 @@ public class HasTooltipTest {
     }
 
     @Test
-    public void setTooltipNull_hasTooltip() {
+    public void setTooltipNull_hasNoTooltip() {
         var tooltip = component.setTooltip("foo");
-        var tooltip2 = component.setTooltip(null);
-        Assert.assertEquals(tooltip, tooltip2);
-        Assert.assertEquals(component.getTooltip().getText(), null);
+        component.setTooltip(null);
+        Assert.assertEquals(component.getTooltip(), null);
+        Assert.assertFalse(getTooltipElement(component).isPresent());
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #3722

Currently, `setTooltip(null)` clears the tooltip text but does not remove the tooltip. 
Added logic to remove it from DOM as that's what some users might expect.

## Type of change

- Feature