### PR TITLE
test: add a test helper for creating a spreadsheet from excel file

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/CellValueShorteningTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/CellValueShorteningTest.java
@@ -15,7 +15,7 @@ public class CellValueShorteningTest {
     private CellValueFormatter cellValueFormatter;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         cellValueFormatter = new CellValueFormatter();
         cellValueFormatter.setLocaleDecimalSymbols(
                 DecimalFormatSymbols.getInstance(Locale.US));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ColumnFiltersTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ColumnFiltersTest.java
@@ -1,7 +1,5 @@
 package com.vaadin.flow.component.spreadsheet.tests;
 
-import java.io.File;
-import java.net.URISyntaxException;
 import java.util.Iterator;
 
 import org.apache.poi.ss.usermodel.Row;
@@ -25,7 +23,7 @@ public class ColumnFiltersTest {
     private Spreadsheet spreadsheet;
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         workbook = new XSSFWorkbook();
         XSSFSheet sheet = workbook.createSheet();
 
@@ -87,19 +85,14 @@ public class ColumnFiltersTest {
     }
 
     @Test
-    public void loadFile_filteredColumnsLoadedAsActive() throws Exception {
-        Spreadsheet spr = new Spreadsheet(
-                getTestSheetFile("autofilter_with_active_column.xlsx"));
+    public void loadFile_filteredColumnsLoadedAsActive() {
+        Spreadsheet spr = TestHelper
+                .createSpreadsheet("autofilter_with_active_column.xlsx");
 
         final SpreadsheetTable table = spr.getTables().iterator().next();
 
         Assert.assertTrue(table.getPopupButton(1).isActive());
         Assert.assertFalse(table.getPopupButton(2).isActive());
-    }
-
-    private File getTestSheetFile(String name) throws URISyntaxException {
-        return new File(getClass().getClassLoader()
-                .getResource("test_sheets" + File.separator + name).toURI());
     }
 
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ConditionalFormatterTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ConditionalFormatterTest.java
@@ -1,15 +1,9 @@
 package com.vaadin.flow.component.spreadsheet.tests;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-
 import com.vaadin.flow.component.spreadsheet.ConditionalFormatter;
 import com.vaadin.flow.component.spreadsheet.SheetImageWrapper;
 import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 import org.apache.poi.ss.usermodel.ClientAnchor;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -19,8 +13,7 @@ import org.junit.Test;
 public class ConditionalFormatterTest {
 
     @Test
-    public void createConditionalFormatterRules_sheetWithStringFormatRuleForNumericCell_rulesCreatedWithoutExceptions()
-            throws URISyntaxException, IOException {
+    public void createConditionalFormatterRules_sheetWithStringFormatRuleForNumericCell_rulesCreatedWithoutExceptions() {
         createConditionalFormatterRulesForSheet("conditional_formatting.xlsx");
     }
 
@@ -34,35 +27,25 @@ public class ConditionalFormatterTest {
      * }. Assertions can be disabled with -DenableAssertions=false in maven.
      */
     @Test
-    public void matchesFormula_rulesWithoutFormula_formulasEvaluatedWithoutExceptions()
-            throws URISyntaxException, IOException {
+    public void matchesFormula_rulesWithoutFormula_formulasEvaluatedWithoutExceptions() {
         // ensure sheet with rules without formulas is active
         createConditionalFormatterRulesForSheet(
                 "ConditionalFormatterSamples.xlsx", 3);
     }
 
     @Test
-    public void createConditionalFormatterRules_ruleWithNullBackgroundColor_rulesCreatedWithoutExceptions()
-            throws URISyntaxException, IOException {
+    public void createConditionalFormatterRules_ruleWithNullBackgroundColor_rulesCreatedWithoutExceptions() {
         createConditionalFormatterRulesForSheet(
                 "conditionalformater_nobackground.xlsx");
     }
 
-    private void createConditionalFormatterRulesForSheet(String fileName)
-            throws URISyntaxException, IOException {
+    private void createConditionalFormatterRulesForSheet(String fileName) {
         createConditionalFormatterRulesForSheet(fileName, null);
     }
 
     private void createConditionalFormatterRulesForSheet(String fileName,
-            Integer sheetIndex) throws URISyntaxException, IOException {
-        ClassLoader classLoader = ConditionalFormatterTest.class
-                .getClassLoader();
-        URL resource = classLoader
-                .getResource("test_sheets" + File.separator + fileName);
-        assert resource != null;
-        File file = new File(resource.toURI());
-
-        Spreadsheet sheet = new Spreadsheet(file);
+            Integer sheetIndex) {
+        Spreadsheet sheet = TestHelper.createSpreadsheet(fileName);
 
         if (sheetIndex != null && sheet.getActiveSheetIndex() != sheetIndex) {
             sheet.setActiveSheetIndex(sheetIndex);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/DefaultHyperlinkCellClickHandlerTests.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/DefaultHyperlinkCellClickHandlerTests.java
@@ -2,12 +2,7 @@ package com.vaadin.flow.component.spreadsheet.tests;
 
 import static org.junit.Assert.*;
 
-import java.io.File;
-import java.net.URL;
-
 import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.Test;
 
 import com.vaadin.flow.component.spreadsheet.DefaultHyperlinkCellClickHandler;
@@ -19,14 +14,8 @@ import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 public class DefaultHyperlinkCellClickHandlerTests {
 
     @Test
-    public void hyperlinkParser_validStrings_correctParsed() throws Exception {
-        URL testSheetResource = this.getClass().getClassLoader()
-                .getResource("test_sheets/hyper_links.xlsx");
-        File testSheetFile = new File(testSheetResource.toURI());
-
-        Workbook workbook = WorkbookFactory.create(testSheetFile);
-
-        final Spreadsheet ss = new Spreadsheet(workbook);
+    public void hyperlinkParser_validStrings_correctParsed() {
+        final Spreadsheet ss = TestHelper.createSpreadsheet("hyper_links.xlsx");
         ss.setActiveSheetIndex(0);
 
         TestHyperlinkCellClickHandler handler = new TestHyperlinkCellClickHandler(

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/EmptyFileTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/EmptyFileTest.java
@@ -1,9 +1,7 @@
 package com.vaadin.flow.component.spreadsheet.tests;
 
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URISyntaxException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,10 +11,8 @@ import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 public class EmptyFileTest {
 
     @Test
-    public void loadFile_emptySheet_firstRowRendered() throws Exception {
-        File f = getTestSheetFile("empty.xlsx");
-
-        Spreadsheet s = new Spreadsheet(f);
+    public void loadFile_emptySheet_firstRowRendered() {
+        var s = TestHelper.createSpreadsheet("empty.xlsx");
 
         var rowH = getSpreadsheetRowH(s);
 
@@ -55,21 +51,4 @@ public class EmptyFileTest {
         Assert.fail("Could not get RowH with reflection");
         return null;
     }
-
-    private File getTestSheetFile(String testSheetFileName) {
-        File file = null;
-
-        try {
-            file = new File(EmptyFileTest.class.getClassLoader()
-                    .getResource(
-                            "test_sheets" + File.separator + testSheetFileName)
-                    .toURI());
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
-        Assert.assertNotNull("Spreadsheet file null", file);
-        Assert.assertTrue("Spreadsheet file does not exist", file.exists());
-        return file;
-    }
-
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
@@ -22,7 +22,7 @@ public class FilterTableTest {
     private SpreadsheetFilterTable table;
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         spreadsheet = new Spreadsheet();
 
         int maxColumns = 5;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -14,7 +14,7 @@ public class FormulasTest {
     private Spreadsheet spreadsheet;
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         spreadsheet = new Spreadsheet();
         var ui = new UI();
         UI.setCurrent(ui);
@@ -66,7 +66,7 @@ public class FormulasTest {
     }
 
     @Test
-    public void setInvalidFormula_invalidFormulaCellsSet() throws Exception {
+    public void setInvalidFormula_invalidFormulaCellsSet() {
         // onSheetScroll must be invoked once, otherwise cell comments are not
         // loaded
         TestHelper.fireClientEvent(spreadsheet, "onSheetScroll",
@@ -81,8 +81,7 @@ public class FormulasTest {
     }
 
     @Test
-    public void setInvalidFormulaErrorMessage_invalidFormulaErrorMessageSet()
-            throws Exception {
+    public void setInvalidFormulaErrorMessage_invalidFormulaErrorMessageSet() {
         spreadsheet.setInvalidFormulaErrorMessage("foo");
         Assert.assertEquals("foo", spreadsheet.getElement()
                 .getProperty("invalidFormulaErrorMessage"));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/MultipleSheetsTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/MultipleSheetsTest.java
@@ -15,7 +15,7 @@ public class MultipleSheetsTest {
     private Spreadsheet spreadsheet;
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         var workbook = new XSSFWorkbook();
         workbook.createSheet("foo");
         workbook.createSheet("bar");
@@ -129,7 +129,7 @@ public class MultipleSheetsTest {
     }
 
     @Test
-    public void addSheetChangeListener_invokesOnSheetChange() throws Exception {
+    public void addSheetChangeListener_invokesOnSheetChange() {
         var listenerInvoked = new AtomicBoolean(false);
         spreadsheet.addSheetChangeListener(event -> {
             listenerInvoked.set(true);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetReadWriteTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetReadWriteTest.java
@@ -6,17 +6,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Test;
-
-import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 
 /*
  * Tests are performed with pure POI and Spreadsheet to find differences and bugs
@@ -25,10 +20,8 @@ public class SpreadsheetReadWriteTest {
 
     @Test
     public void openAndSaveFileWithPOI_emptyXLSXFile_openAndSaveWorks()
-            throws URISyntaxException, IOException, InvalidFormatException {
-        URL testSheetResource = this.getClass().getClassLoader()
-                .getResource("test_sheets/empty.xlsx");
-        File testSheetFIle = new File(testSheetResource.toURI());
+            throws IOException {
+        File testSheetFIle = TestHelper.getTestSheetFile("empty.xlsx");
 
         FileInputStream fis = new FileInputStream(testSheetFIle);
         XSSFWorkbook workbook = (XSSFWorkbook) WorkbookFactory.create(fis);
@@ -44,11 +37,8 @@ public class SpreadsheetReadWriteTest {
 
     @Test
     public void openAndSaveFile_emptyXLSXFile_openAndSaveWorks()
-            throws URISyntaxException, IOException {
-        URL testSheetResource = this.getClass().getClassLoader()
-                .getResource("test_sheets/empty.xlsx");
-        File testSheetFIle = new File(testSheetResource.toURI());
-        Spreadsheet sheet = new Spreadsheet(testSheetFIle);
+            throws IOException {
+        var sheet = TestHelper.createSpreadsheet("empty.xlsx");
 
         File tempFile = File.createTempFile("resultEmptyFile", "xlsx");
         FileOutputStream tempOutputStream = new FileOutputStream(tempFile);
@@ -61,11 +51,8 @@ public class SpreadsheetReadWriteTest {
 
     @Test
     public void openAndSaveFile_emptyXLSXFile_FileDoesNotContainAdditionalDrawing()
-            throws URISyntaxException, IOException {
-        URL testSheetResource = this.getClass().getClassLoader()
-                .getResource("test_sheets/empty.xlsx");
-        File testSheetFIle = new File(testSheetResource.toURI());
-        Spreadsheet sheet = new Spreadsheet(testSheetFIle);
+            throws IOException {
+        var sheet = TestHelper.createSpreadsheet("empty.xlsx");
 
         File tempFile = File.createTempFile("resultEmptyFile", "xlsx");
         FileOutputStream tempOutputStream = new FileOutputStream(tempFile);
@@ -89,10 +76,8 @@ public class SpreadsheetReadWriteTest {
 
     @Test
     public void openAndSaveFileWithPOI_emptyXLSXFile_FileDoesNotContainAdditionalDrawing()
-            throws URISyntaxException, IOException, InvalidFormatException {
-        URL testSheetResource = this.getClass().getClassLoader()
-                .getResource("test_sheets/empty.xlsx");
-        File testSheetFIle = new File(testSheetResource.toURI());
+            throws IOException {
+        File testSheetFIle = TestHelper.getTestSheetFile("empty.xlsx");
 
         FileInputStream fis = new FileInputStream(testSheetFIle);
         XSSFWorkbook workbook = (XSSFWorkbook) WorkbookFactory.create(fis);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
@@ -1,5 +1,9 @@
 package com.vaadin.flow.component.spreadsheet.tests;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 import com.vaadin.flow.component.spreadsheet.Spreadsheet.SpreadsheetEvent;
@@ -23,6 +27,34 @@ class TestHelper {
             String jsonDataArray) {
         ComponentUtil.fireEvent(spreadsheet, new SpreadsheetEvent(spreadsheet,
                 true, eventName, JsonUtil.parse(jsonDataArray)));
+    }
+
+    /**
+     * Ceates a Spreadsheet component with the given Excel file as the data
+     * source.
+     *
+     * @param fileName
+     *            the name of the file. The file must be in the test_sheets
+     *            folder.
+     * @return the test sheet file
+     */
+    static Spreadsheet createSpreadsheet(String fileName) {
+        File testSheetFile = getTestSheetFile(fileName);
+        try {
+            return new Spreadsheet(testSheetFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create Spreadsheet", e);
+        }
+    }
+
+    static File getTestSheetFile(String name) {
+        try {
+            return new File(TestHelper.class.getClassLoader()
+                    .getResource("test_sheets" + File.separator + name)
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Can't find test sheet file " + name);
+        }
     }
 
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
@@ -36,7 +36,7 @@ class TestHelper {
      * @param fileName
      *            the name of the file. The file must be in the test_sheets
      *            folder.
-     * @return the test sheet file
+     * @return the created Spreadsheet component
      */
     static Spreadsheet createSpreadsheet(String fileName) {
         File testSheetFile = getTestSheetFile(fileName);
@@ -47,13 +47,22 @@ class TestHelper {
         }
     }
 
-    static File getTestSheetFile(String name) {
+    /**
+     * Gets the File object for the given file name.
+     *
+     * @param fileName
+     *            the name of the file. The file must be in the test_sheets
+     *            folder.
+     * @return the File object
+     */
+    static File getTestSheetFile(String fileName) {
         try {
             return new File(TestHelper.class.getClassLoader()
-                    .getResource("test_sheets" + File.separator + name)
+                    .getResource("test_sheets" + File.separator + fileName)
                     .toURI());
         } catch (URISyntaxException e) {
-            throw new RuntimeException("Can't find test sheet file " + name);
+            throw new RuntimeException(
+                    "Can't find test sheet file " + fileName);
         }
     }
 


### PR DESCRIPTION
Multiple unit tests read an Excel file and initiate a `Spreadsheet` with the file used as the data source. This PR adds a shared helper for it.