### PR TITLE
fix: make ComboBox serializable when items are provided

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -479,9 +479,10 @@ class ComboBoxDataController<TItem>
         setDataProvider(listDataProvider, filterText -> {
             Optional<SerializablePredicate<TItem>> componentInMemoryFilter = DataViewUtils
                     .getComponentFilter(comboBox);
+            SerializablePredicate<TItem> componentInMemoryFilterOrAlwaysPass = componentInMemoryFilter
+                    .orElse(ignore -> true);
             return item -> itemFilter.test(item, filterText)
-                    && componentInMemoryFilter.orElse(ignore -> true)
-                            .test(item);
+                    && componentInMemoryFilterOrAlwaysPass.test(item);
         });
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboboxSerializableTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboboxSerializableTest.java
@@ -1,6 +1,26 @@
 package com.vaadin.flow.component.combobox;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Test;
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
 public class ComboboxSerializableTest extends ClassesSerializableTest {
+    @Test
+    public void setItems_callSetRequestedRange_comboBoxSerializable() throws Throwable {
+        final ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems(List.of("Item 1", "Item 2"));
+        callSetRequestedRange(comboBox, 0, 2, "");
+        serializeAndDeserialize(comboBox);
+    }
+
+    private void callSetRequestedRange(ComboBox<String> comboBox, int start, int length, String filter)
+            throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Method method = ComboBoxBase.class.getDeclaredMethod("setRequestedRange",
+                int.class, int.class, String.class);
+        method.setAccessible(true);
+        method.invoke(comboBox, start, length, filter);
+    }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboboxSerializableTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboboxSerializableTest.java
@@ -9,17 +9,20 @@ import com.vaadin.flow.testutil.ClassesSerializableTest;
 
 public class ComboboxSerializableTest extends ClassesSerializableTest {
     @Test
-    public void setItems_callSetRequestedRange_comboBoxSerializable() throws Throwable {
+    public void setItems_callSetRequestedRange_comboBoxSerializable()
+            throws Throwable {
         final ComboBox<String> comboBox = new ComboBox<>();
         comboBox.setItems(List.of("Item 1", "Item 2"));
         callSetRequestedRange(comboBox, 0, 2, "");
         serializeAndDeserialize(comboBox);
     }
 
-    private void callSetRequestedRange(ComboBox<String> comboBox, int start, int length, String filter)
-            throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Method method = ComboBoxBase.class.getDeclaredMethod("setRequestedRange",
-                int.class, int.class, String.class);
+    private void callSetRequestedRange(ComboBox<String> comboBox, int start,
+            int length, String filter)
+            throws NoSuchMethodException, IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException {
+        Method method = ComboBoxBase.class.getDeclaredMethod(
+                "setRequestedRange", int.class, int.class, String.class);
         method.setAccessible(true);
         method.invoke(comboBox, start, length, filter);
     }


### PR DESCRIPTION
## Description

The PR fixes ComboBox serialization which was broken because one of the lambdas happened to capture an Optional variable when setting items.

Fixes https://github.com/vaadin/flow-components/issues/3814

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
