### PR TITLE
fix: update sorters only if grid is attached (#3292) (CP: 22)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -50,6 +50,7 @@ public class DetachReattachPage extends Div {
                 });
         resetSortingButton.setId("reset-sorting-button");
 
-        add(btnAttach, btnDetach, btnDisallowDeselect, resetSortingButton, grid);
+        add(btnAttach, btnDetach, btnDisallowDeselect, resetSortingButton,
+                grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -26,7 +26,7 @@ public class DetachReattachPage extends Div {
     public DetachReattachPage() {
         Grid<String> grid = new Grid<String>();
         grid.setItems("A", "B", "C");
-        grid.addColumn(x -> x).setHeader("Col");
+        grid.addColumn(x -> x).setHeader("Col").setSortable(true);
 
         grid.setSelectionMode(Grid.SelectionMode.SINGLE);
 
@@ -44,6 +44,12 @@ public class DetachReattachPage extends Div {
                 });
         btnDisallowDeselect.setId("disallow-deselect-button");
 
-        add(btnAttach, btnDetach, btnDisallowDeselect, grid);
+        NativeButton resetSortingButton = new NativeButton("Reset sorting",
+                e -> {
+                    grid.sort(null);
+                });
+        resetSortingButton.setId("reset-sorting-button");
+
+        add(btnAttach, btnDetach, btnDisallowDeselect, resetSortingButton, grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIt.java
@@ -52,4 +52,23 @@ public class DetachReattachIt extends AbstractComponentIT {
         Assert.assertTrue("Deselection is still disallowed after re-attach.",
                 grid.getRow(1).isSelected());
     }
+
+    @Test
+    public void detachAndReattach_resetSorting_noErrorIsThrown() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        grid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
+
+        // Detach, reset sorting and re-attach
+        $("button").id("detach-button").click();
+
+        $("button").id("reset-sorting-button").click();
+
+        $("button").id("attach-button").click();
+
+        // Check that there are no new exceptions/errors thrown
+        // after re-attaching the grid when sorting is reset
+        checkLogsForErrors();
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3322,8 +3322,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             }
             directions.set(i, direction);
         }
-        getElement().callJsFunction("$connector.setSorterDirections",
-                directions);
+
+        if (getElement().getNode().isAttached()) {
+            getElement().callJsFunction("$connector.setSorterDirections",
+                    directions);
+        }
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of #3292 

(cherry picked from commit 6b697e4f222fe3214dd601933d22e24e95e5392f)
