### PR TITLE
chore: reduce verbosity when running Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,7 @@
                         <argLine>-Xmx2048m</argLine>
                         <reuseForks>false</reuseForks>
                         <trimStackTrace>false</trimStackTrace>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <systemPropertyVariables>
                             <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
                             <com.vaadin.tests.SharedBrowser.reuseBrowser>${com.vaadin.tests.SharedBrowser.reuseBrowser}</com.vaadin.tests.SharedBrowser.reuseBrowser>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,6 @@
                         <argLine>-Xmx2048m</argLine>
                         <reuseForks>false</reuseForks>
                         <trimStackTrace>false</trimStackTrace>
-                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <systemPropertyVariables>
                             <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
                             <com.vaadin.tests.SharedBrowser.reuseBrowser>${com.vaadin.tests.SharedBrowser.reuseBrowser}</com.vaadin.tests.SharedBrowser.reuseBrowser>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,7 +26,7 @@ then
   done
 fi
 
-args="$args -B $quiet"
+args="$args -ntp -B $quiet"
 verify="verify -Dvaadin.pnpm.enable"
 
 ## compute modules that were modified in this PR
@@ -166,7 +166,7 @@ then
    args="$args -P saucelabs -Dtest.use.hub=true -Dsauce.user=$SAUCE_USER -Dsauce.sauceAccessKey=$SAUCE_ACCESS_KEY"
 fi
 
-args="$args -Dfailsafe.rerunFailingTestsCount=2"
+args="$args -Dfailsafe.rerunFailingTestsCount=2 -Dmaven.test.redirectTestOutputToFile=true"
 
 ## Install a selenium hub in local host to run tests against chrome
 if [ "$TBHUB" = "localhost" ]


### PR DESCRIPTION
This should show meaningful messages and errors in the case of failure, otherwise there is no noise in the output when running ITs 