### PR TITLE
refactor: deprecate generated button class and methods

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
  *
  * @author Vaadin Ltd
  */
+@SuppressWarnings("deprecation")
 public class Button extends GeneratedVaadinButton<Button>
         implements HasSize, HasEnabled, HasTooltip {
 

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -27,79 +27,9 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Element;
 
 /**
- * <p>
- * Description copied from corresponding location in WebComponent:
- * </p>
- * <p>
- * {@code <vaadin-button>} is a Web Component providing an accessible and
- * customizable button.
- * </p>
- * <p>
- * &lt;vaadin-button&gt; &lt;/vaadin-button&gt;
- * </p>
- * <p>
- * {@code document.querySelector('vaadin-button').addEventListener('click', () =&gt; alert('Hello World!'));}
- * </p>
- * <h3>Styling</h3>
- * <p>
- * The following shadow DOM parts are exposed for styling:
- * </p>
- * <table>
- * <caption>Shadow DOM parts exposed for styling</caption> <thead>
- * <tr>
- * <th>Part name</th>
- * <th>Description</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code label}</td>
- * <td>The label (text) inside the button</td>
- * </tr>
- * <tr>
- * <td>{@code prefix}</td>
- * <td>A slot for e.g. an icon before the label</td>
- * </tr>
- * <tr>
- * <td>{@code suffix}</td>
- * <td>A slot for e.g. an icon after the label</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * The following attributes are exposed for styling:
- * </p>
- * <table>
- * <caption>Attributes exposed for styling</caption> <thead>
- * <tr>
- * <th>Attribute</th>
- * <th>Description</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code active}</td>
- * <td>Set when the button is pressed down, either with mouse, touch or the
- * keyboard.</td>
- * </tr>
- * <tr>
- * <td>{@code disabled}</td>
- * <td>Set when the button is disabled.</td>
- * </tr>
- * <tr>
- * <td>{@code focus-ring}</td>
- * <td>Set when the button is focused using the keyboard.</td>
- * </tr>
- * <tr>
- * <td>{@code focused}</td>
- * <td>Set when the button is focused.</td>
- * </tr>
- * </tbody>
- * </table>
- * <p>
- * See
- * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
- * – how to apply styles for shadow parts</a>
- * </p>
+ * @deprecated since v23.3, will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-button")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha5")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -122,7 +52,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * </p>
      *
      * @return the {@code autofocus} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected boolean isAutofocusBoolean() {
         return getElement().getProperty("autofocus", false);
     }
@@ -154,7 +87,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * </p>
      *
      * @return the {@code disabled} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected boolean isDisabledBoolean() {
         return getElement().getProperty("disabled", false);
     }
@@ -190,7 +126,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void addToPrefix(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "prefix");
@@ -210,7 +149,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void addToSuffix(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "suffix");
@@ -225,7 +167,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *            The components to remove.
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
@@ -242,7 +187,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * Removes all contents from this component, this includes child components,
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void removeAll() {
         getElement().getChildren()
                 .forEach(child -> child.removeAttribute("slot"));
@@ -250,14 +198,14 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
     }
 
     // Override is only required to keep binary compatibility with other 23.x
-    // minor versions, can be removed in a future major
+    // minor versions, will be removed with the method in v24
     @Override
     public void addThemeVariants(ButtonVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
 
     // Override is only required to keep binary compatibility with other 23.x
-    // minor versions, can be removed in a future major
+    // minor versions, will be removed with the method in v24
     @Override
     public void removeThemeVariants(ButtonVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);
@@ -269,7 +217,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * @param text
      *            the text content to set
      * @see HasText#setText(String)
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     public GeneratedVaadinButton(String text) {
         setText(text);
     }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -103,7 +103,6 @@ import com.vaadin.flow.dom.Element;
  * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
 @Deprecated
-@SuppressWarnings("deprecation")
 @Tag("vaadin-button")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -27,9 +27,83 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Element;
 
 /**
- * @deprecated since v23.3, will be removed in v24.
+ * <p>
+ * Description copied from corresponding location in WebComponent:
+ * </p>
+ * <p>
+ * {@code <vaadin-button>} is a Web Component providing an accessible and
+ * customizable button.
+ * </p>
+ * <p>
+ * &lt;vaadin-button&gt; &lt;/vaadin-button&gt;
+ * </p>
+ * <p>
+ * {@code document.querySelector('vaadin-button').addEventListener('click', () =&gt; alert('Hello World!'));}
+ * </p>
+ * <h3>Styling</h3>
+ * <p>
+ * The following shadow DOM parts are exposed for styling:
+ * </p>
+ * <table>
+ * <caption>Shadow DOM parts exposed for styling</caption> <thead>
+ * <tr>
+ * <th>Part name</th>
+ * <th>Description</th>
+ * </tr>
+ * </thead> <tbody>
+ * <tr>
+ * <td>{@code label}</td>
+ * <td>The label (text) inside the button</td>
+ * </tr>
+ * <tr>
+ * <td>{@code prefix}</td>
+ * <td>A slot for e.g. an icon before the label</td>
+ * </tr>
+ * <tr>
+ * <td>{@code suffix}</td>
+ * <td>A slot for e.g. an icon after the label</td>
+ * </tr>
+ * </tbody>
+ * </table>
+ * <p>
+ * The following attributes are exposed for styling:
+ * </p>
+ * <table>
+ * <caption>Attributes exposed for styling</caption> <thead>
+ * <tr>
+ * <th>Attribute</th>
+ * <th>Description</th>
+ * </tr>
+ * </thead> <tbody>
+ * <tr>
+ * <td>{@code active}</td>
+ * <td>Set when the button is pressed down, either with mouse, touch or the
+ * keyboard.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code disabled}</td>
+ * <td>Set when the button is disabled.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code focus-ring}</td>
+ * <td>Set when the button is focused using the keyboard.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code focused}</td>
+ * <td>Set when the button is focused.</td>
+ * </tr>
+ * </tbody>
+ * </table>
+ * <p>
+ * See
+ * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
+ * – how to apply styles for shadow parts</a>
+ * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 @Tag("vaadin-button")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -53,7 +127,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -70,7 +144,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *
      * @param autofocus
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setAutofocus(boolean autofocus) {
         getElement().setProperty("autofocus", autofocus);
     }
@@ -88,7 +165,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -127,7 +204,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrefix(Component... components) {
@@ -150,7 +227,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void addToSuffix(Component... components) {
@@ -168,7 +245,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -188,7 +265,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {
@@ -218,7 +295,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *            the text content to set
      * @see HasText#setText(String)
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinButton(String text) {
@@ -227,7 +304,10 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
 
     /**
      * Default constructor.
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     public GeneratedVaadinButton() {
     }
 }


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinButton` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the classes except for the methods that cause a public override to appear deprecated. In that case, it is agreed that the deprecation will be apparent via the deprecation of the class itself.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.