### PR TITLE
fix: change the fetch query so that the filter is passed (#3787) (CP: 23.1)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -192,8 +192,10 @@ public abstract class AbstractGridMultiSelectionModel<T>
     @Override
     public void selectAll() {
         updateSelection(
-                getGrid().getDataCommunicator().getDataProvider()
-                        .fetch(new Query<>()).collect(Collectors.toSet()),
+                (Set<T>) getGrid().getDataCommunicator().getDataProvider()
+                        .fetch(getGrid().getDataCommunicator().buildQuery(0,
+                                Integer.MAX_VALUE))
+                        .collect(Collectors.toSet()),
                 Collections.emptySet());
         selectionColumn.setSelectAllCheckboxState(true);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);
@@ -358,7 +360,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
             allItemsStream = fetchAllHierarchical(
                     (HierarchicalDataProvider<T, ?>) dataProvider);
         } else {
-            allItemsStream = dataProvider.fetch(new Query<>());
+            allItemsStream = dataProvider.fetch(getGrid().getDataCommunicator()
+                    .buildQuery(0, Integer.MAX_VALUE));
         }
         doUpdateSelection(allItemsStream.collect(Collectors.toSet()),
                 Collections.emptySet(), true);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -16,12 +16,12 @@
 package com.vaadin.flow.component.grid;
 
 import java.util.HashSet;
-import java.util.Objects;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.data.selection.SelectionListener;
+import com.vaadin.flow.data.provider.*;
 import com.vaadin.flow.dom.Element;
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,10 +29,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
-import com.vaadin.flow.data.provider.CallbackDataProvider;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
-import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.flow.data.provider.Query;
 
 public class AbstractGridMultiSelectionModelTest {
 
@@ -405,6 +401,58 @@ public class AbstractGridMultiSelectionModelTest {
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
                 (boolean) columnElement.getPropertyRaw("indeterminate"));
+    }
+
+    @Test
+    public void setFilterUsingDataView_clientSelectAll_selectionEventContainsFilteredValues() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        List<String> items = List.of("foo", "bar");
+        ListDataView<String, ?> dataView = grid.setItems(items);
+        dataView.setFilter(items.get(0)::equals);
+
+        grid.addSelectionListener(e -> {
+            Assert.assertEquals(
+                    "Selected item count does not match data view item count",
+                    dataView.getItems().count(),
+                    e.getAllSelectedItems().size());
+            Assert.assertTrue("Selected items do not contain filtered item",
+                    e.getAllSelectedItems().contains(items.get(0)));
+        });
+
+        ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel())
+                .clientSelectAll();
+
+        Assert.assertEquals(
+                "Selected item count does not match data view item count",
+                dataView.getItems().count(), grid.getSelectedItems().size());
+        Assert.assertTrue("Selected items do not contain filtered item",
+                grid.getSelectedItems().contains(items.get(0)));
+    }
+
+    @Test
+    public void setFilterUsingDataView_serverSelectAll_selectionEventContainsFilteredValues() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        List<String> items = List.of("foo", "bar");
+        ListDataView<String, ?> dataView = grid.setItems(items);
+        dataView.setFilter(items.get(0)::equals);
+
+        grid.addSelectionListener(e -> {
+            Assert.assertEquals(
+                    "Selected item count does not match data view item count",
+                    dataView.getItems().count(),
+                    e.getAllSelectedItems().size());
+            Assert.assertTrue("Selected items do not contain filtered item",
+                    e.getAllSelectedItems().contains(items.get(0)));
+        });
+
+        ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel())
+                .selectAll();
+
+        Assert.assertEquals(
+                "Selected item count does not match data view item count",
+                dataView.getItems().count(), grid.getSelectedItems().size());
+        Assert.assertTrue("Selected items do not contain filtered item",
+                grid.getSelectedItems().contains(items.get(0)));
     }
 
     private void verifySelectAllCheckboxVisibilityInMultiSelectMode(


### PR DESCRIPTION
## Description

Back-port of [3787](https://github.com/vaadin/flow-components/pull/3787) to 23.1 branch.

For a multi-select Grid, when a filter was introduced using the ListDataView, using the select all check box from the client doesn't take the filter into account. This PR changes the query so that the query contains the filter info that is already present in the DataCommunicator.

Fixes #3614 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.