### PR TITLE
refactor: deprecate constructor with a single string parameter

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -123,7 +123,8 @@ public class RichTextEditor
      *
      * @see #setValue(Object)
      *
-     * @deprecated Since 23.3, this API is deprecated. Use {@link #setValue(String)} instead.
+     * @deprecated Since 23.3, this API is deprecated in order to maintain API consistency.
+     * Use {@link #setValue(String)} instead.
      */
     @Deprecated
     public RichTextEditor(String initialValue) {
@@ -156,7 +157,11 @@ public class RichTextEditor
      *
      * @see #setValue(Object)
      * @see #addValueChangeListener(com.vaadin.flow.component.HasValue.ValueChangeListener)
+     *
+     * @deprecated Since 23.3, this API is deprecated in order to maintain API consistency.
+     * Use {@link #setValue(String)} instead.
      */
+    @Deprecated
     public RichTextEditor(String initialValue,
             ValueChangeListener<? super ComponentValueChangeEvent<RichTextEditor, String>> listener) {
         this();

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -123,7 +123,7 @@ public class RichTextEditor
      *
      * @see #setValue(Object)
      *
-     * @deprecated Since 23.3, this API is deprecated.
+     * @deprecated Since 23.3, this API is deprecated. Use {@link #setValue(String)} instead.
      */
     @Deprecated
     public RichTextEditor(String initialValue) {

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -123,8 +123,8 @@ public class RichTextEditor
      *
      * @see #setValue(Object)
      *
-     * @deprecated Since 23.3, this API is deprecated in order to maintain API consistency.
-     * Use {@link #setValue(String)} instead.
+     * @deprecated Since 23.3, this API is deprecated in order to maintain API
+     *             consistency. Use {@link #setValue(String)} instead.
      */
     @Deprecated
     public RichTextEditor(String initialValue) {
@@ -158,8 +158,8 @@ public class RichTextEditor
      * @see #setValue(Object)
      * @see #addValueChangeListener(com.vaadin.flow.component.HasValue.ValueChangeListener)
      *
-     * @deprecated Since 23.3, this API is deprecated in order to maintain API consistency.
-     * Use {@link #setValue(String)} instead.
+     * @deprecated Since 23.3, this API is deprecated in order to maintain API
+     *             consistency. Use {@link #setValue(String)} instead.
      */
     @Deprecated
     public RichTextEditor(String initialValue,

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -122,7 +122,10 @@ public class RichTextEditor
      *            the initial value in Delta format, not {@code null}
      *
      * @see #setValue(Object)
+     *
+     * @deprecated Since 23.3, this API is deprecated.
      */
+    @Deprecated
     public RichTextEditor(String initialValue) {
         this();
         setValue(initialValue);


### PR DESCRIPTION
## Description

Constructors with a single string parameter should set the label for the component. Currently, RichTextEditor does not support labels but it has a single string parameter constructor which sets the value. For the behaviour to be in line with the other components, this PR deprecates the constructor for v23.3.

This is a temporary change which will be overridden with the [removal](https://github.com/vaadin/flow-components/pull/4027) of the constructor in v24.

Fixes #1276 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
