### PR TITLE
refactor!: remove setPattern API from NumberField

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -310,9 +310,23 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
         return (int) getMinlengthDouble();
     }
 
-    @Override
+    /**
+     * Sets a regular expression for the value to pass on the client-side. The
+     * pattern must be a valid JavaScript Regular Expression that matches the
+     * entire value, not just some subset.
+     *
+     * @param pattern
+     *            the new String pattern
+     *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern">
+     *      https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern</>
+     * @see <a href=
+     *      "https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern">
+     *      https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern</>
+     */
     public void setPattern(String pattern) {
-        super.setPattern(pattern);
+        getElement().setProperty("pattern", pattern == null ? "" : pattern);
         getValidationSupport().setPattern(pattern);
     }
 
@@ -323,7 +337,7 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
      * @return the {@code pattern} property from the webcomponent
      */
     public String getPattern() {
-        return getPatternString();
+        return getElement().getProperty("pattern");
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -719,40 +719,6 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * Description copied from corresponding location in WebComponent:
      * </p>
      * <p>
-     * A regular expression that the value is checked against. The pattern must
-     * match the entire value, not just some subset.
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
-     *
-     * @return the {@code pattern} property from the webcomponent
-     */
-    protected String getPatternString() {
-        return getElement().getProperty("pattern");
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * A regular expression that the value is checked against. The pattern must
-     * match the entire value, not just some subset.
-     * </p>
-     *
-     * @param pattern
-     *            the String value to set
-     */
-    protected void setPattern(String pattern) {
-        getElement().setProperty("pattern", pattern == null ? "" : pattern);
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
      * Message to show to the user when validation fails.
      * <p>
      * This property is not synchronized automatically from the client side, so

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
@@ -261,38 +261,6 @@ public class NumberField extends AbstractNumberField<NumberField, Double> {
         return (int) getMinlengthDouble();
     }
 
-    /**
-     * @deprecated Not supported by NumberField (as it's built on
-     *             {@code <input type="number">} in HTML). You can set numeric
-     *             value constraints with {@link #setMin(double)},
-     *             {@link #setMax(double)} and {@link #setStep(double)}. For
-     *             setting a custom value pattern, use the TextField component
-     *             instead.
-     */
-    @Override
-    @Deprecated
-    public void setPattern(String pattern) {
-        super.setPattern(pattern);
-    }
-
-    /**
-     * A regular expression that the value is checked against. The pattern must
-     * match the entire value, not just some subset.
-     *
-     * @return the {@code pattern} property from the webcomponent
-     *
-     * @deprecated Not supported by NumberField (as it's built on
-     *             {@code <input type="number">} in HTML). You can set numeric
-     *             value constraints with {@link #setMin(double)},
-     *             {@link #setMax(double)} and {@link #setStep(double)}. For
-     *             setting a custom value pattern, use the TextField component
-     *             instead.
-     */
-    @Deprecated
-    public String getPattern() {
-        return getPatternString();
-    }
-
     private static class Formatter
             implements SerializableFunction<Double, String> {
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -332,9 +332,23 @@ public class PasswordField
         getValidationSupport().setRequired(required);
     }
 
-    @Override
+    /**
+     * Sets a regular expression for the value to pass on the client-side. The
+     * pattern must be a valid JavaScript Regular Expression that matches the
+     * entire value, not just some subset.
+     *
+     * @param pattern
+     *            the new String pattern
+     *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern">
+     *      https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern</>
+     * @see <a href=
+     *      "https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern">
+     *      https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern</>
+     */
     public void setPattern(String pattern) {
-        super.setPattern(pattern);
+        getElement().setProperty("pattern", pattern == null ? "" : pattern);
         getValidationSupport().setPattern(pattern);
     }
 
@@ -345,7 +359,7 @@ public class PasswordField
      * @return the {@code pattern} property from the webcomponent
      */
     public String getPattern() {
-        return getPatternString();
+        return getElement().getProperty("pattern");
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -390,7 +390,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
      *      https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern</>
      */
     public void setPattern(String pattern) {
-        getElement().setProperty("pattern", pattern);
+        getElement().setProperty("pattern", pattern == null ? "" : pattern);
         getValidationSupport().setPattern(pattern);
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -407,9 +407,8 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
      *      "https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern">
      *      https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern</>
      */
-    @Override
     public void setPattern(String pattern) {
-        super.setPattern(pattern);
+        getElement().setProperty("pattern", pattern == null ? "" : pattern);
         getValidationSupport().setPattern(pattern);
     }
 
@@ -420,7 +419,7 @@ public class TextField extends GeneratedVaadinTextField<TextField, String>
      * @return the {@code pattern} property from the webcomponent
      */
     public String getPattern() {
-        return getPatternString();
+        return getElement().getProperty("pattern");
     }
 
     /**


### PR DESCRIPTION
## Description

Remove deprecated `setPattern` API from `NumberField` as not supported by `<input type="number">`.

Note, we might revisit the field internals to use `<input type="text">` instead in the future.
However, there are no specific plans at this point, so let's remove this API in Vaadin 24.

If we decide to re-implement `NumberField`, we might add this API back in a future minor version.

## Type of change

- Breaking change