### PR TITLE
refactor: make tooltip forElement api private

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -77,7 +77,7 @@ public class Tooltip implements Serializable {
      *            the element to attach the tooltip to
      * @return the tooltip handle
      */
-    public static Tooltip forElement(Element element) {
+    private static Tooltip forElement(Element element) {
         // Create a new Tooltip handle instance
         var tooltip = new Tooltip();
 


### PR DESCRIPTION
## Description
There was some discussion (in the API review meeting) around the topic of `Tooltip.forComponent`/`Tooltip.forElement` API naming. Eventually, it was decided that the current `Tooltip.forElement` API should be made private (for now at least).

## Type of change

- Refactor