### PR TITLE
fix: properly update selected item key

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -177,6 +177,26 @@ public class ComboBoxPageIT extends AbstractComboBoxIT {
     }
 
     @Test
+    public void selectValueFromClient_open_selectValueFromServer_onlyOneItemMarkedAsSelected() {
+        // Select item 1 on client, this also opens / renders the overlay
+        ComboBoxElement combo = $(ComboBoxElement.class).id("updatable-combo");
+        combo.selectByText("Item 1");
+        // Select item 2 from server
+        WebElement button = findElement(By.id("updatable-combo-button"));
+        button.click();
+
+        // Get overlay items and verify only item 2 is selected
+        combo.openPopup();
+        TestBenchElement overlay = $("vaadin-combo-box-overlay").first();
+        List<TestBenchElement> items = overlay.$("div").id("content")
+                .$("vaadin-combo-box-item").all();
+
+        items.forEach(
+                item -> Assert.assertEquals("Item 2".equals(item.getText()),
+                        item.hasAttribute("selected")));
+    }
+
+    @Test
     public void setValue_setLabelGenerator_selectedItemLabelUpdated() {
         ComboBoxElement combo = $(ComboBoxElement.class)
                 .id("label-generator-after-value");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -1138,8 +1138,12 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         dataCommunicator.setRequestedRange(start, length);
         filterSlot.accept(filter);
         // Send (possibly updated) key for the selected value
-        getElement().executeJs("this._selectedKey=$0",
-                getValue() != null ? getKeyMapper().key(getValue()) : "");
+        if (getValue() != null) {
+            String updatedKey = getKeyMapper().key(getValue());
+            getElement().executeJs(
+                    "if (this.selectedItem) { this.selectedItem.key = $0; this.value = $0; } ",
+                    updatedKey);
+        }
     }
 
     @ClientCallable

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -167,7 +167,7 @@
             comboBox.$connector.clear = tryCatchWrapper((start, length) => {
                 const firstPageToClear = Math.floor(start / comboBox.pageSize);
                 const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
-                
+
                 for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
                     delete cache[i];
                 }
@@ -259,34 +259,6 @@
                 // Let server know we're done
                 comboBox.$server.confirmUpdate(id);
             });
-
-            const patchIsItemSelected = tryCatchWrapper(() => {
-                // IE11 doesn't support {once: true} with event listeners. Need to
-                // remove the listener manually on the first invocation
-                comboBox.removeEventListener('opened-changed', patchIsItemSelected)
-
-                // Patch once the instance is ready and vaadin-combo-box has
-                // been finalized (i.e. opened-changed is emitted)
-
-                const _isItemSelected = comboBox.$.overlay._isItemSelected;
-                // Override comboBox's _isItemSelected logic to handle remapped items
-                comboBox.$.overlay._isItemSelected = (item, selectedItem, itemIdPath) => {
-                    let selected = _isItemSelected.call(comboBox, item, selectedItem, itemIdPath);
-
-                    if (comboBox._selectedKey) {
-                        if (comboBox.filteredItems.indexOf(selectedItem) > -1) {
-                            delete comboBox._selectedKey;
-                        } else {
-                            selected = selected || item.key === comboBox._selectedKey;
-                        }
-                    }
-
-                    return selected;
-                }
-            });
-
-            comboBox.addEventListener('opened-changed', patchIsItemSelected);
-
 
             comboBox.$connector.enableClientValidation = tryCatchWrapper(function( enable ){
                 let input = null;


### PR DESCRIPTION
## Description

Fixes the combo box to only show the current item as selected in the overlay. The fix mostly involves removing a workaround from the connector that broke updating the selected item in the overlay. The purpose of the workaround was to ensure that an item is still displayed as selected if its item key changes in the data communicator (can happen when scrolling it out of view or filtering), as an alternative it seems that just updating the `selectedItem.key` property does the same. Note that this also requires updating `value`, otherwise the web component will clear the selected item if its key does not match the value. I could not observe any unwanted selected item or value change events from the change, I'm guessing these are discarded in `AbstractSinglePropertyField` as the mapped value is still the same.

This issue was already fixed in 23 as part of https://github.com/vaadin/flow-components/pull/2618. The fix did not work for 14 as the `executeJs` call used there was only applied after the overlay had re-rendered. 

Fixes https://github.com/vaadin/flow-components/issues/4009

## Type of change

- Bugfix