### PR TITLE
606 deprecate generated password field

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
@@ -23,27 +23,9 @@ import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableFunction;
 
 /**
- * <p>
- * Description copied from corresponding location in WebComponent:
- * </p>
- * <p>
- * {@code <vaadin-email-field>} is a Web Component for email field control in
- * forms.
- * </p>
- * <p>
- * &lt;vaadin-email-field label=&quot;Email&quot;&gt;
- * &lt;/vaadin-email-field&gt;
- * </p>
- * <h3>Styling</h3>
- * <p>
- * See vaadin-text-field.html for the styling documentation
- * </p>
- * <p>
- * See
- * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
- * – how to apply styles for shadow parts</a>
- * </p>
+ * @deprecated since v23.3, will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-email-field")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha5")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -69,7 +51,10 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      *            a function that converts a model value to a string value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinEmailField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableFunction<P, T> presentationToModel,
@@ -88,7 +73,10 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      *            the default value to use if the value isn't defined
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinEmailField(T initialValue, T defaultValue,
             boolean acceptNullValues) {
         super(initialValue, defaultValue, acceptNullValues);
@@ -113,7 +101,10 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      *            initial value is used only if element has no {@code "value"}
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinEmailField(T initialValue, T defaultValue,
             boolean acceptNullValues, boolean isInitialValueOptional) {
         super(initialValue, defaultValue, acceptNullValues,
@@ -138,7 +129,10 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      *            returns a property value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinEmailField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
@@ -149,7 +143,10 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
 
     /**
      * Default constructor.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinEmailField() {
         this(null, null, null, (SerializableFunction) null,
                 (SerializableFunction) null);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
@@ -23,18 +23,9 @@ import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableFunction;
 
 /**
- * <p>
- * Description copied from corresponding location in WebComponent:
- * </p>
- * <p>
- * {@code <vaadin-number-field>} is a Polymer 2 element for number field control
- * in forms.
- * </p>
- * <p>
- * &lt;vaadin-number-field label=&quot;Number&quot;&gt;
- * &lt;/vaadin-number-field&gt;
- * </p>
+ * @deprecated since v23.3, will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-number-field")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha5")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -56,7 +47,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * </p>
      *
      * @return the {@code hasControls} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean hasControlsBoolean() {
         return getElement().getProperty("hasControls", false);
     }
@@ -88,7 +82,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * </p>
      *
      * @return the {@code min} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected double getMinDouble() {
         return getElement().getProperty("min", 0.0);
     }
@@ -103,7 +100,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *
      * @param min
      *            the double value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setMin(double min) {
         getElement().setProperty("min", min);
     }
@@ -120,7 +120,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * </p>
      *
      * @return the {@code max} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected double getMaxDouble() {
         return getElement().getProperty("max", 0.0);
     }
@@ -135,7 +138,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *
      * @param max
      *            the double value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setMax(double max) {
         getElement().setProperty("max", max);
     }
@@ -152,7 +158,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * </p>
      *
      * @return the {@code step} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected double getStepDouble() {
         return getElement().getProperty("step", 0.0);
     }
@@ -167,11 +176,17 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *
      * @param step
      *            the double value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setStep(double step) {
         getElement().setProperty("step", step);
     }
 
+    /**
+     * @deprecated since v23.3, will be removed in v24.
+     */
     @Override
     protected void checkValidity() {
         getElement().callJsFunction("checkValidity");
@@ -202,7 +217,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *            ignored and the initial value is set
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinNumberField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableFunction<P, T> presentationToModel,
@@ -229,7 +247,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *            a function that converts a model value to a string value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinNumberField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableFunction<P, T> presentationToModel,
@@ -248,7 +269,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *            the default value to use if the value isn't defined
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinNumberField(T initialValue, T defaultValue,
             boolean acceptNullValues) {
         super(initialValue, defaultValue, acceptNullValues);
@@ -272,7 +296,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *            returns a property value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinNumberField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
@@ -283,7 +310,10 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
 
     /**
      * Default constructor.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinNumberField() {
         this(null, null, null, (SerializableFunction) null,
                 (SerializableFunction) null);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
@@ -23,63 +23,9 @@ import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableFunction;
 
 /**
- * <p>
- * Description copied from corresponding location in WebComponent:
- * </p>
- * <p>
- * {@code <vaadin-password-field>} is a Web Component for password field control
- * in forms.
- * </p>
- * <p>
- * &lt;vaadin-password-field label=&quot;Password&quot;&gt;
- * &lt;/vaadin-password-field&gt;
- * </p>
- * <h3>Styling</h3>
- * <p>
- * See vaadin-text-field.html for the styling documentation
- * </p>
- * <p>
- * In addition to vaadin-text-field parts, here's the list of
- * vaadin-password-field specific parts
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Part name</th>
- * <th>Description</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code reveal-button}</td>
- * <td>The eye icon which toggles the password visibility</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * In addition to vaadin-text-field state attributes, here's the list of
- * vaadin-password-field specific attributes
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Attribute</th>
- * <th>Description</th>
- * <th>Part name</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code password-visible}</td>
- * <td>Set when the password is visible</td>
- * <td>:host</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * See
- * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
- * – how to apply styles for shadow parts</a>
- * </p>
+ * @deprecated since v23.3, will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-password-field")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha5")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -101,7 +47,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      * </p>
      *
      * @return the {@code revealButtonHidden} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isRevealButtonHiddenBoolean() {
         return getElement().getProperty("revealButtonHidden", false);
     }
@@ -116,7 +65,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *
      * @param revealButtonHidden
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setRevealButtonHidden(boolean revealButtonHidden) {
         getElement().setProperty("revealButtonHidden", revealButtonHidden);
     }
@@ -133,7 +85,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      * </p>
      *
      * @return the {@code passwordVisible} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isPasswordVisibleBoolean() {
         return getElement().getProperty("passwordVisible", false);
     }
@@ -154,7 +109,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *            a function that converts a model value to a string value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinPasswordField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableFunction<P, T> presentationToModel,
@@ -182,7 +140,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *            initial value is used only if element has no {@code "value"}
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinPasswordField(T initialValue, T defaultValue,
             boolean acceptNullValues, boolean isInitialValueOptional) {
         super(initialValue, defaultValue, acceptNullValues,
@@ -207,7 +168,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *            returns a property value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinPasswordField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
@@ -218,7 +182,10 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
 
     /**
      * Default constructor.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinPasswordField() {
         this(null, null, null, (SerializableFunction) null,
                 (SerializableFunction) null);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -32,135 +32,9 @@ import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * <p>
- * Description copied from corresponding location in WebComponent:
- * </p>
- * <p>
- * {@code <vaadin-text-field>} is a Web Component for text field control in
- * forms.
- * </p>
- * <p>
- * &lt;vaadin-text-field label=&quot;First Name&quot;&gt;
- * &lt;/vaadin-text-field&gt;
- * </p>
- * <h3>Prefixes and suffixes</h3>
- * <p>
- * These are child elements of a {@code <vaadin-text-field>} that are displayed
- * inline with the input, before or after. In order for an element to be
- * considered as a prefix, it must have the slot attribute set to {@code prefix}
- * (and similarly for {@code suffix}).
- * </p>
- * <p>
- * &lt;vaadin-text-field label=&quot;Email address&quot;&gt; &lt;div
- * slot=&quot;prefix&quot;&gt;Sent to:&lt;/div&gt; &lt;div
- * slot=&quot;suffix&quot;&gt;@vaadin.com&lt;/div&gt; &lt;/vaadin-text-area&gt;
- * </p>
- * <h3>Styling</h3>
- * <p>
- * The following custom properties are available for styling:
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Custom property</th>
- * <th>Description</th>
- * <th>Default</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code --vaadin-text-field-default-width}</td>
- * <td>Set the default width of the input field</td>
- * <td>{@code 12em}</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * The following shadow DOM parts are available for styling:
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Part name</th>
- * <th>Description</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code label}</td>
- * <td>The label element</td>
- * </tr>
- * <tr>
- * <td>{@code input-field}</td>
- * <td>The element that wraps prefix, value and suffix</td>
- * </tr>
- * <tr>
- * <td>{@code value}</td>
- * <td>The text value element inside the {@code input-field} element</td>
- * </tr>
- * <tr>
- * <td>{@code error-message}</td>
- * <td>The error message element</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * The following state attributes are available for styling:
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Attribute</th>
- * <th>Description</th>
- * <th>Part name</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code disabled}</td>
- * <td>Set to a disabled text field</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code has-value}</td>
- * <td>Set when the element has a value</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code has-label}</td>
- * <td>Set when the element has a label</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code invalid}</td>
- * <td>Set when the element is invalid</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code input-prevented}</td>
- * <td>Temporarily set when invalid input is prevented</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code focused}</td>
- * <td>Set when the element is focused</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code focus-ring}</td>
- * <td>Set when the element is keyboard focused</td>
- * <td>:host</td>
- * </tr>
- * <tr>
- * <td>{@code readonly}</td>
- * <td>Set to a readonly text field</td>
- * <td>:host</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * See
- * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
- * – how to apply styles for shadow parts</a>
- * </p>
+ * @deprecated since v23.3, will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha5")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -183,7 +57,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code autofocus} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isAutofocusBoolean() {
         return getElement().getProperty("autofocus", false);
     }
@@ -215,7 +92,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code disabled} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isDisabledBoolean() {
         return getElement().getProperty("disabled", false);
     }
@@ -230,7 +110,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param disabled
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setDisabled(boolean disabled) {
         getElement().setProperty("disabled", disabled);
     }
@@ -250,7 +133,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code autocomplete} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getAutocompleteString() {
         return getElement().getProperty("autocomplete");
     }
@@ -268,7 +154,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param autocomplete
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setAutocomplete(String autocomplete) {
         getElement().setProperty("autocomplete",
                 autocomplete == null ? "" : autocomplete);
@@ -289,7 +178,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code autocorrect} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getAutocorrectString() {
         return getElement().getProperty("autocorrect");
     }
@@ -307,7 +199,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param autocorrect
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setAutocorrect(String autocorrect) {
         getElement().setProperty("autocorrect",
                 autocorrect == null ? "" : autocorrect);
@@ -329,7 +224,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code autocapitalize} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getAutocapitalizeString() {
         return getElement().getProperty("autocapitalize");
     }
@@ -348,7 +246,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param autocapitalize
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setAutocapitalize(String autocapitalize) {
         getElement().setProperty("autocapitalize",
                 autocapitalize == null ? "" : autocapitalize);
@@ -367,7 +268,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code autoselect} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isAutoselectBoolean() {
         return getElement().getProperty("autoselect", false);
     }
@@ -400,7 +304,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code errorMessage} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getErrorMessageString() {
         return getElement().getProperty("errorMessage");
     }
@@ -433,7 +340,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code label} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getLabelString() {
         return getElement().getProperty("label");
     }
@@ -466,7 +376,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code maxlength} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected double getMaxlengthDouble() {
         return getElement().getProperty("maxlength", 0.0);
     }
@@ -482,7 +395,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param maxlength
      *            the double value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setMaxlength(double maxlength) {
         getElement().setProperty("maxlength", maxlength);
     }
@@ -500,7 +416,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code minlength} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected double getMinlengthDouble() {
         return getElement().getProperty("minlength", 0.0);
     }
@@ -516,7 +435,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param minlength
      *            the double value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setMinlength(double minlength) {
         getElement().setProperty("minlength", minlength);
     }
@@ -533,7 +455,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code name} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getNameString() {
         return getElement().getProperty("name");
     }
@@ -548,7 +473,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param name
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setName(String name) {
         getElement().setProperty("name", name == null ? "" : name);
     }
@@ -565,7 +493,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code placeholder} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getPlaceholderString() {
         return getElement().getProperty("placeholder");
     }
@@ -599,7 +530,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code readonly} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isReadonlyBoolean() {
         return getElement().getProperty("readonly", false);
     }
@@ -615,7 +549,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param readonly
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setReadonly(boolean readonly) {
         getElement().setProperty("readonly", readonly);
     }
@@ -632,7 +569,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code required} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isRequiredBoolean() {
         return getElement().getProperty("required", false);
     }
@@ -661,7 +601,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code invalid} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected boolean isInvalidBoolean() {
         return getElement().getProperty("invalid", false);
     }
@@ -736,7 +679,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code list} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getListString() {
         return getElement().getProperty("list");
     }
@@ -752,7 +698,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @param list
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void setList(String list) {
         getElement().setProperty("list", list == null ? "" : list);
     }
@@ -770,7 +719,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code pattern} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getPatternString() {
         return getElement().getProperty("pattern");
     }
@@ -803,7 +755,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * </p>
      *
      * @return the {@code title} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected String getTitleString() {
         return getElement().getProperty("title");
     }
@@ -836,7 +791,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * This function is not supported by Flow because it returns a
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     @NotSupported
     protected void checkValidity() {
     }
@@ -858,6 +816,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
     protected void validate() {
     }
 
+    /**
+     * @deprecated since v23.3, will be removed in v24
+     */
+    @Deprecated
     @DomEvent("change")
     public static class ChangeEvent<R extends GeneratedVaadinTextField<R, ?>>
             extends ComponentEvent<R> {
@@ -872,7 +834,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addChangeListener(
             ComponentEventListener<ChangeEvent<R>> listener) {
@@ -880,6 +845,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
                 (ComponentEventListener) listener);
     }
 
+    /**
+     * @deprecated since v23.3, will be removed in v24
+     */
+    @Deprecated
     public static class InvalidChangeEvent<R extends GeneratedVaadinTextField<R, ?>>
             extends ComponentEvent<R> {
         private final boolean invalid;
@@ -901,7 +870,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<R>> listener) {
         return getElement()
@@ -923,7 +895,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void addToPrefix(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "prefix");
@@ -943,7 +918,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void addToInput(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "input");
@@ -963,7 +941,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void addToSuffix(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "suffix");
@@ -978,7 +959,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            The components to remove.
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
@@ -995,7 +979,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * Removes all contents from this component, this includes child components,
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     protected void removeAll() {
         getElement().getChildren()
                 .forEach(child -> child.removeAttribute("slot"));
@@ -1018,7 +1005,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            a function that converts a model value to a string value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableFunction<P, T> presentationToModel,
@@ -1053,7 +1043,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            ignored and the initial value is set
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableFunction<P, T> presentationToModel,
@@ -1077,7 +1070,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            the default value to use if the value isn't defined
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinTextField(T initialValue, T defaultValue,
             boolean acceptNullValues) {
         this(initialValue, defaultValue, acceptNullValues, false);
@@ -1102,7 +1098,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            initial value is used only if element has no {@code "value"}
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinTextField(T initialValue, T defaultValue,
             boolean acceptNullValues, boolean isInitialValueOptional) {
         super("value", defaultValue, acceptNullValues);
@@ -1130,7 +1129,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            returns a property value
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
@@ -1167,7 +1169,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            ignored and the initial value is set
      * @param <P>
      *            the property type
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
             Class<P> elementPropertyType,
             SerializableBiFunction<R, P, T> presentationToModel,
@@ -1183,7 +1188,10 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
 
     /**
      * Default constructor.
+     *
+     * @deprecated since v23.3, will be removed in v24
      */
+    @Deprecated
     public GeneratedVaadinTextField() {
         this(null, null, null, (SerializableFunction) null,
                 (SerializableFunction) null);


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinNumberField`, `GeneratedVaadinEmailField`, `GeneratedVaadinPasswordField`, and `GeneratedVaadinTextField` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes. 

`GeneratedVaadinNumberField`, `GeneratedVaadinEmailField`, and `GeneratedVaadinPasswordField` used to extend `GeneratedVaadinTextField`.

Deprecate the methods in the classes except for the methods that cause a public override to appear deprecated. In that case, it is agreed that the deprecation will be apparent via the deprecation of the class itself.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
