### PR TITLE
fix: prevent debouncer override in callback

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -302,8 +302,9 @@ public class LazyLoadingPage extends Div {
         ComboBox<String> comboBox = new ComboBox<>(2);
         comboBox.setId("lazy-small-page-size");
 
-        comboBox.setItems(query -> IntStream.range(0, 500)
-                    .mapToObj(String::valueOf).skip(query.getOffset()).limit(query.getLimit()));
+        comboBox.setItems(
+                query -> IntStream.range(0, 500).mapToObj(String::valueOf)
+                        .skip(query.getOffset()).limit(query.getLimit()));
 
         add(comboBox);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -280,7 +280,7 @@ public class LazyLoadingPage extends Div {
     }
 
     private void createComboBoxWithDisabledLazyLoading() {
-        addTitle("");
+        addTitle("ComboBox with disabled lazy loading");
         ComboBox<Integer> comboBox = new ComboBox<>(100);
         comboBox.setId("disabled-lazy-loading");
         // Having a number of items less than or equal than the page size will
@@ -300,7 +300,7 @@ public class LazyLoadingPage extends Div {
     private void createComboBoxWithSmallPageSizeAndLazyLoading() {
         addTitle("Callback data provider with small page size 2");
         ComboBox<String> comboBox = new ComboBox<>(2);
-        comboBox.setId("lazy-small-page-size");
+        comboBox.setId("lazy-small-custom-page-size");
 
         comboBox.setItems(
                 query -> IntStream.range(0, 500).mapToObj(String::valueOf)

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -68,6 +68,8 @@ public class LazyLoadingPage extends Div {
         addSeparator();
         createComboBoxWithDisabledLazyLoading();
         addSeparator();
+        createComboBoxWithSmallPageSizeAndLazyLoading();
+        addSeparator();
     }
 
     private void createListDataProviderWithStringsAutoOpenDisabled() {
@@ -278,7 +280,7 @@ public class LazyLoadingPage extends Div {
     }
 
     private void createComboBoxWithDisabledLazyLoading() {
-        addTitle("ComboBox with disabled lazy loading");
+        addTitle("");
         ComboBox<Integer> comboBox = new ComboBox<>(100);
         comboBox.setId("disabled-lazy-loading");
         // Having a number of items less than or equal than the page size will
@@ -293,6 +295,17 @@ public class LazyLoadingPage extends Div {
         enableLazyLoading.setId("enable-lazy-loading");
 
         add(comboBox, enableLazyLoading);
+    }
+
+    private void createComboBoxWithSmallPageSizeAndLazyLoading() {
+        addTitle("Callback data provider with small page size 2");
+        ComboBox<String> comboBox = new ComboBox<>(2);
+        comboBox.setId("lazy-small-page-size");
+
+        comboBox.setItems(query -> IntStream.range(0, 500)
+                    .mapToObj(String::valueOf).skip(query.getOffset()).limit(query.getLimit()));
+
+        add(comboBox);
     }
 
     public static List<String> generateStrings(int count) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -581,7 +581,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
     @Test
     // https://github.com/vaadin/flow-components/issues/3595
-    public void customPageSize_filter_selectItem_loadingStateResolved() {
+    public void smallCustomPageSize_filter_selectItem_loadingStateResolved() {
         String item = "2";
 
         lazyWithSmallCustomPageSize.selectByText(item);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -580,6 +580,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     }
 
     @Test
+    // https://github.com/vaadin/flow-components/issues/3595
     public void customPageSize_filter_selectItem_loadingStateResolved() {
         String item = "2";
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -64,7 +64,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         disabledLazyLoadingBox = $(ComboBoxElement.class)
                 .id("disabled-lazy-loading");
         lazyWithSmallCustomPageSize = $(ComboBoxElement.class)
-                .id("lazy-small-page-size");
+                .id("lazy-small-custom-page-size");
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -38,6 +38,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     private ComboBoxElement emptyCallbackBox;
     private ComboBoxElement lazyCustomPageSize;
     private ComboBoxElement disabledLazyLoadingBox;
+    private ComboBoxElement lazyWithSmallCustomPageSize;
 
     private WebElement lazySizeRequestCountSpan;
 
@@ -62,6 +63,8 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
                 By.id("callback-dataprovider-size-request-count"));
         disabledLazyLoadingBox = $(ComboBoxElement.class)
                 .id("disabled-lazy-loading");
+        lazyWithSmallCustomPageSize = $(ComboBoxElement.class)
+                .id("lazy-small-page-size");
     }
 
     @Test
@@ -562,7 +565,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         disabledLazyLoadingBox.openPopup();
         assertLoadedItemsCount("Initially all 100 items should be loaded", 100,
                 disabledLazyLoadingBox);
-        lazyCustomPageSize.closePopup();
+        disabledLazyLoadingBox.closePopup();
 
         clickButton("enable-lazy-loading");
         disabledLazyLoadingBox.openPopup();
@@ -574,6 +577,21 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount("Scrolling down should load further pages", 100,
                 disabledLazyLoadingBox);
         assertRendered("99");
+    }
+
+    @Test
+    public void customPageSize_filter_selectItem_loadingStateResolved() {
+        String item = "2";
+
+        lazyWithSmallCustomPageSize.selectByText(item);
+        lazyWithSmallCustomPageSize.setFilter(item);
+        Assert.assertEquals(item, getSelectedItemLabel(lazyWithSmallCustomPageSize));
+
+        lazyWithSmallCustomPageSize.closePopup();
+        Assert.assertEquals(item, getSelectedItemLabel(lazyWithSmallCustomPageSize));
+
+        lazyWithSmallCustomPageSize.click();
+        assertLoadingStateResolved(lazyWithSmallCustomPageSize);
     }
 
     private void assertMessage(String expectedMessage) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -585,10 +585,12 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         lazyWithSmallCustomPageSize.selectByText(item);
         lazyWithSmallCustomPageSize.setFilter(item);
-        Assert.assertEquals(item, getSelectedItemLabel(lazyWithSmallCustomPageSize));
+        Assert.assertEquals(item,
+                getSelectedItemLabel(lazyWithSmallCustomPageSize));
 
         lazyWithSmallCustomPageSize.closePopup();
-        Assert.assertEquals(item, getSelectedItemLabel(lazyWithSmallCustomPageSize));
+        Assert.assertEquals(item,
+                getSelectedItemLabel(lazyWithSmallCustomPageSize));
 
         lazyWithSmallCustomPageSize.click();
         assertLoadingStateResolved(lazyWithSmallCustomPageSize);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -21,7 +21,6 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         const pageCallbacks = {};
         let cache = {};
         let lastFilter = '';
-        let pageInDebouncer;
         const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
         const MAX_RANGE_COUNT = Math.max(comboBox.pageSize * 2, 500); // Max item count in active range
 
@@ -71,13 +70,6 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
         };
 
         comboBox.dataProvider = function (params, callback) {
-          const filterUnchanged = params.filter === lastFilter;
-          if (filterUnchanged && this._debouncer) {
-            if (pageInDebouncer !== params.page) {
-              pageCallbacks[params.page] = callback;
-            }
-            return;
-          }
           if (params.pageSize != comboBox.pageSize) {
             throw 'Invalid pageSize';
           }
@@ -100,11 +92,11 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             }
           }
 
-          if (!filterUnchanged) {
+          const filterChanged = params.filter !== lastFilter;
+          if (filterChanged) {
             cache = {};
             lastFilter = params.filter;
-            this._debouncer = Debouncer.debounce(this._debouncer, timeOut.after(500), () => {
-              pageInDebouncer = params.page;
+            this._filterDebouncer = Debouncer.debounce(this._filterDebouncer, timeOut.after(500), () => {
               if (serverFacade.getLastFilterSentToServer() === params.filter) {
                 // Fixes the case when the filter changes
                 // to something else and back to the original value
@@ -115,11 +107,16 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
               if (params.filter !== lastFilter) {
                 throw new Error("Expected params.filter to be '" + lastFilter + "' but was '" + params.filter + "'");
               }
-              this._debouncer = undefined;
+              this._filterDebouncer = undefined;
               // Call the method again after debounce.
               clearPageCallbacks();
               comboBox.dataProvider(params, callback);
             });
+            return;
+          }
+
+          if (this._filterDebouncer) {
+            pageCallbacks[params.page] = callback;
             return;
           }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -107,6 +107,8 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
               if (params.filter !== lastFilter) {
                 throw new Error("Expected params.filter to be '" + lastFilter + "' but was '" + params.filter + "'");
               }
+              // Remove the debouncer before clearing page callbacks.
+              // This makes sure that they are executed.
               this._filterDebouncer = undefined;
               // Call the method again after debounce.
               clearPageCallbacks();
@@ -115,6 +117,8 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             return;
           }
 
+          // Postpone the execution of new callbacks if there is an active debouncer.
+          // They will be executed when the page callbacks are cleared within the debouncer.
           if (this._filterDebouncer) {
             pageCallbacks[params.page] = callback;
             return;


### PR DESCRIPTION
## Description

There was a single debouncer, and 2 ways to set it in the connector. In some cases, the debouncer is overridden by the other, which results in callbacks that are never completed and never cleared. Therefore, the loading state is never resolved.

This PR prevents the debouncer override. The data request is now performed without the debouncer. While the debouncer is active, the callbacks that do not contain filter changes are not executed right away, but within the debouncer. 

Fixes #3595 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
