### PR TITLE
chore: update date-dns to 2.29.3

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package-lock.json
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package-lock.json
@@ -129,9 +129,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "deepmerge": {
       "version": "4.2.2",

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package.json
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/date-fns/package.json
@@ -8,7 +8,7 @@
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
   "dependencies": {
-    "date-fns": "2.23.0"
+    "date-fns": "2.29.3"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "13.0.4",


### PR DESCRIPTION
## Description

Update `date-fns` to latest version in 14 branches.

See #3750 
