### PR TITLE
refactor!: remove the implementation of clicknotifier interface

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
-import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -143,7 +142,7 @@ import elemental.json.JsonObject;
 @JsModule("@vaadin/context-menu/src/vaadin-context-menu.js")
 @JsModule("@vaadin/polymer-legacy-adapter/template-renderer.js")
 public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContextMenu<R>>
-        extends Component implements HasStyle, ClickNotifier<R> {
+        extends Component implements HasStyle {
 
     /**
      * <p>


### PR DESCRIPTION
## Description

`ContextMenu` element is not clickable, therefore the implementation of `ClickNotifier` interface is unnecessary. This PR removes the implementation of this interface.

This is a breaking change and should not be back-ported.

Fixes #1250 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.