### PR TITLE
feat: add tooltip defaults configuration

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipDefaultsPage.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipDefaultsPage.java
@@ -32,7 +32,7 @@ public class TooltipDefaultsPage extends Div {
 
         Button button = new Button("Set tooltip default hide delay to 1000");
         // Use component-specific delay to override the default
-        button.setTooltip("Tooltip").setHoverDelay(100);
+        button.setTooltipText("Tooltip").setHoverDelay(100);
 
         // Dynamically change the default hide delay
         button.addClickListener(

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipDefaultsPage.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipDefaultsPage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.button.tests;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.shared.TooltipConfiguration;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@PreserveOnRefresh
+@Route("vaadin-button/tooltip-defaults")
+public class TooltipDefaultsPage extends Div {
+
+    public TooltipDefaultsPage() {
+        // Default values for focus & hover delay
+        TooltipConfiguration.setDefaultFocusDelay(500);
+        TooltipConfiguration.setDefaultHoverDelay(500);
+
+        Button button = new Button("Set tooltip default hide delay to 1000");
+        // Use component-specific delay to override the default
+        button.setTooltip("Tooltip").setHoverDelay(100);
+
+        // Dynamically change the default hide delay
+        button.addClickListener(
+                e -> TooltipConfiguration.setDefaultHideDelay(1000));
+
+        add(button);
+    }
+}

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipDefaultsIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipDefaultsIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.button.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-button/tooltip-defaults")
+public class TooltipDefaultsIT extends AbstractComponentIT {
+
+    private ButtonElement button;
+
+    @Before
+    public void init() {
+        open();
+        button = $(ButtonElement.class).first();
+    }
+
+    @Test
+    public void checkTooltipConfig() {
+        Assert.assertEquals(500, getActiveFocusDelay(button));
+        Assert.assertEquals(100, getActiveHoverDelay(button));
+    }
+
+    @Test
+    public void dynamicallyChangeDefaults_checkTooltipConfig() {
+        button.click();
+        Assert.assertEquals(1000, getActiveHideDelay(button));
+    }
+
+    @Test
+    public void refreshBrowser_checkTooltipConfig() {
+        getDriver().navigate().refresh();
+        button = $(ButtonElement.class).first();
+        Assert.assertEquals(500, getActiveFocusDelay(button));
+        Assert.assertEquals(100, getActiveHoverDelay(button));
+    }
+
+    private int getActiveFocusDelay(ButtonElement button) {
+        return getTooltipFunctionValue(button, "__getFocusDelay");
+    }
+
+    private int getActiveHoverDelay(ButtonElement button) {
+        return getTooltipFunctionValue(button, "__getHoverDelay");
+    }
+
+    private int getActiveHideDelay(ButtonElement button) {
+        return getTooltipFunctionValue(button, "__getHideDelay");
+    }
+
+    private int getTooltipFunctionValue(ButtonElement button,
+            String functionName) {
+        var tooltipElement = button.$("vaadin-tooltip").first();
+        var value = executeScript("return arguments[0][arguments[1]]();",
+                tooltipElement, functionName);
+        return ((Number) value).intValue();
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -40,6 +40,10 @@ public class Tooltip implements Serializable {
      */
     private final Element tooltipElement = new Element("vaadin-tooltip");
 
+    private Tooltip() {
+        super();
+    }
+
     /**
      * Tooltip position in relation to the target element.
      */

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/TooltipConfiguration.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/TooltipConfiguration.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * A configuration class for a tooltips default behavior.
+ *
+ * @author Vaadin Ltd
+ */
+@NpmPackage(value = "@vaadin/tooltip", version = "23.3.0-alpha1")
+@JsModule("./tooltip.ts")
+public class TooltipConfiguration implements Serializable {
+
+    private static Integer defaultHideDelay;
+    private static Integer defaultFocusDelay;
+    private static Integer defaultHoverDelay;
+    private static boolean uiInitListenerRegistered = false;
+
+    /**
+     * Sets the default focus delay to be used by all tooltip instances (running
+     * in the same JVM), except for those that have focus delay configured using
+     * property.
+     *
+     * @param defaultFocusDelay
+     *            the default focus delay
+     */
+    public static void setDefaultFocusDelay(int defaultFocusDelay) {
+        TooltipConfiguration.defaultFocusDelay = defaultFocusDelay;
+        applyConfiguration();
+    }
+
+    /**
+     * Sets the default hide delay to be used by all tooltip instances (running
+     * in the same JVM), except for those that have hide delay configured using
+     * property.
+     *
+     * @param defaultHideDelay
+     *            the default hide delay
+     */
+    public static void setDefaultHideDelay(int defaultHideDelay) {
+        TooltipConfiguration.defaultHideDelay = defaultHideDelay;
+        applyConfiguration();
+    }
+
+    /**
+     * Sets the default hover delay to be used by all tooltip instances (running
+     * in the same JVM), except for those that have hover delay configured using
+     * property.
+     *
+     * @param defaultHoverDelay
+     *            the default hover delay
+     */
+    public static void setDefaultHoverDelay(int defaultHoverDelay) {
+        TooltipConfiguration.defaultHoverDelay = defaultHoverDelay;
+        applyConfiguration();
+    }
+
+    private static void applyConfiguration() {
+        if (UI.getCurrent() != null) {
+            // Apply the default tooltip configuration for the current UI
+            applyConfigurationForUI(UI.getCurrent());
+        }
+
+        if (!uiInitListenerRegistered) {
+            // Apply the tooltip configuration for all new UIs
+            VaadinService.getCurrent()
+                    .addUIInitListener(e -> applyConfigurationForUI(e.getUI()));
+            uiInitListenerRegistered = true;
+        }
+    }
+
+    private static void applyConfigurationForUI(UI ui) {
+        if (defaultHideDelay != null) {
+            ui.getElement().executeJs(
+                    "window.Vaadin.Flow.tooltip.setDefaultHideDelay($0)",
+                    defaultHideDelay);
+        }
+
+        if (defaultFocusDelay != null) {
+            ui.getElement().executeJs(
+                    "window.Vaadin.Flow.tooltip.setDefaultFocusDelay($0)",
+                    defaultFocusDelay);
+        }
+
+        if (defaultHoverDelay != null) {
+            ui.getElement().executeJs(
+                    "window.Vaadin.Flow.tooltip.setDefaultHoverDelay($0)",
+                    defaultHoverDelay);
+        }
+    }
+
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
@@ -1,0 +1,10 @@
+import { Tooltip } from '@vaadin/tooltip';
+
+const Vaadin = (window as any).Vaadin ||= {};
+const Flow = Vaadin.Flow ||= {};
+
+Flow.tooltip = {
+  setDefaultHideDelay: (hideDelay: number) => Tooltip.setDefaultHideDelay(hideDelay),
+  setDefaultFocusDelay: (focusDelay: number) => Tooltip.setDefaultFocusDelay(focusDelay),
+  setDefaultHoverDelay: (hoverDelay: number) => Tooltip.setDefaultHoverDelay(hoverDelay),
+}


### PR DESCRIPTION
## Description

Add tooltip defaults configuration as specified in the [tooltip API summary](https://github.com/vaadin/platform/discussions/3196#discussioncomment-3626110)

Example:
```java
TooltipConfiguration.setDefaultFocusDelay(500);
```

## Type of change

- Feature