### PR TITLE
fix: update sorters only if grid is attached (#3292) (CP: 14.9)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-grid/detach-reattach-page")
+public class DetachReattachPage extends Div {
+    public DetachReattachPage() {
+        Grid<String> grid = new Grid<String>();
+        grid.setItems("A", "B", "C");
+        grid.addColumn(x -> x).setHeader("Col").setSortable(true);
+
+        grid.setSelectionMode(Grid.SelectionMode.SINGLE);
+
+        NativeButton btnAttach = new NativeButton("Attach", e -> add(grid));
+        btnAttach.setId("attach-button");
+
+        NativeButton btnDetach = new NativeButton("Detach", e -> remove(grid));
+        btnDetach.setId("detach-button");
+
+        NativeButton resetSortingButton = new NativeButton("Reset sorting",
+                e -> {
+                    grid.sort(null);
+                });
+        resetSortingButton.setId("reset-sorting-button");
+
+        add(btnAttach, btnDetach, resetSortingButton, grid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Test;
+
+@TestPath("vaadin-grid/detach-reattach-page")
+public class DetachReattachIt extends AbstractComponentIT {
+
+    @Test
+    public void detachAndReattach_resetSorting_noErrorIsThrown() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        grid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
+
+        // Detach, reset sorting and re-attach
+        $("button").id("detach-button").click();
+
+        $("button").id("reset-sorting-button").click();
+
+        $("button").id("attach-button").click();
+
+        // Check that there are no new exceptions/errors thrown
+        // after re-attaching the grid when sorting is reset
+        checkLogsForErrors();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3142,8 +3142,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             }
             directions.set(i, direction);
         }
-        getElement().callJsFunction("$connector.setSorterDirections",
-                directions);
+
+        if (getElement().getNode().isAttached()) {
+            getElement().callJsFunction("$connector.setSorterDirections",
+                    directions);
+        }
     }
 
     private void sort(boolean userOriginated) {


### PR DESCRIPTION
Cherry-pick of #3292 

Part of #3959, see https://github.com/vaadin/flow-components/issues/3959#issuecomment-1293611904. I'll add tests for that issue in a separate PR.

(cherry picked from commit 6b697e4f222fe3214dd601933d22e24e95e5392f)
