### PR TITLE
fix: fix spreadsheet context menu positioning

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetConnector.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetConnector.java
@@ -30,7 +30,6 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.ContextMenuHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.addon.spreadsheet.client.SpreadsheetWidget.SheetContextMenuHandler;
@@ -38,6 +37,7 @@ import com.vaadin.addon.spreadsheet.shared.SpreadsheetState;
 import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.ConnectorHierarchyChangeEvent;
+import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractHasComponentsConnector;
 import com.vaadin.client.ui.Action;
@@ -85,18 +85,17 @@ public class SpreadsheetConnector extends AbstractHasComponentsConnector
             int left;
             int top;
             if (latestCellContextMenuEvent != null) {
-                left = SpreadsheetWidget
+                left = WidgetUtil
                         .getTouchOrMouseClientX(latestCellContextMenuEvent);
-                top = SpreadsheetWidget
+                top = WidgetUtil
                         .getTouchOrMouseClientY(latestCellContextMenuEvent);
             } else {
-                left = SpreadsheetWidget
+                left = WidgetUtil
                         .getTouchOrMouseClientX(latestHeaderContextMenuEvent);
-                top = SpreadsheetWidget
+                top = WidgetUtil
                         .getTouchOrMouseClientY(latestHeaderContextMenuEvent);
             }
-            top += Window.getScrollTop();
-            left += Window.getScrollLeft();
+
             getConnection().getContextMenu().showAt(new ActionOwner() {
 
                 @Override

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ContextMenuIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ContextMenuIT.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.interactions.Actions;
 
@@ -15,6 +16,25 @@ public class ContextMenuIT extends AbstractSpreadsheetIT {
         getDriver().get(getBaseURL());
 
         loadFile("conditional_formatting_with_formula_on_second_sheet.xlsx");
+    }
+
+    @Test
+    public void documentScroll_overlayPosition() {
+        // Make sure to use a small enough viewport so that the document needs
+        // to be scrolled to see the cell
+        getDriver().manage().window().setSize(WINDOW_SIZE_SMALL);
+        // Scroll the document horizontally
+        executeScript("document.documentElement.scrollLeft = 100");
+
+        var cell = getSpreadsheet().getCellAt("B2");
+        // Open context menu for the cell
+        cell.contextClick();
+
+        var cellRect = cell.getRect();
+        var overlayRect = findElement(By.className("v-contextmenu")).getRect();
+        // Assert that the overlay is positioned over the cell
+        assertInRange(cellRect.x, overlayRect.x, cellRect.x + cellRect.width);
+        assertInRange(cellRect.y, overlayRect.y, cellRect.y + cellRect.height);
     }
 
     @Test


### PR DESCRIPTION
## Description

If the document is scrolled, the coordinates for the Spreadsheet context menu get miscalculated. This PR fixes the positioning logic.

The issue also occurs with the V8 Spreadsheet but it becomes very apparent with the Flow spreadsheet once embedded on the Vaadin docs page where you need to scroll the document to see the Spreadsheet:

![Screenshot 2022-11-03 at 15 57 46](https://user-images.githubusercontent.com/1222264/199740282-6dfbe188-d5b0-4964-8916-6d431de8755a.png)

## Type of change

- [X] Bugfix
- [ ] Feature
