### PR TITLE
fix: create aria label from header component

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -79,9 +79,8 @@ public class SortingIT extends AbstractComponentIT {
     public void setInitialSortOrder_sorterAriaLabels() {
         findElement(By.id("sort-by-age")).click();
         List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter").all();
-        // The first sorter uses a ComponentRenderer so an aria-label can't be
-        // generated
-        Assert.assertEquals(false, sorters.get(0).hasAttribute("aria-label"));
+        Assert.assertEquals("Sort by Name",
+                sorters.get(0).getAttribute("aria-label"));
         Assert.assertEquals("Sort by Age",
                 sorters.get(1).getAttribute("aria-label"));
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
@@ -413,8 +413,8 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
                 ColumnGroup group = ColumnGroupHelpers.wrapInColumnGroup(grid,
                         col);
                 AbstractColumn<?> oldGroup = leftColumns.next();
-                group.setHeaderRenderer(oldGroup.getHeaderRenderer());
-                group.setFooterRenderer(oldGroup.getFooterRenderer());
+                oldGroup.moveHeaderContent(group);
+                oldGroup.moveFooterContent(group);
                 newColumns.add(group);
 
                 CELL next = leftCells.next();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2414,13 +2414,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         IntStream.range(0, groups.size()).forEach(i -> {
             // Move templates from columns to column-groups
             if (forFooterRow) {
-                groups.get(i)
-                        .setFooterRenderer(columns.get(i).getFooterRenderer());
+                columns.get(i).moveFooterContent(groups.get(i));
                 columns.get(i).setFooterRenderer(null);
             }
             if (forHeaderRow) {
-                groups.get(i)
-                        .setHeaderRenderer(columns.get(i).getHeaderRenderer());
+                columns.get(i).moveHeaderContent(groups.get(i));
                 columns.get(i).setHeaderRenderer(null);
             }
         });


### PR DESCRIPTION
## Description

Fixes the grid column to also create a sorter aria label when using a header component.

Targetting 23.3 as this has already been fixed in 24 as part of this refactoring: https://github.com/vaadin/flow-components/pull/4025

Fixes https://github.com/vaadin/web-components/issues/3470

## Type of change

- Bugfix
