### PR TITLE
fix: fix pane freezing in large spreadsheets

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneIT.java
@@ -65,4 +65,23 @@ public class FreezePaneIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("0px",
                 firstRowHeader.getWrappedElement().getCssValue("top"));
     }
+
+    @Test
+    public void largeSheet_addFreezePane_verticalAndHorizontal_firstHeaderIsPlacedCorrectly()
+            throws Exception {
+        loadFile("100_000_rows.xlsx");
+
+        addFreezePane();
+
+        SheetHeaderElement firstColumnHeader = getSpreadsheet()
+                .getColumnHeader(1);
+        SheetHeaderElement firstRowHeader = getSpreadsheet().getRowHeader(1);
+        Assert.assertEquals("A", firstColumnHeader.getText());
+        Assert.assertEquals("0px",
+                firstColumnHeader.getWrappedElement().getCssValue("left"));
+        Assert.assertEquals("1", firstRowHeader.getText());
+        Assert.assertEquals("0px",
+                firstRowHeader.getWrappedElement().getCssValue("top"));
+    }
+
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -1029,6 +1029,10 @@ public class SpreadsheetFactory implements Serializable {
         // only freeze panes supported
         if (paneInformation != null && paneInformation.isFreezePane()) {
 
+            // With a large sheet, getTopRow could become negative.
+            var topRow = Math.max(0, sheet.getTopRow());
+            var leftCol = Math.max(0, sheet.getLeftCol());
+
             /*
              * In POI, HorizontalSplit means rows and VerticalSplit means
              * columns.
@@ -1036,22 +1040,20 @@ public class SpreadsheetFactory implements Serializable {
              * In Spreadsheet the meaning is the opposite.
              */
             spreadsheet.setHorizontalSplitPosition(
-                    paneInformation.getVerticalSplitPosition()
-                            + sheet.getLeftCol());
+                    paneInformation.getVerticalSplitPosition() + leftCol);
 
             spreadsheet.setVerticalSplitPosition(
-                    paneInformation.getHorizontalSplitPosition()
-                            + sheet.getTopRow());
+                    paneInformation.getHorizontalSplitPosition() + topRow);
 
             /*
              * If the view was scrolled down / right when panes were frozen, the
              * invisible frozen rows/columns are effectively hidden in Excel. We
              * mimic this behavior here.
              */
-            for (int col = 0; col < sheet.getLeftCol(); col++) {
+            for (int col = 0; col < leftCol; col++) {
                 spreadsheet.setColumnHidden(col, true);
             }
-            for (int row = 0; row < sheet.getTopRow(); row++) {
+            for (int row = 0; row < topRow; row++) {
                 spreadsheet.setRowHidden(row, true);
             }
         } else {


### PR DESCRIPTION
Addresses the issue described [here](https://docs.google.com/spreadsheets/d/1dpRq-pHZ8DwtEEmmSTVLraix-7AWTzzPp1YutVU0qRg/edit#gid=0&range=33:33): "Freezing panes on the "100_000_rows.xlsx" file leads to browser console error and the sheet breaks and can't be used after that."

The issue was caused by a regression from https://github.com/vaadin/spreadsheet/pull/532