### PR TITLE
test: migrate tabsheet IT from v8 spreadsheet

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -115,6 +115,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-tabs-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spreadsheet-testbench</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -128,6 +133,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-combo-box-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-tabs-testbench</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetTabSheetPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetTabSheetPage.java
@@ -1,0 +1,36 @@
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import org.apache.poi.ss.util.CellRangeAddress;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetTable;
+import com.vaadin.flow.component.tabs.TabSheet;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-spreadsheet/tabsheet")
+public class SpreadsheetTabSheetPage extends Div {
+
+    public SpreadsheetTabSheetPage() {
+        super();
+        setSizeFull();
+
+        final Spreadsheet sheet = new Spreadsheet();
+        sheet.setSizeFull();
+
+        CellRangeAddress range = new CellRangeAddress(1, 4, 1, 4);
+
+        final SpreadsheetTable table = new SpreadsheetTable(sheet, range);
+        sheet.registerTable(table);
+
+        TabSheet tabsheet = new TabSheet();
+        tabsheet.setSizeFull();
+        tabsheet.add("First tab", new Span("First"));
+        tabsheet.add("Spreadsheet", sheet);
+        tabsheet.add("Third tab", new Span("Third"));
+
+        add(tabsheet);
+
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetTabSheetPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetTabSheetPage.java
@@ -24,11 +24,24 @@ public class SpreadsheetTabSheetPage extends Div {
         final SpreadsheetTable table = new SpreadsheetTable(sheet, range);
         sheet.registerTable(table);
 
+        var sheetWrapper = new Div(sheet);
+        sheetWrapper.setHeight("400px");
+
         TabSheet tabsheet = new TabSheet();
         tabsheet.setSizeFull();
         tabsheet.add("First tab", new Span("First"));
-        tabsheet.add("Spreadsheet", sheet);
+        var sheetTab = tabsheet.add("Spreadsheet", sheetWrapper);
         tabsheet.add("Third tab", new Span("Third"));
+
+        // Since V23 TabSheet doesn't detach tab content on tab change, we need
+        // to do it manually to make this test case work.
+        tabsheet.addSelectedChangeListener(event -> {
+            if (event.getSelectedTab() == sheetTab) {
+                sheetWrapper.add(sheet);
+            } else {
+                sheetWrapper.removeAll();
+            }
+        });
 
         add(tabsheet);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SpreadsheetTabSheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SpreadsheetTabSheetIT.java
@@ -1,0 +1,43 @@
+package com.vaadin.flow.component.spreadsheet.test;
+
+import com.vaadin.flow.component.tabs.testbench.TabSheetElement;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+public class SpreadsheetTabSheetIT extends AbstractSpreadsheetIT {
+
+    @Before
+    public void init() {
+        getDriver().get(getBaseURL() + "/tabsheet");
+    }
+
+    @Test
+    public void spreadsheetWithTableInTabsheet_changeTabs_tableVisible()
+            throws Exception {
+        TabSheetElement tabSheet = $(TabSheetElement.class).get(0);
+        // first tab open by default no spreadsheet in this tab
+        checkPopupButtons(0);
+        // open second tab
+        tabSheet.setSelectedTabIndex(1);
+        // tab contains a spreadsheet with a 4x4 table
+        checkPopupButtons(4);
+        // open third tab
+        tabSheet.setSelectedTabIndex(2);
+        // no spreadsheet in this tab
+        checkPopupButtons(0);
+        // re-open second tab
+        tabSheet.setSelectedTabIndex(1);
+        // tab contains a spreadsheet with a 4x4 table
+        checkPopupButtons(4);
+    }
+
+    public void checkPopupButtons(int expected) {
+        int actual = findElements(By.className("popupbutton")).size();
+        Assert.assertTrue(expected + " PopupButtons were expected, but "
+                + actual + " were found.", actual == expected);
+    }
+
+}


### PR DESCRIPTION
Part of https://github.com/vaadin/components-team-tasks/issues/604

Migrate [SpreadsheetTabsheetTest](https://github.com/vaadin/spreadsheet/blob/flow-port/legacy/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/SpreadsheetTabsheetTest.java) to Flow Spreadsheet