### PR TITLE
refactor: deprecate generated dialog class and methods

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -71,6 +71,7 @@ import com.vaadin.flow.shared.Registration;
  */
 @JsModule("./dialogConnector.js")
 @JsModule("./flow-component-renderer.js")
+@SuppressWarnings("deprecation")
 public class Dialog extends GeneratedVaadinDialog<Dialog>
         implements HasComponents, HasSize, HasTheme, HasStyle {
 
@@ -852,7 +853,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      */
     @Override
     public Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent<Dialog>> listener) {
+            ComponentEventListener<OpenedChangeEvent> listener) {
         return super.addOpenedChangeListener(listener);
     }
 
@@ -964,4 +965,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 "Dialog does not support adding styles to overlay");
     }
 
+    public static class OpenedChangeEvent
+            extends GeneratedVaadinDialog.OpenedChangeEvent<Dialog> {
+        public OpenedChangeEvent(Dialog source, boolean fromClient) {
+            super(source, fromClient);
+        }
+    }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -47,7 +47,10 @@ import com.vaadin.flow.shared.Registration;
  * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
  * – how to apply styles for shadow parts</a>
  * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-dialog")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -70,7 +73,9 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      * </p>
      *
      * @return the {@code opened} property from the webcomponent
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
     protected boolean isOpenedBoolean() {
         return getElement().getProperty("opened", false);
@@ -86,7 +91,9 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      *
      * @param opened
      *            the boolean value to set
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setOpened(boolean opened) {
         getElement().setProperty("opened", opened);
     }
@@ -106,7 +113,9 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      * </p>
      *
      * @return the {@code ariaLabel} property from the webcomponent
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected String getAriaLabelString() {
         return getElement().getProperty("ariaLabel");
     }
@@ -124,12 +133,18 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      *
      * @param ariaLabel
      *            the String value to set
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setAriaLabel(String ariaLabel) {
         getElement().setProperty("ariaLabel",
                 ariaLabel == null ? "" : ariaLabel);
     }
 
+    /**
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     */
+    @Deprecated
     public static class OpenedChangeEvent<R extends GeneratedVaadinDialog<R>>
             extends ComponentEvent<R> {
         private final boolean opened;
@@ -151,13 +166,15 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent<R>> listener) {
+            ComponentEventListener<Dialog.OpenedChangeEvent> listener) {
         return getElement()
                 .addPropertyChangeListener("opened",
                         event -> listener.onComponentEvent(
-                                new OpenedChangeEvent<R>((R) this,
+                                new Dialog.OpenedChangeEvent((Dialog) this,
                                         event.isUserOriginated())));
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -142,7 +142,8 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link Dialog.OpenedChangeEvent} instead.
      */
     @Deprecated
     public static class OpenedChangeEvent<R extends GeneratedVaadinDialog<R>>


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinDialog` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the classes except for the methods that cause a public override to appear deprecated. In that case, it is agreed that the deprecation will be apparent via the deprecation of the class itself.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.