### PR TITLE
refactor: remove spreadsheet inline styles

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SizingPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SizingPage.java
@@ -70,6 +70,15 @@ public class SizingPage extends Div {
                 getButton("Default (block)", "layoutDisplayDefault",
                         e -> layout.getStyle().remove("display"))));
 
+        layoutList.add(new ListItem(new Span("Flex: "), getButton(
+                "Column / align-start", "layoutFlexColumnStart", e -> {
+                    layout.getStyle().set("flex-direction", "column");
+                    layout.getStyle().set("align-items", "start");
+                }), getButton("Default", "layoutFlexColumnStartDefault", e -> {
+                    layout.getStyle().remove("flex-direction");
+                    layout.getStyle().remove("align-items");
+                })));
+
         add(layoutList);
 
         add(layout);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SizingIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SizingIT.java
@@ -91,6 +91,17 @@ public class SizingIT extends AbstractComponentIT {
     }
 
     @Test
+    public void layoutFlexColumnStart_spreadsheetFullWidth() {
+        findElement(By.id("layoutDisplayFlex")).click();
+        findElement(By.id("layoutFlexColumnStart")).click();
+
+        var layoutWidth = layout.getSize().getWidth();
+        var internal = spreadsheet.$(DivElement.class).first();
+        Assert.assertEquals(layoutWidth, internal.getSize().getWidth());
+        Assert.assertEquals(layoutWidth, spreadsheet.getSize().getWidth());
+    }
+
+    @Test
     public void toggleSpreadsheetAttached_noMissingRows() {
         // Detach spreadsheet
         findElement(By.id("spreadsheetAttachedToggle")).click();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1169,7 +1169,6 @@ public class Spreadsheet extends Component
         sheetOverlays = new HashSet<SheetOverlayWrapper>();
         tables = new HashSet<SpreadsheetTable>();
         registerRpc(new SpreadsheetHandlerImpl(this));
-        setSizeFull(); // Default to full size
         defaultActionHandler = new SpreadsheetDefaultActionHandler();
         hyperlinkCellClickHandler = new DefaultHyperlinkCellClickHandler(this);
         addActionHandler(defaultActionHandler);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet-styles.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet-styles.js
@@ -8,6 +8,7 @@ import { css } from 'lit';
 export const spreadsheetStyles = css`
   :host {
     display: block;
+    width: 100%;
     height: 100%;
     flex: 1 1 auto;
     isolation: isolate;


### PR DESCRIPTION
The `<vaadin-spreadsheet>` Web Component currently gets applied inline styles for `height: 100%; width: 100%` due to an internal call to `setSizeFull();`. The Web Component should size correctly even without inline styles.

This PR removes the internal `setSizeFull();` call and adds missing `width: 100%;` to the spreadsheet Web Component host styles.