### PR TITLE
test: add a helper for dispatching spreadsheet events

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -69,7 +69,8 @@ public class FormulasTest {
     public void setInvalidFormula_invalidFormulaCellsSet() throws Exception {
         // onSheetScroll must be invoked once, otherwise cell comments are not
         // loaded
-        TestHelper.fireClientEvent(spreadsheet, "onSheetScroll", "[1, 1, 1, 1]");
+        TestHelper.fireClientEvent(spreadsheet, "onSheetScroll",
+                "[1, 1, 1, 1]");
 
         // Create a formula cell with an invalid formula
         var A1 = spreadsheet.createFormulaCell(0, 0, "Sheet2!A1");

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -69,10 +69,7 @@ public class FormulasTest {
     public void setInvalidFormula_invalidFormulaCellsSet() throws Exception {
         // onSheetScroll must be invoked once, otherwise cell comments are not
         // loaded
-        var method = Spreadsheet.class.getDeclaredMethod("onSheetScroll",
-                int.class, int.class, int.class, int.class);
-        method.setAccessible(true);
-        method.invoke(spreadsheet, 1, 1, 1, 1);
+        TestHelper.fireClientEvent(spreadsheet, "onSheetScroll", "[1, 1, 1, 1]");
 
         // Create a formula cell with an invalid formula
         var A1 = spreadsheet.createFormulaCell(0, 0, "Sheet2!A1");

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/MultipleSheetsTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/MultipleSheetsTest.java
@@ -139,15 +139,7 @@ public class MultipleSheetsTest {
             Assert.assertEquals("bar", event.getNewSheet().getSheetName());
         });
 
-        // TODO: setActiveSheetIndex doesn't currently dispatch an event so need
-        // to use reflection
-        // spreadsheet.setActiveSheetIndex(1);
-
-        var onSheetSelected = Spreadsheet.class.getDeclaredMethod(
-                "onSheetSelected", int.class, int.class, int.class);
-        onSheetSelected.setAccessible(true);
-        onSheetSelected.invoke(spreadsheet, 1, 0, 0);
-
+        TestHelper.fireClientEvent(spreadsheet, "sheetSelected", "[1, 0, 0]");
         Assert.assertTrue(listenerInvoked.get());
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
@@ -1,0 +1,28 @@
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet.SpreadsheetEvent;
+
+import elemental.json.impl.JsonUtil;
+
+class TestHelper {
+
+    /**
+     * Fires a SpreadsheetEvent with the given event name and data. Can be used
+     * to simulate events dispatched by the <vaadin-spreadsheet> Web Component.
+     *
+     * @param spreadsheet
+     *            the Spreadsheet component
+     * @param eventName
+     *            the name of the event
+     * @param jsonDataArray
+     *            the data of the event as a JSON array, for example "[1, 1, 0]"
+     */
+    static void fireClientEvent(Spreadsheet spreadsheet, String eventName,
+            String jsonDataArray) {
+        ComponentUtil.fireEvent(spreadsheet, new SpreadsheetEvent(spreadsheet,
+                true, eventName, JsonUtil.parse(jsonDataArray)));
+    }
+
+}


### PR DESCRIPTION
Add a helper for dispatching simulated [client events](https://github.com/vaadin/flow-components/blob/b975fe57019cb9466ebb14ddd17857a0ba795aa4/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js#L433-L598) in Spreadsheet Junit tests