### PR TITLE
refactor!: remove template usage from grid header and footer

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewFilteringIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewFilteringIT.java
@@ -42,8 +42,7 @@ public class GridViewFilteringIT extends AbstractComponentIT {
 
         IntStream.range(0, 4).forEach(i -> {
             GridTHTDElement headerCell = grid.getHeaderCell(i);
-            assertRendereredHeaderCell(headerCell, "<vaadin-text-field", true,
-                    false);
+            assertRendereredHeaderCell(headerCell, "<vaadin-text-field", false);
         });
 
         grid.findElement(By.tagName("vaadin-text-field")).sendKeys("6");
@@ -66,16 +65,13 @@ public class GridViewFilteringIT extends AbstractComponentIT {
     }
 
     private void assertRendereredHeaderCell(GridTHTDElement headerCell,
-            String text, boolean componentRenderer, boolean withSorter) {
+            String text, boolean withSorter) {
 
         String html = headerCell.getInnerHTML();
         if (withSorter) {
             Assert.assertTrue(html.contains("<vaadin-grid-sorter"));
         } else {
             Assert.assertFalse(html.contains("<vaadin-grid-sorter"));
-        }
-        if (componentRenderer) {
-            Assert.assertTrue(html.contains("<flow-component-renderer"));
         }
         Assert.assertTrue(html.contains(text));
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsIT.java
@@ -42,32 +42,23 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
                 .id("grid-with-header-and-footer-rows");
         scrollToElement(grid);
 
-        assertRendereredHeaderCell(grid.getHeaderCell(0), "Name", false, true);
-        assertRendereredHeaderCell(grid.getHeaderCell(1), "Age", false, true);
-        assertRendereredHeaderCell(grid.getHeaderCell(2), "Street", false,
-                false);
-        assertRendereredHeaderCell(grid.getHeaderCell(3), "Postal Code", false,
-                false);
-
-        List<WebElement> columnGroups = grid
-                .findElements(By.tagName("vaadin-grid-column-group"));
+        assertRendereredHeaderCell(grid.getHeaderCell(0), "Name", true);
+        assertRendereredHeaderCell(grid.getHeaderCell(1), "Age", true);
+        assertRendereredHeaderCell(grid.getHeaderCell(2), "Street", false);
+        assertRendereredHeaderCell(grid.getHeaderCell(3), "Postal Code", false);
 
         Assert.assertTrue(
                 "The first column group should have 'Basic Information' header text",
-                columnGroups.get(0).getAttribute("innerHTML")
+                grid.getHeaderCellContent(0, 0).getText()
                         .contains("Basic Information"));
 
         Assert.assertTrue(
                 "The second column group should have 'Address Information' header text",
-                columnGroups.get(1).getAttribute("innerHTML")
+                grid.getHeaderCellContent(0, 1).getText()
                         .contains("Address Information"));
 
-        List<WebElement> columns = grid
-                .findElements(By.tagName("vaadin-grid-column"));
-
         Assert.assertTrue("There should be a cell with the renderered footer",
-                columns.get(0).getAttribute("innerHTML")
-                        .contains("Total: 500 people"));
+                grid.getFooterCell(0).getText().contains("Total: 500 people"));
     }
 
     @Test
@@ -77,31 +68,30 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
         scrollToElement(grid);
 
         GridTHTDElement headerCell = grid.getHeaderCell(0);
-        assertRendereredHeaderCell(headerCell, "<span>Name</span>", true, true);
+        assertRendereredHeaderCell(headerCell, "<span>Name</span>", true);
 
         headerCell = grid.getHeaderCell(1);
-        assertRendereredHeaderCell(headerCell, "<span>Age</span>", true, true);
+        assertRendereredHeaderCell(headerCell, "<span>Age</span>", true);
 
         headerCell = grid.getHeaderCell(2);
-        assertRendereredHeaderCell(headerCell, "<span>Street</span>", true,
-                false);
+        assertRendereredHeaderCell(headerCell, "<span>Street</span>", false);
 
         headerCell = grid.getHeaderCell(3);
-        assertRendereredHeaderCell(headerCell, "<span>Postal Code</span>", true,
+        assertRendereredHeaderCell(headerCell, "<span>Postal Code</span>",
                 false);
 
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Basic Information' header",
-                hasComponentRendereredHeaderCell(grid,
-                        "<span>Basic Information</span>"));
+                hasComponentRendereredHeaderCell(grid, "span",
+                        "Basic Information"));
 
         Assert.assertTrue("There should be a cell with the renderered footer",
-                hasComponentRendereredHeaderCell(grid,
-                        "<span>Total: 500 people</span>"));
+                hasComponentRendereredHeaderCell(grid, "span",
+                        "Total: 500 people"));
     }
 
     private void assertRendereredHeaderCell(GridTHTDElement headerCell,
-            String text, boolean componentRenderer, boolean withSorter) {
+            String text, boolean withSorter) {
 
         String html = headerCell.getInnerHTML();
         if (withSorter) {
@@ -109,16 +99,12 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
         } else {
             Assert.assertFalse(html.contains("<vaadin-grid-sorter"));
         }
-        if (componentRenderer) {
-            Assert.assertTrue(html.contains("<flow-component-renderer"));
-        }
         Assert.assertTrue(html.contains(text));
     }
 
     private boolean hasComponentRendereredHeaderCell(WebElement grid,
-            String text) {
-        return hasComponentRendereredCell(grid, text,
-                "flow-component-renderer");
+            String tagName, String text) {
+        return hasComponentRendereredCell(grid, text, tagName);
     }
 
     private boolean hasComponentRendereredCell(WebElement grid, String text,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -79,9 +79,7 @@ public class SortingIT extends AbstractComponentIT {
     public void setInitialSortOrder_sorterAriaLabels() {
         findElement(By.id("sort-by-age")).click();
         List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter").all();
-        // The first sorter uses a ComponentRenderer so an aria-label can't be
-        // generated
-        Assert.assertEquals(false, sorters.get(0).hasAttribute("aria-label"));
+        Assert.assertEquals("Sort by Name", sorters.get(0).getAttribute("aria-label"));
         Assert.assertEquals("Sort by Age",
                 sorters.get(1).getAttribute("aria-label"));
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -79,7 +79,8 @@ public class SortingIT extends AbstractComponentIT {
     public void setInitialSortOrder_sorterAriaLabels() {
         findElement(By.id("sort-by-age")).click();
         List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter").all();
-        Assert.assertEquals("Sort by Name", sorters.get(0).getAttribute("aria-label"));
+        Assert.assertEquals("Sort by Name",
+                sorters.get(0).getAttribute("aria-label"));
         Assert.assertEquals("Sort by Age",
                 sorters.get(1).getAttribute("aria-label"));
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -206,8 +206,8 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
 
     private Component replaceChildComponent(Component oldComponent,
             Component newComponent) {
-        if (oldComponent != null
-                && oldComponent.getParent().isPresent() && oldComponent.getParent().get() == this) {
+        if (oldComponent != null && oldComponent.getParent().isPresent()
+                && oldComponent.getParent().get() == this) {
             getElement().removeVirtualChild(oldComponent.getElement());
         }
         if (newComponent != null) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -192,18 +192,52 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         setFooterContent(null, component);
     }
 
+    /**
+     * Sets the content of the column header to either a text or a component,
+     * and triggers a re-render of the header. If both are null, then the
+     * content of the header is cleared.
+     *
+     * @param text
+     *            the new text content, can be null
+     * @param component
+     *            the new component content, can be null
+     */
     void setHeaderContent(String text, Component component) {
         headerText = text;
         headerComponent = replaceChildComponent(headerComponent, component);
         scheduleHeaderRendering();
     }
 
+    /**
+     * Sets the content of the column footer to either a text or a component,
+     * and triggers a re-render of the footer. If both are null, then the
+     * content of the footer is cleared.
+     *
+     * @param text
+     *            the new text content, can be null
+     * @param component
+     *            the new component content, can be null
+     */
     void setFooterContent(String text, Component component) {
         footerText = text;
         footerComponent = replaceChildComponent(footerComponent, component);
         scheduleFooterRendering();
     }
 
+    /**
+     * Removes the old component as a virtual child, adds the new component as a
+     * virtual child. Both components can be null, in which case the operation
+     * does nothing. Additionally, the old component will only be removed if it
+     * is still a child of this component, and the new component will be removed
+     * from its current parent before adding it to this component.
+     *
+     * @param oldComponent
+     *            the component to remove as a virtual child, can be null
+     * @param newComponent
+     *            the component to add as a virtual child, can be null
+     * @return the newly added component, or null if there was no component to
+     *         add
+     */
     private Component replaceChildComponent(Component oldComponent,
             Component newComponent) {
         if (oldComponent != null && oldComponent.getParent().isPresent()
@@ -220,11 +254,25 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         return newComponent;
     }
 
+    /**
+     * Moves the current header content, either a text or a component, to a
+     * different column or column group. Also clears the content of this column.
+     *
+     * @param otherColumn
+     *            the column or group to move the content to
+     */
     protected void moveHeaderContent(AbstractColumn<?> otherColumn) {
         otherColumn.setHeaderContent(headerText, headerComponent);
         setHeaderContent(null, null);
     }
 
+    /**
+     * Moves the current footer content, either a text or a component, to a
+     * different column or column group. Also clears the content of this column.
+     *
+     * @param otherColumn
+     *            the column or group to move the content to
+     */
     protected void moveFooterContent(AbstractColumn<?> otherColumn) {
         otherColumn.setFooterContent(footerText, footerComponent);
         setFooterContent(null, null);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -193,47 +193,41 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     }
 
     void setHeaderContent(String text, Component component) {
-        if (headerComponent != null) {
-            getElement().removeVirtualChild(headerComponent.getElement());
-        }
-
         headerText = text;
-        headerComponent = component;
-
-        if (headerComponent != null) {
-            getElement().appendVirtualChild(headerComponent.getElement());
-        }
-
+        headerComponent = replaceChildComponent(headerComponent, component);
         scheduleHeaderRendering();
     }
 
     void setFooterContent(String text, Component component) {
-        if (footerComponent != null) {
-            getElement().removeVirtualChild(footerComponent.getElement());
-        }
-
         footerText = text;
-        footerComponent = component;
-
-        if (footerComponent != null) {
-            getElement().appendVirtualChild(footerComponent.getElement());
-        }
-
+        footerComponent = replaceChildComponent(footerComponent, component);
         scheduleFooterRendering();
     }
 
+    private Component replaceChildComponent(Component oldComponent,
+            Component newComponent) {
+        if (oldComponent != null
+                && oldComponent.getElement().getParent() == this.getElement()) {
+            getElement().removeVirtualChild(oldComponent.getElement());
+        }
+        if (newComponent != null) {
+            if (newComponent.getElement().getParent() != null) {
+                newComponent.getElement().getParent()
+                        .removeVirtualChild(newComponent.getElement());
+            }
+            getElement().appendVirtualChild(newComponent.getElement());
+        }
+        return newComponent;
+    }
+
     protected void moveHeaderContent(AbstractColumn<?> otherColumn) {
-        String text = headerText;
-        Component component = headerComponent;
+        otherColumn.setHeaderContent(headerText, headerComponent);
         setHeaderContent(null, null);
-        otherColumn.setHeaderContent(text, component);
     }
 
     protected void moveFooterContent(AbstractColumn<?> otherColumn) {
-        String text = footerText;
-        Component component = footerComponent;
+        otherColumn.setFooterContent(footerText, footerComponent);
         setFooterContent(null, null);
-        otherColumn.setFooterContent(text, component);
     }
 
     /**
@@ -301,5 +295,4 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
                         .collect(Collectors.toList()));
         return columnChildren;
     }
-
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -207,7 +207,7 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     private Component replaceChildComponent(Component oldComponent,
             Component newComponent) {
         if (oldComponent != null
-                && oldComponent.getElement().getParent() == this.getElement()) {
+                && oldComponent.getParent().isPresent() && oldComponent.getParent().get() == this) {
             getElement().removeVirtualChild(oldComponent.getElement());
         }
         if (newComponent != null) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
@@ -413,8 +413,8 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
                 ColumnGroup group = ColumnGroupHelpers.wrapInColumnGroup(grid,
                         col);
                 AbstractColumn<?> oldGroup = leftColumns.next();
-                group.setHeaderRenderer(oldGroup.getHeaderRenderer());
-                group.setFooterRenderer(oldGroup.getFooterRenderer());
+                oldGroup.moveHeaderContent(group);
+                oldGroup.moveFooterContent(group);
                 newColumns.add(group);
 
                 CELL next = leftCells.next();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
@@ -38,7 +38,8 @@ public class FooterRow extends AbstractRow<FooterCell> {
 
         FooterCell(AbstractColumn<?> column) {
             super(column);
-            if (column.getFooterRenderer() == null) {
+            if (column.getFooterText() == null
+                    && column.getFooterComponent() == null) {
                 column.setFooterText("");
             }
         }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2411,16 +2411,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         ColumnLayer newBottomLayer = new ColumnLayer(this, columns);
 
         IntStream.range(0, groups.size()).forEach(i -> {
-            // Move templates from columns to column-groups
+            // Move content from columns to column-groups
             if (forFooterRow) {
-                groups.get(i)
-                        .setFooterRenderer(columns.get(i).getFooterRenderer());
-                columns.get(i).setFooterRenderer(null);
+                columns.get(i).moveFooterContent(groups.get(i));
             }
             if (forHeaderRow) {
-                groups.get(i)
-                        .setHeaderRenderer(columns.get(i).getHeaderRenderer());
-                columns.get(i).setHeaderRenderer(null);
+                columns.get(i).moveHeaderContent(groups.get(i));
             }
         });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -47,7 +47,8 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
          */
         HeaderCell(AbstractColumn<?> column) {
             super(column);
-            if (column.getHeaderRenderer() == null) {
+            if (column.getHeaderText() == null
+                    && column.getHeaderComponent() == null) {
                 column.setHeaderText("");
             }
         }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1028,6 +1028,18 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             );
         };
 
+        const renderOnce = (renderer) => {
+          let rendered = false;
+
+          return (root) => {
+            if (rendered) {
+              return;
+            }
+            rendered = true;
+            renderer(root);
+          };
+        };
+
         grid.$connector.setHeaderRenderer = tryCatchWrapper(function (column, options) {
           const { content, showSorter, sorterPath } = options;
 
@@ -1036,7 +1048,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             return;
           }
 
-          column.headerRenderer = (root, _) => {
+          column.headerRenderer = renderOnce((root, _) => {
             // Clear previous contents
             root.innerHTML = '';
             // Render sorter
@@ -1059,7 +1071,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             } else {
               contentRoot.textContent = content;
             }
-          };
+          });
         });
 
         grid.$connector.setFooterRenderer = tryCatchWrapper(function (column, options) {
@@ -1070,7 +1082,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             return;
           }
 
-          column.footerRenderer = (root, _) => {
+          column.footerRenderer = renderOnce((root, _) => {
             // Clear previous contents
             root.innerHTML = '';
             // Add content
@@ -1079,7 +1091,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             } else {
               root.textContent = content;
             }
-          };
+          });
         });
 
         grid.addEventListener(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -460,7 +460,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
                 // order for the sort indicators to match the order on the server. For "append"
                 // just keep the order passed from the server.
                 if (grid.multiSortPriority !== 'append') {
-                  directions = directions.reverse()
+                  directions = directions.reverse();
                 }
                 directions.forEach(({ column, direction }) => {
                   sorters.forEach((sorter) => {
@@ -676,9 +676,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             cache[pkey][page] = slice;
 
             grid.$connector.doSelection(slice.filter((item) => item.selected));
-            grid.$connector.doDeselection(
-              slice.filter((item) => !item.selected && selectedKeys[item.key])
-            );
+            grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
 
             const updatedItems = updateGridCache(page, pkey);
             if (updatedItems) {
@@ -1029,6 +1027,60 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               }))
             );
         };
+
+        grid.$connector.setHeaderRenderer = tryCatchWrapper(function (column, options) {
+          const { content, showSorter, sorterPath } = options;
+
+          if (content === null) {
+            column.headerRenderer = null;
+            return;
+          }
+
+          column.headerRenderer = (root, _) => {
+            // Clear previous contents
+            root.innerHTML = '';
+            // Render sorter
+            let contentRoot = root;
+            if (showSorter) {
+              const sorter = document.createElement('vaadin-grid-sorter');
+              sorter.setAttribute('path', sorterPath);
+              const ariaLabel = content instanceof Node ? content.textContent : content;
+              if (ariaLabel) {
+                sorter.setAttribute('aria-label', `Sort by ${ariaLabel}`);
+              }
+              root.appendChild(sorter);
+
+              // Use sorter as content root
+              contentRoot = sorter;
+            }
+            // Add content
+            if (content instanceof Node) {
+              contentRoot.appendChild(content);
+            } else {
+              contentRoot.textContent = content;
+            }
+          };
+        });
+
+        grid.$connector.setFooterRenderer = tryCatchWrapper(function (column, options) {
+          const { content } = options;
+
+          if (content === null) {
+            column.footerRenderer = null;
+            return;
+          }
+
+          column.footerRenderer = (root, _) => {
+            // Clear previous contents
+            root.innerHTML = '';
+            // Add content
+            if (content instanceof Node) {
+              root.appendChild(content);
+            } else {
+              root.textContent = content;
+            }
+          };
+        });
 
         grid.addEventListener(
           'vaadin-context-menu-before-open',

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1028,15 +1028,12 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             );
         };
 
-        const renderOnce = (renderer) => {
-          let rendered = false;
-
+        const singleTimeRenderer = (renderer) => {
           return (root) => {
-            if (rendered) {
-              return;
+            if (renderer) {
+              renderer(root);
+              renderer = null;
             }
-            rendered = true;
-            renderer(root);
           };
         };
 
@@ -1048,7 +1045,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             return;
           }
 
-          column.headerRenderer = renderOnce((root, _) => {
+          column.headerRenderer = singleTimeRenderer((root) => {
             // Clear previous contents
             root.innerHTML = '';
             // Render sorter
@@ -1082,7 +1079,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             return;
           }
 
-          column.footerRenderer = renderOnce((root, _) => {
+          column.footerRenderer = singleTimeRenderer((root) => {
             // Clear previous contents
             root.innerHTML = '';
             // Add content

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.grid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -43,8 +42,6 @@ public class HeaderFooterTest {
     private static final Predicate<Element> isColumn = element -> "vaadin-grid-column"
             .equals(element.getTag());
     private static final Predicate<Element> isColumnGroup = element -> "vaadin-grid-column-group"
-            .equals(element.getTag());
-    private static final Predicate<Element> isTemplate = element -> "template"
             .equals(element.getTag());
 
     Grid<String> grid;
@@ -80,17 +77,6 @@ public class HeaderFooterTest {
         List<List<Element>> layers = getColumnLayers();
         Assert.assertTrue("Grid should not have column groups initially",
                 layers.size() == 1);
-    }
-
-    @Test
-    public void initGrid_noHeaderFooterTemplates() {
-        List<List<Element>> layers = getColumnLayersAndAssertCount(1);
-        Assert.assertTrue(
-                "Grid columns should not have header or "
-                        + "footer templates initially",
-                layers.get(0).stream().noneMatch(
-                        element -> getHeaderTemplate(element).isPresent()
-                                || getFooterTemplate(element).isPresent()));
     }
 
     @Test
@@ -907,8 +893,6 @@ public class HeaderFooterTest {
         List<Element> children = grid.getElement().getChildren()
                 .collect(Collectors.toList());
         while (children.stream().anyMatch(isColumnGroup)) {
-            children = children.stream().filter(isTemplate.negate())
-                    .collect(Collectors.toList());
             if (!children.stream().allMatch(isColumnGroup)) {
                 throw new IllegalStateException(
                         "All column-children on the same hierarchy level "
@@ -924,8 +908,6 @@ public class HeaderFooterTest {
                     .collect(Collectors.toList());
         }
         if (children.stream().anyMatch(isColumn)) {
-            children = children.stream().filter(isTemplate.negate())
-                    .collect(Collectors.toList());
             if (!children.stream().allMatch(isColumn)) {
                 throw new IllegalStateException(
                         "All column-children on the same hierarchy level "
@@ -945,30 +927,6 @@ public class HeaderFooterTest {
         // from inner-most to out-most
         Collections.reverse(layers);
         return layers;
-    }
-
-    private boolean isHeaderRow(List<Element> layer) {
-        return layer.stream()
-                .allMatch(element -> getHeaderTemplate(element).isPresent());
-    }
-
-    private boolean isFooterRow(List<Element> layer) {
-        return layer.stream()
-                .allMatch(element -> getFooterTemplate(element).isPresent());
-    }
-
-    private Optional<Element> getHeaderTemplate(Element element) {
-        return getTemplate(element, "header");
-    }
-
-    private Optional<Element> getFooterTemplate(Element element) {
-        return getTemplate(element, "footer");
-    }
-
-    private Optional<Element> getTemplate(Element element, String className) {
-        return element.getChildren().filter(isTemplate)
-                .filter(template -> template.getClassList().contains(className))
-                .findFirst();
     }
 
     private void assertIsVirtualChild(Component child, Component expectedParent) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -929,7 +929,8 @@ public class HeaderFooterTest {
         return layers;
     }
 
-    private void assertIsVirtualChild(Component child, Component expectedParent) {
+    private void assertIsVirtualChild(Component child,
+            Component expectedParent) {
         Assert.assertTrue(child.getParent().isPresent());
         Assert.assertSame(child.getParent().get(), expectedParent);
         Assert.assertTrue(child.getElement().isVirtualChild());

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -104,7 +104,7 @@ public class HeaderFooterTest {
     }
 
     @Test
-    public void getHeaderText() {
+    public void setHeaderText() {
         firstColumn.setHeader("foo");
 
         Assert.assertEquals("foo", firstColumn.getHeaderText());
@@ -113,13 +113,16 @@ public class HeaderFooterTest {
     }
 
     @Test
-    public void getHeaderComponent() {
+    public void setHeaderComponent() {
         TextField textField = new TextField();
         firstColumn.setHeader(textField);
 
+        // Getter should return component
         Assert.assertEquals(textField, firstColumn.getHeaderComponent());
         Assert.assertEquals(textField, grid.getHeaderRows().get(0)
                 .getCell(firstColumn).getComponent());
+        // Should be added as virtual child
+        assertIsVirtualChild(textField, firstColumn);
     }
 
     @Test
@@ -133,6 +136,8 @@ public class HeaderFooterTest {
         firstColumn.setHeader(textField);
         firstColumn.setHeader((String) null);
         Assert.assertNull(firstColumn.getHeaderComponent());
+        // Component should be removed
+        assertIsNotVirtualChild(textField);
     }
 
     @Test
@@ -149,6 +154,53 @@ public class HeaderFooterTest {
     }
 
     @Test
+    public void replaceHeaderComponent_replacesVirtualChild() {
+        TextField firstField = new TextField();
+        firstColumn.setHeader(firstField);
+
+        TextField secondField = new TextField();
+        firstColumn.setHeader(secondField);
+
+        assertIsNotVirtualChild(firstField);
+        assertIsVirtualChild(secondField, firstColumn);
+    }
+
+    @Test
+    public void moveHeaderContent() {
+        // Move text
+        firstColumn.setHeader("Header");
+        firstColumn.moveHeaderContent(secondColumn);
+
+        Assert.assertNull(firstColumn.getHeaderText());
+        Assert.assertEquals("Header", secondColumn.getHeaderText());
+
+        // Move component
+        TextField firstField = new TextField();
+        firstColumn.setHeader(firstField);
+        firstColumn.moveHeaderContent(secondColumn);
+
+        Assert.assertNull(firstColumn.getHeaderComponent());
+        Assert.assertNull(secondColumn.getHeaderText());
+        Assert.assertEquals(firstField, secondColumn.getHeaderComponent());
+        assertIsVirtualChild(firstField, secondColumn);
+
+        // Replace component
+        TextField secondField = new TextField();
+        firstColumn.setHeader(secondField);
+        firstColumn.moveHeaderContent(secondColumn);
+
+        assertIsNotVirtualChild(firstField);
+        assertIsVirtualChild(secondField, secondColumn);
+
+        // Overwrite component with text
+        firstColumn.setHeader("Header");
+        firstColumn.moveHeaderContent(secondColumn);
+
+        Assert.assertNull(secondColumn.getHeaderComponent());
+        assertIsNotVirtualChild(secondField);
+    }
+
+    @Test
     public void setFooter_firstFooterRowCreated() {
         firstColumn.setFooter("foo");
         Assert.assertEquals(
@@ -159,7 +211,7 @@ public class HeaderFooterTest {
     }
 
     @Test
-    public void getFooterText() {
+    public void setFooterText() {
         firstColumn.setFooter("foo");
 
         Assert.assertEquals("foo", firstColumn.getFooterText());
@@ -168,13 +220,16 @@ public class HeaderFooterTest {
     }
 
     @Test
-    public void getFooterComponent() {
+    public void setFooterComponent() {
         TextField textField = new TextField();
         firstColumn.setFooter(textField);
 
+        // Getter should return component
         Assert.assertEquals(textField, firstColumn.getFooterComponent());
         Assert.assertEquals(textField, grid.getFooterRows().get(0)
                 .getCell(firstColumn).getComponent());
+        // Should be added as virtual child
+        assertIsVirtualChild(textField, firstColumn);
     }
 
     @Test
@@ -188,6 +243,7 @@ public class HeaderFooterTest {
         firstColumn.setFooter(textField);
         firstColumn.setFooter((String) null);
         Assert.assertNull(firstColumn.getFooterComponent());
+        assertIsNotVirtualChild(textField);
     }
 
     @Test
@@ -201,6 +257,53 @@ public class HeaderFooterTest {
         firstColumn.setFooter("foo");
         firstColumn.setFooter((Component) null);
         Assert.assertNull(firstColumn.getFooterText());
+    }
+
+    @Test
+    public void replaceFooterComponent_replacesVirtualChild() {
+        TextField firstField = new TextField();
+        firstColumn.setFooter(firstField);
+
+        TextField secondField = new TextField();
+        firstColumn.setFooter(secondField);
+
+        assertIsNotVirtualChild(firstField);
+        assertIsVirtualChild(secondField, firstColumn);
+    }
+
+    @Test
+    public void moveFooterContent() {
+        // Move text
+        firstColumn.setFooter("Footer");
+        firstColumn.moveFooterContent(secondColumn);
+
+        Assert.assertNull(firstColumn.getFooterText());
+        Assert.assertEquals("Footer", secondColumn.getFooterText());
+
+        // Move component
+        TextField firstField = new TextField();
+        firstColumn.setFooter(firstField);
+        firstColumn.moveFooterContent(secondColumn);
+
+        Assert.assertNull(firstColumn.getFooterComponent());
+        Assert.assertNull(secondColumn.getFooterText());
+        Assert.assertEquals(firstField, secondColumn.getFooterComponent());
+        assertIsVirtualChild(firstField, secondColumn);
+
+        // Replace component
+        TextField secondField = new TextField();
+        firstColumn.setFooter(secondField);
+        firstColumn.moveFooterContent(secondColumn);
+
+        assertIsNotVirtualChild(firstField);
+        assertIsVirtualChild(secondField, secondColumn);
+
+        // Overwrite component with text
+        firstColumn.setFooter("Header");
+        firstColumn.moveFooterContent(secondColumn);
+
+        Assert.assertNull(secondColumn.getFooterComponent());
+        assertIsNotVirtualChild(secondField);
     }
 
     @Test
@@ -866,5 +969,16 @@ public class HeaderFooterTest {
         return element.getChildren().filter(isTemplate)
                 .filter(template -> template.getClassList().contains(className))
                 .findFirst();
+    }
+
+    private void assertIsVirtualChild(Component child, Component expectedParent) {
+        Assert.assertTrue(child.getParent().isPresent());
+        Assert.assertSame(child.getParent().get(), expectedParent);
+        Assert.assertTrue(child.getElement().isVirtualChild());
+    }
+
+    private void assertIsNotVirtualChild(Component component) {
+        Assert.assertFalse(component.getParent().isPresent());
+        Assert.assertFalse(component.getElement().isVirtualChild());
     }
 }


### PR DESCRIPTION
## Description

Removes the usage of `TemplateRenderer` and `ComponentRenderer` for rendering header and footer content in grid columns, and instead adds connector methods to define header/footer renderer functions on the client grid column that render the respective text or component content. This effectively removes any usage of the `<template>` element for grid headers and footers.

Breaking changes:
- Header and footer do not contain a `<flow-component-renderer>` tag anymore when using component header or footer
- removes protected `AbstractColumn.setHeaderRenderer`
- removes protected `AbstractColumn.getHeaderRenderer`
- removes protected `AbstractColumn.setFooterRenderer`
- removes protected `AbstractColumn.getFooterRenderer`

Closes https://github.com/vaadin/flow-components/issues/3574
Fixes https://github.com/vaadin/web-components/issues/3470

## Type of change

- Refactoring