### PR TITLE
chore: inherit nexus-staging-maven-plugin from vaadin-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,11 +465,6 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.1.0</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
-                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
## Description

There is no need in defining `nexus-staging-maven-plugin` in `pom.xml` since it can be inherited from `vaadin-parent`. Inheritance also helps keep versions consistent.

Related to https://github.com/vaadin/flow/pull/14798
Related to https://github.com/vaadin/flow/pull/14799

## Type of change

- [x] Chore

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
