### PR TITLE
fix: set tabsheet selected property on setSelectedIndex

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -211,8 +211,8 @@ public class TabSheet extends Component
      *            the zero-based index of the selected tab, -1 to unselect all
      */
     public void setSelectedIndex(int selectedIndex) {
-        getElement().setProperty("selected", selectedIndex);
         tabs.setSelectedIndex(selectedIndex);
+        getElement().setProperty("selected", tabs.getSelectedIndex());
     }
 
     /**
@@ -234,6 +234,7 @@ public class TabSheet extends Component
      */
     public void setSelectedTab(Tab selectedTab) {
         tabs.setSelectedTab(selectedTab);
+        getElement().setProperty("selected", tabs.getSelectedIndex());
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -211,6 +211,7 @@ public class TabSheet extends Component
      *            the zero-based index of the selected tab, -1 to unselect all
      */
     public void setSelectedIndex(int selectedIndex) {
+        getElement().setProperty("selected", selectedIndex);
         tabs.setSelectedIndex(selectedIndex);
     }
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -266,6 +266,8 @@ public class TabSheetTest {
         tabSheet.setSelectedIndex(1);
         Assert.assertEquals(1, tabSheet.getSelectedIndex());
         Assert.assertEquals(tab1, tabSheet.getSelectedTab());
+        Assert.assertEquals(1,
+                tabSheet.getElement().getProperty("selected", 0));
     }
 
     @Test

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -277,6 +277,8 @@ public class TabSheetTest {
         tabSheet.setSelectedTab(tab1);
         Assert.assertEquals(1, tabSheet.getSelectedIndex());
         Assert.assertEquals(tab1, tabSheet.getSelectedTab());
+        Assert.assertEquals(1,
+                tabSheet.getElement().getProperty("selected", 0));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/3843