### PR TITLE
VS-4408 Support to improve Grid multiselection performance.

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -49,27 +49,25 @@ import elemental.json.JsonObject;
 /**
  * Abstract implementation of a GridMultiSelectionModel.
  *
- * @param <T>
- *            the grid type
+ * @param <T> the grid type
  * @author Vaadin Ltd.
  */
 public abstract class AbstractGridMultiSelectionModel<T>
         extends AbstractGridExtension<T> implements GridMultiSelectionModel<T> {
 
-    private final Set<T> selected;
+    private final Map<Object, T> selected;
     private final GridSelectionColumn selectionColumn;
     private SelectAllCheckboxVisibility selectAllCheckBoxVisibility;
 
     /**
      * Constructor for passing a reference of the grid to this implementation.
      *
-     * @param grid
-     *            reference to the grid for which this selection model is
-     *            created
+     * @param grid reference to the grid for which this selection model is
+     *             created
      */
     public AbstractGridMultiSelectionModel(Grid<T> grid) {
         super(grid);
-        selected = new LinkedHashSet<>();
+        selected = new LinkedHashMap<>();
         selectionColumn = new GridSelectionColumn(this::clientSelectAll,
                 this::clientDeselectAll);
         selectAllCheckBoxVisibility = SelectAllCheckboxVisibility.DEFAULT;
@@ -107,25 +105,24 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (isSelected(item)) {
             return;
         }
-        Set<T> oldSelection = new LinkedHashSet<>(selected);
-        boolean added = selected.add(item);
-        if (added) {
-            fireSelectionEvent(new MultiSelectionEvent<>(getGrid(),
-                    getGrid().asMultiSelect(), oldSelection, true));
+        Set<T> oldSelection = getSelectedItems();
+        selected.put(getItemId(item), item);
 
-            if (!isSelectAllCheckboxVisible()) {
-                // Skip changing the state of Select All checkbox if it was
-                // meant to be hidden
-                return;
-            }
+        fireSelectionEvent(new MultiSelectionEvent<>(getGrid(),
+                getGrid().asMultiSelect(), oldSelection, true));
 
-            long size = getDataProviderSize();
-            selectionColumn.setSelectAllCheckboxState(
-                    !isHierarchicalDataProvider() && size == selected.size());
-            selectionColumn.setSelectAllCheckboxIndeterminateState(
-                    isHierarchicalDataProvider() ? selected.size() > 0
-                            : selected.size() > 0 && selected.size() < size);
+        if (!isSelectAllCheckboxVisible()) {
+            // Skip changing the state of Select All checkbox if it was
+            // meant to be hidden
+            return;
         }
+
+        long size = getDataProviderSize();
+        selectionColumn.setSelectAllCheckboxState(
+                !isHierarchicalDataProvider() && size == selected.size());
+        selectionColumn.setSelectAllCheckboxIndeterminateState(
+                isHierarchicalDataProvider() ? selected.size() > 0
+                        : selected.size() > 0 && selected.size() < size);
     }
 
     @Override
@@ -133,18 +130,17 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (!isSelected(item)) {
             return;
         }
-        Set<T> oldSelection = new LinkedHashSet<>(selected);
-        boolean removed = selected.remove(item);
-        if (removed) {
-            fireSelectionEvent(new MultiSelectionEvent<>(getGrid(),
-                    getGrid().asMultiSelect(), oldSelection, true));
+        Set<T> oldSelection = getSelectedItems();
+        selected.remove(getItemId(item));
 
-            long size = getDataProviderSize();
-            selectionColumn.setSelectAllCheckboxState(false);
-            selectionColumn.setSelectAllCheckboxIndeterminateState(
-                    isHierarchicalDataProvider() ? selected.size() > 0
-                            : selected.size() > 0 && selected.size() < size);
-        }
+        fireSelectionEvent(new MultiSelectionEvent<>(getGrid(),
+                getGrid().asMultiSelect(), oldSelection, true));
+
+        long size = getDataProviderSize();
+        selectionColumn.setSelectAllCheckboxState(false);
+        selectionColumn.setSelectAllCheckboxIndeterminateState(
+                isHierarchicalDataProvider() ? selected.size() > 0
+                        : selected.size() > 0 && selected.size() < size);
     }
 
     @Override
@@ -154,12 +150,13 @@ public abstract class AbstractGridMultiSelectionModel<T>
          * ConcurrentModificationExceptions when changing the selection during
          * an iteration
          */
-        return Collections.unmodifiableSet(new LinkedHashSet<>(selected));
+        return Collections
+                .unmodifiableSet(new LinkedHashSet<>(selected.values()));
     }
 
     @Override
     public Optional<T> getFirstSelectedItem() {
-        return selected.stream().findFirst();
+        return selected.values().stream().findFirst();
     }
 
     @Override
@@ -213,8 +210,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
 
     @Override
     public boolean isSelected(T item) {
-        return getSelectedItems().stream().anyMatch(selectedItem -> Objects
-                .equals(getItemId(selectedItem), getItemId(item)));
+        return selected.containsKey(getItemId(item));
     }
 
     @Override
@@ -424,16 +420,13 @@ public abstract class AbstractGridMultiSelectionModel<T>
     private void doUpdateSelection(Map<Object, T> addedItems,
             Map<Object, T> removedItems, boolean userOriginated) {
 
-        Map<Object, T> selectedMap = mapItemsById(selected);
-        if (selectedMap.keySet().containsAll(addedItems.keySet()) && Collections
-                .disjoint(selectedMap.keySet(), removedItems.keySet())) {
+        if (selected.keySet().containsAll(addedItems.keySet()) && Collections
+                .disjoint(selected.keySet(), removedItems.keySet())) {
             return;
         }
-        Set<T> oldSelection = new LinkedHashSet<>(selected);
-        removedItems.keySet().forEach(selectedMap::remove);
-        selectedMap.putAll(addedItems);
-        selected.clear();
-        selected.addAll(selectedMap.values());
+        Set<T> oldSelection = getSelectedItems();
+        removedItems.keySet().forEach(selected::remove);
+        selected.putAll(addedItems);
 
         sendSelectionUpdate(new LinkedHashSet<>(addedItems.values()),
                 getGrid()::doClientSideSelection);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionModelTest.java
@@ -15,11 +15,10 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,8 +49,8 @@ public class GridMultiSelectionModelTest {
 
     private Grid<Person> grid;
     private GridMultiSelectionModel<Person> selectionModel;
-    private AtomicReference<List<Person>> currentSelectionCapture;
-    private AtomicReference<List<Person>> oldSelectionCapture;
+    private AtomicReference<Set<Person>> currentSelectionCapture;
+    private AtomicReference<Set<Person>> oldSelectionCapture;
     private AtomicInteger events;
 
     @Before
@@ -67,8 +66,8 @@ public class GridMultiSelectionModelTest {
         events = new AtomicInteger();
 
         selectionModel.addMultiSelectionListener(event -> {
-            currentSelectionCapture.set(new ArrayList<>(event.getValue()));
-            oldSelectionCapture.set(new ArrayList<>(event.getOldSelection()));
+            currentSelectionCapture.set(new HashSet<>(event.getValue()));
+            oldSelectionCapture.set(new HashSet<>(event.getOldSelection()));
             events.incrementAndGet();
         });
     }
@@ -85,30 +84,29 @@ public class GridMultiSelectionModelTest {
         customGrid.setSelectionMode(SelectionMode.MULTI);
         customGrid.setItems("Foo", "Bar", "Baz");
 
-        List<String> selectionChanges = new ArrayList<>();
-        AtomicReference<List<String>> oldSelectionCapture = new AtomicReference<>();
+        Set<String> selectionChanges = new HashSet<>();
+        AtomicReference<Set<String>> oldSelectionCapture = new AtomicReference<>();
         ((GridMultiSelectionModel<String>) customGrid.getSelectionModel())
                 .addMultiSelectionListener(e -> {
                     selectionChanges.addAll(e.getValue());
-                    oldSelectionCapture
-                            .set(new ArrayList<>(e.getOldSelection()));
+                    oldSelectionCapture.set(new HashSet<>(e.getOldSelection()));
                 });
 
         customGrid.getSelectionModel().select("Foo");
-        assertEquals(Arrays.asList("Foo"), selectionChanges);
+        assertEquals(asSet("Foo"), selectionChanges);
         selectionChanges.clear();
 
         customGrid.getSelectionModel().select("Bar");
         assertEquals("Foo",
                 customGrid.getSelectionModel().getFirstSelectedItem().get());
-        assertEquals(Arrays.asList("Foo", "Bar"), selectionChanges);
+        assertEquals(asSet("Bar", "Foo"), selectionChanges);
         selectionChanges.clear();
 
         customGrid.setSelectionMode(SelectionMode.SINGLE);
         assertFalse(customGrid.getSelectionModel().getFirstSelectedItem()
                 .isPresent());
-        assertEquals(Collections.emptyList(), selectionChanges);
-        assertEquals(Arrays.asList("Foo", "Bar"), oldSelectionCapture.get());
+        assertEquals(Collections.emptySet(), selectionChanges);
+        assertEquals(asSet("Bar", "Foo"), oldSelectionCapture.get());
     }
 
     @Test
@@ -127,14 +125,13 @@ public class GridMultiSelectionModelTest {
         model.select("Bar");
         assertTrue(model.isSelected("Foo"));
         assertTrue(model.isSelected("Bar"));
-        assertEquals(Arrays.asList("Foo", "Bar"),
-                new ArrayList<>(model.getSelectedItems()));
+        assertEquals(asSet("Bar", "Foo"), model.getSelectedItems());
 
         model.deselect("Bar");
         assertFalse(model.isSelected("Bar"));
         assertTrue(model.getFirstSelectedItem().isPresent());
-        assertEquals(Collections.singletonList("Foo"),
-                new ArrayList<>(model.getSelectedItems()));
+        assertEquals(asSet("Foo"), model.getSelectedItems());
+
     }
 
     @Test
@@ -150,8 +147,7 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Collections.singletonList(PERSON_B),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_B), currentSelectionCapture.get());
 
         selectionModel.select(PERSON_A);
         assertEquals(PERSON_B,
@@ -161,8 +157,7 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Arrays.asList(PERSON_B, PERSON_A),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_A, PERSON_B), currentSelectionCapture.get());
         assertEquals(2, events.get());
     }
 
@@ -177,7 +172,7 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
         assertEquals(2, events.get());
     }
 
@@ -194,15 +189,14 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Arrays.asList(PERSON_C, PERSON_B),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_B), currentSelectionCapture.get());
 
         selectionModel.selectItems(PERSON_A, PERSON_C); // partly NOOP
         assertTrue(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Arrays.asList(PERSON_C, PERSON_B, PERSON_A),
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 currentSelectionCapture.get());
         assertEquals(2, events.get());
     }
@@ -221,8 +215,7 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Arrays.asList(PERSON_C, PERSON_B),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_B), currentSelectionCapture.get());
 
         selectionModel.deselectItems(PERSON_A, PERSON_B, PERSON_C);
         assertNull(selectionModel.getFirstSelectedItem().orElse(null));
@@ -232,7 +225,7 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
 
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
         assertEquals(3, events.get());
     }
 
@@ -240,49 +233,41 @@ public class GridMultiSelectionModelTest {
     public void selectionEvent_newSelection_oldSelection() {
         selectionModel.selectItems(PERSON_C, PERSON_A, PERSON_B);
 
-        assertEquals(Arrays.asList(PERSON_C, PERSON_A, PERSON_B),
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 currentSelectionCapture.get());
-        assertEquals(Collections.emptyList(), oldSelectionCapture.get());
+        assertEquals(Collections.emptySet(), oldSelectionCapture.get());
 
         selectionModel.deselect(PERSON_A);
 
-        assertEquals(Arrays.asList(PERSON_C, PERSON_B),
-                currentSelectionCapture.get());
-        assertEquals(Arrays.asList(PERSON_C, PERSON_A, PERSON_B),
+        assertEquals(asSet(PERSON_C, PERSON_B), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 oldSelectionCapture.get());
 
         selectionModel.deselectItems(PERSON_A, PERSON_B, PERSON_C);
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
-        assertEquals(Arrays.asList(PERSON_C, PERSON_B),
-                oldSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_B), oldSelectionCapture.get());
 
         selectionModel.selectItems(PERSON_A);
-        assertEquals(Collections.singletonList(PERSON_A),
-                currentSelectionCapture.get());
-        assertEquals(Collections.emptyList(), oldSelectionCapture.get());
+         assertEquals(asSet(PERSON_A), currentSelectionCapture.get());
+         assertEquals(Collections.emptySet(), oldSelectionCapture.get());
 
         selectionModel.updateSelection(
-                new LinkedHashSet<>(Arrays.asList(PERSON_B, PERSON_C)),
-                new LinkedHashSet<>(Collections.singletonList(PERSON_A)));
-        assertEquals(Arrays.asList(PERSON_B, PERSON_C),
-                currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_A),
-                oldSelectionCapture.get());
+                new LinkedHashSet<>(asSet(PERSON_C, PERSON_B)),
+                new LinkedHashSet<>(asSet(PERSON_A)));
+        assertEquals(asSet(PERSON_C, PERSON_B), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_A), oldSelectionCapture.get());
 
         selectionModel.deselectAll();
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
-        assertEquals(Arrays.asList(PERSON_B, PERSON_C),
-                oldSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_B), oldSelectionCapture.get());
 
         selectionModel.select(PERSON_C);
-        assertEquals(Collections.singletonList(PERSON_C),
-                currentSelectionCapture.get());
-        assertEquals(Collections.emptyList(), oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_C), currentSelectionCapture.get());
+        assertEquals(Collections.emptySet(), oldSelectionCapture.get());
 
         selectionModel.deselect(PERSON_C);
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_C),
-                oldSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C), oldSelectionCapture.get());
     }
 
     @Test
@@ -292,7 +277,7 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
-        assertEquals(Arrays.asList(PERSON_A, PERSON_C, PERSON_B),
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 currentSelectionCapture.get());
         assertEquals(1, events.get());
 
@@ -300,8 +285,8 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
-        assertEquals(Arrays.asList(PERSON_A, PERSON_C, PERSON_B),
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 oldSelectionCapture.get());
         assertEquals(2, events.get());
 
@@ -309,18 +294,16 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.singletonList(PERSON_C),
-                currentSelectionCapture.get());
-        assertEquals(Collections.emptyList(), oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_C), currentSelectionCapture.get());
+        assertEquals(Collections.emptySet(), oldSelectionCapture.get());
         assertEquals(3, events.get());
 
         selectionModel.deselectAll();
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_C),
-                oldSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C), oldSelectionCapture.get());
         assertEquals(4, events.get());
 
         selectionModel.deselectAll();
@@ -337,7 +320,7 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
-        assertEquals(Arrays.asList(PERSON_A, PERSON_B, PERSON_C),
+        assertEquals(asSet(PERSON_A, PERSON_B, PERSON_C),
                 currentSelectionCapture.get());
         assertEquals(1, events.get());
 
@@ -346,7 +329,7 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Arrays.asList(PERSON_A, PERSON_B, PERSON_C),
+        assertEquals(asSet(PERSON_A, PERSON_B, PERSON_C),
                 oldSelectionCapture.get());
 
         selectionModel.selectAll();
@@ -354,10 +337,9 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
-        assertEquals(Arrays.asList(PERSON_B, PERSON_A, PERSON_C),
+        assertEquals(asSet(PERSON_B, PERSON_A, PERSON_C),
                 currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_B),
-                oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_B), oldSelectionCapture.get());
         assertEquals(3, events.get());
     }
 
@@ -368,8 +350,7 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_A));
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.singletonList(PERSON_A),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_A), currentSelectionCapture.get());
         assertEquals(1, events.get());
 
         selectionModel.updateSelection(asSet(PERSON_B), asSet(PERSON_A));
@@ -377,10 +358,8 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.singletonList(PERSON_B),
-                currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_A),
-                oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_B), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_A), oldSelectionCapture.get());
         assertEquals(2, events.get());
 
         selectionModel.updateSelection(asSet(PERSON_B), asSet(PERSON_A)); // NOOP
@@ -388,10 +367,8 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.singletonList(PERSON_B),
-                currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_A),
-                oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_B), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_A), oldSelectionCapture.get());
         assertEquals(2, events.get());
 
         selectionModel.updateSelection(asSet(PERSON_A, PERSON_C),
@@ -400,10 +377,8 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
-        assertEquals(Arrays.asList(PERSON_B, PERSON_C),
-                currentSelectionCapture.get());
-        assertEquals(Collections.singletonList(PERSON_B),
-                oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_B), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_B), oldSelectionCapture.get());
         assertEquals(3, events.get());
 
         selectionModel.updateSelection(asSet(PERSON_B, PERSON_A),
@@ -412,10 +387,9 @@ public class GridMultiSelectionModelTest {
         assertTrue(selectionModel.isSelected(PERSON_A));
         assertTrue(selectionModel.isSelected(PERSON_B));
         assertTrue(selectionModel.isSelected(PERSON_C));
-        assertEquals(Arrays.asList(PERSON_B, PERSON_C, PERSON_A),
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 currentSelectionCapture.get());
-        assertEquals(Arrays.asList(PERSON_B, PERSON_C),
-                oldSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_B), oldSelectionCapture.get());
         assertEquals(4, events.get());
 
         selectionModel.updateSelection(asSet(),
@@ -424,8 +398,8 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
-        assertEquals(Arrays.asList(PERSON_B, PERSON_C, PERSON_A),
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C, PERSON_A, PERSON_B),
                 oldSelectionCapture.get());
         assertEquals(5, events.get());
     }
@@ -449,23 +423,21 @@ public class GridMultiSelectionModelTest {
         assertEquals(Optional.of(PERSON_C),
                 selectionModel.getFirstSelectedItem());
 
-        assertEquals(Collections.singletonList(PERSON_C),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C), currentSelectionCapture.get());
         assertEquals(1, events.get());
     }
 
     @Test
     public void deselectTwice() {
         selectionModel.select(PERSON_C);
-        assertEquals(Collections.singletonList(PERSON_C),
-                currentSelectionCapture.get());
+        assertEquals(asSet(PERSON_C), currentSelectionCapture.get());
         assertEquals(1, events.get());
 
         selectionModel.deselect(PERSON_C);
 
         assertFalse(selectionModel.getFirstSelectedItem().isPresent());
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
         assertEquals(2, events.get());
 
         selectionModel.deselect(PERSON_C);
@@ -474,7 +446,7 @@ public class GridMultiSelectionModelTest {
         assertFalse(selectionModel.isSelected(PERSON_A));
         assertFalse(selectionModel.isSelected(PERSON_B));
         assertFalse(selectionModel.isSelected(PERSON_C));
-        assertEquals(Collections.emptyList(), currentSelectionCapture.get());
+        assertEquals(Collections.emptySet(), currentSelectionCapture.get());
         assertEquals(2, events.get());
     }
 
@@ -509,8 +481,7 @@ public class GridMultiSelectionModelTest {
                 model.asMultiSelect(), Collections.emptySet(), true));
 
         assertEquals(grid, event.get().getSource());
-        assertEquals(new LinkedHashSet<>(Collections.singletonList(value)),
-                event.get().getValue());
+        assertEquals(new LinkedHashSet<>(asSet(value)), event.get().getValue());
         assertTrue(event.get().isFromClient());
 
         Mockito.verify(model, Mockito.times(1)).getSelectedItems();


### PR DESCRIPTION
## Description

Grid component in newest Vaadin 23 versions isSelected is optimized (in v14 there is slow performance because this method is called each time selection is updated)

Backported to 14.9
https://github.com/vaadin/flow-components/commit/11f0c3e58728825c1ebcf3d5e27807c7aecd4c65 [https://github.com/vaadin/flow-components/commit/4a3dde6effeee85ba8af3da28641f784f32ee2b1 ]

Fixes # (issue)
VS-4408 Support to improve Grid multiselection performance.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
