### PR TITLE
refactor: deprecate generated tab class and its methods

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
@@ -88,7 +88,10 @@ Tab 1
  * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
  * – how to apply styles for shadow parts</a>
  * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-tab")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -103,7 +106,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @param variants
      *            theme variants to add
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     public void addThemeVariants(TabVariant... variants) {
         getThemeNames().addAll(Stream.of(variants)
                 .map(TabVariant::getVariantName).collect(Collectors.toList()));
@@ -114,7 +120,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @param variants
      *            theme variants to remove
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     public void removeThemeVariants(TabVariant... variants) {
         getThemeNames().removeAll(Stream.of(variants)
                 .map(TabVariant::getVariantName).collect(Collectors.toList()));
@@ -133,7 +142,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * </p>
      *
      * @return the {@code value} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected String getValueString() {
         return getElement().getProperty("value");
     }
@@ -149,7 +161,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @param value
      *            the String value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setValue(String value) {
         getElement().setProperty("value", value == null ? "" : value);
     }
@@ -166,7 +181,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * </p>
      *
      * @return the {@code disabled} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected boolean isDisabledBoolean() {
         return getElement().getProperty("disabled", false);
     }
@@ -181,7 +199,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @param disabled
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setDisabled(boolean disabled) {
         getElement().setProperty("disabled", disabled);
     }
@@ -198,7 +219,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * </p>
      *
      * @return the {@code selected} property from the webcomponent
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected boolean isSelectedBoolean() {
         return getElement().getProperty("selected", false);
     }
@@ -213,7 +237,10 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @param selected
      *            the boolean value to set
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void setSelected(boolean selected) {
         getElement().setProperty("selected", selected);
     }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.shared.HasTooltip;
  *
  * @author Vaadin Ltd.
  */
+@SuppressWarnings("deprecation")
 public class Tab extends GeneratedVaadinTab<Tab>
         implements HasComponents, HasLabel, HasTooltip {
 
@@ -155,5 +156,27 @@ public class Tab extends GeneratedVaadinTab<Tab>
     @Override
     public String toString() {
         return "Tab{" + getLabel() + "}";
+    }
+
+    /**
+     * Adds theme variants to the component.
+     *
+     * @param variants
+     *            theme variants to add
+     */
+    @Override
+    public void addThemeVariants(TabVariant... variants) {
+        super.addThemeVariants(variants);
+    }
+
+    /**
+     * Removes theme variants from the component.
+     *
+     * @param variants
+     *            theme variants to remove
+     */
+    @Override
+    public void removeThemeVariants(TabVariant... variants) {
+        super.removeThemeVariants(variants);
     }
 }


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinTab` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the class. Override the public methods of the generated class in the main component, and make them call the ones in the generated class. 

Add suppress warning annotation to the main component.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.