### PR TITLE
fix: update selected property on selected change

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -60,7 +60,10 @@ public class TabSheet extends Component
         tabs.getElement().setAttribute("slot", "tabs");
         getElement().appendChild(tabs.getElement());
 
-        addSelectedChangeListener(e -> updateContent());
+        addSelectedChangeListener(e -> {
+            getElement().setProperty("selected", tabs.getSelectedIndex());
+            updateContent();
+        });
     }
 
     /**
@@ -212,7 +215,6 @@ public class TabSheet extends Component
      */
     public void setSelectedIndex(int selectedIndex) {
         tabs.setSelectedIndex(selectedIndex);
-        getElement().setProperty("selected", tabs.getSelectedIndex());
     }
 
     /**
@@ -234,7 +236,6 @@ public class TabSheet extends Component
      */
     public void setSelectedTab(Tab selectedTab) {
         tabs.setSelectedTab(selectedTab);
-        getElement().setProperty("selected", tabs.getSelectedIndex());
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -415,6 +415,7 @@ public class TabSheetTest {
         tabSheet.add("Tab 0", new Span("Content 0"));
         tabSheet.add("Tab 1", new Span("Content 1"));
         tabs.setSelectedIndex(1);
-        Assert.assertEquals(1, tabSheet.getElement().getProperty("selected", 0));
+        Assert.assertEquals(1,
+                tabSheet.getElement().getProperty("selected", 0));
     }
 }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -409,4 +409,12 @@ public class TabSheetTest {
         tabSheet.add("Tab 0", new Span("Content 0"));
         Assert.assertEquals(-1, tabSheet.getIndexOf(new Tab()));
     }
+
+    @Test
+    public void selectTabFromTabs_selectedUpdated() {
+        tabSheet.add("Tab 0", new Span("Content 0"));
+        tabSheet.add("Tab 1", new Span("Content 1"));
+        tabs.setSelectedIndex(1);
+        Assert.assertEquals(1, tabSheet.getElement().getProperty("selected", 0));
+    }
 }


### PR DESCRIPTION
Follow-up for https://github.com/vaadin/flow-components/pull/3846

Since the selected index can change due to various reasons, it's safer to synchronize the property value inside the internal selected change listener.