### PR TITLE
test: add initial multi-sort IT

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/InitialMultiSortPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/InitialMultiSortPage.java
@@ -1,0 +1,49 @@
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridSortOrder;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.router.Route;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Route("vaadin-grid/initial-multi-sort")
+public class InitialMultiSortPage extends Div {
+    int clientSortEventCount = 0;
+    Span clientSortEventCountSpan = new Span();
+
+    public InitialMultiSortPage() {
+        Grid<String> grid = new Grid<>();
+
+        Grid.Column<String> firstColumn = grid.addColumn(value -> "A" + value)
+                .setSortable(true).setHeader("A");
+        Grid.Column<String> secondColumn = grid.addColumn(value -> "B" + value)
+                .setSortable(true).setHeader("B");
+
+        List<GridSortOrder<String>> sorts = new ArrayList<>();
+        sorts.add(new GridSortOrder<>(firstColumn, SortDirection.DESCENDING));
+        sorts.add(new GridSortOrder<>(secondColumn, SortDirection.ASCENDING));
+
+        grid.setMultiSort(true);
+        grid.sort(sorts);
+        add(grid);
+
+        add(clientSortEventCountSpan);
+        clientSortEventCountSpan.setId("client-sort-event-count");
+        updateEventCountSpan();
+        grid.addSortListener(e -> {
+            if (e.isFromClient()) {
+                clientSortEventCount++;
+                updateEventCountSpan();
+            }
+        });
+    }
+
+    private void updateEventCountSpan() {
+        clientSortEventCountSpan
+                .setText("Client sort events: " + clientSortEventCount);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/InitialMultiSortIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/InitialMultiSortIT.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-grid/initial-multi-sort")
+public class InitialMultiSortIT extends AbstractComponentIT {
+    private TestBenchElement clientSortEventCount;
+
+    @Before
+    public void init() {
+        open();
+        clientSortEventCount = $("span").id("client-sort-event-count");
+    }
+
+    @Test
+    public void initialMultiSort_noClientSideSortEvents() {
+        Assert.assertEquals("Client sort events: 0",
+                clientSortEventCount.getText());
+    }
+}


### PR DESCRIPTION
## Description

Adds an integration test to verify that setting an initial multi-sort does not trigger client-side sort change events. This effectively tests this condition, which was added for a different reason as part of https://github.com/vaadin/flow-components/pull/3292:
https://github.com/vaadin/flow-components/blob/37071dd840b85c64d014bf42aebaea8317b8b6c1/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java#L3473-L3476

Adding this test and back-porting #3292 to 14 (see #3964) effectively resolves #3959.

Closes https://github.com/vaadin/flow-components/issues/3959

