### PR TITLE
refactor: rename setTooltipTextGenerator to setTooltipGenerator

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
@@ -28,13 +28,13 @@ public class GridTooltipPage extends Div {
         var grid = new Grid<>(Person.class);
         grid.setItems(new Person("Jack", 32), new Person("Jill", 33));
 
-        grid.getColumnByKey("firstName").setTooltipTextGenerator(
+        grid.getColumnByKey("firstName").setTooltipGenerator(
                 person -> "First name of the person is "
                         + person.getFirstName());
 
         var setAgeTooltipButton = new NativeButton("Set tooltip to age column",
                 event -> {
-                    grid.getColumnByKey("age").setTooltipTextGenerator(
+                    grid.getColumnByKey("age").setTooltipGenerator(
                             person -> "Age of the person is "
                                     + person.getAge());
                 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
@@ -28,8 +28,8 @@ public class GridTooltipPage extends Div {
         var grid = new Grid<>(Person.class);
         grid.setItems(new Person("Jack", 32), new Person("Jill", 33));
 
-        grid.getColumnByKey("firstName").setTooltipGenerator(
-                person -> "First name of the person is "
+        grid.getColumnByKey("firstName")
+                .setTooltipGenerator(person -> "First name of the person is "
                         + person.getFirstName());
 
         var setAgeTooltipButton = new NativeButton("Set tooltip to age column",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -477,7 +477,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         private Rendering<T> rendering;
 
         private SerializableFunction<T, String> classNameGenerator = item -> null;
-        private SerializableFunction<T, String> tooltipTextGenerator = item -> null;
+        private SerializableFunction<T, String> tooltipGenerator = item -> null;
 
         /**
          * Constructs a new Column for use inside a Grid.
@@ -1036,16 +1036,16 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * in this column. Returning {@code null} from the generator results in
          * no tooltip being set.
          *
-         * @param tooltipTextGenerator
-         *            the tooltip text generator to set, not {@code null}
+         * @param tooltipGenerator
+         *            the tooltip generator to set, not {@code null}
          * @return this column
          * @throws NullPointerException
          *             if {@code classNameGenerator} is {@code null}
          */
-        public Column<T> setTooltipTextGenerator(
-                SerializableFunction<T, String> tooltipTextGenerator) {
+        public Column<T> setTooltipGenerator(
+                SerializableFunction<T, String> tooltipGenerator) {
             Objects.requireNonNull(classNameGenerator,
-                    "Tooltip text generator can not be null");
+                    "Tooltip generator can not be null");
 
             if (!getGrid().getElement().getChildren().anyMatch(
                     child -> "tooltip".equals(child.getAttribute("slot")))) {
@@ -1054,7 +1054,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 tooltipElement.setAttribute("slot", "tooltip");
 
                 tooltipElement.addAttachListener(e -> {
-                    // Assigns a textGenerator that returns a column-specfic
+                    // Assigns a generator that returns a column-specfic
                     // tooltip text from the item
                     tooltipElement.executeJs(
                             "this.textGenerator = ({item, column}) => item.gridtooltips[column._flowId]");
@@ -1062,7 +1062,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 getGrid().getElement().appendChild(tooltipElement);
             }
 
-            this.tooltipTextGenerator = tooltipTextGenerator;
+            this.tooltipGenerator = tooltipGenerator;
             getGrid().getDataCommunicator().reset();
             return this;
         }
@@ -1077,8 +1077,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             return classNameGenerator;
         }
 
-        public SerializableFunction<T, String> getTooltipTextGenerator() {
-            return tooltipTextGenerator;
+        public SerializableFunction<T, String> getTooltipGenerator() {
+            return tooltipGenerator;
         }
 
         @Override
@@ -3905,7 +3905,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         JsonObject tooltips = Json.createObject();
 
         idToColumnMap.forEach((id, column) -> {
-            String cellTooltip = column.getTooltipTextGenerator().apply(item);
+            String cellTooltip = column.getTooltipGenerator().apply(item);
             if (cellTooltip != null) {
                 tooltips.put(id, cellTooltip);
             }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
@@ -45,29 +45,29 @@ public class GridTooltipTest {
     }
 
     @Test
-    public void setTooltipTextGenerator_hasTooltipElement() {
-        grid.addColumn(item -> item).setTooltipTextGenerator(item -> item);
+    public void setTooltipGenerator_hasTooltipElement() {
+        grid.addColumn(item -> item).setTooltipGenerator(item -> item);
         Assert.assertTrue(getTooltipElement(grid).isPresent());
     }
 
     @Test
-    public void setTooltipTextGenerator_hasFluidAPI() {
+    public void setTooltipGenerator_hasFluidAPI() {
         var column = grid.addColumn(item -> item)
-                .setTooltipTextGenerator(item -> item).setAutoWidth(true);
+                .setTooltipGenerator(item -> item).setAutoWidth(true);
         Assert.assertTrue(column.isAutoWidth());
     }
 
     @Test
     public void setTooltip_tooltipHasSlot() {
-        grid.addColumn(item -> item).setTooltipTextGenerator(item -> item);
+        grid.addColumn(item -> item).setTooltipGenerator(item -> item);
         Assert.assertEquals("tooltip",
                 getTooltipElement(grid).get().getAttribute("slot"));
     }
 
     @Test
-    public void setAnotherTooltipTextGenerator_hasOneTooltipElement() {
-        grid.addColumn(item -> item).setTooltipTextGenerator(item -> item);
-        grid.addColumn(item -> item).setTooltipTextGenerator(item -> item);
+    public void setAnotherTooltipGenerator_hasOneTooltipElement() {
+        grid.addColumn(item -> item).setTooltipGenerator(item -> item);
+        grid.addColumn(item -> item).setTooltipGenerator(item -> item);
         Assert.assertEquals(1, getTooltipElements(grid).count());
     }
 


### PR DESCRIPTION
Apply the following changes (as agreed in API review):
- Rename `gridColumn.setTooltipTextGenerator` to `gridColumn.setTooltipGenerator`

Related to (but does not depend on) https://github.com/vaadin/web-components/pull/4616