### PR TITLE
fix: allow setting filterable data providers with setItems

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2526,7 +2526,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     @Override
-    public GridDataView<T> setItems(DataProvider<T, Void> dataProvider) {
+    public GridDataView<T> setItems(DataProvider<T, ?> dataProvider) {
         setDataProvider(dataProvider);
         return getGenericDataView();
     }


### PR DESCRIPTION
## Description

This PR allows setting filterable data providers with the `setItems` method to align with the deprecated `setDataProvider` method.

- [x] Implementation
- [ ] Unit tests 

Fixes #3842

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
