### PR TITLE
fix: pass the object to be used by method

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ConditionalFormatter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ConditionalFormatter.java
@@ -156,7 +156,7 @@ public class ConditionalFormatter implements Serializable {
         cellToIndex.clear();
         topBorders.clear();
         leftBorders.clear();
-        HashMap<Integer, String> _conditionalFormattingStyles = new HashMap<Integer, String>();
+        HashMap<Integer, String> conditionalFormattingStyles = new HashMap<>();
 
         SheetConditionalFormatting cfs = spreadsheet.getActiveSheet()
                 .getSheetConditionalFormatting();
@@ -245,9 +245,10 @@ public class ConditionalFormatter implements Serializable {
                     }
                 }
 
-                cssIndex = addBorderFormatting(cf, rule, css, cssIndex);
+                cssIndex = addBorderFormatting(cf, rule, css, cssIndex,
+                        conditionalFormattingStyles);
 
-                _conditionalFormattingStyles.put(cssIndex, css.toString());
+                conditionalFormattingStyles.put(cssIndex, css.toString());
 
                 // check actual cells
                 runCellMatcher(cf, rule, cssIndex);
@@ -257,10 +258,9 @@ public class ConditionalFormatter implements Serializable {
                     break;
                 }
             }
-
         }
-        spreadsheet
-                .setConditionalFormattingStyles(_conditionalFormattingStyles);
+
+        spreadsheet.setConditionalFormattingStyles(conditionalFormattingStyles);
     }
 
     /**
@@ -318,7 +318,8 @@ public class ConditionalFormatter implements Serializable {
      * @return the new cssIndex
      */
     private int addBorderFormatting(ConditionalFormatting cf,
-            ConditionalFormattingRule rule, StringBuilder css, int cssIndex) {
+            ConditionalFormattingRule rule, StringBuilder css, int cssIndex,
+            HashMap<Integer, String> conditionalFormattingStyles) {
 
         if (!(rule instanceof XSSFConditionalFormattingRule)) {
             // HSSF not supported
@@ -370,10 +371,6 @@ public class ConditionalFormatter implements Serializable {
                 }
             }
 
-            // top and left borders might be applied to another cell, so store
-            // them with a different index
-            HashMap<Integer, String> _conditionalFormattingStyles = spreadsheet
-                    .getConditionalFormattingStyles();
             if (isTopSet) {
                 // bottom border for cell above
                 final StringBuilder sb2 = new StringBuilder("border-bottom:");
@@ -382,7 +379,7 @@ public class ConditionalFormatter implements Serializable {
                     sb2.append(colorConverter.getBorderColorCSS(BorderSide.TOP,
                             "border-bottom-color", borderFormatting));
 
-                    _conditionalFormattingStyles.put(cssIndex, sb2.toString());
+                    conditionalFormattingStyles.put(cssIndex, sb2.toString());
                     topBorders.put(cf, cssIndex++);
                 } else {
                     css.append(BORDER_STYLE_DEFAULT);
@@ -397,14 +394,12 @@ public class ConditionalFormatter implements Serializable {
                     sb2.append(colorConverter.getBorderColorCSS(BorderSide.LEFT,
                             "border-right-color", borderFormatting));
 
-                    _conditionalFormattingStyles.put(cssIndex, sb2.toString());
+                    conditionalFormattingStyles.put(cssIndex, sb2.toString());
                     leftBorders.put(cf, cssIndex++);
                 } else {
                     css.append(BORDER_STYLE_DEFAULT);
                 }
             }
-            spreadsheet.setConditionalFormattingStyles(
-                    _conditionalFormattingStyles);
         }
 
         return cssIndex;
@@ -465,7 +460,7 @@ public class ConditionalFormatter implements Serializable {
     }
 
     /**
-     * @param i
+     * @param b
      *            0 - left, 1 - top, 2 - right, 3 - bottom
      */
     private boolean isBorderSet(XSSFBorderFormatting borderFormatting,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ConditionalFormatterTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ConditionalFormatterTest.java
@@ -33,7 +33,6 @@ public class ConditionalFormatterTest {
      *         assert false : "hashCode not designed";
      * }. Assertions can be disabled with -DenableAssertions=false in maven.
      */
-    @Ignore("The file throws NPE when loaded. The same does not happen on the V8 version.")
     @Test
     public void matchesFormula_rulesWithoutFormula_formulasEvaluatedWithoutExceptions()
             throws URISyntaxException, IOException {


### PR DESCRIPTION
## Description

The `ConditionalFormatter::addBorderFormatting `method calls `Spreadsheet::getConditionalFormattingStyles` to add more styles to the map object.
But when it happens, there is no object returned by the method, so an `NPE` is thrown.
Change the implementation to pass the map created by `createConditionalFormatterRules` to `addBorderFormatting` and only call `Spreadsheet::setConditionalFormattingStyles` at the end of the method, since it also sets a property on the web component.

