### PR TITLE
refactor: use date-fns for locale-based parsing and formatting

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -1,94 +1,40 @@
 package com.vaadin.flow.component.datepicker;
 
-import java.time.LocalDate;
-import java.time.Month;
-import java.util.Locale;
-
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
+
+import java.util.Locale;
 
 @Route("vaadin-date-picker/date-picker-locale")
 public class DatePickerLocalePage extends Div {
-
-    private final LocalDate may3rd = LocalDate.of(2018, Month.MAY, 3);
-
     public DatePickerLocalePage() {
-        createDatePicker();
-        createDatePickerWithGermanLocale();
-        createDatePickerWithValue();
-        createDatePickerWithValueAndChinaLocale();
-        createDatePickerWithValueAndFrenchLocale();
-        createDatePickerWithValueAndPolishLocale();
-        createDatePickerWithValueAndKoreanLocale();
-    }
-
-    private void createDatePicker() {
         DatePicker datePicker = new DatePicker();
         datePicker.setId("picker");
 
-        NativeButton setUKLocale = new NativeButton("Set UK locale");
-        setUKLocale.setId("picker-set-uk-locale");
-        setUKLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
+        Input localeInput = new Input();
+        localeInput.setId("locale-input");
+        localeInput.setPlaceholder("Enter locale string");
+        NativeButton applyLocale = new NativeButton("Apply locale", e -> {
+            String localeString = localeInput.getValue();
+            String[] localeParts = localeString.split("_");
+            Locale locale = null;
+            if (localeParts.length == 1) {
+                locale = new Locale(localeParts[0]);
+            }
+            if (localeParts.length == 2) {
+                locale = new Locale(localeParts[0], localeParts[1]);
+            }
+            if (localeParts.length == 3) {
+                locale = new Locale(localeParts[0], localeParts[1],
+                        localeParts[2]);
+            }
 
-        NativeButton setInvalidLocale = new NativeButton("Set invalid locale");
-        setInvalidLocale.addClickListener(
-                event -> datePicker.setLocale(new Locale("i", "i", "i")));
-        setInvalidLocale.setId("picker-set-invalid-locale");
+            datePicker.setLocale(locale);
+        });
+        applyLocale.setId("apply-locale");
 
-        addCard("DatePicker", datePicker, setUKLocale, setInvalidLocale);
+        add(datePicker, localeInput, applyLocale);
     }
-
-    private void createDatePickerWithGermanLocale() {
-        DatePicker datePicker = new DatePicker(null, Locale.GERMAN);
-        datePicker.setId("picker-with-german-locale");
-        addCard("DatePicker with German locale", datePicker);
-    }
-
-    private void createDatePickerWithValue() {
-        DatePicker datePicker = new DatePicker(may3rd);
-        datePicker.setId("picker-with-value");
-
-        NativeButton setUKLocale = new NativeButton("Set UK locale");
-        setUKLocale.setId("picker-with-value-set-uk-locale");
-        setUKLocale.addClickListener(e -> datePicker.setLocale(Locale.UK));
-
-        addCard("DatePicker with value", datePicker, setUKLocale);
-    }
-
-    private void createDatePickerWithValueAndFrenchLocale() {
-        DatePicker datePicker = new DatePicker(may3rd, Locale.FRENCH);
-        datePicker.setId("picker-with-value-and-french-locale");
-        addCard("DatePicker with value and French locale", datePicker);
-    }
-
-    private void createDatePickerWithValueAndPolishLocale() {
-        DatePicker datePicker = new DatePicker(may3rd, new Locale("pl", "PL"));
-        datePicker.setId("picker-with-value-and-polish-locale");
-        addCard("DatePicker with value and Polish locale", datePicker);
-    }
-
-    private void createDatePickerWithValueAndKoreanLocale() {
-        DatePicker datePicker = new DatePicker(may3rd, new Locale("ko", "KR"));
-        datePicker.setId("picker-with-value-and-korean-locale");
-        addCard("DatePicker with value and Korean locale", datePicker);
-    }
-
-    private void createDatePickerWithValueAndChinaLocale() {
-        DatePicker datePicker = new DatePicker(may3rd, Locale.CHINA);
-        datePicker.setId("picker-with-value-and-china-locale");
-        addCard("DatePicker with value and China locale", datePicker);
-    }
-
-    private void addCard(String title, Component... components) {
-        VerticalLayout layout = new VerticalLayout();
-        layout.setMargin(true);
-        layout.add(new H2(title));
-        layout.add(components);
-        add(layout);
-    }
-
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -2,10 +2,13 @@ package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,40 +23,89 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("vaadin-date-picker/date-picker-locale")
 public class DatePickerLocaleIT extends AbstractComponentIT {
 
+    private DatePickerElement picker;
+
     @Before
     public void init() {
         open();
+        picker = $(DatePickerElement.class).id("picker");
     }
 
     @Test
-    public void datePickerWithValueAndLocale_assertDisplayedValue() {
-        DatePickerElement chinaLocalePicker = $(DatePickerElement.class)
-                .id("picker-with-value-and-china-locale");
+    public void datePickerWithValue_setLocale_assertDisplayedValue() {
+        picker.setDate(LocalDate.of(2018, Month.MAY, 3));
+
+        applyLocale(Locale.CHINA);
         Assert.assertEquals("Should display the value using China date format",
-                "2018/5/3", chinaLocalePicker.getInputValue());
+                "2018/5/3", picker.getInputValue());
 
-        DatePickerElement frenchLocalePicker = $(DatePickerElement.class)
-                .id("picker-with-value-and-french-locale");
+        applyLocale(Locale.FRENCH);
         Assert.assertEquals("Should display the value using French date format",
-                "03/05/2018", frenchLocalePicker.getInputValue());
+                "03/05/2018", picker.getInputValue());
 
-        DatePickerElement koreanLocalePicker = $(DatePickerElement.class)
-                .id("picker-with-value-and-korean-locale");
+        applyLocale(new Locale("ko", "KR"));
         Assert.assertEquals("Should display the value using Korean date format",
-                "2018. 5. 3.", koreanLocalePicker.getInputValue());
+                "2018. 5. 3.", picker.getInputValue());
 
-        DatePickerElement polishLocalePicker = $(DatePickerElement.class)
-                .id("picker-with-value-and-polish-locale");
+        applyLocale(new Locale("pl", "PL"));
         Assert.assertEquals("Should display the value using Polish date format",
-                "3.05.2018", polishLocalePicker.getInputValue());
+                "3.05.2018", picker.getInputValue());
+
+        applyLocale(new Locale("bg"));
+        Assert.assertEquals(
+                "Should display the value using Bulgarian date format",
+                "3.05.2018 г.", picker.getInputValue());
+
+        assertNoWarnings();
+    }
+
+    @Test
+    public void datePickerWithLocale_enterValue_assertParsedValue() {
+        LocalDate mayThird = LocalDate.of(2018, Month.MAY, 3);
+
+        applyLocale(Locale.CHINA);
+        picker.setInputValue("2018/5/3");
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals("Should parse the value using China date format",
+                mayThird, picker.getDate());
+
+        picker.setDate(null);
+        applyLocale(Locale.FRENCH);
+        picker.setInputValue("03/05/2018");
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals("Should parse the value using French date format",
+                mayThird, picker.getDate());
+
+        picker.setDate(null);
+        applyLocale(new Locale("ko", "KR"));
+        picker.setInputValue("2018. 5. 3.");
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals("Should parse the value using Korean date format",
+                mayThird, picker.getDate());
+
+        picker.setDate(null);
+        applyLocale(new Locale("pl", "PL"));
+        picker.setInputValue("3.05.2018");
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals("Should parse the value using Polish date format",
+                mayThird, picker.getDate());
+
+        picker.setDate(null);
+        applyLocale(new Locale("bg"));
+        picker.setInputValue("3.05.2018 г.");
+        picker.sendKeys(Keys.TAB);
+        Assert.assertEquals(
+                "Should parse the value using Bulgarian date format", mayThird,
+                picker.getDate());
 
         assertNoWarnings();
     }
 
     @Test
     public void datePickerWithValueAndLocale_blur_assertDisplayedValue() {
-        DatePickerElement picker = $(DatePickerElement.class)
-                .id("picker-with-value-and-polish-locale");
+        picker.setDate(LocalDate.of(2018, Month.MAY, 3));
+        applyLocale(new Locale("pl", "PL"));
+
         // trigger the validation on the from clientside
         picker.sendKeys(Keys.TAB);
         Assert.assertEquals("Should display the value using Polish date format",
@@ -66,13 +118,12 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
     @Test
     public void datePicker_setValue_setLocale_assertDisplayedValue() {
-        DatePickerElement picker = $(DatePickerElement.class).id("picker");
-
         picker.setDate(LocalDate.of(2018, Month.MAY, 3));
-        $("button").id("picker-set-uk-locale").click();
+
+        applyLocale(Locale.UK);
+
         Assert.assertEquals("Should display the value using UK date format",
                 "03/05/2018", picker.getInputValue());
-
         assertNoWarnings();
     }
 
@@ -80,7 +131,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     public void datePicker_setInvalidLocale_warningIsShown() {
         assertNoWarnings();
 
-        $("button").id("picker-set-invalid-locale").click();
+        applyLocale(new Locale("i", "i", "i"));
 
         waitUntil(driver -> getWarningEntries().toString().contains(
                 "The locale is not supported, using default locale setting(en-US)."));
@@ -88,9 +139,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
     @Test
     public void datePicker_setInvalidLocale_defaultUSLocaleIsUsed() {
-        DatePickerElement picker = $(DatePickerElement.class).id("picker");
-
-        $("button").id("picker-set-invalid-locale").click();
+        applyLocale(new Locale("i", "i", "i"));
         picker.setDate(LocalDate.of(2018, Month.MAY, 3));
 
         Assert.assertEquals(
@@ -99,21 +148,35 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     }
 
     @Test
-    public void datePickerWithValue_setLocale_assertDisplayedValue() {
-        DatePickerElement picker = $(DatePickerElement.class)
-                .id("picker-with-value");
-
-        $("button").id("picker-with-value-set-uk-locale").click();
-        Assert.assertEquals("Should display the value using UK date format",
-                "03/05/2018", picker.getInputValue());
-
+    public void datePicker_setUnsupportedLocale_warningIsShown() {
         assertNoWarnings();
+
+        applyLocale(new Locale("th", "TH"));
+
+        waitUntil(driver -> getWarningEntries().toString().contains(
+                "The locale is not supported, using default locale setting(en-US)."));
+    }
+
+    @Test
+    public void datePicker_setUnsupportedLocale_defaultUSLocaleIsUsed() {
+        picker.setDate(LocalDate.of(2018, Month.MAY, 3));
+
+        List<Locale> unsupportedLocales = List.of(new Locale("ar", "SA"),
+                new Locale("th", "TH"), new Locale("fa"), new Locale("ks"));
+
+        unsupportedLocales.forEach(unsupportedLocale -> {
+            applyLocale(unsupportedLocale);
+
+            Assert.assertEquals(
+                    "Should display the value using the default US date format for locale "
+                            + unsupportedLocale,
+                    "5/3/2018", picker.getInputValue());
+        });
     }
 
     @Test
     public void datePickerWithLocale_setInputValue_blur_assertDisplayedValue() {
-        DatePickerElement picker = $(DatePickerElement.class)
-                .id("picker-with-german-locale");
+        applyLocale(Locale.GERMAN);
 
         picker.setInputValue("3.5.2018");
         picker.sendKeys(Keys.TAB);
@@ -121,6 +184,16 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 "3.5.2018", picker.getInputValue());
 
         assertNoWarnings();
+    }
+
+    private void applyLocale(Locale locale) {
+        TestBenchElement localeInput = $("input").id("locale-input");
+        localeInput.setProperty("value", locale.toString());
+        localeInput.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+
+        TestBenchElement applyLocale = $("button").id("apply-locale");
+        applyLocale.click();
     }
 
     private List<LogEntry> getWarningEntries() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -7,25 +7,6 @@ import dateFnsIsValid from 'date-fns/isValid';
     return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker');
   };
 
-  /* helper class for parsing regex from formatted date string */
-
-  class FlowDatePickerPart {
-    constructor(initial) {
-      this.initial = initial;
-      this.index = 0;
-      this.value = 0;
-    }
-
-    static compare(part1, part2) {
-      if (part1.index < part2.index) {
-        return -1;
-      }
-      if (part1.index > part2.index) {
-        return 1;
-      }
-      return 0;
-    }
-  }
   window.Vaadin.Flow.datepickerConnector = {
     initLazy: (datepicker) =>
       tryCatchWrapper(function (datepicker) {
@@ -35,16 +16,6 @@ import dateFnsIsValid from 'date-fns/isValid';
         }
 
         datepicker.$connector = {};
-
-        /* init helper parts for reverse-engineering date-regex */
-        datepicker.$connector.dayPart = new FlowDatePickerPart('22');
-        datepicker.$connector.monthPart = new FlowDatePickerPart('11');
-        datepicker.$connector.yearPart = new FlowDatePickerPart('1987');
-        datepicker.$connector.parts = [
-          datepicker.$connector.dayPart,
-          datepicker.$connector.monthPart,
-          datepicker.$connector.yearPart
-        ];
 
         datepicker.addEventListener(
           'blur',
@@ -63,18 +34,7 @@ import dateFnsIsValid from 'date-fns/isValid';
           return string.replace(/[^\x00-\x7F]/g, '');
         });
 
-        const getInputValue = tryCatchWrapper(function () {
-          let inputValue = '';
-          try {
-            inputValue = datepicker._inputValue;
-          } catch (err) {
-            /* component not ready: falling back to stored value */
-            inputValue = datepicker.value || '';
-          }
-          return inputValue;
-        });
-
-        const createLocaleBasedFormatterAndParser = tryCatchWrapper(function (locale) {
+        const createLocaleBasedDateFormat = tryCatchWrapper(function(locale) {
           try {
             // Check whether the locale is supported or not
             new Date().toLocaleDateString(locale);
@@ -83,79 +43,26 @@ import dateFnsIsValid from 'date-fns/isValid';
             console.warn('The locale is not supported, using default locale setting(en-US).');
           }
 
-          /* create test-string where to extract parsing regex */
-          let testDate = new Date(
-            Date.UTC(
-              datepicker.$connector.yearPart.initial,
-              datepicker.$connector.monthPart.initial - 1,
-              datepicker.$connector.dayPart.initial
-            )
-          );
-          let testString = cleanString(testDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
-          datepicker.$connector.parts.forEach(function (part) {
-            part.index = testString.indexOf(part.initial);
-          });
-          /* sort items to match correct places in regex groups */
-          datepicker.$connector.parts.sort(FlowDatePickerPart.compare);
-          /* create regex
-           * regex will be the date, so that:
-           * - day-part is '(\d{1,2})' (1 or 2 digits),
-           * - month-part is '(\d{1,2})' (1 or 2 digits),
-           * - year-part is '(\d{1,4})' (1 to 4 digits)
-           *
-           * and everything else is left as is.
-           * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{1,4})".
-           *
-           * The sorting part solves that which part is which (for example,
-           * here the first part is month, second day and third year)
-           *  */
-          datepicker.$connector.regex = testString
-            .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
-            .replace(datepicker.$connector.dayPart.initial, '(\\d{1,2})')
-            .replace(datepicker.$connector.monthPart.initial, '(\\d{1,2})')
-            .replace(datepicker.$connector.yearPart.initial, '(\\d{1,4})');
+          // format test date and convert to date-fns pattern
+          const testDate = new Date(Date.UTC(1234, 4, 6));
+          let pattern = cleanString(testDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
 
-          function formatDate(date) {
-            let rawDate = datepicker._parseDate(`${date.year}-${date.month + 1}-${date.day}`);
-
-            // Workaround for Safari DST offset issue when using Date.toLocaleDateString().
-            // This is needed to keep the correct date in formatted result even if Safari
-            // makes an error of an hour or more in the result with some past dates.
-            // See https://github.com/vaadin/vaadin-date-picker-flow/issues/126#issuecomment-508169514
-            rawDate.setHours(12);
-
-            return cleanString(rawDate.toLocaleDateString(locale));
+          if (/06/.test(pattern)) {
+            pattern = pattern.replace('06', 'dd')
+          } else {
+            pattern = pattern.replace('6', 'd')
           }
-
-          function parseDate(dateString) {
-            dateString = cleanString(dateString);
-
-            if (dateString.length == 0) {
-              return;
-            }
-
-            let match = dateString.match(datepicker.$connector.regex);
-            if (match && match.length == 4) {
-              for (let i = 1; i < 4; i++) {
-                datepicker.$connector.parts[i - 1].value = parseInt(match[i]);
-              }
-              return {
-                day: datepicker.$connector.dayPart.value,
-                month: datepicker.$connector.monthPart.value - 1,
-                year: datepicker.$connector.yearPart.value
-              };
-            } else {
-              return false;
-            }
+          if (/05/.test(pattern)) {
+            pattern = pattern.replace('05', 'MM')
+          } else {
+            pattern = pattern.replace('5', 'M')
           }
+          pattern = pattern.replace('1234', 'y')
 
-          return {
-            formatDate: formatDate,
-            parseDate: parseDate
-          };
+          return pattern;
         });
 
-        const createCustomFormatBasedFormatterAndParser = tryCatchWrapper(function (formats) {
+        const createFormatterAndParser = tryCatchWrapper(function (formats) {
           if (!formats || formats.length === 0) {
             throw new Error('Array of custom date formats is null or empty');
           }
@@ -189,15 +96,10 @@ import dateFnsIsValid from 'date-fns/isValid';
         });
 
         datepicker.$connector.updateI18n = tryCatchWrapper(function (locale, i18n) {
-          // Create formatting and parsing functions, either based on custom formats set in i18n object,
-          // or based on the locale set in the date picker
-          // Custom formats take priority over locale
-          const hasDateFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
-          const formatterAndParser = hasDateFormats
-            ? createCustomFormatBasedFormatterAndParser(i18n.dateFormats)
-            : locale
-            ? createLocaleBasedFormatterAndParser(locale)
-            : null;
+          // Either use custom formats specified in I18N, or create format from locale
+          const hasCustomFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
+          const usedFormats = hasCustomFormats ? i18n.dateFormats : [createLocaleBasedDateFormat(locale)];
+          const formatterAndParser = createFormatterAndParser(usedFormats);
 
           // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
           datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);


### PR DESCRIPTION
## Description

Changes the date picker connector to use date-fns for locale-based parsing and formatting instead of implementing custom logic.
- creates a date-dns pattern from the output of `Date.toLocaleDateString(locale)` instead of creating a regex for parsing
- re-uses the existing date-fns parsing and formatting logic using the created pattern, removes custom parsing and formatting logic for locale-based mode
- adds additional check for unsupported locales and falls back to `en-US` if a valid pattern could not be created
- restructure locale-based ITs to use a single date picker that allows changing the locale

## Type of change

- Refactoring

