### PR TITLE
fix: remove existing file before writing the worksheet

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -294,6 +294,10 @@ public class SpreadsheetFactory implements Serializable {
             }
         }
         final File file = new File(fileName);
+        if (file.exists()) {
+            // If the file exists beforehand, it needs to be deleted first
+            file.delete();
+        }
         FileOutputStream fos = null;
         try {
             fos = new FileOutputStream(file);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetReadWriteTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetReadWriteTest.java
@@ -50,6 +50,19 @@ public class SpreadsheetReadWriteTest {
     }
 
     @Test
+    public void writeFileMultipleTimes() throws IOException {
+        var sheet = TestHelper.createSpreadsheet("empty.xlsx");
+
+        // Write the file
+        sheet.write("resultEmptyFile.xlsx");
+        // Write the same file again
+        var tempFile = sheet.write("resultEmptyFile.xlsx");
+
+        tempFile.delete();
+        // no exceptions, everything ok
+    }
+
+    @Test
     public void openAndSaveFile_emptyXLSXFile_FileDoesNotContainAdditionalDrawing()
             throws IOException {
         var sheet = TestHelper.createSpreadsheet("empty.xlsx");


### PR DESCRIPTION
## Description

Addresses the DX test finding: "[Multiple saving to the same file seems not to work](https://docs.google.com/spreadsheets/d/1dpRq-pHZ8DwtEEmmSTVLraix-7AWTzzPp1YutVU0qRg/edit#gid=0)"

## Type of change

- [x] Bugfix
- [ ] Feature