### PR TITLE
refactor: deprecate generated tabs class and its methods

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
@@ -96,7 +96,10 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
  * – how to apply styles for shadow parts</a>
  * </p>
+ *
+ * @deprecated since v23.3, deprecated classes will be removed in v24.
  */
+@Deprecated
 @Tag("vaadin-tabs")
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "23.3.0-alpha6")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
@@ -111,7 +114,10 @@ public abstract class GeneratedVaadinTabs<R extends GeneratedVaadinTabs<R>>
      *
      * @param variants
      *            theme variants to add
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     public void addThemeVariants(TabsVariant... variants) {
         getThemeNames().addAll(Stream.of(variants)
                 .map(TabsVariant::getVariantName).collect(Collectors.toList()));
@@ -122,12 +128,18 @@ public abstract class GeneratedVaadinTabs<R extends GeneratedVaadinTabs<R>>
      *
      * @param variants
      *            theme variants to remove
+     *
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     public void removeThemeVariants(TabsVariant... variants) {
         getThemeNames().removeAll(Stream.of(variants)
                 .map(TabsVariant::getVariantName).collect(Collectors.toList()));
     }
 
+    /**
+     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     */
     protected void focus() {
         getElement().callJsFunction("focus");
     }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
@@ -140,6 +140,7 @@ public abstract class GeneratedVaadinTabs<R extends GeneratedVaadinTabs<R>>
     /**
      * @deprecated since v23.3, deprecated classes will be removed in v24.
      */
+    @Deprecated
     protected void focus() {
         getElement().callJsFunction("focus");
     }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -54,6 +54,7 @@ import com.vaadin.flow.shared.Registration;
  *
  * @author Vaadin Ltd.
  */
+@SuppressWarnings("deprecation")
 public class Tabs extends GeneratedVaadinTabs<Tabs>
         implements HasOrderedComponents, HasSize {
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -510,4 +510,25 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
         }
     }
 
+    /**
+     * Adds theme variants to the component.
+     *
+     * @param variants
+     *            theme variants to add
+     */
+    @Override
+    public void addThemeVariants(TabsVariant... variants) {
+        super.addThemeVariants(variants);
+    }
+
+    /**
+     * Removes theme variants from the component.
+     *
+     * @param variants
+     *            theme variants to remove
+     */
+    @Override
+    public void removeThemeVariants(TabsVariant... variants) {
+        super.removeThemeVariants(variants);
+    }
 }


### PR DESCRIPTION
## Description

Deprecate `GeneratedVaadinTabs` as a part of the https://github.com/vaadin/components-team-tasks/issues/606 considering the deprecation of generated classes.

Deprecate the methods in the class. Override the public methods of the generated class in the main component, and make them call the ones in the generated class. 

Add suppress warning annotation to the main component.

Fixes #[606](https://github.com/vaadin/components-team-tasks/issues/606) partially.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.