### PR TITLE
refactor!: remove deprecated setHeightByRows from Grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewAllRowsVisiblePage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewAllRowsVisiblePage.java
@@ -22,14 +22,10 @@ import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-grid-it-demo/height-by-rows")
-public class GridViewHeightByRowsPage extends LegacyTestView {
+@Route("vaadin-grid-it-demo/all-rows-visible")
+public class GridViewAllRowsVisiblePage extends LegacyTestView {
 
-    public GridViewHeightByRowsPage() {
-        createHeightByRows();
-    }
-
-    private void createHeightByRows() {
+    public GridViewAllRowsVisiblePage() {
         Grid<Person> grid = new Grid<>();
 
         // When using allRowsVisible, all items are fetched and
@@ -44,7 +40,7 @@ public class GridViewHeightByRowsPage extends LegacyTestView {
 
         grid.setSelectionMode(SelectionMode.NONE);
 
-        grid.setId("grid-height-by-rows");
-        addCard("Height by Rows", "Using height by rows", grid);
+        grid.setId("grid-all-rows-visible");
+        add(grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewAllRowsVisibleIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewAllRowsVisibleIT.java
@@ -23,8 +23,8 @@ import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
-@TestPath("vaadin-grid-it-demo/height-by-rows")
-public class GridViewHeightByRowsIT extends AbstractComponentIT {
+@TestPath("vaadin-grid-it-demo/all-rows-visible")
+public class GridViewAllRowsVisibleIT extends AbstractComponentIT {
 
     @Before
     public void init() {
@@ -32,12 +32,12 @@ public class GridViewHeightByRowsIT extends AbstractComponentIT {
     }
 
     @Test
-    public void heightByRows_allRowsAreFetched() {
-        GridElement grid = $(GridElement.class).id("grid-height-by-rows");
+    public void allRowsVisible_allRowsAreFetched() {
+        GridElement grid = $(GridElement.class).id("grid-all-rows-visible");
         scrollToElement(grid);
         waitUntil(driver -> grid.getRowCount() == 50);
 
-        Assert.assertEquals("Grid should have heightByRows set to true", "true",
-                grid.getAttribute("allRowsVisible"));
+        Assert.assertEquals("Grid should have allRowsVisible set to true",
+                "true", grid.getAttribute("allRowsVisible"));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3571,42 +3571,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * are fetched from the {@link DataProvider}, and the Grid shows no vertical
      * scroll bar.
      * <p>
-     * Note: <code>setHeightByRows</code> disables the grid's virtual scrolling
-     * so that all the rows are rendered in the DOM at once. If the grid has a
-     * large number of items, using the feature is discouraged to avoid
-     * performance issues.
-     *
-     * @deprecated since 14.7 - use {@link #setAllRowsVisible(boolean)}
-     * @see #setAllRowsVisible(boolean)
-     *
-     * @param heightByRows
-     *            <code>true</code> to make Grid compute its height by the
-     *            number of rows, <code>false</code> for the default behavior
-     */
-    @Deprecated
-    public void setHeightByRows(boolean heightByRows) {
-        setAllRowsVisible(heightByRows);
-    }
-
-    /**
-     * Gets whether grid's height is defined by the number of its rows.
-     *
-     * @deprecated since 14.7 - use {@link #isAllRowsVisible()}
-     * @see #isAllRowsVisible()
-     *
-     * @return <code>true</code> if Grid computes its height by the number of
-     *         rows, <code>false</code> otherwise
-     */
-    @Deprecated
-    public boolean isHeightByRows() {
-        return isAllRowsVisible();
-    }
-
-    /**
-     * If <code>true</code>, the grid's height is defined by its rows. All items
-     * are fetched from the {@link DataProvider}, and the Grid shows no vertical
-     * scroll bar.
-     * <p>
      * Note: <code>setAllRowsVisible</code> disables the grid's virtual
      * scrolling so that all the rows are rendered in the DOM at once. If the
      * grid has a large number of items, using the feature is discouraged to

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -72,18 +72,6 @@ public class GridTest {
     }
 
     @Test
-    public void setHeightByRows_allRowsAreVisible() {
-        final Grid<String> grid = new Grid<>();
-
-        Assert.assertEquals(null,
-                grid.getElement().getProperty("allRowsVisible"));
-
-        grid.setHeightByRows(true);
-        Assert.assertEquals("true",
-                grid.getElement().getProperty("allRowsVisible"));
-    }
-
-    @Test
     public void setAllRowsVisible_allRowsAreVisible() {
         final Grid<String> grid = new Grid<>();
 
@@ -96,11 +84,10 @@ public class GridTest {
     }
 
     @Test
-    public void setAllRowsVisibleProperty_isHeightByRowsAndIsAllRowsVisibleWork() {
+    public void setAllRowsVisibleProperty_isAllRowsVisibleWork() {
         final Grid<String> grid = new Grid<>();
         grid.getElement().setProperty("allRowsVisible", true);
 
-        Assert.assertTrue(grid.isHeightByRows());
         Assert.assertTrue(grid.isAllRowsVisible());
     }
 


### PR DESCRIPTION
## Description

Removed deprecated `setHeightByRows` API and renamed ITs to match the `setAllRowsVisible` API.

## Type of change

- Breaking change