### PR TITLE
feat: add tooltip API to menubar

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-menu-bar/tooltip")
+public class MenuBarTooltipPage extends Div {
+
+    public MenuBarTooltipPage() {
+        MenuBar menuBar = new MenuBar();
+        // Use each add API with tooltip parameter to add menu items
+        menuBar.addItem("Edit", "Edit tooltip");
+        menuBar.addItem(new Span("Share"), "Share tooltip");
+        menuBar.addItem("Move", "Move tooltip", (e) -> {
+        });
+        menuBar.addItem(new Span("Duplicate"), "Duplicate tooltip");
+
+        // Add a button for toggling the menu-bar attached state.
+        var toggleAttachedButton = new NativeButton("Toggle attached",
+                event -> {
+                    if (menuBar.getParent().isPresent()) {
+                        remove(menuBar);
+                    } else {
+                        add(menuBar);
+                    }
+                });
+        toggleAttachedButton.setId("toggle-attached-button");
+
+        add(toggleAttachedButton, menuBar);
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("vaadin-menu-bar/tooltip")
+public class MenuBarTooltipIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void hoverOverMenuBarButton_showTooltip() {
+        var menuBar = $(MenuBarElement.class).first();
+
+        showTooltip(menuBar.getButtons().get(0));
+        Assert.assertEquals("Edit tooltip", getActiveTooltipText());
+
+        showTooltip(menuBar.getButtons().get(1));
+        Assert.assertEquals("Share tooltip", getActiveTooltipText());
+
+        showTooltip(menuBar.getButtons().get(2));
+        Assert.assertEquals("Move tooltip", getActiveTooltipText());
+
+        showTooltip(menuBar.getButtons().get(3));
+        Assert.assertEquals("Duplicate tooltip", getActiveTooltipText());
+    }
+
+    @Test
+    public void toggleAttached_hoverOverTooltipColumnCell_showTooltip() {
+        // Remove the menubar
+        clickElementWithJs("toggle-attached-button");
+        // Add the menubar
+        clickElementWithJs("toggle-attached-button");
+
+        var menuBar = $(MenuBarElement.class).first();
+        showTooltip(menuBar.getButtons().get(0));
+        Assert.assertEquals("Edit tooltip", getActiveTooltipText());
+    }
+
+    private void showTooltip(TestBenchElement button) {
+        executeScript(
+                "arguments[0].dispatchEvent(new Event('mouseover', {bubbles:true}))",
+                button);
+    }
+
+    private String getActiveTooltipText() {
+        return findElement(By.tagName("vaadin-tooltip-overlay")).getText();
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -216,6 +216,8 @@ public class MenuBar extends Component
      *
      * @param component
      *            the component to add inside new item
+     * @param tooltipText
+     *            the tooltip text for the new item
      * @return the added {@link MenuItem} component
      */
     public MenuItem addItem(Component component, String tooltipText) {
@@ -239,6 +241,8 @@ public class MenuBar extends Component
      *
      * @param text
      *            the text content for the new item
+     * @param tooltipText
+     *            the tooltip text for the new item
      * @param clickListener
      *            the handler for clicking the new item, can be {@code null} to
      *            not add listener
@@ -266,6 +270,8 @@ public class MenuBar extends Component
      *
      * @param component
      *            the component to add inside the added menu item
+     * @param tooltipText
+     *            the tooltip text for the new item
      * @param clickListener
      *            the handler for clicking the new item, can be {@code null} to
      *            not add listener

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.contextmenu.MenuManager;
 import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonSerializer;
 
@@ -174,6 +175,107 @@ public class MenuBar extends Component
     public MenuItem addItem(Component component,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         return menuManager.addItem(component, clickListener);
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the provided text content
+     * and the tooltip text and adds it to the root level of this menu bar.
+     * <p>
+     * The added {@link MenuItem} component is placed inside a button in the
+     * menu bar. If this button overflows the menu bar horizontally, the
+     * {@link MenuItem} is moved out of the button, into a context menu openable
+     * via an overflow button at the end of the button row.
+     * <p>
+     * To add content to the sub menu opened by clicking the root level item,
+     * use {@link MenuItem#getSubMenu()}.
+     *
+     * @param text
+     *            the text content for the new item
+     * @param tooltipText
+     *            the tooltip text for the new item
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(String text, String tooltipText) {
+        var item = addItem(text);
+        setTooltip(item, tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the provided tooltip text
+     * and adds it to the root level of this menu bar. The provided component is
+     * added into the created {@link MenuItem}.
+     * <p>
+     * The added {@link MenuItem} component is placed inside a button in the
+     * menu bar. If this button overflows the menu bar horizontally, the
+     * {@link MenuItem} is moved out of the button, into a context menu openable
+     * via an overflow button at the end of the button row.
+     * <p>
+     * To add content to the sub menu opened by clicking the root level item,
+     * use {@link MenuItem#getSubMenu()}.
+     *
+     * @param component
+     *            the component to add inside new item
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(Component component, String tooltipText) {
+        var item = addItem(component);
+        setTooltip(item, tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the provided text content
+     * and the tooltip text and click listener and adds it to the root level of
+     * this menu bar.
+     * <p>
+     * The added {@link MenuItem} component is placed inside a button in the
+     * menu bar. If this button overflows the menu bar horizontally, the
+     * {@link MenuItem} is moved out of the button, into a context menu openable
+     * via an overflow button at the end of the button row.
+     * <p>
+     * To add content to the sub menu opened by clicking the root level item,
+     * use {@link MenuItem#getSubMenu()}.
+     *
+     * @param text
+     *            the text content for the new item
+     * @param clickListener
+     *            the handler for clicking the new item, can be {@code null} to
+     *            not add listener
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(String text, String tooltipText,
+            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+        var item = addItem(text, clickListener);
+        setTooltip(item, tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the provided click listener
+     * and the tooltip text and adds it to the root level of this menu bar. The
+     * provided component is added into the created {@link MenuItem}.
+     * <p>
+     * The added {@link MenuItem} component is placed inside a button in the
+     * menu bar. If this button overflows the menu bar horizontally, the
+     * {@link MenuItem} is moved out of the button, into a context menu openable
+     * via an overflow button at the end of the button row.
+     * <p>
+     * To add content to the sub menu opened by clicking the root level item,
+     * use {@link MenuItem#getSubMenu()}.
+     *
+     * @param component
+     *            the component to add inside the added menu item
+     * @param clickListener
+     *            the handler for clicking the new item, can be {@code null} to
+     *            not add listener
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(Component component, String tooltipText,
+            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+        var item = addItem(component, clickListener);
+        setTooltip(item, tooltipText);
+        return item;
     }
 
     /**
@@ -392,5 +494,29 @@ public class MenuBar extends Component
             this.moreOptions = moreOptions;
             return this;
         }
+    }
+
+    /**
+     * Sets the tooltip property for the given menu item. A vaadin-tooltip
+     * element with a custom generator is created and added inside the menu bar
+     * in case it doesn't exist.
+     */
+    private void setTooltip(MenuItem item, String tooltipText) {
+        if (!getElement().getChildren().anyMatch(
+                child -> "tooltip".equals(child.getAttribute("slot")))) {
+            // No <vaadin-tooltip> yet added, add one
+            var tooltipElement = new Element("vaadin-tooltip");
+            tooltipElement.setAttribute("slot", "tooltip");
+
+            tooltipElement.addAttachListener(e -> {
+                // Assigns a generator that reads the tooltip property of the
+                // item component
+                tooltipElement.executeJs(
+                        "this.textGenerator = ({item}) => { return (item && item.component) ? item.component.tooltip : ''; }");
+            });
+            getElement().appendChild(tooltipElement);
+        }
+
+        item.getElement().setProperty("tooltip", tooltipText);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -56,8 +56,10 @@ import elemental.json.JsonType;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./menubarConnector.js")
 @JsModule("@vaadin/menu-bar/src/vaadin-menu-bar.js")
+@JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 @NpmPackage(value = "@vaadin/menu-bar", version = "23.3.0-alpha1")
 @NpmPackage(value = "@vaadin/vaadin-menu-bar", version = "23.3.0-alpha1")
+@NpmPackage(value = "@vaadin/tooltip", version = "23.3.0-alpha1")
 public class MenuBar extends Component
         implements HasMenuItems, HasSize, HasStyle, HasTheme, HasEnabled {
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Unit tests for MenuBar tooltip.
+ *
+ * @author Vaadin Ltd.
+ */
+public class MenuBarTooltipTest {
+
+    private MenuBar menuBar;
+
+    @Before
+    public void setup() {
+        menuBar = new MenuBar();
+    }
+
+    @Test
+    public void default_doesNotHaveTooltipElement() {
+        Assert.assertFalse(getTooltipElement(menuBar).isPresent());
+    }
+
+    @Test
+    public void addItemWithTooltip_hasTooltipElement() {
+        menuBar.addItem("Item", "Item tooltip");
+        Assert.assertTrue(getTooltipElement(menuBar).isPresent());
+    }
+
+    @Test
+    public void addItemWithTooltip_tooltipHasSlot() {
+        menuBar.addItem("Item", "Item tooltip");
+        Assert.assertEquals("tooltip",
+                getTooltipElement(menuBar).get().getAttribute("slot"));
+    }
+
+    @Test
+    public void addAnotherItemWithTooltip_hasOneTooltipElement() {
+        menuBar.addItem("Item 0", "Item 0 tooltip");
+        menuBar.addItem("Item 1", "Item 1 tooltip");
+        Assert.assertEquals(1, getTooltipElements(menuBar).count());
+    }
+
+    private Optional<Element> getTooltipElement(MenuBar menuBar) {
+        return getTooltipElements(menuBar).findFirst();
+    }
+
+    private Stream<Element> getTooltipElements(MenuBar menuBar) {
+        return menuBar.getElement().getChildren()
+                .filter(child -> child.getTag().equals("vaadin-tooltip"));
+    }
+
+}


### PR DESCRIPTION
## Description

Added tooltip API to `MenuBar` as specified in the [tooltip API summary](https://github.com/vaadin/platform/discussions/3196#discussioncomment-3626110)

Note, the `MenuBar` is not supposed to implement `HasTooltip`.

## Type of change

- Feature