### PR TITLE
chore: remove apache snapshot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,10 +152,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>apache snapshots</id>
-            <url>https://repository.apache.org/content/repositories/snapshots</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
flow has removed the snapshot dependency, so let us remove the snapshot repo
fix #3816

