### PR TITLE
fix: update sheet styles when active sheet is hidden

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/FreezePaneLocalePage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/FreezePaneLocalePage.java
@@ -6,8 +6,11 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 
+import org.apache.poi.ss.usermodel.SheetVisibility;
+
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.framework.Action;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-spreadsheet/freeze-pane-locale")
@@ -30,6 +33,24 @@ public class FreezePaneLocalePage extends Div {
 
             add(sheet);
 
+            SpreadsheetActionHandler handler = new SpreadsheetActionHandler();
+            handler.addCellHandler(new SpreadsheetActionHandler.Cell() {
+                @Override
+                public void handleAction(Action action,
+                        Spreadsheet.SelectionChangeEvent sender,
+                        Spreadsheet target) {
+                    sheet.setSheetHidden(sheet.getActiveSheetPOIIndex(),
+                            SheetVisibility.HIDDEN);
+                }
+
+                @Override
+                public Action[] getActions(
+                        Spreadsheet.SelectionChangeEvent selection,
+                        Spreadsheet sender) {
+                    return new Action[] { new Action("Hide sheet"), };
+                }
+            });
+            sheet.addActionHandler(handler);
         } catch (URISyntaxException e) {
             e.printStackTrace();
         } catch (IOException e) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneLocaleIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneLocaleIT.java
@@ -21,6 +21,9 @@ public class FreezePaneLocaleIT extends AbstractSpreadsheetIT {
         getDriver().get(getBaseURL() + "/freeze-pane-locale");
         setSpreadsheet($(SpreadsheetElement.class).first());
 
+        Assert.assertNotEquals("1px",
+                getCellStyle("B5", "border-bottom-width"));
+
         getCellAt(1, 1).contextClick();
         clickItem("Hide sheet");
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneLocaleIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneLocaleIT.java
@@ -16,4 +16,15 @@ public class FreezePaneLocaleIT extends AbstractSpreadsheetIT {
                 $(SpreadsheetElement.class).exists());
     }
 
+    @Test
+    public void hideFirstSheet_borderStylesUpdated() {
+        getDriver().get(getBaseURL() + "/freeze-pane-locale");
+        setSpreadsheet($(SpreadsheetElement.class).first());
+
+        getCellAt(1, 1).contextClick();
+        clickItem("Hide sheet");
+
+        Assert.assertEquals("1px", getCellStyle("B5", "border-bottom-width"));
+    }
+
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1702,6 +1702,8 @@ public class Spreadsheet extends Component
                 reloadActiveSheetData();
                 SpreadsheetFactory.reloadSpreadsheetData(this,
                         getActiveSheet());
+
+                getSpreadsheetStyleFactory().reloadActiveSheetCellStyles();
             }
         }
     }


### PR DESCRIPTION
Addresses the issue described [here](https://docs.google.com/spreadsheets/d/1dpRq-pHZ8DwtEEmmSTVLraix-7AWTzzPp1YutVU0qRg/edit#gid=0&range=28:28): When the active sheet gets hidden, another sheet becomes the new active sheet, but the cell styles don't get automatically updated.