### PR TITLE
feat: deprecate getFlexDirection with parameter, add a replacement

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
@@ -323,12 +323,27 @@ public class FlexLayout extends Component
     }
 
     /**
+     * Gets the flex direction property of the layout.
+     *
+     * @return the flex direction property, or {@link FlexDirection#ROW} if none
+     *         was set
+     */
+    public FlexDirection getFlexDirection() {
+        return FlexDirection.toFlexDirection(
+                getElement().getStyle()
+                        .get(FlexConstants.FLEX_DIRECTION_CSS_PROPERTY),
+                FlexDirection.ROW);
+    }
+
+    /**
      * Gets the flex direction property of a given element container.
      *
      * @param elementContainer
      *            the element container to read the flex direction property from
      * @return the flex direction property, or {@link FlexDirection#ROW} if none
      *         was set
+     * @deprecated since 23.3 - use {@link #getFlexDirection()} to get the flex
+     *             direction property of the layout directly
      */
     public FlexDirection getFlexDirection(HasElement elementContainer) {
         return FlexDirection.toFlexDirection(


### PR DESCRIPTION
## Description

The method getFlexDirection of FlexLayout is not a static method and has an unnecessary parameter that should just be the object itself. This PR deprecates that method and introduces a new method without parameters.

This is a temporary change and the deprecated method will be [removed](https://github.com/vaadin/flow-components/pull/4029) in v24.

Fixes #2847 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.