### PR TITLE
refactor: contextmenu deprecate clicknotifier methods v23

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -370,7 +370,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated()
+    @Deprecated
     @Override
     public ShortcutRegistration addClickShortcut(Key key,
             KeyModifier... keyModifiers) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -355,7 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated
+    @Deprecated(forRemoval=true)
     @Override
     public Registration addClickListener(
             ComponentEventListener<ClickEvent<R>> listener) {
@@ -370,7 +370,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated
+    @Deprecated(forRemoval=true)
     @Override
     public ShortcutRegistration addClickShortcut(Key key,
             KeyModifier... keyModifiers) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -355,7 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated(forRemoval=true)
+    @Deprecated(forRemoval = true)
     @Override
     public Registration addClickListener(
             ComponentEventListener<ClickEvent<R>> listener) {
@@ -370,7 +370,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated(forRemoval=true)
+    @Deprecated(forRemoval = true)
     @Override
     public ShortcutRegistration addClickShortcut(Key key,
             KeyModifier... keyModifiers) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -15,7 +15,17 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
-import com.vaadin.flow.component.*;
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.ShortcutRegistration;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -370,7 +370,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     @Override
     public ShortcutRegistration addClickShortcut(Key key,
             KeyModifier... keyModifiers) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -355,7 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated()
+    @Deprecated
     @Override
     public Registration addClickListener(
             ComponentEventListener<ClickEvent<R>> listener) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -355,7 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     @Override
     public Registration addClickListener(
             ComponentEventListener<ClickEvent<R>> listener) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -15,13 +15,7 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
-import com.vaadin.flow.component.ClickNotifier;
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.*;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
@@ -351,5 +345,33 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
                         event -> listener.onComponentEvent(
                                 new OpenedChangeEvent<R>((R) this,
                                         event.isUserOriginated())));
+    }
+
+    /**
+     * Has no effect for ContextMenu because the element for ContextMenu is not
+     * clickable. Therefore, this method should not be used.
+     *
+     * @see #addClickListener(ComponentEventListener)
+     *
+     * @deprecated since 23.3
+     */
+    @Override
+    public Registration addClickListener(
+            ComponentEventListener<ClickEvent<R>> listener) {
+        return ClickNotifier.super.addClickListener(listener);
+    }
+
+    /**
+     * Has no effect for ContextMenu because the element for ContextMenu is not
+     * clickable. Therefore, this method should not be used.
+     *
+     * @see #addClickShortcut(Key, KeyModifier...)
+     *
+     * @deprecated since 23.3
+     */
+    @Override
+    public ShortcutRegistration addClickShortcut(Key key,
+            KeyModifier... keyModifiers) {
+        return ClickNotifier.super.addClickShortcut(key, keyModifiers);
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -355,6 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
+    @Deprecated
     @Override
     public Registration addClickListener(
             ComponentEventListener<ClickEvent<R>> listener) {
@@ -369,6 +370,7 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @deprecated since 23.3
      */
+    @Deprecated
     @Override
     public ShortcutRegistration addClickShortcut(Key key,
             KeyModifier... keyModifiers) {


### PR DESCRIPTION
## Description

`ContextMenu` element is not clickable, therefore the implementation of `ClickNotifier` interface is unnecessary. This PR deprecates the use of the methods that are provided by this interface.

This is a temporary change and the interface will be [removed](https://github.com/vaadin/flow-components/pull/4031) in v24.

Fixes #1250 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.