### PR TITLE
refactor: deprecate generated split layout class and its methods

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -187,7 +187,10 @@ import com.vaadin.flow.shared.Registration;
  * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
  * – how to apply styles for shadow parts</a>
  * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-split-layout")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -200,7 +203,11 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *
      * @param variants
      *            theme variants to add
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link SplitLayout#addThemeVariants} instead.
      */
+    @Deprecated
     public void addThemeVariants(SplitLayoutVariant... variants) {
         getThemeNames().addAll(
                 Stream.of(variants).map(SplitLayoutVariant::getVariantName)
@@ -212,7 +219,11 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *
      * @param variants
      *            theme variants to remove
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link SplitLayout#removeThemeVariants} instead.
      */
+    @Deprecated
     public void removeThemeVariants(SplitLayoutVariant... variants) {
         getThemeNames().removeAll(
                 Stream.of(variants).map(SplitLayoutVariant::getVariantName)
@@ -232,7 +243,10 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * </p>
      *
      * @return the {@code orientation} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected String getOrientationString() {
         return getElement().getProperty("orientation");
     }
@@ -248,12 +262,18 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *
      * @param orientation
      *            the String value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setOrientation(String orientation) {
         getElement().setProperty("orientation",
                 orientation == null ? "" : orientation);
     }
 
+    /**
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     */
     @DomEvent("iron-resize")
     @Deprecated
     public static class IronResizeEvent<R extends GeneratedVaadinSplitLayout<R>>
@@ -270,7 +290,8 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated Since 23.2, this API is deprecated.
+     * @deprecated Since 23.2, this API is deprecated, deprecated classes will
+     *             be removed in v24.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Deprecated
@@ -280,6 +301,11 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
                 (ComponentEventListener) listener);
     }
 
+    /**
+     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     *             {@link SplitLayout.SplitterDragendEvent} instead.
+     */
+    @Deprecated
     @DomEvent("splitter-dragend")
     public static class SplitterDragendEvent<R extends GeneratedVaadinSplitLayout<R>>
             extends ComponentEvent<R> {
@@ -295,12 +321,14 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addSplitterDragendListener(
-            ComponentEventListener<SplitterDragendEvent<R>> listener) {
-        return addListener(SplitterDragendEvent.class,
-                (ComponentEventListener) listener);
+            ComponentEventListener<SplitLayout.SplitterDragendEvent> listener) {
+        return addListener(SplitLayout.SplitterDragendEvent.class, listener);
     }
 
     /**
@@ -315,7 +343,10 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void addToPrimary(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "primary");
@@ -335,7 +366,10 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @see <a href=
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void addToSecondary(Component... components) {
         for (Component component : components) {
             component.getElement().setAttribute("slot", "secondary");
@@ -350,7 +384,10 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *            The components to remove.
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
@@ -367,7 +404,10 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * Removes all contents from this component, this includes child components,
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void removeAll() {
         getElement().getChildren()
                 .forEach(child -> child.removeAttribute("slot"));

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -19,7 +19,9 @@ import java.util.Locale;
 import java.util.Objects;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -33,6 +35,7 @@ import com.vaadin.flow.shared.Registration;
  *
  * @author Vaadin Ltd
  */
+@SuppressWarnings("deprecation")
 @NpmPackage(value = "@vaadin/split-layout", version = "23.3.0-alpha6")
 @NpmPackage(value = "@vaadin/vaadin-split-layout", version = "23.3.0-alpha6")
 public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
@@ -304,7 +307,7 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      */
     @Override
     public Registration addSplitterDragendListener(
-            ComponentEventListener<SplitterDragendEvent<SplitLayout>> listener) {
+            ComponentEventListener<SplitterDragendEvent> listener) {
         return super.addSplitterDragendListener(listener);
     }
 
@@ -318,6 +321,35 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
             getElement().executeJs(
                     "var element = this.children[$0]; if (element) { element.style[$1]=$2; }",
                     primary ? 0 : 1, styleName, value);
+        }
+    }
+
+    /**
+     * Adds theme variants to the component.
+     *
+     * @param variants
+     *            theme variants to add
+     */
+    @Override
+    public void addThemeVariants(SplitLayoutVariant... variants) {
+        super.addThemeVariants(variants);
+    }
+
+    /**
+     * Removes theme variants from the component.
+     *
+     * @param variants
+     *            theme variants to remove
+     */
+    @Override
+    public void removeThemeVariants(SplitLayoutVariant... variants) {
+        super.removeThemeVariants(variants);
+    }
+
+    public static class SplitterDragendEvent extends
+            GeneratedVaadinSplitLayout.SplitterDragendEvent<SplitLayout> {
+        public SplitterDragendEvent(SplitLayout source, boolean fromClient) {
+            super(source, fromClient);
         }
     }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -19,9 +19,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.NpmPackage;


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinSplitLayout` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the class. Override the public methods of the generated class in the main component, and make them call the ones in the generated class. 

Add suppress warning annotation to the main component.

Create a `SplitterDragendEvent ` in `SplitLayout` which extends the one in the generated class. Alter the listeners in both classes to use the new event class.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.