### PR TITLE
fix: downgrade ts syntax used in tooltip.ts

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
@@ -1,9 +1,10 @@
 import { Tooltip } from '@vaadin/tooltip';
 
-const Vaadin = (window as any).Vaadin ||= {};
-const Flow = Vaadin.Flow ||= {};
+const _window = window as any;
+_window.Vaadin = _window.Vaadin || {};
+_window.Vaadin.Flow = _window.Vaadin.Flow || {};
 
-Flow.tooltip = {
+_window.Vaadin.Flow.tooltip = {
   setDefaultHideDelay: (hideDelay: number) => Tooltip.setDefaultHideDelay(hideDelay),
   setDefaultFocusDelay: (focusDelay: number) => Tooltip.setDefaultFocusDelay(focusDelay),
   setDefaultHoverDelay: (hoverDelay: number) => Tooltip.setDefaultHoverDelay(hoverDelay),


### PR DESCRIPTION
While upgrading `docs`, we discovered that `docs-app` doesn't yet support this modern TS syntax. Let's downgrade the syntax used in `tooltip.ts` for now.