### PR TITLE
refactor: remove constructor with a single string parameter

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -116,19 +116,6 @@ public class RichTextEditor
     }
 
     /**
-     * Constructs a {@code RichTextEditor} with the initial value
-     *
-     * @param initialValue
-     *            the initial value in Delta format, not {@code null}
-     *
-     * @see #setValue(Object)
-     */
-    public RichTextEditor(String initialValue) {
-        this();
-        setValue(initialValue);
-    }
-
-    /**
      * Constructs an empty {@code RichTextEditor} with a value change listener.
      *
      * @param listener


### PR DESCRIPTION
## Description

Constructors with a single string parameter should set the label for the component. Currently, RichTextEditor does not support labels but it has a single string parameter constructor which sets the value. For the behaviour to be in line with the other components, this PR removes the constructor. 

This is a breaking change and should not be backported.

Fixes #1276 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
