### PR TITLE
fix: add better checks to grid tooltip generator function

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
@@ -33,6 +33,11 @@ public class GridTooltipIT extends AbstractComponentIT {
     }
 
     @Test
+    public void tooltipGenerator_shouldNotProduceErrors() {
+        checkLogsForErrors(msg -> !msg.contains("Cannot read properties of undefined"));
+    }
+
+    @Test
     public void hoverOverTooltipColumnCell_showTooltip() {
         var grid = $(GridElement.class).first();
         showTooltip(grid.getCell("Jack"));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
@@ -34,7 +34,8 @@ public class GridTooltipIT extends AbstractComponentIT {
 
     @Test
     public void tooltipGenerator_shouldNotProduceErrors() {
-        checkLogsForErrors(msg -> !msg.contains("Cannot read properties of undefined"));
+        checkLogsForErrors(
+                msg -> !msg.contains("Cannot read properties of undefined"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1057,7 +1057,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     // Assigns a generator that returns a column-specfic
                     // tooltip text from the item
                     tooltipElement.executeJs(
-                            "this.textGenerator = ({item, column}) => { return (item && item.gridtooltips) ? item.gridtooltips[column._flowId] : ''; }");
+                            "this.textGenerator = ({item, column}) => { return (item && item.gridtooltips && column) ? item.gridtooltips[column._flowId] : ''; }");
                 });
                 getGrid().getElement().appendChild(tooltipElement);
             }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1057,7 +1057,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     // Assigns a generator that returns a column-specfic
                     // tooltip text from the item
                     tooltipElement.executeJs(
-                            "this.textGenerator = ({item, column}) => item.gridtooltips[column._flowId]");
+                            "this.textGenerator = ({item, column}) => { return (item && item.gridtooltips) ? item.gridtooltips[column._flowId] : ''; }");
                 });
                 getGrid().getElement().appendChild(tooltipElement);
             }


### PR DESCRIPTION
## Description

Grid's tooltip generator function made an assumption that the `item` is always truthy and that it contains a `gridtooltips` object. Align the implementation with that of `MenuBar` / check that the required properties are defined.

## Type of change

- Fix