### PR TITLE
refactor: throw an exception for Text as TabSheet content

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -171,9 +171,10 @@ public class TabSheet extends Component
                 "The content of the tab to be removed cannot be null");
 
         if (content instanceof Text) {
-            throw new IllegalArgumentException("Text as content is not supported.");
+            throw new IllegalArgumentException(
+                    "Text as content is not supported.");
         }
-                
+
         var tab = tabToContent.entrySet().stream()
                 .filter(entry -> entry.getValue().equals(content.getElement()))
                 .map(Map.Entry::getKey).findFirst().orElse(null);
@@ -291,7 +292,8 @@ public class TabSheet extends Component
 
         if (component != null) {
             if (component instanceof Text) {
-                throw new IllegalArgumentException("Text as a prefix is not supported. Consider wrapping the Text inside a Div.");
+                throw new IllegalArgumentException(
+                        "Text as a prefix is not supported. Consider wrapping the Text inside a Div.");
             }
 
             component.getElement().setAttribute("slot", "prefix");
@@ -326,7 +328,8 @@ public class TabSheet extends Component
 
         if (component != null) {
             if (component instanceof Text) {
-                throw new IllegalArgumentException("Text as a suffix is not supported. Consider wrapping the Text inside a Div.");
+                throw new IllegalArgumentException(
+                        "Text as a suffix is not supported. Consider wrapping the Text inside a Div.");
             }
 
             component.getElement().setAttribute("slot", "suffix");

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -118,6 +119,11 @@ public class TabSheet extends Component
         Objects.requireNonNull(content,
                 "The content to be added cannot be null");
 
+        if (content instanceof Text) {
+            throw new IllegalArgumentException(
+                    "Text as content is not supported. Consider wrapping the Text inside a Div.");
+        }
+
         if (position < 0) {
             tabs.add(tab);
         } else {
@@ -163,6 +169,11 @@ public class TabSheet extends Component
     public void remove(Component content) {
         Objects.requireNonNull(content,
                 "The content of the tab to be removed cannot be null");
+
+        if (content instanceof Text) {
+            throw new IllegalArgumentException("Text as content is not supported.");
+        }
+                
         var tab = tabToContent.entrySet().stream()
                 .filter(entry -> entry.getValue().equals(content.getElement()))
                 .map(Map.Entry::getKey).findFirst().orElse(null);
@@ -279,6 +290,10 @@ public class TabSheet extends Component
         SlotUtils.clearSlot(this, "prefix");
 
         if (component != null) {
+            if (component instanceof Text) {
+                throw new IllegalArgumentException("Text as a prefix is not supported. Consider wrapping the Text inside a Div.");
+            }
+
             component.getElement().setAttribute("slot", "prefix");
             getElement().appendChild(component.getElement());
         }
@@ -310,6 +325,10 @@ public class TabSheet extends Component
         SlotUtils.clearSlot(this, "suffix");
 
         if (component != null) {
+            if (component instanceof Text) {
+                throw new IllegalArgumentException("Text as a suffix is not supported. Consider wrapping the Text inside a Div.");
+            }
+
             component.getElement().setAttribute("slot", "suffix");
             getElement().appendChild(component.getElement());
         }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.TabSheet;
@@ -158,6 +159,11 @@ public class TabSheetTest {
         tabSheet.add("Tab 0", (Span) null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void addTextContent_throws() {
+        tabSheet.add("Tab 0", new Text("Tab 0 content"));
+    }
+
     @Test
     public void changeTab_selectedChangeEvent() {
         var tab0 = tabSheet.add("Tab 0", new Span("Content 0"));
@@ -184,6 +190,11 @@ public class TabSheetTest {
     @Test(expected = NullPointerException.class)
     public void removeNullContent_throws() {
         tabSheet.remove((Span) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void removeTextContent_throws() {
+        tabSheet.remove(new Text("Tab 0 content"));
     }
 
     @Test
@@ -273,11 +284,21 @@ public class TabSheetTest {
         Assert.assertEquals(prefix, tabSheet.getPrefixComponent());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void setTextAsPrefix_throws() {
+        tabSheet.setPrefixComponent(new Text("Prefix"));
+    }
+
     @Test
     public void setSuffix_hasSuffix() {
         var suffix = new Span("suffix");
         tabSheet.setSuffixComponent(suffix);
         Assert.assertEquals(suffix, tabSheet.getSuffixComponent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setTextAsSuffix_throws() {
+        tabSheet.setSuffixComponent(new Text("Suffix"));
     }
 
     @Test


### PR DESCRIPTION
Throw an `IllegalArgumentException` when `Text` is passed as the TabSheet's...
- content
- prefix
- suffix
- remove argument

Fixes https://github.com/vaadin/flow-components/issues/3803