### PR TITLE
refactor: deprecate generated progress bar class and its methods

### DIFF
--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/GeneratedVaadinProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/GeneratedVaadinProgressBar.java
@@ -98,7 +98,10 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * </tr>
  * </tbody>
  * </table>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-progress-bar")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -111,7 +114,11 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @param variants
      *            theme variants to add
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link ProgressBar#addThemeVariants} instead.
      */
+    @Deprecated
     public void addThemeVariants(ProgressBarVariant... variants) {
         getThemeNames().addAll(
                 Stream.of(variants).map(ProgressBarVariant::getVariantName)
@@ -123,7 +130,11 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @param variants
      *            theme variants to remove
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link ProgressBar#removeThemeVariants} instead.
      */
+    @Deprecated
     public void removeThemeVariants(ProgressBarVariant... variants) {
         getThemeNames().removeAll(
                 Stream.of(variants).map(ProgressBarVariant::getVariantName)
@@ -142,7 +153,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * </p>
      *
      * @return the {@code value} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected double getValueDouble() {
         return getElement().getProperty("value", 0.0);
     }
@@ -157,7 +171,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @param value
      *            the double value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setValue(double value) {
         getElement().setProperty("value", value);
     }
@@ -174,7 +191,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * </p>
      *
      * @return the {@code min} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected double getMinDouble() {
         return getElement().getProperty("min", 0.0);
     }
@@ -189,7 +209,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @param min
      *            the double value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setMin(double min) {
         getElement().setProperty("min", min);
     }
@@ -206,7 +229,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * </p>
      *
      * @return the {@code max} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected double getMaxDouble() {
         return getElement().getProperty("max", 0.0);
     }
@@ -221,7 +247,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @param max
      *            the double value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setMax(double max) {
         getElement().setProperty("max", max);
     }
@@ -239,7 +268,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * </p>
      *
      * @return the {@code indeterminate} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected boolean isIndeterminateBoolean() {
         return getElement().getProperty("indeterminate", false);
     }
@@ -255,7 +287,10 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @param indeterminate
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setIndeterminate(boolean indeterminate) {
         getElement().setProperty("indeterminate", indeterminate);
     }

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  *
  * @author Vaadin Ltd.
  */
+@SuppressWarnings("deprecation")
 @NpmPackage(value = "@vaadin/progress-bar", version = "23.3.0-alpha6")
 @NpmPackage(value = "@vaadin/vaadin-progress-bar", version = "23.3.0-alpha6")
 public class ProgressBar extends GeneratedVaadinProgressBar<ProgressBar>
@@ -166,5 +167,27 @@ public class ProgressBar extends GeneratedVaadinProgressBar<ProgressBar>
      */
     public boolean isIndeterminate() {
         return isIndeterminateBoolean();
+    }
+
+    /**
+     * Adds theme variants to the component.
+     *
+     * @param variants
+     *            theme variants to add
+     */
+    @Override
+    public void addThemeVariants(ProgressBarVariant... variants) {
+        super.addThemeVariants(variants);
+    }
+
+    /**
+     * Removes theme variants from the component.
+     *
+     * @param variants
+     *            theme variants to remove
+     */
+    @Override
+    public void removeThemeVariants(ProgressBarVariant... variants) {
+        super.removeThemeVariants(variants);
     }
 }


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinProgressBar` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the class. Override the public methods of the generated class in the main component, and make them call the ones in the generated class. 

Add suppress warning annotation to the main component.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.