### PR TITLE
feat: add Tooltip method chaining API

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -169,6 +169,17 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * String used as a tooltip content.
+     *
+     * @param text
+     *            the text to set
+     */
+    public Tooltip withText(String text) {
+        setText(text);
+        return this;
+    }
+
+    /**
      * The delay in milliseconds before the tooltip is opened on focus, when not
      * in manual mode.
      *
@@ -187,6 +198,18 @@ public class Tooltip implements Serializable {
      */
     public int getFocusDelay() {
         return tooltipElement.getProperty("focusDelay", 0);
+    }
+
+    /**
+     * The delay in milliseconds before the tooltip is opened on focus, when not
+     * in manual mode.
+     *
+     * @param focusDelay
+     *            the delay in milliseconds
+     */
+    public Tooltip withFocusDelay(int focusDelay) {
+        setFocusDelay(focusDelay);
+        return this;
     }
 
     /**
@@ -211,6 +234,18 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * The delay in milliseconds before the tooltip is closed on losing hover,
+     * when not in manual mode. On blur, the tooltip is closed immediately.
+     *
+     * @param hideDelay
+     *            the delay in milliseconds
+     */
+    public Tooltip withHideDelay(int hideDelay) {
+        setHideDelay(hideDelay);
+        return this;
+    }
+
+    /**
      * The delay in milliseconds before the tooltip is opened on hover, when not
      * in manual mode.
      *
@@ -229,6 +264,18 @@ public class Tooltip implements Serializable {
      */
     public int getHoverDelay() {
         return tooltipElement.getProperty("hoverDelay", 0);
+    }
+
+    /**
+     * The delay in milliseconds before the tooltip is opened on hover, when not
+     * in manual mode.
+     *
+     * @param hoverDelay
+     *            the delay in milliseconds
+     */
+    public Tooltip withHoverDelay(int hoverDelay) {
+        setHoverDelay(hoverDelay);
+        return this;
     }
 
     /**
@@ -253,6 +300,17 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * Position of the tooltip with respect to its target.
+     *
+     * @param position
+     *            the position to set
+     */
+    public Tooltip withPosition(TooltipPosition position) {
+        setPosition(position);
+        return this;
+    }
+
+    /**
      * When true, the tooltip is controlled programmatically instead of reacting
      * to focus and mouse events.
      *
@@ -271,6 +329,18 @@ public class Tooltip implements Serializable {
      */
     public boolean isManual() {
         return tooltipElement.getProperty("manual", false);
+    }
+
+    /**
+     * When true, the tooltip is controlled programmatically instead of reacting
+     * to focus and mouse events.
+     *
+     * @param manual
+     *            true to enable manual mode
+     */
+    public Tooltip withManual(boolean manual) {
+        setManual(manual);
+        return this;
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -128,6 +128,34 @@ public class TooltipTest {
         Assert.assertEquals(true, tooltip.isOpened());
     }
 
+    @Test
+    public void createTooltip_fluentAPI() {
+        ui.add(component);
+        
+        var tooltip =  Tooltip.forComponent(component)
+            .withText("foo")
+            .withFocusDelay(200)
+            .withHideDelay(1000)
+            .withHoverDelay(500)
+            .withPosition(TooltipPosition.BOTTOM_END)
+            .withManual(true);
+
+        tooltip.setOpened(true);
+        
+        Assert.assertEquals("foo",
+                getTooltipElement().get().getProperty("text"));
+        Assert.assertEquals(200,
+                getTooltipElement().get().getProperty("focusDelay", 0));
+        Assert.assertEquals(1000,
+                getTooltipElement().get().getProperty("hideDelay", 0));
+        Assert.assertEquals(500,
+                getTooltipElement().get().getProperty("hoverDelay", 0));
+        Assert.assertEquals("bottom-end",
+                getTooltipElement().get().getProperty("position"));
+        Assert.assertEquals(true,
+                getTooltipElement().get().getProperty("manual", false));
+    }
+
     private Optional<Element> getTooltipElement() {
         return ui.getElement().getChildren()
                 .filter(child -> child.getTag().equals("vaadin-tooltip"))

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -131,17 +131,13 @@ public class TooltipTest {
     @Test
     public void createTooltip_fluentAPI() {
         ui.add(component);
-        
-        var tooltip =  Tooltip.forComponent(component)
-            .withText("foo")
-            .withFocusDelay(200)
-            .withHideDelay(1000)
-            .withHoverDelay(500)
-            .withPosition(TooltipPosition.BOTTOM_END)
-            .withManual(true);
+
+        var tooltip = Tooltip.forComponent(component).withText("foo")
+                .withFocusDelay(200).withHideDelay(1000).withHoverDelay(500)
+                .withPosition(TooltipPosition.BOTTOM_END).withManual(true);
 
         tooltip.setOpened(true);
-        
+
         Assert.assertEquals("foo",
                 getTooltipElement().get().getProperty("text"));
         Assert.assertEquals(200,


### PR DESCRIPTION
## Description

Add tooltip method chaining API as specified in the [tooltip API summary](https://github.com/vaadin/platform/discussions/3196#discussioncomment-3626110)

Example:
```java
textField.setTooltip("Other users can see this")
    .withFocusDelay(200)
    .withHideDelay(1000)
    .withHoverDelay(500)
    .withPosition(TooltipPosition.BOTTOM_END);
```

## Type of change

- Feature