### PR TITLE
refactor: deprecate generated notification class and its methods

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -85,7 +85,10 @@ Your work has been saved
  * Note: the {@code theme} attribute value set on {@code <vaadin-notification>}
  * is propagated to the internal {@code <vaadin-notification-card>}.
  * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-notification")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -109,7 +112,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * </p>
      *
      * @return the {@code duration} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected double getDurationDouble() {
         return getElement().getProperty("duration", 0.0);
     }
@@ -125,7 +131,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *
      * @param duration
      *            the double value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setDuration(double duration) {
         getElement().setProperty("duration", duration);
     }
@@ -142,7 +151,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * </p>
      *
      * @return the {@code opened} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
     protected boolean isOpenedBoolean() {
         return getElement().getProperty("opened", false);
@@ -158,7 +170,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *
      * @param opened
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setOpened(boolean opened) {
         getElement().setProperty("opened", opened);
     }
@@ -176,7 +191,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * </p>
      *
      * @return the {@code position} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected String getPositionString() {
         return getElement().getProperty("position");
     }
@@ -192,7 +210,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *
      * @param position
      *            the String value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setPosition(String position) {
         getElement().setProperty("position", position == null ? "" : position);
     }
@@ -204,7 +225,10 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * <p>
      * Opens the notification.
      * </p>
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void open() {
         getElement().callJsFunction("open");
     }
@@ -216,11 +240,19 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * <p>
      * Closes the notification.
      * </p>
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void close() {
         getElement().callJsFunction("close");
     }
 
+    /**
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link Notification.OpenedChangeEvent} instead.
+     */
+    @Deprecated
     public static class OpenedChangeEvent<R extends GeneratedVaadinNotification<R>>
             extends ComponentEvent<R> {
         private final boolean opened;
@@ -242,13 +274,15 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return getElement()
-                .addPropertyChangeListener("opened",
-                        event -> listener.onComponentEvent(
-                                new OpenedChangeEvent<R>((R) this,
-                                        event.isUserOriginated())));
+            ComponentEventListener<Notification.OpenedChangeEvent> listener) {
+        return getElement().addPropertyChangeListener("opened",
+                event -> listener.onComponentEvent(
+                        new Notification.OpenedChangeEvent((Notification) this,
+                                event.isUserOriginated())));
     }
 }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.shared.Registration;
  *
  * @author Vaadin Ltd
  */
+@SuppressWarnings("deprecation")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./notificationConnector.js")
 public class Notification extends GeneratedVaadinNotification<Notification>
@@ -487,7 +488,7 @@ public class Notification extends GeneratedVaadinNotification<Notification>
 
     @Override
     public Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent<Notification>> listener) {
+            ComponentEventListener<OpenedChangeEvent> listener) {
         return super.addOpenedChangeListener(listener);
     }
 
@@ -617,5 +618,12 @@ public class Notification extends GeneratedVaadinNotification<Notification>
     public Style getStyle() {
         throw new UnsupportedOperationException(
                 "Notification does not support adding styles to card element");
+    }
+
+    public static class OpenedChangeEvent extends
+            GeneratedVaadinNotification.OpenedChangeEvent<Notification> {
+        public OpenedChangeEvent(Notification source, boolean fromClient) {
+            super(source, fromClient);
+        }
     }
 }


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinNotification` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the classes.

Add suppress warning annotation to the main component. 

Create an `OpenedChangeEvent` in `Notification` which extends the one in the generated class. Alter the listeners in both classes to use the new event class.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.