### PR TITLE
fix: add missing JS imports

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
@@ -28,6 +28,9 @@ import com.vaadin.flow.component.details.Details;
 @Tag("vaadin-accordion-panel")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
+@NpmPackage(value = "@vaadin/accordion", version = "23.3.0-alpha2")
+@NpmPackage(value = "@vaadin/vaadin-accordion", version = "23.3.0-alpha2")
+@JsModule("@vaadin/accordion/src/vaadin-accordion-panel.js")
 public class AccordionPanel extends Details {
 
     /**


### PR DESCRIPTION
## Description

The PR adds some missing JS imports to `AccordionPanel` so that it can be used alone on the page, without the main  `Accordion` component.

Fixes https://github.com/vaadin/flow-components/issues/3702

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
