### PR TITLE
test: wait for tooltip overlay to open

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -66,6 +66,7 @@ public class MenuBarTooltipIT extends AbstractComponentIT {
         executeScript(
                 "arguments[0].dispatchEvent(new Event('mouseover', {bubbles:true}))",
                 button);
+        waitForElementPresent(By.tagName("vaadin-tooltip-overlay"));
     }
 
     private String getActiveTooltipText() {


### PR DESCRIPTION
## Description

Tried to fast the following ITs by waiting for the overlay element to open:

```
MenuBarTooltipIT.hoverOverMenuBarButton_showTooltip[ANY_Chrome_]
--
org.openqa.selenium.NoSuchElementException: no such element: Unable to locate element: {"method":"tag name","selector":"vaadin-tooltip-overlay"}

MenuBarTooltipIT.toggleAttached_hoverOverTooltipColumnCell_showTooltip[ANY_Chrome_]
--
org.openqa.selenium.NoSuchElementException: no such element: Unable to locate element: {"method":"tag name","selector":"vaadin-tooltip-overlay"}
```

## Type of change

- Tests