### PR TITLE
refactor: deprecate generated context menu class and methods

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -46,7 +46,6 @@ import com.vaadin.flow.function.SerializableRunnable;
  *
  * @author Vaadin Ltd.
  */
-@SuppressWarnings({"serial", "deprecation"})
 public class ContextMenu extends ContextMenuBase<ContextMenu, MenuItem, SubMenu>
         implements HasMenuItems {
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -46,7 +46,7 @@ import com.vaadin.flow.function.SerializableRunnable;
  *
  * @author Vaadin Ltd.
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({"serial", "deprecation"})
 public class ContextMenu extends ContextMenuBase<ContextMenu, MenuItem, SubMenu>
         implements HasMenuItems {
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -45,7 +45,7 @@ import elemental.json.JsonObject;
  *
  * @author Vaadin Ltd.
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({"serial", "deprecation"})
 @JsModule("./flow-component-renderer.js")
 @JsModule("./contextMenuConnector.js")
 @JsModule("./contextMenuTargetConnector.js")

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -45,7 +45,7 @@ import elemental.json.JsonObject;
  *
  * @author Vaadin Ltd.
  */
-@SuppressWarnings({"serial", "deprecation"})
+@SuppressWarnings("deprecation")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./contextMenuConnector.js")
 @JsModule("./contextMenuTargetConnector.js")
@@ -439,5 +439,12 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         getElement().executeJs(
                 "window.Vaadin.Flow.contextMenuConnector.initLazy(this, $0)",
                 appId);
+    }
+
+    public static class OpenedChangeEvent<C extends ContextMenuBase<C, ?, ?>>
+            extends GeneratedVaadinContextMenu.OpenedChangeEvent<C> {
+        public OpenedChangeEvent(C source, boolean fromClient) {
+            super(source, fromClient);
+        }
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -33,113 +33,9 @@ import com.vaadin.flow.shared.Registration;
 import elemental.json.JsonObject;
 
 /**
- * <p>
- * Description copied from corresponding location in WebComponent:
- * </p>
- * <p>
- * &lt;vaadin-context-menu&gt; &lt;template&gt; &lt;vaadin-list-box&gt;
- * &lt;vaadin-item&gt;First menu item&lt;/vaadin-item&gt;
- * &lt;vaadin-item&gt;Second menu item&lt;/vaadin-item&gt;
- * &lt;/vaadin-list-box&gt; &lt;/template&gt; &lt;/vaadin-context-menu&gt;
- * </p>
- * <h3>“vaadin-contextmenu” Gesture Event</h3>
- * <p>
- * {@code vaadin-contextmenu} is a gesture event (a custom event fired by
- * Polymer), which is dispatched after either {@code contextmenu} and long touch
- * events. This enables support for both mouse and touch environments in a
- * uniform way.
- * </p>
- * <p>
- * {@code <vaadin-context-menu>} opens the menu overlay on the
- * {@code vaadin-contextmenu} event by default.
- * </p>
- * <h3>Menu Listener</h3>
- * <p>
- * By default, the {@code <vaadin-context-menu>} element listens for the menu
- * opening event on itself. In order to have a context menu on your content,
- * wrap your content with the {@code <vaadin-context-menu>} element, and add a
- * template element with a menu. Example:
- * </p>
- * <p>
- * &lt;vaadin-context-menu&gt; &lt;template&gt; &lt;vaadin-list-box&gt;
- * &lt;vaadin-item&gt;First menu item&lt;/vaadin-item&gt;
- * &lt;vaadin-item&gt;Second menu item&lt;/vaadin-item&gt;
- * &lt;/vaadin-list-box&gt; &lt;/template&gt;
- * </p>
- * <p>
- * &lt;p&gt;This paragraph has the context menu provided in the above
- * template.&lt;/p&gt; &lt;p&gt;Another paragraph with the context
- * menu.&lt;/p&gt; &lt;/vaadin-context-menu&gt;
- * </p>
- * <p>
- * In case if you do not want to wrap the page content, you can listen for
- * events on an element outside the {@code <vaadin-context-menu>} by setting the
- * {@code listenOn} property:
- * </p>
- * <p>
- * &lt;vaadin-context-menu id=&quot;customListener&quot;&gt; &lt;template&gt;
- * &lt;vaadin-list-box&gt; ... &lt;/vaadin-list-box&gt; &lt;/template&gt;
- * &lt;/vaadin-context-menu&gt;
- * </p>
- * <p>
- * &lt;div id=&quot;menuListener&quot;&gt;The element that listens for the
- * context menu.&lt;/div&gt;
- * </p>
- * <p>
- * &amp;lt;script&amp;gt; const contextMenu =
- * document.querySelector('vaadin-context-menu#customListener');
- * contextMenu.listenOn = document.querySelector('#menuListener');
- * &amp;lt;/script&amp;gt;
- * </p>
- * <h3>Filtering Menu Targets</h3>
- * <p>
- * By default, the listener element and all its descendants open the context
- * menu. You can filter the menu targets to a smaller set of elements inside the
- * listener element by setting the {@code selector} property.
- * </p>
- * <p>
- * In the following example, only the elements matching {@code .has-menu} will
- * open the context menu:
- * </p>
- * <p>
- * &lt;vaadin-context-menu selector=&quot;.has-menu&quot;&gt; &lt;template&gt;
- * &lt;vaadin-list-box&gt; ... &lt;/vaadin-list-box&gt; &lt;/template&gt;
- * </p>
- * <p>
- * &lt;p class=&quot;has-menu&quot;&gt;This paragraph opens the context
- * menu&lt;/p&gt; &lt;p&gt;This paragraph does not open the context
- * menu&lt;/p&gt; &lt;/vaadin-context-menu&gt;
- * </p>
- * <h3>Menu Context</h3>
- * <p>
- * You can bind to the following properties in the menu template:
- * </p>
- * <ul>
- * <li>{@code target} is the menu opening event target, which is the element
- * that the user has called the context menu for</li>
- * <li>{@code detail} is the menu opening event detail</li>
- * </ul>
- * <p>
- * In the following example, the menu item text is composed with the contents of
- * the element that opened the menu:
- * </p>
- * <p>
- * &lt;vaadin-context-menu selector=&quot;li&quot;&gt; &lt;template&gt;
- * &lt;vaadin-list-box&gt; &lt;vaadin-item&gt;The menu target:
- * [[target.textContent]]&lt;/vaadin-item&gt; &lt;/vaadin-list-box&gt;
- * &lt;/template&gt;
- * </p>
- * <p>
- * &lt;ul&gt; &lt;li&gt;Foo&lt;/li&gt; &lt;li&gt;Bar&lt;/li&gt;
- * &lt;li&gt;Baz&lt;/li&gt; &lt;/ul&gt; &lt;/vaadin-context-menu&gt;
- * </p>
- * <h3>Styling</h3>
- * <p>
- * See
- * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
- * – how to apply styles for shadow parts</a>
- * </p>
+ * @deprecated since v23.3, will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-context-menu")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -163,7 +59,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * </p>
      *
      * @return the {@code selector} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected String getSelectorString() {
         return getElement().getProperty("selector");
     }
@@ -179,7 +78,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @param selector
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void setSelector(String selector) {
         getElement().setProperty("selector", selector == null ? "" : selector);
     }
@@ -196,7 +98,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * </p>
      *
      * @return the {@code opened} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
     protected boolean isOpenedBoolean() {
         return getElement().getProperty("opened", false);
@@ -214,7 +119,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * </p>
      *
      * @return the {@code openOn} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected String getOpenOnString() {
         return getElement().getProperty("openOn");
     }
@@ -229,7 +137,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @param openOn
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void setOpenOn(String openOn) {
         getElement().setProperty("openOn", openOn == null ? "" : openOn);
     }
@@ -248,7 +159,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * </p>
      *
      * @return the {@code listenOn} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected JsonObject getListenOnJsonObject() {
         return (JsonObject) getElement().getPropertyRaw("listenOn");
     }
@@ -265,7 +179,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @param listenOn
      *            the JsonObject value to set
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void setListenOn(JsonObject listenOn) {
         getElement().setPropertyJson("listenOn", listenOn);
     }
@@ -282,7 +199,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * </p>
      *
      * @return the {@code closeOn} property from the webcomponent
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected String getCloseOnString() {
         return getElement().getProperty("closeOn");
     }
@@ -297,7 +217,10 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @param closeOn
      *            the String value to set
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void setCloseOn(String closeOn) {
         getElement().setProperty("closeOn", closeOn == null ? "" : closeOn);
     }
@@ -321,11 +244,18 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * <p>
      * Opens the overlay.
      * </p>
+     *
+     * @deprecated since v23.3, will be removed in v24.
      */
+    @Deprecated
     protected void open() {
         getElement().callFunction("open");
     }
 
+    /**
+     * @deprecated since v23.3, will be removed in v24.
+     */
+    @Deprecated
     public static class OpenedChangeEvent<R extends GeneratedVaadinContextMenu<R>>
             extends ComponentEvent<R> {
         private final boolean opened;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -44,7 +44,7 @@ import elemental.json.JsonObject;
 @NpmPackage(value = "@vaadin/vaadin-context-menu", version = "23.3.0-alpha6")
 @JsModule("@vaadin/context-menu/src/vaadin-context-menu.js")
 @JsModule("@vaadin/polymer-legacy-adapter/template-renderer.js")
-public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContextMenu<R>>
+public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?, ?>>
         extends Component implements HasStyle, ClickNotifier<R> {
 
     /**
@@ -269,14 +269,15 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
 
     /**
      * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     *             classes. Use {@link ContextMenuBase.OpenedChangeEvent}
+     *             instead.
      */
     @Deprecated
-    public static class OpenedChangeEvent<R extends GeneratedVaadinContextMenu<R>>
-            extends ComponentEvent<R> {
+    public static class OpenedChangeEvent<C extends ContextMenuBase<C, ?, ?>>
+            extends ComponentEvent<C> {
         private final boolean opened;
 
-        public OpenedChangeEvent(R source, boolean fromClient) {
+        public OpenedChangeEvent(C source, boolean fromClient) {
             super(source, fromClient);
             this.opened = source.isOpenedBoolean();
         }
@@ -299,12 +300,11 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return getElement()
-                .addPropertyChangeListener("opened",
-                        event -> listener.onComponentEvent(
-                                new OpenedChangeEvent<R>((R) this,
-                                        event.isUserOriginated())));
+            ComponentEventListener<ContextMenuBase.OpenedChangeEvent<R>> listener) {
+        return getElement().addPropertyChangeListener("opened",
+                event -> listener.onComponentEvent(
+                        new ContextMenuBase.OpenedChangeEvent<>((R) this,
+                                event.isUserOriginated())));
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -33,8 +33,114 @@ import com.vaadin.flow.shared.Registration;
 import elemental.json.JsonObject;
 
 /**
- * @deprecated since v23.3. Will be removed in v24 along with all generated
- *             classes.
+ * <p>
+ * Description copied from corresponding location in WebComponent:
+ * </p>
+ * <p>
+ * &lt;vaadin-context-menu&gt; &lt;template&gt; &lt;vaadin-list-box&gt;
+ * &lt;vaadin-item&gt;First menu item&lt;/vaadin-item&gt;
+ * &lt;vaadin-item&gt;Second menu item&lt;/vaadin-item&gt;
+ * &lt;/vaadin-list-box&gt; &lt;/template&gt; &lt;/vaadin-context-menu&gt;
+ * </p>
+ * <h3>“vaadin-contextmenu” Gesture Event</h3>
+ * <p>
+ * {@code vaadin-contextmenu} is a gesture event (a custom event fired by
+ * Polymer), which is dispatched after either {@code contextmenu} and long touch
+ * events. This enables support for both mouse and touch environments in a
+ * uniform way.
+ * </p>
+ * <p>
+ * {@code <vaadin-context-menu>} opens the menu overlay on the
+ * {@code vaadin-contextmenu} event by default.
+ * </p>
+ * <h3>Menu Listener</h3>
+ * <p>
+ * By default, the {@code <vaadin-context-menu>} element listens for the menu
+ * opening event on itself. In order to have a context menu on your content,
+ * wrap your content with the {@code <vaadin-context-menu>} element, and add a
+ * template element with a menu. Example:
+ * </p>
+ * <p>
+ * &lt;vaadin-context-menu&gt; &lt;template&gt; &lt;vaadin-list-box&gt;
+ * &lt;vaadin-item&gt;First menu item&lt;/vaadin-item&gt;
+ * &lt;vaadin-item&gt;Second menu item&lt;/vaadin-item&gt;
+ * &lt;/vaadin-list-box&gt; &lt;/template&gt;
+ * </p>
+ * <p>
+ * &lt;p&gt;This paragraph has the context menu provided in the above
+ * template.&lt;/p&gt; &lt;p&gt;Another paragraph with the context
+ * menu.&lt;/p&gt; &lt;/vaadin-context-menu&gt;
+ * </p>
+ * <p>
+ * In case if you do not want to wrap the page content, you can listen for
+ * events on an element outside the {@code <vaadin-context-menu>} by setting the
+ * {@code listenOn} property:
+ * </p>
+ * <p>
+ * &lt;vaadin-context-menu id=&quot;customListener&quot;&gt; &lt;template&gt;
+ * &lt;vaadin-list-box&gt; ... &lt;/vaadin-list-box&gt; &lt;/template&gt;
+ * &lt;/vaadin-context-menu&gt;
+ * </p>
+ * <p>
+ * &lt;div id=&quot;menuListener&quot;&gt;The element that listens for the
+ * context menu.&lt;/div&gt;
+ * </p>
+ * <p>
+ * &amp;lt;script&amp;gt; const contextMenu =
+ * document.querySelector('vaadin-context-menu#customListener');
+ * contextMenu.listenOn = document.querySelector('#menuListener');
+ * &amp;lt;/script&amp;gt;
+ * </p>
+ * <h3>Filtering Menu Targets</h3>
+ * <p>
+ * By default, the listener element and all its descendants open the context
+ * menu. You can filter the menu targets to a smaller set of elements inside the
+ * listener element by setting the {@code selector} property.
+ * </p>
+ * <p>
+ * In the following example, only the elements matching {@code .has-menu} will
+ * open the context menu:
+ * </p>
+ * <p>
+ * &lt;vaadin-context-menu selector=&quot;.has-menu&quot;&gt; &lt;template&gt;
+ * &lt;vaadin-list-box&gt; ... &lt;/vaadin-list-box&gt; &lt;/template&gt;
+ * </p>
+ * <p>
+ * &lt;p class=&quot;has-menu&quot;&gt;This paragraph opens the context
+ * menu&lt;/p&gt; &lt;p&gt;This paragraph does not open the context
+ * menu&lt;/p&gt; &lt;/vaadin-context-menu&gt;
+ * </p>
+ * <h3>Menu Context</h3>
+ * <p>
+ * You can bind to the following properties in the menu template:
+ * </p>
+ * <ul>
+ * <li>{@code target} is the menu opening event target, which is the element
+ * that the user has called the context menu for</li>
+ * <li>{@code detail} is the menu opening event detail</li>
+ * </ul>
+ * <p>
+ * In the following example, the menu item text is composed with the contents of
+ * the element that opened the menu:
+ * </p>
+ * <p>
+ * &lt;vaadin-context-menu selector=&quot;li&quot;&gt; &lt;template&gt;
+ * &lt;vaadin-list-box&gt; &lt;vaadin-item&gt;The menu target:
+ * [[target.textContent]]&lt;/vaadin-item&gt; &lt;/vaadin-list-box&gt;
+ * &lt;/template&gt;
+ * </p>
+ * <p>
+ * &lt;ul&gt; &lt;li&gt;Foo&lt;/li&gt; &lt;li&gt;Bar&lt;/li&gt;
+ * &lt;li&gt;Baz&lt;/li&gt; &lt;/ul&gt; &lt;/vaadin-context-menu&gt;
+ * </p>
+ * <h3>Styling</h3>
+ * <p>
+ * See
+ * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
+ * – how to apply styles for shadow parts</a>
+ * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-context-menu")
@@ -61,8 +167,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code selector} property from the webcomponent
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected String getSelectorString() {
@@ -81,8 +186,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param selector
      *            the String value to set
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void setSelector(String selector) {
@@ -102,8 +206,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code opened} property from the webcomponent
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -124,8 +227,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code openOn} property from the webcomponent
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected String getOpenOnString() {
@@ -143,8 +245,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param openOn
      *            the String value to set
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void setOpenOn(String openOn) {
@@ -166,8 +267,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code listenOn} property from the webcomponent
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected JsonObject getListenOnJsonObject() {
@@ -187,8 +287,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param listenOn
      *            the JsonObject value to set
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void setListenOn(JsonObject listenOn) {
@@ -208,8 +307,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code closeOn} property from the webcomponent
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected String getCloseOnString() {
@@ -227,8 +325,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param closeOn
      *            the String value to set
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void setCloseOn(String closeOn) {
@@ -243,8 +340,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * Closes the overlay.
      * </p>
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void close() {
@@ -259,8 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * Opens the overlay.
      * </p>
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     protected void open() {
@@ -268,9 +363,8 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
     }
 
     /**
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes. Use {@link ContextMenuBase.OpenedChangeEvent}
-     *             instead.
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link ContextMenuBase.OpenedChangeEvent} instead.
      */
     @Deprecated
     public static class OpenedChangeEvent<C extends ContextMenuBase<C, ?, ?>>
@@ -295,8 +389,8 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3. Will be removed in v24 along with all generated
-     *             classes.
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link ContextMenuBase#addOpenedChangeListener} instead.
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
@@ -313,7 +407,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @see #addClickListener(ComponentEventListener)
      *
-     * @deprecated since 23.3
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     @Override
@@ -328,7 +422,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @see #addClickShortcut(Key, KeyModifier...)
      *
-     * @deprecated since 23.3
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
     @Deprecated
     @Override

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -33,7 +33,8 @@ import com.vaadin.flow.shared.Registration;
 import elemental.json.JsonObject;
 
 /**
- * @deprecated since v23.3, will be removed in v24.
+ * @deprecated since v23.3. Will be removed in v24 along with all generated
+ *             classes.
  */
 @Deprecated
 @Tag("vaadin-context-menu")
@@ -60,7 +61,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @return the {@code selector} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected String getSelectorString() {
@@ -79,7 +81,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * @param selector
      *            the String value to set
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected void setSelector(String selector) {
@@ -99,7 +102,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @return the {@code opened} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -120,7 +124,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @return the {@code openOn} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected String getOpenOnString() {
@@ -138,7 +143,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * @param openOn
      *            the String value to set
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected void setOpenOn(String openOn) {
@@ -160,7 +166,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @return the {@code listenOn} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected JsonObject getListenOnJsonObject() {
@@ -180,7 +187,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * @param listenOn
      *            the JsonObject value to set
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected void setListenOn(JsonObject listenOn) {
@@ -200,7 +208,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      *
      * @return the {@code closeOn} property from the webcomponent
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected String getCloseOnString() {
@@ -218,7 +227,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * @param closeOn
      *            the String value to set
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected void setCloseOn(String closeOn) {
@@ -232,7 +242,11 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * <p>
      * Closes the overlay.
      * </p>
+     *
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
+    @Deprecated
     protected void close() {
         getElement().callFunction("close");
     }
@@ -245,7 +259,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * Opens the overlay.
      * </p>
      *
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     protected void open() {
@@ -253,7 +268,8 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
     }
 
     /**
-     * @deprecated since v23.3, will be removed in v24.
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
     @Deprecated
     public static class OpenedChangeEvent<R extends GeneratedVaadinContextMenu<R>>
@@ -277,7 +293,11 @@ public abstract class GeneratedVaadinContextMenu<R extends GeneratedVaadinContex
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     *
+     * @deprecated since v23.3. Will be removed in v24 along with all generated
+     *             classes.
      */
+    @Deprecated
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
         return getElement()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
@@ -36,7 +36,6 @@ import elemental.json.JsonObject;
  *
  * @author Vaadin Ltd.
  */
-@SuppressWarnings({"serial", "deprecation"})
 public class GridContextMenu<T> extends
         ContextMenuBase<GridContextMenu<T>, GridMenuItem<T>, GridSubMenu<T>>
         implements HasGridMenuItems<T> {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
@@ -36,7 +36,7 @@ import elemental.json.JsonObject;
  *
  * @author Vaadin Ltd.
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({"serial", "deprecation"})
 public class GridContextMenu<T> extends
         ContextMenuBase<GridContextMenu<T>, GridMenuItem<T>, GridSubMenu<T>>
         implements HasGridMenuItems<T> {


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinContextMenu` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the classes except for the methods that cause a public override to appear deprecated. In that case, it is agreed that the deprecation will be apparent via the deprecation of the class itself.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.