### PR TITLE
fix: fix filter table content after a row is deleted

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
@@ -39,15 +39,13 @@ public class SheetFilterTableIT extends AbstractSpreadsheetIT {
 
     @Test
     public void sheetWithFilterTable_rowIsRemoved_filterOptionsAvailable() {
-        selectRegion("A1", "A5");
-        final var cell = getCellAt(1, 1);
-        cell.contextClick();
-        clickItem("Create Table on A1:A5");
+        loadTestFixture(TestFixtures.SpreadsheetTable);
+        final var cell = getSpreadsheet().getCellAt("B2");
 
         assertSelectAll(cell);
 
-        contextClickOnRowHeader(3);
-        clickItem("Delete row 3");
+        contextClickOnRowHeader(4);
+        clickItem("Delete row 4");
 
         assertSelectAll(cell);
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.component.spreadsheet.test;
 import com.vaadin.flow.component.spreadsheet.testbench.SheetCellElement;
 import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,5 +35,25 @@ public class SheetFilterTableIT extends AbstractSpreadsheetIT {
         cell.contextClick();
         spreadsheet.getContextMenu().getItem("Delete Table B2:F6").click();
         waitUntil(arg0 -> !cell.hasPopupButton());
+    }
+
+    @Test
+    public void sheetWithFilterTable_rowIsRemoved_filterOptionsAvailable() {
+        selectRegion("A1", "A5");
+        final var cell = getCellAt(1, 1);
+        cell.contextClick();
+        clickItem("Create Table on A1:A5");
+
+        assertSelectAll(cell);
+
+        contextClickOnRowHeader(3);
+        clickItem("Delete row 3");
+
+        assertSelectAll(cell);
+    }
+
+    private void assertSelectAll(SheetCellElement cell) {
+        cell.popupButtonClick();
+        Assert.assertTrue(hasOption("(Select All)"));
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/PopupButton.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/PopupButton.java
@@ -97,7 +97,7 @@ public class PopupButton extends Component {
      */
     public CellReference getCellReference() {
         return new CellReference(getState().sheet, getState().row - 1,
-                getState().col - 1, false, false);
+                getState().col - 1, true, true);
     }
 
     void setCellReference(CellReference cellReference) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -2904,7 +2904,8 @@ public class Spreadsheet extends Component
                 } else if (numberOfRowsAboveWasChanged(row, last, first)) {
                     int newRow = cell.getRow() + n;
                     int col = cell.getCol();
-                    CellReference newCell = new CellReference(newRow, col);
+                    CellReference newCell = new CellReference(newRow, col, true,
+                            true);
                     pbutton.setCellReference(newCell);
                     updated.put(newCell, pbutton);
                 } else {


### PR DESCRIPTION
## Description

This PR intends to fix ["Table filters stop working after deleting row in table"](https://docs.google.com/document/d/1U6uRAyUsSML_q7U2J6hmAX6q3EmLhmOJJaiJn4LHCrQ/edit#heading=h.cd50bw3zrwb5) issue found on the DX tests.

Make `CellReference` returned by `PopupButton#getCellReference` and created when a row is moved consistent with the ones used by the hash map. This is to ensure that [`Spreadsheet#onPopupButtonClick`](https://github.com/vaadin/flow-components/blob/e1a8c8faa070a4a38e3c3bd59a6f09298d9cd7ce/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java#L647) will always be able to find the popup button by row and column.

## Type of change

- [X] Bugfix
- [ ] Feature
