### PR TITLE
fix: clean up old content on tabsheet.add

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -104,6 +104,11 @@ public class TabSheet extends Component
                 "The content to be added cannot be null");
         tabs.add(tab);
 
+        // Make sure possible old content related to the same tab gets removed
+        if (tabToContent.containsKey(tab)) {
+            tabToContent.get(tab).removeFromParent();
+        }
+
         // On the client, content is associated with a tab by id
         var id = "tabsheet-tab-" + UUID.randomUUID().toString();
         tab.setId(id);

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -66,6 +66,23 @@ public class TabSheetTest {
     }
 
     @Test
+    public void addSameTabAgainWithNewContent_oldContentRemoved() {
+        // Add a tab with content
+        var content0 = new Span("Content 0");
+        var tab0 = tabSheet.add("Tab 0", content0);
+
+        // Assert that the content is attached to the parent (the tab is
+        // selected)
+        Assert.assertEquals(tabSheet, content0.getParent().get());
+
+        // Add the same Tab instance again but with a new content component
+        tabSheet.add(tab0, new Span("Content 0"));
+
+        // Check that the old content is no longer attached to the parent
+        Assert.assertFalse(content0.getParent().isPresent());
+    }
+
+    @Test
     public void addSecondTab_contentNotAdded() {
         tabSheet.add("Tab 0", new Span("Content 0"));
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -83,6 +83,21 @@ public class TabSheetTest {
     }
 
     @Test
+    public void addSameTabAgain_addedAsTheLastTab() {
+        // Add a tab
+        var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
+        // Add another tab
+        tabSheet.add("Tab 1", new Span("Content 1"));
+
+        // Add the same Tab instance again
+        tabSheet.add(tab0, new Span("Content 0"));
+
+        // Check that the tab gets added as the last tab
+        Assert.assertEquals(1,
+                tab0.getElement().getParent().indexOfChild(tab0.getElement()));
+    }
+
+    @Test
     public void addSecondTab_contentNotAdded() {
         tabSheet.add("Tab 0", new Span("Content 0"));
 


### PR DESCRIPTION
## Description
Even though it's an edge case, it is techincally possible to add the same `Tab` instance to a `TabSheet` more than once and with different content. In this case, make sure any possible content previously related to the same tab gets cleaned up.

## Type of change

- Fix