### PR TITLE
fix: reset data communicator on non sequential page request

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -136,6 +136,9 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
         comboBox.openPopup();
         executeScript("arguments[0]._scroller.scrollIntoView(arguments[1])",
                 comboBox, index);
+        // Wait for the scroller to request missing pages.
+        getCommandExecutor().getDriver()
+                .executeAsyncScript("requestAnimationFrame(arguments[0])");
     }
 
     protected void waitUntilTextInContent(String text) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxClientSideDataRangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxClientSideDataRangeIT.java
@@ -35,6 +35,18 @@ public class ComboBoxClientSideDataRangeIT extends AbstractComboBoxIT {
     }
 
     @Test
+    public void defaultPageSize_scrollToEnd_scrollToBeginning_firstPageLoaded() {
+        comboBox.openPopup();
+        assertLoadingStateResolved(comboBox);
+        getCommandExecutor().getDriver()
+                .executeAsyncScript("arguments[0]._scrollIntoView(999);" +
+                        "arguments[0]._scrollIntoView(0);" +
+                        "requestAnimationFrame(arguments[1])", comboBox);
+        waitUntilTextInContent("Item 0");
+        assertLoadingStateResolved(comboBox);
+    }
+
+    @Test
     public void defaultPageSize_scrollUpAndDown_morePagesLoaded_overflowingPagesDiscarded() {
         scrollUpAndDown_morePagesLoaded_overflowingPagesDiscarded(50, 500);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -152,7 +152,7 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
               // by the end of which combo-box ends up at the same position
               // as before but the cache has been already cleared, e.g:
               // scroll from the page 0 to 100 and then immediatelly back to 0.
-              serverFacade.needsDataCommunicatorReset();
+              // serverFacade.needsDataCommunicatorReset();
               // Clear the cache so combo-box will request
               // the currently visible pages.
               clearPageCallbacks();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -133,20 +133,6 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
             const rangeMin = Math.min(...activePages);
             const rangeMax = Math.max(...activePages);
 
-            if (rangeMax - rangeMin + 1 !== activePages.length) {
-              // The range doens't form a sequence anymore because of a jumping page request.
-              // Force the server to resend the range in case
-              // there are several synchronous scroll jumps back and forth,
-              // by the end of which combo-box ends up at the same position
-              // as before but the cache has been already cleared, e.g:
-              // scroll from the page 0 to 100 and then immediatelly back to 0.
-              serverFacade.needsDataCommunicatorReset();
-              // Clear the cache so combo-box will request
-              // the currently visible pages.
-              clearPageCallbacks();
-              return;
-            }
-
             if (activePages.length * params.pageSize > maxRangeCount) {
               // The range reached the max size.
               if (params.page === rangeMin) {
@@ -159,13 +145,23 @@ import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-plac
                 clearPageCallbacks([String(rangeMin)]);
               }
               comboBox.dataProvider(params, callback);
-              return;
+            } else if (rangeMax - rangeMin + 1 !== activePages.length) {
+              // The range doens't form a sequence anymore because of a jumping page request.
+              // Force the server to resend the range in case
+              // there are several synchronous scroll jumps back and forth,
+              // by the end of which combo-box ends up at the same position
+              // as before but the cache has been already cleared, e.g:
+              // scroll from the page 0 to 100 and then immediatelly back to 0.
+              serverFacade.needsDataCommunicatorReset();
+              // Clear the cache so combo-box will request
+              // the currently visible pages.
+              clearPageCallbacks();
+            } else {
+              // The requested page was sequential, extend the requested range
+              const startIndex = params.pageSize * rangeMin;
+              const endIndex = params.pageSize * (rangeMax + 1);
+              serverFacade.requestData(startIndex, endIndex, params);
             }
-
-            // The requested page was sequential, extend the requested range
-            const startIndex = params.pageSize * rangeMin;
-            const endIndex = params.pageSize * (rangeMax + 1);
-            serverFacade.requestData(startIndex, endIndex, params);
           }
         };
 


### PR DESCRIPTION
## Description

This PR makes the connector reset the ComboBox data communicator on non-sequential page request. This is needed to force the data communicator to resend the range in case there are several synchronous scroll jumps back and forth (can be programmatic scrolling), by the end of which ComboBox ends up at the same position as before but the cache has been already cleared.

- [x] Implementation
- [ ] Integration tests

Fixes #3678 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
