### PR TITLE
chore: remove the license-checker dependency from project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -623,12 +623,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <!--testing use -->
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>license-checker</artifactId>
-            <version>1.10.1</version>
-        </dependency>
-    </dependencies>
 </project>


### PR DESCRIPTION
this was added when flow doesn't have the related change now this should come from flow directly
so let us remove it here

part of https://github.com/vaadin/flow-components/issues/3816