### PR TITLE
fix: improve the check if an event originates from shadow root

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -427,7 +427,7 @@ public class SheetWidget extends Panel {
 
     static native Element getEventTarget(NativeEvent event)
     /*-{
-       if (!event.target || event.target.localName === 'vaadin-spreadsheet') {
+       if (!event.target || event.target.shadowRoot) {
            return event.composedPath()[0];
        }
        return event.target;


### PR DESCRIPTION
Follow-up fix to https://github.com/vaadin/flow-components/pull/3977

Improve the check in `SheetWidget.getEventTarget(NativeEvent event)` to also fall back to `composedPath()` if the event target is some custom element other than `<vaadin-spreadsheet>` (for example the spreadsheet itself may be wrapped inside another shadow root).