### PR TITLE
refactor: rename tabsheet.indexOf to tabsheet.getIndexOf

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -245,7 +245,7 @@ public class TabSheet extends Component
      *            the tab to look up, can not be <code>null</code>
      * @return the index of the tab or -1 if the tab is not added
      */
-    public int indexOf(Tab tab) {
+    public int getIndexOf(Tab tab) {
         return tabs.indexOf(tab);
     }
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -369,19 +369,19 @@ public class TabSheetTest {
     public void indexOfTab_returnsIndex() {
         var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
-        Assert.assertEquals(0, tabSheet.indexOf(tab0));
-        Assert.assertEquals(1, tabSheet.indexOf(tab1));
+        Assert.assertEquals(0, tabSheet.getIndexOf(tab0));
+        Assert.assertEquals(1, tabSheet.getIndexOf(tab1));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void indexOfNull_throws() {
+    public void getIndexOfNull_throws() {
         tabSheet.add("Tab 0", new Span("Content 0"));
-        tabSheet.indexOf(null);
+        tabSheet.getIndexOf(null);
     }
 
     @Test
-    public void indexOfNonAttachedTab_returnsMinusOne() {
+    public void getIndexOfNonAttachedTab_returnsMinusOne() {
         tabSheet.add("Tab 0", new Span("Content 0"));
-        Assert.assertEquals(-1, tabSheet.indexOf(new Tab()));
+        Assert.assertEquals(-1, tabSheet.getIndexOf(new Tab()));
     }
 }


### PR DESCRIPTION
## Description

Rename `tabsheet.indexOf(Tab tab)` to `tabsheet.getIndexOf(Tab tab)` . Even though aligned with `tabs.indexOf(Component component)`, the discoverability of the current API proved to be insufficient during the DX test sessions.