### PR TITLE
test: re-enable some ignored spreadsheet ITs

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaColumnsIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaColumnsIT.java
@@ -98,7 +98,6 @@ public class FormulaColumnsIT extends AbstractSpreadsheetIT {
     }
 
     @Test
-    @Ignore("Formulas with quotes are not working")
     public void testFloatOperations() {
         for (int i = 0; i < floatColumn.length; i++) {
             getSpreadsheet().getCellAt(i + 1, 1).setValue(floatColumn[i]);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NavigationIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NavigationIT.java
@@ -235,7 +235,6 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     }
 
     @Test
-    @Ignore("Keys.RETURN loses active position indication")
     public void testNavigationInSelectionWithEnterAndTab() throws Exception {
         setAddressFieldValue("A1:C2");
         // Assert that everything is selected
@@ -243,10 +242,10 @@ public class NavigationIT extends AbstractSpreadsheetIT {
 
         // Press enter/return 2 times to end up in cell B1
         assertActiveCellInsideSelection("A1");
-        new Actions(getDriver()).sendKeys(Keys.ENTER, Keys.ENTER).build()
+        new Actions(getDriver()).sendKeys(Keys.ENTER).build()
                 .perform();
         assertActiveCellInsideSelection("A2");
-        new Actions(getDriver()).sendKeys(Keys.ENTER, Keys.ENTER).build()
+        new Actions(getDriver()).sendKeys(Keys.ENTER).build()
                 .perform();
         assertActiveCellInsideSelection("B1");
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NavigationIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NavigationIT.java
@@ -242,11 +242,9 @@ public class NavigationIT extends AbstractSpreadsheetIT {
 
         // Press enter/return 2 times to end up in cell B1
         assertActiveCellInsideSelection("A1");
-        new Actions(getDriver()).sendKeys(Keys.ENTER).build()
-                .perform();
+        new Actions(getDriver()).sendKeys(Keys.ENTER).build().perform();
         assertActiveCellInsideSelection("A2");
-        new Actions(getDriver()).sendKeys(Keys.ENTER).build()
-                .perform();
+        new Actions(getDriver()).sendKeys(Keys.ENTER).build().perform();
         assertActiveCellInsideSelection("B1");
 
         // Continue from B1 by pressing TAB twice, getting to A2 and shift tab


### PR DESCRIPTION
- testFloatOperations passes locally now
- testNavigationInSelectionWithEnterAndTab was authored wrong, it applied 4 enter presses where 2 was expected. With the correct script, the tests passes locally