### PR TITLE
refactor!: remove unnecessary parameter from getter

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
@@ -323,16 +323,14 @@ public class FlexLayout extends Component
     }
 
     /**
-     * Gets the flex direction property of a given element container.
+     * Gets the flex direction property of the layout.
      *
-     * @param elementContainer
-     *            the element container to read the flex direction property from
      * @return the flex direction property, or {@link FlexDirection#ROW} if none
      *         was set
      */
-    public FlexDirection getFlexDirection(HasElement elementContainer) {
+    public FlexDirection getFlexDirection() {
         return FlexDirection.toFlexDirection(
-                elementContainer.getElement().getStyle()
+                getElement().getStyle()
                         .get(FlexConstants.FLEX_DIRECTION_CSS_PROPERTY),
                 FlexDirection.ROW);
     }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexLayoutTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexLayoutTest.java
@@ -103,11 +103,11 @@ public class FlexLayoutTest {
         layout.setFlexDirection(direction);
 
         Assert.assertEquals("should set flex-direction",
-                layout.getFlexDirection(layout), direction);
+                layout.getFlexDirection(), direction);
 
         layout.setFlexDirection(null);
         Assert.assertEquals("should return row if no flex-direction set",
-                layout.getFlexDirection(layout), FlexLayout.FlexDirection.ROW);
+                layout.getFlexDirection(), FlexLayout.FlexDirection.ROW);
     }
 
     @Test


### PR DESCRIPTION
## Description

The method `getFlexDirection` of `FlexLayout` is not a static method and has an unnecessary parameter that should just be the object itself. This PR removes that parameter.

This is a breaking change and should not be backported.

Fixes #2847 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.