### PR TITLE
fix: blur input when stopping spreadsheet cell edit

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -5306,6 +5306,7 @@ public class SheetWidget extends Panel {
 
         jsniUtil.replaceSelector(editedCellFreezeColumnStyle,
                 ".notusedselector", 0);
+        input.setFocus(false);
         input.setValue("");
         input.setWidth("0");
         input.setHeight("");


### PR DESCRIPTION
Fixes #3909 

The issue occurred when disposing of the `<input>` element that was used for editing the cell. This PR makes the `<input>` lose focus before disposal to avoid the undesired scroll position side effect.