### PR TITLE
fix: prevent filter on popup open

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
@@ -50,6 +50,22 @@ public class SheetFilterTableIT extends AbstractSpreadsheetIT {
         assertSelectAll(cell);
     }
 
+    @Test
+    public void filteredTable_unhideRowAndOpenPopup_rowIsUnhidden() {
+        loadTestFixture(TestFixtures.SpreadsheetTable);
+        final var cell = getSpreadsheet().getCellAt("B2");
+
+        cell.popupButtonClick();
+        clickItem("4");
+        contextClickOnRowHeader(3);
+        clickItem("Unhide row 4");
+        cell.popupButtonClick();
+
+        var displayValue = getSpreadsheet().getRowHeader(4)
+                .getCssValue("display");
+        Assert.assertNotEquals(displayValue, "none");
+    }
+
     private void assertSelectAll(SheetCellElement cell) {
         cell.popupButtonClick();
         Assert.assertTrue(hasOption("(Select All)"));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetFilterTableIT.java
@@ -50,22 +50,6 @@ public class SheetFilterTableIT extends AbstractSpreadsheetIT {
         assertSelectAll(cell);
     }
 
-    @Test
-    public void filteredTable_unhideRowAndOpenPopup_rowIsUnhidden() {
-        loadTestFixture(TestFixtures.SpreadsheetTable);
-        final var cell = getSpreadsheet().getCellAt("B2");
-
-        cell.popupButtonClick();
-        clickItem("4");
-        contextClickOnRowHeader(3);
-        clickItem("Unhide row 4");
-        cell.popupButtonClick();
-
-        var displayValue = getSpreadsheet().getRowHeader(4)
-                .getCssValue("display");
-        Assert.assertNotEquals(displayValue, "none");
-    }
-
     private void assertSelectAll(SheetCellElement cell) {
         cell.popupButtonClick();
         Assert.assertTrue(hasOption("(Select All)"));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
@@ -246,6 +246,7 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
         cancelValueChangeUpdate = false;
         filterOptionsProvider = new ListDataProvider<>(filterOptions);
         filterCheckbox.setItems(filterOptionsProvider);
+        firstUpdate = true;
         filterCheckbox.setValue(visibleValues);
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
@@ -138,6 +138,16 @@ public class FilterTableTest {
         table.registerFilter(new PopupButton(), getItemFilter());
     }
 
+    @Test
+    public void filteredTable_unhideRowAndOpenPopup_rowIsUnhidden() {
+        getFilterCheckboxGroup().deselect("4");
+
+        spreadsheet.setRowHidden(3, false);
+        getPopupButton().openPopup();
+
+        Assert.assertFalse(spreadsheet.isRowHidden(3));
+    }
+
     private CheckboxGroup<String> getFilterCheckboxGroup() {
         return (CheckboxGroup<String>) getItemFilter().getChildren()
                 .filter(component -> component instanceof CheckboxGroup)


### PR DESCRIPTION
## Description

This intends to fix ["Table filter hides row when opening"](https://docs.google.com/document/d/1U6uRAyUsSML_q7U2J6hmAX6q3EmLhmOJJaiJn4LHCrQ/edit#heading=h.j44p8x2gb4ch) issue discovered on the DX tests.

This change brings the same behavior from Spreadsheet for V8, where if a filtered row is unhidden from the context menu keeps its state when the popup button is opened. 

## Type of change

- [X] Bugfix
- [ ] Feature
