### PR TITLE
fix: add missing contextMenuConnector import

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -53,7 +53,6 @@ import elemental.json.JsonType;
 @Tag("vaadin-menu-bar")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha1")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@JsModule("./contextMenuConnector.js")
 @JsModule("./menubarConnector.js")
 @JsModule("@vaadin/menu-bar/src/vaadin-menu-bar.js")
 @NpmPackage(value = "@vaadin/menu-bar", version = "23.3.0-alpha1")

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -53,6 +53,7 @@ import elemental.json.JsonType;
 @Tag("vaadin-menu-bar")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha1")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
+@JsModule("./contextMenuConnector.js")
 @JsModule("./menubarConnector.js")
 @JsModule("@vaadin/menu-bar/src/vaadin-menu-bar.js")
 @NpmPackage(value = "@vaadin/menu-bar", version = "23.3.0-alpha1")

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+import './contextMenuConnector.js';
 
 (function () {
   const tryCatchWrapper = function (callback) {


### PR DESCRIPTION
## Description

This PR adds a missing contextMenuConnector import to MenuBar which is an attempt to fix https://github.com/vaadin/flow-components/issues/3655.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
