### PR TITLE
fix: clear selected key when item selected

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
@@ -53,6 +53,7 @@ public class ComboBoxPage extends Div {
         createWithUpdateProvider();
         createWithValueChangeListener();
         createWithUpdatableValue();
+        createWithUpdateOnValueChange();
         createWithPresetValue();
         createWithButtonRenderer();
         setLabelGeneratorAfterValue();
@@ -167,6 +168,22 @@ public class ComboBoxPage extends Div {
         message.setId("updatable-combo-message");
         button.setId("updatable-combo-button");
         add(combo, message, button);
+    }
+
+    private void createWithUpdateOnValueChange() {
+        ComboBox<String> combo = new ComboBox<>();
+        combo.setItems("1", "2", "3");
+        combo.setValue("1");
+        AtomicInteger i = new AtomicInteger(1);
+        
+        NativeButton button = new NativeButton("Set next");
+        button.addClickListener(e -> {
+            combo.setValue(""+i.addAndGet(1));
+        });
+        button.setId("set-next-button");
+
+        combo.setId("update-on-change-combo");
+        add(combo, button);
     }
 
     private void setLabelGeneratorAfterValue() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
 
-import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +25,8 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
 
 import static org.junit.Assert.assertFalse;
 
@@ -174,6 +175,31 @@ public class ComboBoxPageIT extends AbstractComboBoxIT {
         Assert.assertEquals("Item 2", getSelectedItemLabel(combo));
         Assert.assertEquals("Value: Item 2 isFromClient: false",
                 message.getText());
+    }
+
+    @Test
+    public void changeValue_oldSelectedItemKeyIsReset() {
+        ComboBoxElement combo = $(ComboBoxElement.class)
+                .id("update-on-change-combo");
+        combo.openPopup();
+
+        TestBenchElement overlay = $("vaadin-combo-box-overlay").first();
+        ElementQuery<TestBenchElement> items = overlay.$("div").id("content")
+                .$("vaadin-combo-box-item");
+
+        TestBenchElement item1 = items.get(0);
+        TestBenchElement item2 = items.get(1);
+
+        Assert.assertTrue(item1.hasAttribute("selected"));
+        Assert.assertFalse(item2.hasAttribute("selected"));
+
+        WebElement button = findElement(By.id("set-next-button"));
+        button.click();
+
+        combo.openPopup();
+
+        Assert.assertFalse(item1.hasAttribute("selected"));
+        Assert.assertTrue(item2.hasAttribute("selected"));
     }
 
     @Test


### PR DESCRIPTION
Integration tests so far

I assumed that fix should be backport of this https://github.com/vaadin/flow-components/pull/2618/files

However I noticed that
1. The original integration test is possibly too thin, this PR now includes better one that really fails when not fixed
2. I tested locally the original fix for newer Vaadin version, but integration test still fails

Fixes #4009