### PR TITLE
fix: include `CellData.value` on object serialization

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ScrollingIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ScrollingIT.java
@@ -1,0 +1,26 @@
+package com.vaadin.flow.component.spreadsheet.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ScrollingIT extends AbstractSpreadsheetIT {
+
+    @Before
+    public void init() {
+        getDriver().get(getBaseURL());
+        loadFile("freezepanels.xlsx");
+        selectSheetAt(2);
+    }
+
+    @Test
+    public void cellCustomStyle_sheetIsScrolledToRightAndLeft_cellStyleNotRemoved() {
+        final var cellAddress = "E1";
+        final var expectedCellColor = getCellColor(cellAddress);
+        getSpreadsheet().scrollLeft(1000);
+        getSpreadsheet().scrollLeft(0);
+        final var actualCellColor = getCellColor(cellAddress);
+
+        Assert.assertEquals(expectedCellColor, actualCellColor);
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/CellData.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/CellData.java
@@ -13,6 +13,8 @@ package com.vaadin.flow.component.spreadsheet.client;
  * #L%
  */
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.io.Serializable;
 
 @SuppressWarnings("serial")
@@ -20,6 +22,7 @@ public class CellData implements Serializable {
 
     public int row;
     public int col;
+    @JsonInclude
     public String value;
     public String formulaValue;
     public String originalValue;


### PR DESCRIPTION
## Description

`SheetWidget` keeps a map with cached `CellData`, but a new entry is only added if the `CellData` object has the property `value` different from `null`. The serialization done to send data from the server to the client ignores properties that have null or empty values.

This breaks the following logic because `SheetWidget` won't put the entry to the map due to the missing property:

https://github.com/vaadin/flow-components/blob/5876423ab1e14d4888ea5f8d800c6bfca5e0d6f1/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java#L4193-L4197

Fixes #3911

## Type of change

- [X] Bugfix
- [ ] Feature
