### PR TITLE
chore: update vaadin-parent to 2.1.0

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-flow-components</artifactId>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-flow-components-integration-tests</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.5</version>
+        <version>2.1.0</version>
     </parent>
     <url>https://vaadin.com/components</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>vaadin-flow-components</artifactId>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin Flow Components Root Project</name>
     <parent>
@@ -12,14 +12,14 @@
     </parent>
     <url>https://vaadin.com/components</url>
     <properties>
-        <flow.version>23.3-SNAPSHOT</flow.version>
+        <flow.version>24.0-SNAPSHOT</flow.version>
         <testbench.version>8.1.1</testbench.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
                 </project.reporting.outputEncoding>
-        <jetty.version>9.4.49.v20220914</jetty.version>
+        <jetty.version>11.0.8</jetty.version>
         <jetty.http.port>8080</jetty.http.port>
         <jetty.stop.port>9999</jetty.stop.port>
         <karaf-maven-plugin.version>4.4.0</karaf-maven-plugin.version>
@@ -38,6 +38,7 @@
         <osgi.bundle.license>http://www.apache.org/licenses/LICENSE-2.0</osgi.bundle.license>
         <osgi.export.package>default</osgi.export.package>
         <cvdlName></cvdlName>
+        <jakarta.servlet.api.version>5.0.0</jakarta.servlet.api.version>
 
         <!-- spreadsheet -->
         <poi.version>5.2.3</poi.version>
@@ -150,6 +151,10 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>apache snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -266,7 +271,6 @@
                         <httpConnector>
                             <port>${jetty.http.port}</port>
                         </httpConnector>
-                        <scanIntervalSeconds>-1</scanIntervalSeconds>
                         <stopPort>${jetty.stop.port}</stopPort>
                         <stopWait>5</stopWait>
                         <stopKey>foo</stopKey>
@@ -291,7 +295,7 @@
                             <id>start-jetty</id>
                             <phase>pre-integration-test</phase>
                             <goals>
-                                <goal>deploy-war</goal>
+                                <goal>start-war</goal>
                             </goals>
                         </execution>
                         <execution>
@@ -545,6 +549,12 @@
                 <version>1.7.36</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet.api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.cmpn</artifactId>
                 <version>7.0.0</version>
@@ -613,4 +623,12 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <!--testing use -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/vaadin-accordion-flow-parent/pom.xml
+++ b/vaadin-accordion-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-accordion-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
@@ -4,16 +4,15 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-accordion-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-flow</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin Accordion</name>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-accordion-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-app-layout-flow-parent/pom.xml
+++ b/vaadin-app-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-app-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -20,10 +20,8 @@
             <version>1.7.36</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
@@ -4,17 +4,15 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-app-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-flow</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin App Layout</name>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-app-layout-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-avatar-flow-parent/pom.xml
+++ b/vaadin-avatar-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-avatar-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-avatar-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-flow</artifactId>
     <packaging>jar</packaging>
@@ -22,10 +22,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-testbench/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-avatar-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-board-flow-parent/pom.xml
+++ b/vaadin-board-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-board-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -15,10 +15,8 @@
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-board-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-flow</artifactId>
     <packaging>jar</packaging>
@@ -14,10 +14,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-board-flow-parent/vaadin-board-testbench/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-board-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-button-flow-parent/pom.xml
+++ b/vaadin-button-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-button-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-button-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-flow</artifactId>
     <packaging>jar</packaging>
@@ -22,10 +22,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-button-flow-parent/vaadin-button-testbench/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-button-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-charts-flow-parent/pom.xml
+++ b/vaadin-charts-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-charts-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-charts-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-flow-svg-generator</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-charts-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-flow</artifactId>
     <packaging>jar</packaging>
@@ -24,10 +24,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/vaadin-charts-flow-parent/vaadin-charts-testbench/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-charts-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-checkbox-flow-parent/pom.xml
+++ b/vaadin-checkbox-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-checkbox-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-checkbox-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-flow</artifactId>
     <packaging>jar</packaging>
@@ -21,9 +21,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-checkbox-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-combo-box-flow-parent/pom.xml
+++ b/vaadin-combo-box-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-combo-box-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-combo-box-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-flow</artifactId>
     <packaging>jar</packaging>
@@ -28,9 +28,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-combo-box-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-confirm-dialog-flow-parent/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -15,10 +15,8 @@
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
@@ -4,17 +4,15 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-flow</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin Confirm Dialog</name>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-testbench/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-context-menu-flow-parent/pom.xml
+++ b/vaadin-context-menu-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-context-menu-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-context-menu-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-flow</artifactId>
     <packaging>jar</packaging>
@@ -31,10 +31,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-context-menu-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-cookie-consent-flow-parent/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-cookie-consent-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-cookie-consent-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-cookie-consent-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -15,9 +15,8 @@
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-cookie-consent-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-cookie-consent-flow</artifactId>
     <packaging>jar</packaging>
@@ -14,9 +14,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-testbench/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-cookie-consent-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-cookie-consent-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-crud-flow-parent/pom.xml
+++ b/vaadin-crud-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-crud-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-crud-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-flow</artifactId>
     <packaging>jar</packaging>
@@ -14,9 +14,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-crud-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-custom-field-flow-parent/pom.xml
+++ b/vaadin-custom-field-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-custom-field-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-custom-field-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,9 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-custom-field-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-date-picker-flow-parent/pom.xml
+++ b/vaadin-date-picker-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-picker-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-picker-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-flow</artifactId>
     <packaging>jar</packaging>
@@ -26,10 +26,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-date-picker-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-date-time-picker-flow-parent/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-flow</artifactId>
     <packaging>jar</packaging>
@@ -31,10 +31,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-details-flow-parent/pom.xml
+++ b/vaadin-details-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-details-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-details-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,10 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-details-flow-parent/vaadin-details-testbench/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-details-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-dialog-flow-parent/pom.xml
+++ b/vaadin-dialog-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -95,10 +95,8 @@
             <artifactId>flow-polymer-template</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,9 +16,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-testbench/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-field-highlighter-flow-parent/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-field-highlighter-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-field-highlighter-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-field-highlighter-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-field-highlighter-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-field-highlighter-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-flow-components-shared-parent/pom.xml
+++ b/vaadin-flow-components-shared-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-flow-components</artifactId>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-flow-components-shared-parent</artifactId>
   <packaging>pom</packaging>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-flow-components-shared-parent</artifactId>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-flow-components-base</artifactId>
   <packaging>jar</packaging>
@@ -26,9 +26,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
   </dependency>
   </dependencies>
   <build>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-flow-components-shared-parent</artifactId>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-flow-components-test-util</artifactId>
   <packaging>jar</packaging>

--- a/vaadin-form-layout-flow-parent/pom.xml
+++ b/vaadin-form-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-form-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-form-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,9 +16,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-testbench/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-form-layout-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-grid-flow-parent/pom.xml
+++ b/vaadin-grid-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -163,9 +163,8 @@
             <version>${flow.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-flow</artifactId>
     <packaging>jar</packaging>
@@ -36,10 +36,8 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-grid-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-grid-pro-flow-parent/pom.xml
+++ b/vaadin-grid-pro-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-pro-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-pro-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-flow</artifactId>
     <packaging>jar</packaging>
@@ -14,9 +14,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-grid-pro-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-icons-flow-parent/pom.xml
+++ b/vaadin-icons-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,10 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-icons-flow-parent/vaadin-icons-testbench/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-icons-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-iron-list-flow-parent/pom.xml
+++ b/vaadin-iron-list-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-iron-list-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-iron-list-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-iron-list-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-iron-list-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-iron-list-flow</artifactId>
     <packaging>jar</packaging>
@@ -26,10 +26,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-testbench/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-iron-list-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-iron-list-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-list-box-flow-parent/pom.xml
+++ b/vaadin-list-box-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-list-box-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-list-box-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,10 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-list-box-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-login-flow-parent/pom.xml
+++ b/vaadin-login-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-login-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -4,17 +4,15 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-login-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-flow</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin Login</name>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-login-flow-parent/vaadin-login-testbench/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-login-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-lumo-theme-flow-parent/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-lumo-theme-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-lumo-theme-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-lumo-theme-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-lumo-theme-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-lumo-theme</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-map-flow-parent/pom.xml
+++ b/vaadin-map-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-map-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -15,10 +15,8 @@
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-map-flow-parent/vaadin-map-flow/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-map-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-flow</artifactId>
     <packaging>jar</packaging>
@@ -28,10 +28,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/vaadin-map-flow-parent/vaadin-map-testbench/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-map-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-material-theme-flow-parent/pom.xml
+++ b/vaadin-material-theme-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-material-theme-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/pom.xml
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-material-theme-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-material-theme-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/pom.xml
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-material-theme-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-material-theme</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-menu-bar-flow-parent/pom.xml
+++ b/vaadin-menu-bar-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-menu-bar-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-menu-bar-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-flow</artifactId>
     <packaging>jar</packaging>
@@ -31,10 +31,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-menu-bar-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-messages-flow-parent/pom.xml
+++ b/vaadin-messages-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-messages-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-messages-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-flow</artifactId>
     <packaging>jar</packaging>
@@ -26,10 +26,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-messages-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-notification-flow-parent/pom.xml
+++ b/vaadin-notification-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-notification-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -80,10 +80,8 @@
             <artifactId>flow-polymer-template</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -4,17 +4,15 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-notification-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-flow</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin Notification</name>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-notification-flow-parent/vaadin-notification-testbench/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-notification-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-ordered-layout-flow-parent/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-flow</artifactId>
     <packaging>jar</packaging>
@@ -26,10 +26,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-testbench/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-progress-bar-flow-parent/pom.xml
+++ b/vaadin-progress-bar-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-progress-bar-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-progress-bar-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-flow</artifactId>
     <packaging>jar</packaging>
@@ -21,10 +21,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-testbench/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-progress-bar-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-radio-button-flow-parent/pom.xml
+++ b/vaadin-radio-button-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-radio-button-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-radio-button-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,10 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-testbench/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-radio-button-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-renderer-flow-parent/pom.xml
+++ b/vaadin-renderer-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-renderer-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-renderer-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-renderer-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-renderer-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-renderer-flow</artifactId>
     <packaging>jar</packaging>
@@ -24,10 +24,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-rich-text-editor-flow-parent/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -15,9 +15,8 @@
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-flow</artifactId>
     <packaging>jar</packaging>
@@ -14,9 +14,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-select-flow-parent/pom.xml
+++ b/vaadin-select-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-select-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-select-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,10 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-select-flow-parent/vaadin-select-testbench/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-select-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-split-layout-flow-parent/pom.xml
+++ b/vaadin-split-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-split-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-split-layout-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-flow</artifactId>
     <packaging>jar</packaging>
@@ -21,10 +21,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-testbench/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-split-layout-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-spreadsheet-flow-parent/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <groupId>com.vaadin</groupId>
   <artifactId>vaadin-spreadsheet-flow-client</artifactId>
@@ -24,6 +24,10 @@
 
     <!-- optimizations -->
     <gwt.loglevel>WARN</gwt.loglevel>
+    <!-- Source level must be one of [auto, 1.8, 1.9, 1.10, 1.11].
+         17 is not an option for sourcelevel in gwt-maven-plugin
+         use `auto` for this case -->
+    <gwt.sourcelevel>auto</gwt.sourcelevel>
     <gwt.disableCastChecking>true</gwt.disableCastChecking>
     <gwt.enableAssertions>false</gwt.enableAssertions>
     <gwt.closure>true</gwt.closure>
@@ -132,6 +136,7 @@
           <draftCompile>${gwt.draft.compile}</draftCompile>
 
           <logLevel>${gwt.loglevel}</logLevel>
+          <sourceLevel>${gwt.sourcelevel}</sourceLevel>
           <gwtVersion>${gwt.version}</gwtVersion>
           <compileReport>${gwt.report}</compileReport>
           <compileMetrics>${gwt.report}</compileMetrics>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-flow</artifactId>
     <packaging>jar</packaging>
@@ -81,9 +81,8 @@
             <artifactId>poi-ooxml-full</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-tabs-flow-parent/pom.xml
+++ b/vaadin-tabs-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-tabs-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-tabs-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-flow</artifactId>
     <packaging>jar</packaging>
@@ -16,10 +16,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-tabs-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-text-field-flow-parent/pom.xml
+++ b/vaadin-text-field-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-flow</artifactId>
     <packaging>jar</packaging>
@@ -21,10 +21,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-time-picker-flow-parent/pom.xml
+++ b/vaadin-time-picker-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-time-picker-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-time-picker-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-flow</artifactId>
     <packaging>jar</packaging>
@@ -36,10 +36,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-time-picker-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-upload-flow-parent/pom.xml
+++ b/vaadin-upload-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-upload-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-integration-tests</artifactId>
     <packaging>war</packaging>
@@ -76,9 +76,8 @@
             <artifactId>flow-polymer-template</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -4,17 +4,15 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-upload-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-flow</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin Upload</name>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-upload-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-virtual-list-flow-parent/pom.xml
+++ b/vaadin-virtual-list-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-virtual-list-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-virtual-list-flow-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-flow</artifactId>
     <packaging>jar</packaging>
@@ -26,10 +26,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-testbench/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>vaadin-virtual-list-flow-parent</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-testbench</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
for JDK 17 support 