### PR TITLE
fix: update invalid mark on cell refresh

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
@@ -1190,6 +1190,10 @@ public class CellValueManager implements Serializable {
                 final String key = SpreadsheetUtil.toKey(columnIndex + 1,
                         rowIndex + 1);
 
+                // Remove existing invalid formula markers
+                spreadsheet.removeInvalidFormulaMark(cell.getColumnIndex() + 1,
+                        cell.getRowIndex() + 1);
+
                 // Mark for update if there are formatting rules.
                 if (spreadsheet.getConditionalFormatter()
                         .getCellFormattingIndex(cell) != null) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
@@ -510,6 +510,9 @@ public class CellValueManager implements Serializable {
      *            Cell to mark for updates
      */
     protected void cellUpdated(Cell cell) {
+        // Remove existing invalid formula markers
+        spreadsheet.removeInvalidFormulaMark(cell.getColumnIndex() + 1,
+                cell.getRowIndex() + 1);
         getFormulaEvaluator().notifyUpdateCell(cell);
         markCellForUpdate(cell);
     }
@@ -1189,10 +1192,6 @@ public class CellValueManager implements Serializable {
                 int columnIndex = cell.getColumnIndex();
                 final String key = SpreadsheetUtil.toKey(columnIndex + 1,
                         rowIndex + 1);
-
-                // Remove existing invalid formula markers
-                spreadsheet.removeInvalidFormulaMark(cell.getColumnIndex() + 1,
-                        cell.getRowIndex() + 1);
 
                 // Mark for update if there are formatting rules.
                 if (spreadsheet.getConditionalFormatter()

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -109,6 +109,34 @@ public class FormulasTest {
     }
 
     @Test
+    public void setInvalidFormula_overwriteFormula_invalidFormulaCellsCleared() {
+        // Create a formula cell with an invalid formula
+        var A1 = spreadsheet.createFormulaCell(0, 0, "Sheet2!A1");
+        spreadsheet.refreshCells(A1);
+
+        // Overwrite the formula with a valid one
+        A1.setCellFormula("1+1");
+        spreadsheet.refreshCells(A1);
+
+        Assert.assertEquals("[]",
+                spreadsheet.getElement().getProperty("invalidFormulaCells"));
+    }
+
+    @Test
+    public void setValidFormula_overwriteWithInvalidFormula_invalidFormulaCellsSet() {
+        // Create a formula cell with a valid formula
+        var A1 = spreadsheet.createFormulaCell(0, 0, "1+1");
+        spreadsheet.refreshCells(A1);
+
+        // Overwrite the formula with an invalid one
+        A1.setCellFormula("Sheet2!A1");
+        spreadsheet.refreshCells(A1);
+
+        Assert.assertEquals("[\"col1 row1\"]",
+                spreadsheet.getElement().getProperty("invalidFormulaCells"));
+    }
+
+    @Test
     public void setInvalidFormulaErrorMessage_invalidFormulaErrorMessageSet() {
         spreadsheet.setInvalidFormulaErrorMessage("foo");
         Assert.assertEquals("foo", spreadsheet.getElement()


### PR DESCRIPTION
## Description

Addresses the issue: "[Updating a cell marked invalid (formula) programmatically does not remove the invalid indicator.](https://docs.google.com/spreadsheets/d/1dpRq-pHZ8DwtEEmmSTVLraix-7AWTzzPp1YutVU0qRg/edit#gid=0)"

Depends on https://github.com/vaadin/flow-components/pull/4089

## Type of change

- [x] Bugfix
- [ ] Feature