### PR TITLE
refactor: remove useless function from grid connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -675,9 +675,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
             cache[pkey][page] = slice;
 
-            grid.$connector.doSelection(slice.filter((item) => item.selected && !isSelectedOnGrid(item)));
+            grid.$connector.doSelection(slice.filter((item) => item.selected));
             grid.$connector.doDeselection(
-              slice.filter((item) => !item.selected && (selectedKeys[item.key] || isSelectedOnGrid(item)))
+              slice.filter((item) => !item.selected && selectedKeys[item.key])
             );
 
             const updatedItems = updateGridCache(page, pkey);
@@ -809,17 +809,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           }
           grid._cache.updateSize();
         });
-
-        const isSelectedOnGrid = function (item) {
-          const selectedItems = grid.selectedItems;
-          for (let i = 0; i < selectedItems; i++) {
-            let selectedItem = selectedItems[i];
-            if (selectedItem.key === item.key) {
-              return true;
-            }
-          }
-          return false;
-        };
 
         grid.$connector.reset = tryCatchWrapper(function () {
           grid.size = 0;


### PR DESCRIPTION
## Description

Removes the `isSelectedOnGrid` function which has a flawed implementation in that it always returns false, effectively doing nothing in the places where it's used.

Closes #3829

## Type of change

- Refactor