### PR TITLE
refactor: deprecate no longer used week string

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -1030,6 +1030,7 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
          *
          * @return the translated word for week
          */
+        @Deprecated
         public String getWeek() {
             return week;
         }
@@ -1041,6 +1042,7 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
          *            the translated word for week
          * @return this instance for method chaining
          */
+        @Deprecated
         public DatePickerI18n setWeek(String week) {
             this.week = week;
             return this;


### PR DESCRIPTION
## Description

The `i18n.week` has been removed by https://github.com/vaadin/web-components/pull/4799
Let's deprecate it for `23.3` branch so that we can remove it in V24.

## Type of change

- Deprecation