### PR TITLE
refactor: deprecate grid column renderer APIs

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -104,6 +104,7 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
      * @deprecated since 23.3, internal usage of renderers for grid headers and
      *             footers will be removed in 24
      */
+    @Deprecated
     protected void setHeaderRenderer(Renderer<?> renderer) {
         headerRenderer = renderer;
         scheduleHeaderRendering();
@@ -168,6 +169,7 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
      * @deprecated since 23.3, internal usage of renderers for grid headers and
      *             footers will be removed in 24
      */
+    @Deprecated
     protected void setFooterRenderer(Renderer<?> renderer) {
         footerRenderer = renderer;
         scheduleFooterRendering();
@@ -268,6 +270,7 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
      * @deprecated since 23.3, internal usage of renderers for grid headers and
      *             footers will be removed in 24
      */
+    @Deprecated
     protected Renderer<?> getFooterRenderer() {
         return footerRenderer;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -96,6 +96,14 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         super.setVisible(visible);
     }
 
+    /**
+     * Only intended for internal use.
+     *
+     * @param renderer
+     *            the new footer renderer
+     * @deprecated since 23.3, internal usage of renderers for grid headers and
+     *             footers will be removed in 24
+     */
     protected void setHeaderRenderer(Renderer<?> renderer) {
         headerRenderer = renderer;
         scheduleHeaderRendering();
@@ -152,6 +160,14 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
                 }));
     }
 
+    /**
+     * Only intended for internal use.
+     *
+     * @param renderer
+     *            the new footer renderer
+     * @deprecated since 23.3, internal usage of renderers for grid headers and
+     *             footers will be removed in 24
+     */
     protected void setFooterRenderer(Renderer<?> renderer) {
         footerRenderer = renderer;
         scheduleFooterRendering();
@@ -233,10 +249,25 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         setFooterRenderer(new ComponentRenderer<>(() -> component));
     }
 
+    /**
+     * Only intended for internal use.
+     *
+     * @return the header renderer
+     * @deprecated since 23.3, internal usage of renderers for grid headers and
+     *             footers will be removed in 24
+     */
+    @Deprecated
     protected Renderer<?> getHeaderRenderer() {
         return headerRenderer;
     }
 
+    /**
+     * Only intended for internal use.
+     *
+     * @return the footer renderer
+     * @deprecated since 23.3, internal usage of renderers for grid headers and
+     *             footers will be removed in 24
+     */
     protected Renderer<?> getFooterRenderer() {
         return footerRenderer;
     }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
@@ -323,12 +323,27 @@ public class FlexLayout extends Component
     }
 
     /**
+     * Gets the flex direction property of the layout.
+     *
+     * @return the flex direction property, or {@link FlexDirection#ROW} if none
+     *         was set
+     */
+    public FlexDirection getFlexDirection() {
+        return FlexDirection.toFlexDirection(
+                getElement().getStyle()
+                        .get(FlexConstants.FLEX_DIRECTION_CSS_PROPERTY),
+                FlexDirection.ROW);
+    }
+
+    /**
      * Gets the flex direction property of a given element container.
      *
      * @param elementContainer
      *            the element container to read the flex direction property from
      * @return the flex direction property, or {@link FlexDirection#ROW} if none
      *         was set
+     * @deprecated since 23.3 - use {@link #getFlexDirection()} to get the flex
+     *             direction property of the layout directly
      */
     public FlexDirection getFlexDirection(HasElement elementContainer) {
         return FlexDirection.toFlexDirection(


### PR DESCRIPTION
## Description

Deprecates the protected renderer APIs on the grid column, which are scheduled to be removed in 24 (see https://github.com/vaadin/flow-components/pull/4025). These APIs were intended to be used internally and have been given protected accessibility to facilitate internal features, but there is a change that someone is using them in custom grid column classes.

## Type of change

- Refactoring