### PR TITLE
fix: ensure style rules to be added in the same order

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/NewSpreadsheetEditPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/NewSpreadsheetEditPage.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.spreadsheet.tests;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 import com.vaadin.flow.router.Route;
@@ -12,9 +13,14 @@ public class NewSpreadsheetEditPage extends Div {
     public NewSpreadsheetEditPage() {
         setSizeFull();
 
+        var freezePaneButton = new Button("Freeze pane", e -> {
+            spreadsheet.createFreezePane(6, 6);
+        });
+        freezePaneButton.setId("freeze-pane-button");
+
         spreadsheet = new Spreadsheet();
         spreadsheet.setSizeFull();
 
-        add(spreadsheet);
+        add(spreadsheet, freezePaneButton);
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NewSpreadsheetEditIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NewSpreadsheetEditIT.java
@@ -4,21 +4,45 @@ import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 @TestPath("vaadin-spreadsheet/new-spreadsheet-edit-page")
 public class NewSpreadsheetEditIT extends AbstractComponentIT {
 
+    SpreadsheetElement spreadsheetElement;
+
+    @Before
+    public void init() {
+        open();
+        spreadsheetElement = $(SpreadsheetElement.class).first();
+    }
+
     @Test
     public void spreadsheetLoaded_cellEdited_valueIsCorrectlySet() {
-        open();
-        SpreadsheetElement spreadsheetElement = $(SpreadsheetElement.class)
-                .first();
+        final var inputValue = "input";
+        final var cellAddress = "B2";
+
         Assert.assertTrue(spreadsheetElement.isDisplayed());
-        String inputValue = "input";
-        String cellAddress = "B2";
         spreadsheetElement.getCellAt(cellAddress).setValue(inputValue);
         Assert.assertEquals(inputValue,
                 spreadsheetElement.getCellAt(cellAddress).getText());
+    }
+
+    @Test
+    public void spreadsheetLoaded_freezePaneCreated_cellMaintainWidth() {
+        final var cellAddress = "F1";
+
+        // The cell width shouldn't change after freeze pane is called
+        final var expectedWidth = getCellWidth(cellAddress);
+        findElement(By.id("freeze-pane-button")).click();
+        final var actualWidth = getCellWidth(cellAddress);
+
+        Assert.assertEquals(expectedWidth, actualWidth);
+    }
+
+    private String getCellWidth(String cellAddress) {
+        return spreadsheetElement.getCellAt(cellAddress).getCssValue("width");
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
@@ -200,7 +200,9 @@ export class VaadinSpreadsheet extends LitElement {
       document.head.appendChild(e);
       const rulesToBeAdded = e.__removedRules;
       for (let i = 0; i < rulesToBeAdded.length; i++) {
-        e.sheet.insertRule(rulesToBeAdded.item(i).cssText);
+        // To guarantee that the rules are added on the same order
+        // they were added by spreadsheet, we pass current index
+        e.sheet.insertRule(rulesToBeAdded.item(i).cssText, i);
       }
     });
   }


### PR DESCRIPTION
## Description

`SpreadsheetWidget` creates styles with some rules having `.notusedselector` as the selector.
These rules selectors can be changed depending on the sheet state. For instance, if a freeze pane is set, `SpreadsheetWidget` changes one of these rules to target the cells on the edge of the pane.
To do that, the order of rules needs to be respected, so the right rules get replaced.

To fix #3369, the changes in #3837 save the rules for each style in `disconnectedCallback` to be reinserted again in `connectedCallback`.
However, the rules are added in reversed order, so when `SpreadsheetWidget` needs to replace the selector, it gets the wrong rule, causing the issue described in #3910.

This change ensures that rules are added in the same order as done by `SpreadsheetWidget`.

Fixes #3910

## Type of change

- [X] Bugfix
- [ ] Feature