### PR TITLE
fix: filter all items on select all uncheck

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
@@ -163,10 +163,10 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
                 cancelValueChangeUpdate = true;
                 if (value) {
                     filterCheckbox.setValue(new HashSet<>(allCellValues));
-                    updateFilteredItems(allCellValues);
                 } else {
                     filterCheckbox.setValue(Collections.emptySet());
                 }
+                updateFilteredItems(filterCheckbox.getValue());
                 cancelValueChangeUpdate = false;
             }
         });

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.spreadsheet.ItemFilter;
 import com.vaadin.flow.component.spreadsheet.PopupButton;
@@ -138,10 +139,35 @@ public class FilterTableTest {
         table.registerFilter(new PopupButton(), getItemFilter());
     }
 
+    @Test
+    public void uncheckSelectAll_allRowsHidden() {
+        getSelectAllCheckbox().setValue(false);
+        Assert.assertTrue(spreadsheet.isRowHidden(2));
+        Assert.assertTrue(spreadsheet.isRowHidden(3));
+        Assert.assertTrue(spreadsheet.isRowHidden(4));
+        Assert.assertTrue(spreadsheet.isRowHidden(5));
+    }
+
+    @Test
+    public void reCheckSelectAll_allRowsVisible() {
+        getSelectAllCheckbox().setValue(false);
+        getSelectAllCheckbox().setValue(true);
+        Assert.assertFalse(spreadsheet.isRowHidden(2));
+        Assert.assertFalse(spreadsheet.isRowHidden(3));
+        Assert.assertFalse(spreadsheet.isRowHidden(4));
+        Assert.assertFalse(spreadsheet.isRowHidden(5));
+    }
+
     private CheckboxGroup<String> getFilterCheckboxGroup() {
         return (CheckboxGroup<String>) getItemFilter().getChildren()
                 .filter(component -> component instanceof CheckboxGroup)
                 .findFirst().get();
+    }
+
+    private Checkbox getSelectAllCheckbox() {
+        return (Checkbox) getItemFilter().getChildren()
+                .filter(component -> component instanceof Checkbox).findFirst()
+                .get();
     }
 
     private ItemFilter getItemFilter() {


### PR DESCRIPTION
## Description

Addresses the issue: "[Clearing the "Select all" checkbox on a filter table does nothing](https://docs.google.com/spreadsheets/d/1dpRq-pHZ8DwtEEmmSTVLraix-7AWTzzPp1YutVU0qRg/edit#gid=0)"

## Type of change

- [x] Bugfix
- [ ] Feature