### PR TITLE
chore: clarify deprecation notices

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -100,7 +100,7 @@ import com.vaadin.flow.dom.Element;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-button")
@@ -126,7 +126,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -144,7 +144,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * @param autofocus
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -164,7 +164,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -203,7 +203,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrefix(Component... components) {
@@ -226,7 +226,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToSuffix(Component... components) {
@@ -244,7 +244,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -264,7 +264,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {
@@ -294,7 +294,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *            the text content to set
      * @see HasText#setText(String)
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinButton(String text) {
@@ -304,7 +304,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinButton() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
@@ -116,7 +116,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-checkbox")
@@ -142,7 +142,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -159,7 +159,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *
      * @param autofocus
      *            the boolean value to set
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -179,7 +179,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -197,7 +197,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -210,7 +210,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *
      * @return the {@code name} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getNameString() {
@@ -221,7 +221,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @param name
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setName(String name) {
@@ -244,7 +244,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *
      * @return the {@code indeterminate} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "indeterminate", value = "indeterminate-changed")
@@ -265,7 +265,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *
      * @param indeterminate
      *            the boolean value to set
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setIndeterminate(boolean indeterminate) {
@@ -273,7 +273,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @DomEvent("change")
@@ -291,7 +291,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -302,7 +302,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class CheckedChangeEvent<R extends GeneratedVaadinCheckbox<R, ?>>
@@ -320,7 +320,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addCheckedChangeListener(
@@ -333,7 +333,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class IndeterminateChangeEvent<R extends GeneratedVaadinCheckbox<R, ?>>
@@ -358,7 +358,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addIndeterminateChangeListener(
@@ -386,7 +386,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinCheckbox(T initialValue, T defaultValue,
@@ -421,7 +421,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *            property value, otherwise element {@code "checked"} property
      *            is ignored and the initial value is set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinCheckbox(T initialValue, T defaultValue,
@@ -449,7 +449,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinCheckbox(T initialValue, T defaultValue,
@@ -476,7 +476,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinCheckbox(T initialValue, T defaultValue,
@@ -493,7 +493,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinCheckbox() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
@@ -116,7 +116,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-checkbox-group")
@@ -135,7 +135,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link CheckboxGroup#addThemeVariants} instead.
      */
     @Deprecated
@@ -151,7 +151,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link CheckboxGroup#removeThemeVariants} instead.
      */
     @Deprecated
@@ -175,7 +175,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -194,7 +194,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -214,7 +214,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      *
      * @return the {@code label} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getLabelString() {
@@ -232,7 +232,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param label
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setLabel(String label) {
@@ -252,7 +252,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      *
      * @return the {@code errorMessage} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getErrorMessageString() {
@@ -270,7 +270,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param errorMessage
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setErrorMessage(String errorMessage) {
@@ -291,7 +291,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      *
      * @return the {@code required} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRequiredBoolean() {
@@ -309,7 +309,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param required
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRequired(boolean required) {
@@ -325,7 +325,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      *
      * @return the {@code invalid} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isInvalidBoolean() {
@@ -343,7 +343,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param invalid
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInvalid(boolean invalid) {
@@ -363,7 +363,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -371,7 +371,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class InvalidChangeEvent<R extends GeneratedVaadinCheckboxGroup<R, ?>>
@@ -396,7 +396,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
@@ -425,7 +425,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinCheckboxGroup(T initialValue, T defaultValue,
@@ -450,7 +450,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinCheckboxGroup(T initialValue, T defaultValue,
@@ -489,7 +489,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinCheckboxGroup(T initialValue, T defaultValue,
@@ -528,7 +528,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinCheckboxGroup(T initialValue, T defaultValue,
@@ -542,7 +542,7 @@ public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinChec
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinCheckboxGroup() {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -140,7 +140,7 @@ import elemental.json.JsonObject;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-context-menu")
@@ -167,7 +167,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code selector} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getSelectorString() {
@@ -186,7 +186,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param selector
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setSelector(String selector) {
@@ -206,7 +206,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code opened} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -227,7 +227,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code openOn} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getOpenOnString() {
@@ -245,7 +245,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param openOn
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setOpenOn(String openOn) {
@@ -267,7 +267,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code listenOn} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected JsonObject getListenOnJsonObject() {
@@ -287,7 +287,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param listenOn
      *            the JsonObject value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setListenOn(JsonObject listenOn) {
@@ -307,7 +307,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @return the {@code closeOn} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getCloseOnString() {
@@ -325,7 +325,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * @param closeOn
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setCloseOn(String closeOn) {
@@ -340,7 +340,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * Closes the overlay.
      * </p>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void close() {
@@ -355,7 +355,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      * Opens the overlay.
      * </p>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void open() {
@@ -363,7 +363,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link ContextMenuBase.OpenedChangeEvent} instead.
      */
     @Deprecated
@@ -389,7 +389,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link ContextMenuBase#addOpenedChangeListener} instead.
      */
     @Deprecated
@@ -407,7 +407,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @see #addClickListener(ComponentEventListener)
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Override
@@ -422,7 +422,7 @@ public abstract class GeneratedVaadinContextMenu<R extends ContextMenuBase<R, ?,
      *
      * @see #addClickShortcut(Key, KeyModifier...)
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Override

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -252,7 +252,7 @@ import elemental.json.JsonObject;
  * is propagated to the internal themable components listed above.
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-date-picker")
@@ -278,7 +278,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -296,7 +296,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param autofocus
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -316,7 +316,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -334,7 +334,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -354,7 +354,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code required} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRequiredBoolean() {
@@ -372,7 +372,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param required
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRequired(boolean required) {
@@ -392,7 +392,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code name} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getNameString() {
@@ -410,7 +410,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param name
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setName(String name) {
@@ -433,7 +433,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code initialPosition} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getInitialPositionString() {
@@ -454,7 +454,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param initialPosition
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInitialPosition(String initialPosition) {
@@ -475,7 +475,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code label} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getLabelString() {
@@ -493,7 +493,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param label
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setLabel(String label) {
@@ -513,7 +513,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code opened} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -532,7 +532,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param opened
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setOpened(boolean opened) {
@@ -554,7 +554,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code showWeekNumbers} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isShowWeekNumbersBoolean() {
@@ -574,7 +574,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param showWeekNumbers
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setShowWeekNumbers(boolean showWeekNumbers) {
@@ -663,7 +663,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code i18n} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected JsonObject getI18nJsonObject() {
@@ -753,7 +753,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param i18n
      *            the JsonObject value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setI18n(JsonObject i18n) {
@@ -782,7 +782,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code min} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getMinAsStringString() {
@@ -809,7 +809,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param minAsString
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMinAsString(String minAsString) {
@@ -837,7 +837,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code max} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getMaxAsStringString() {
@@ -863,7 +863,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param maxAsString
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMaxAsString(String maxAsString) {
@@ -883,7 +883,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code errorMessage} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getErrorMessageString() {
@@ -901,7 +901,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param errorMessage
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setErrorMessage(String errorMessage) {
@@ -923,7 +923,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code placeholder} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getPlaceholderString() {
@@ -942,7 +942,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param placeholder
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setPlaceholder(String placeholder) {
@@ -963,7 +963,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code readonly} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isReadonlyBoolean() {
@@ -981,7 +981,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param readonly
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setReadonly(boolean readonly) {
@@ -998,7 +998,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *
      * @return the {@code invalid} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isInvalidBoolean() {
@@ -1016,7 +1016,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param invalid
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInvalid(boolean invalid) {
@@ -1031,7 +1031,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * Opens the dropdown.
      * </p>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void open() {
@@ -1046,7 +1046,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * Closes the dropdown.
      * </p>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void close() {
@@ -1069,7 +1069,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param value
      *            Value to validate. Optional, defaults to user's input value.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -1095,7 +1095,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param value
      *            Value to validate. Optional, defaults to the selected date.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -1103,7 +1103,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @DomEvent("change")
@@ -1121,7 +1121,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1132,7 +1132,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link DatePicker.InvalidChangeEvent} instead.
      */
     @Deprecated
@@ -1158,7 +1158,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
@@ -1170,7 +1170,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link DatePicker.OpenedChangeEvent} instead.
      */
     @Deprecated
@@ -1196,7 +1196,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
@@ -1220,7 +1220,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrefix(Component... components) {
@@ -1238,7 +1238,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -1258,7 +1258,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {
@@ -1289,7 +1289,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinDatePicker(T initialValue, T defaultValue,
@@ -1321,7 +1321,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinDatePicker(T initialValue, T defaultValue,
@@ -1349,7 +1349,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinDatePicker(T initialValue, T defaultValue,
@@ -1364,7 +1364,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinDatePicker() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -48,7 +48,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-dialog")
@@ -73,7 +73,7 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      * </p>
      *
      * @return the {@code opened} property from the webcomponent
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -91,7 +91,7 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      *
      * @param opened
      *            the boolean value to set
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setOpened(boolean opened) {
@@ -113,7 +113,7 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      * </p>
      *
      * @return the {@code ariaLabel} property from the webcomponent
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAriaLabelString() {
@@ -133,7 +133,7 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      *
      * @param ariaLabel
      *            the String value to set
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAriaLabel(String ariaLabel) {
@@ -142,7 +142,7 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link Dialog.OpenedChangeEvent} instead.
      */
     @Deprecated
@@ -167,7 +167,7 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addOpenedChangeListener(

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormItem.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormItem.java
@@ -163,7 +163,7 @@ import com.vaadin.flow.dom.Element;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-form-item")
@@ -188,7 +188,7 @@ public abstract class GeneratedVaadinFormItem<R extends GeneratedVaadinFormItem<
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToLabel(Component... components) {
@@ -206,7 +206,7 @@ public abstract class GeneratedVaadinFormItem<R extends GeneratedVaadinFormItem<
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -226,7 +226,7 @@ public abstract class GeneratedVaadinFormItem<R extends GeneratedVaadinFormItem<
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormLayout.java
@@ -135,7 +135,7 @@ import elemental.json.JsonObject;
  * </tbody>
  * </table>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-form-layout")
@@ -190,7 +190,7 @@ public abstract class GeneratedVaadinFormLayout<R extends GeneratedVaadinFormLay
      *
      * @return the {@code responsiveSteps} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected JsonObject getResponsiveStepsJsonObject() {
@@ -238,7 +238,7 @@ public abstract class GeneratedVaadinFormLayout<R extends GeneratedVaadinFormLay
      * @param responsiveSteps
      *            the JsonObject value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setResponsiveSteps(JsonObject responsiveSteps) {
@@ -256,7 +256,7 @@ public abstract class GeneratedVaadinFormLayout<R extends GeneratedVaadinFormLay
      * @param _Args
      *            Missing documentation!
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void updateStyles(JsonObject _Args) {

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -86,7 +86,7 @@ Your work has been saved
  * is propagated to the internal {@code <vaadin-notification-card>}.
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-notification")
@@ -113,7 +113,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *
      * @return the {@code duration} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getDurationDouble() {
@@ -132,7 +132,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * @param duration
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDuration(double duration) {
@@ -152,7 +152,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *
      * @return the {@code opened} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -171,7 +171,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * @param opened
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setOpened(boolean opened) {
@@ -192,7 +192,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *
      * @return the {@code position} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getPositionString() {
@@ -211,7 +211,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * @param position
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setPosition(String position) {
@@ -226,7 +226,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * Opens the notification.
      * </p>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void open() {
@@ -241,7 +241,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      * Closes the notification.
      * </p>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void close() {
@@ -249,7 +249,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link Notification.OpenedChangeEvent} instead.
      */
     @Deprecated
@@ -275,7 +275,7 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addOpenedChangeListener(

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/GeneratedVaadinProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/GeneratedVaadinProgressBar.java
@@ -99,7 +99,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * </tbody>
  * </table>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-progress-bar")
@@ -115,7 +115,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link ProgressBar#addThemeVariants} instead.
      */
     @Deprecated
@@ -131,7 +131,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link ProgressBar#removeThemeVariants} instead.
      */
     @Deprecated
@@ -154,7 +154,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @return the {@code value} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getValueDouble() {
@@ -172,7 +172,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * @param value
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setValue(double value) {
@@ -192,7 +192,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @return the {@code min} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMinDouble() {
@@ -210,7 +210,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * @param min
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMin(double min) {
@@ -230,7 +230,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @return the {@code max} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMaxDouble() {
@@ -248,7 +248,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * @param max
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMax(double max) {
@@ -269,7 +269,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      *
      * @return the {@code indeterminate} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isIndeterminateBoolean() {
@@ -288,7 +288,7 @@ public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgre
      * @param indeterminate
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setIndeterminate(boolean indeterminate) {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioButton.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioButton.java
@@ -98,7 +98,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-radio-button")
@@ -121,7 +121,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -139,7 +139,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      * @param autofocus
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -159,7 +159,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -177,7 +177,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -190,7 +190,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *
      * @return the {@code name} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getNameString() {
@@ -201,7 +201,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      * @param name
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setName(String name) {
@@ -221,7 +221,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *
      * @return the {@code checked} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "checked", value = "checked-changed")
@@ -240,7 +240,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      * @param checked
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setChecked(boolean checked) {
@@ -260,7 +260,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *
      * @return the {@code value} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getValueString() {
@@ -278,7 +278,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      * @param value
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setValue(String value) {
@@ -286,7 +286,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class CheckedChangeEvent<R extends GeneratedVaadinRadioButton<R>>
@@ -311,7 +311,7 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addCheckedChangeListener(

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioGroup.java
@@ -113,7 +113,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-radio-group")
@@ -130,7 +130,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link RadioButtonGroup#addThemeVariants} instead.
      */
     @Deprecated
@@ -146,7 +146,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link RadioButtonGroup#removeThemeVariants} instead.
      */
     @Deprecated
@@ -170,7 +170,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -189,7 +189,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -210,7 +210,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *
      * @return the {@code readonly} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isReadonlyBoolean() {
@@ -229,7 +229,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param readonly
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setReadonly(boolean readonly) {
@@ -245,7 +245,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *
      * @return the {@code invalid} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isInvalidBoolean() {
@@ -263,7 +263,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param invalid
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInvalid(boolean invalid) {
@@ -283,7 +283,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *
      * @return the {@code required} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRequiredBoolean() {
@@ -301,7 +301,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param required
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRequired(boolean required) {
@@ -321,7 +321,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *
      * @return the {@code errorMessage} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getErrorMessageString() {
@@ -339,7 +339,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param errorMessage
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setErrorMessage(String errorMessage) {
@@ -360,7 +360,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *
      * @return the {@code label} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getLabelString() {
@@ -378,7 +378,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param label
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setLabel(String label) {
@@ -398,7 +398,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -418,7 +418,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -426,7 +426,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class InvalidChangeEvent<R extends GeneratedVaadinRadioGroup<R, ?>>
@@ -451,7 +451,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
@@ -480,7 +480,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinRadioGroup(T initialValue, T defaultValue,
@@ -505,7 +505,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinRadioGroup(T initialValue, T defaultValue,
@@ -544,7 +544,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinRadioGroup(T initialValue, T defaultValue,
@@ -579,7 +579,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinRadioGroup(T initialValue, T defaultValue,
@@ -593,7 +593,7 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinRadioGroup() {

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
@@ -186,7 +186,7 @@ import elemental.json.JsonArray;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-rich-text-editor")
@@ -205,7 +205,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link RichTextEditor#addThemeVariants} instead.
      */
     @Deprecated
@@ -221,7 +221,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link RichTextEditor#removeThemeVariants} instead.
      */
     @Deprecated
@@ -244,7 +244,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      *
      * @return the {@code htmlValue} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "htmlValue", value = "html-value-changed")
@@ -265,7 +265,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -283,7 +283,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -303,7 +303,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      *
      * @return the {@code readonly} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isReadonlyBoolean() {
@@ -321,7 +321,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param readonly
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setReadonly(boolean readonly) {
@@ -342,7 +342,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      *
      * @return the {@code i18n} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected JsonArray getI18nJsonArray() {
@@ -361,7 +361,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param i18n
      *            the JsonArray value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setI18n(JsonArray i18n) {
@@ -369,7 +369,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @DomEvent("change")
@@ -387,7 +387,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -414,7 +414,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinRichTextEditor(T initialValue, T defaultValue,
@@ -444,7 +444,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinRichTextEditor(T initialValue, T defaultValue,
@@ -475,7 +475,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinRichTextEditor(T initialValue, T defaultValue,
@@ -492,7 +492,7 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinRichTextEditor() {

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
@@ -184,7 +184,7 @@ import com.vaadin.flow.shared.Registration;
  * propagated to the internal themable components listed above.
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-select")
@@ -211,7 +211,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -229,7 +229,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param autofocus
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -249,7 +249,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -267,7 +267,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -287,7 +287,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code opened} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Synchronize(property = "opened", value = "opened-changed")
@@ -306,7 +306,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param opened
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setOpened(boolean opened) {
@@ -326,7 +326,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code errorMessage} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getErrorMessageString() {
@@ -344,7 +344,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param errorMessage
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setErrorMessage(String errorMessage) {
@@ -365,7 +365,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code label} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getLabelString() {
@@ -383,7 +383,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param label
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setLabel(String label) {
@@ -403,7 +403,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code required} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRequiredBoolean() {
@@ -421,7 +421,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param required
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRequired(boolean required) {
@@ -441,7 +441,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code invalid} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isInvalidBoolean() {
@@ -459,7 +459,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param invalid
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInvalid(boolean invalid) {
@@ -479,7 +479,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code name} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getNameString() {
@@ -497,7 +497,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param name
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setName(String name) {
@@ -520,7 +520,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code placeholder} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getPlaceholderString() {
@@ -541,7 +541,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param placeholder
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setPlaceholder(String placeholder) {
@@ -562,7 +562,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *
      * @return the {@code readonly} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isReadonlyBoolean() {
@@ -580,7 +580,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param readonly
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setReadonly(boolean readonly) {
@@ -600,7 +600,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -608,7 +608,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class OpenedChangeEvent<R extends GeneratedVaadinSelect<R, ?>>
@@ -633,7 +633,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
@@ -646,7 +646,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class InvalidChangeEvent<R extends GeneratedVaadinSelect<R, ?>>
@@ -671,7 +671,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
@@ -696,7 +696,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrefix(Component... components) {
@@ -714,7 +714,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -734,7 +734,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {
@@ -760,7 +760,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinSelect(T initialValue, T defaultValue,
@@ -785,7 +785,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinSelect(T initialValue, T defaultValue,
@@ -815,7 +815,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinSelect(T initialValue, T defaultValue,
@@ -854,7 +854,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinSelect(T initialValue, T defaultValue,
@@ -873,7 +873,7 @@ public abstract class GeneratedVaadinSelect<R extends GeneratedVaadinSelect<R, T
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinSelect() {

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -188,7 +188,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-split-layout")
@@ -204,7 +204,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link SplitLayout#addThemeVariants} instead.
      */
     @Deprecated
@@ -220,7 +220,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link SplitLayout#removeThemeVariants} instead.
      */
     @Deprecated
@@ -244,7 +244,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *
      * @return the {@code orientation} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getOrientationString() {
@@ -263,7 +263,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @param orientation
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setOrientation(String orientation) {
@@ -272,7 +272,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @DomEvent("iron-resize")
     @Deprecated
@@ -290,8 +290,8 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated Since 23.2, this API is deprecated, deprecated classes will
-     *             be removed in v24.
+     * @deprecated Since 23.2, this API is deprecated, generated classes will be
+     *             removed in v24.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Deprecated
@@ -302,7 +302,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24. Use
+     * @deprecated since v23.3, generated classes will be removed in v24. Use
      *             {@link SplitLayout.SplitterDragendEvent} instead.
      */
     @Deprecated
@@ -322,7 +322,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -344,7 +344,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrimary(Component... components) {
@@ -367,7 +367,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToSecondary(Component... components) {
@@ -385,7 +385,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -405,7 +405,7 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
@@ -89,7 +89,7 @@ Tab 1
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-tab")
@@ -107,7 +107,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public void addThemeVariants(TabVariant... variants) {
@@ -121,7 +121,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public void removeThemeVariants(TabVariant... variants) {
@@ -143,7 +143,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @return the {@code value} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getValueString() {
@@ -162,7 +162,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * @param value
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setValue(String value) {
@@ -182,7 +182,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -200,7 +200,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -220,7 +220,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      *
      * @return the {@code selected} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isSelectedBoolean() {
@@ -238,7 +238,7 @@ public abstract class GeneratedVaadinTab<R extends GeneratedVaadinTab<R>>
      * @param selected
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setSelected(boolean selected) {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
@@ -97,7 +97,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-tabs")
@@ -115,7 +115,7 @@ public abstract class GeneratedVaadinTabs<R extends GeneratedVaadinTabs<R>>
      * @param variants
      *            theme variants to add
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public void addThemeVariants(TabsVariant... variants) {
@@ -129,7 +129,7 @@ public abstract class GeneratedVaadinTabs<R extends GeneratedVaadinTabs<R>>
      * @param variants
      *            theme variants to remove
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public void removeThemeVariants(TabsVariant... variants) {
@@ -138,7 +138,7 @@ public abstract class GeneratedVaadinTabs<R extends GeneratedVaadinTabs<R>>
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void focus() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.function.SerializableFunction;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-email-field")
@@ -73,7 +73,7 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinEmailField(T initialValue, T defaultValue,
@@ -95,7 +95,7 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinEmailField(T initialValue, T defaultValue,
@@ -123,7 +123,7 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinEmailField(T initialValue, T defaultValue,
@@ -151,7 +151,7 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinEmailField(T initialValue, T defaultValue,
@@ -165,7 +165,7 @@ public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailFi
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinEmailField() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
@@ -35,7 +35,7 @@ import com.vaadin.flow.function.SerializableFunction;
  * &lt;/vaadin-number-field&gt;
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-number-field")
@@ -101,7 +101,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *
      * @return the {@code min} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMinDouble() {
@@ -119,7 +119,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param min
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMin(double min) {
@@ -139,7 +139,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *
      * @return the {@code max} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMaxDouble() {
@@ -157,7 +157,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param max
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMax(double max) {
@@ -177,7 +177,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      *
      * @return the {@code step} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getStepDouble() {
@@ -195,7 +195,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param step
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setStep(double step) {
@@ -203,7 +203,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @Override
@@ -237,7 +237,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinNumberField(T initialValue, T defaultValue,
@@ -267,7 +267,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinNumberField(T initialValue, T defaultValue,
@@ -289,7 +289,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinNumberField(T initialValue, T defaultValue,
@@ -316,7 +316,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinNumberField(T initialValue, T defaultValue,
@@ -330,7 +330,7 @@ public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumber
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinNumberField() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
@@ -80,7 +80,7 @@ import com.vaadin.flow.function.SerializableFunction;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-password-field")
@@ -105,7 +105,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *
      * @return the {@code revealButtonHidden} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRevealButtonHiddenBoolean() {
@@ -123,7 +123,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      * @param revealButtonHidden
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRevealButtonHidden(boolean revealButtonHidden) {
@@ -143,7 +143,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *
      * @return the {@code passwordVisible} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isPasswordVisibleBoolean() {
@@ -167,7 +167,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinPasswordField(T initialValue, T defaultValue,
@@ -198,7 +198,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinPasswordField(T initialValue, T defaultValue,
@@ -226,7 +226,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinPasswordField(T initialValue, T defaultValue,
@@ -240,7 +240,7 @@ public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPass
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinPasswordField() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -137,7 +137,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-text-area")
@@ -163,7 +163,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -181,7 +181,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param autofocus
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -201,7 +201,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -219,7 +219,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -242,7 +242,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code autocomplete} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAutocompleteString() {
@@ -263,7 +263,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param autocomplete
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutocomplete(String autocomplete) {
@@ -287,7 +287,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code autocorrect} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAutocorrectString() {
@@ -308,7 +308,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param autocorrect
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutocorrect(String autocorrect) {
@@ -333,7 +333,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code autocapitalize} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAutocapitalizeString() {
@@ -355,7 +355,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param autocapitalize
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutocapitalize(String autocapitalize) {
@@ -377,7 +377,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code autoselect} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutoselectBoolean() {
@@ -396,7 +396,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param autoselect
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutoselect(boolean autoselect) {
@@ -416,7 +416,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code errorMessage} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getErrorMessageString() {
@@ -434,7 +434,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param errorMessage
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setErrorMessage(String errorMessage) {
@@ -455,7 +455,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code label} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getLabelString() {
@@ -473,7 +473,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param label
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setLabel(String label) {
@@ -494,7 +494,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code maxlength} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMaxlengthDouble() {
@@ -513,7 +513,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param maxlength
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMaxlength(double maxlength) {
@@ -534,7 +534,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code minlength} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMinlengthDouble() {
@@ -553,7 +553,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param minlength
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMinlength(double minlength) {
@@ -573,7 +573,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code name} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getNameString() {
@@ -591,7 +591,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param name
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setName(String name) {
@@ -611,7 +611,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code placeholder} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getPlaceholderString() {
@@ -629,7 +629,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param placeholder
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setPlaceholder(String placeholder) {
@@ -651,7 +651,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code readonly} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isReadonlyBoolean() {
@@ -670,7 +670,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param readonly
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setReadonly(boolean readonly) {
@@ -690,7 +690,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code required} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRequiredBoolean() {
@@ -708,7 +708,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param required
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRequired(boolean required) {
@@ -725,7 +725,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *
      * @return the {@code invalid} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isInvalidBoolean() {
@@ -743,7 +743,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param invalid
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInvalid(boolean invalid) {
@@ -803,7 +803,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -823,7 +823,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -831,7 +831,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @DomEvent("change")
@@ -849,7 +849,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -860,7 +860,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class InvalidChangeEvent<R extends GeneratedVaadinTextArea<R, ?>>
@@ -885,7 +885,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
@@ -910,7 +910,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrefix(Component... components) {
@@ -933,7 +933,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToTextarea(Component... components) {
@@ -956,7 +956,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToSuffix(Component... components) {
@@ -974,7 +974,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -994,7 +994,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {
@@ -1020,7 +1020,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinTextArea(T initialValue, T defaultValue,
@@ -1046,7 +1046,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinTextArea(T initialValue, T defaultValue,
@@ -1070,7 +1070,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinTextArea(T initialValue, T defaultValue,
@@ -1101,7 +1101,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinTextArea(T initialValue, T defaultValue,
@@ -1118,7 +1118,7 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinTextArea() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -161,7 +161,7 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  *
- * @deprecated since v23.3, deprecated classes will be removed in v24.
+ * @deprecated since v23.3, generated classes will be removed in v24.
  */
 @Deprecated
 @Tag("vaadin-text-field")
@@ -187,7 +187,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code autofocus} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutofocusBoolean() {
@@ -205,7 +205,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param autofocus
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutofocus(boolean autofocus) {
@@ -225,7 +225,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code disabled} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isDisabledBoolean() {
@@ -243,7 +243,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param disabled
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setDisabled(boolean disabled) {
@@ -266,7 +266,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code autocomplete} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAutocompleteString() {
@@ -287,7 +287,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param autocomplete
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutocomplete(String autocomplete) {
@@ -311,7 +311,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code autocorrect} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAutocorrectString() {
@@ -332,7 +332,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param autocorrect
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutocorrect(String autocorrect) {
@@ -357,7 +357,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code autocapitalize} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getAutocapitalizeString() {
@@ -379,7 +379,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param autocapitalize
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutocapitalize(String autocapitalize) {
@@ -401,7 +401,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code autoselect} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isAutoselectBoolean() {
@@ -420,7 +420,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param autoselect
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setAutoselect(boolean autoselect) {
@@ -440,7 +440,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code errorMessage} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getErrorMessageString() {
@@ -458,7 +458,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param errorMessage
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setErrorMessage(String errorMessage) {
@@ -479,7 +479,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code label} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getLabelString() {
@@ -497,7 +497,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param label
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setLabel(String label) {
@@ -518,7 +518,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code maxlength} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMaxlengthDouble() {
@@ -537,7 +537,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param maxlength
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMaxlength(double maxlength) {
@@ -558,7 +558,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code minlength} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected double getMinlengthDouble() {
@@ -577,7 +577,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param minlength
      *            the double value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setMinlength(double minlength) {
@@ -597,7 +597,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code name} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getNameString() {
@@ -615,7 +615,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param name
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setName(String name) {
@@ -635,7 +635,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code placeholder} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getPlaceholderString() {
@@ -653,7 +653,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param placeholder
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setPlaceholder(String placeholder) {
@@ -675,7 +675,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code readonly} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isReadonlyBoolean() {
@@ -694,7 +694,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param readonly
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setReadonly(boolean readonly) {
@@ -714,7 +714,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code required} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isRequiredBoolean() {
@@ -732,7 +732,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param required
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setRequired(boolean required) {
@@ -749,7 +749,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code invalid} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected boolean isInvalidBoolean() {
@@ -767,7 +767,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param invalid
      *            the boolean value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setInvalid(boolean invalid) {
@@ -830,7 +830,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code list} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getListString() {
@@ -849,7 +849,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param list
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setList(String list) {
@@ -870,7 +870,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code pattern} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getPatternString() {
@@ -889,7 +889,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param pattern
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setPattern(String pattern) {
@@ -909,7 +909,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *
      * @return the {@code title} property from the webcomponent
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected String getTitleString() {
@@ -928,7 +928,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param title
      *            the String value to set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void setTitle(String title) {
@@ -948,7 +948,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -968,7 +968,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * <code>boolean</code>. Functions with return types different than void are
      * not supported at this moment.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @NotSupported
@@ -976,7 +976,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @DomEvent("change")
@@ -994,7 +994,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1005,7 +1005,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
     }
 
     /**
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public static class InvalidChangeEvent<R extends GeneratedVaadinTextField<R, ?>>
@@ -1030,7 +1030,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            the listener
      * @return a {@link Registration} for removing the event listener
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
@@ -1055,7 +1055,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToPrefix(Component... components) {
@@ -1078,7 +1078,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToInput(Component... components) {
@@ -1101,7 +1101,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void addToSuffix(Component... components) {
@@ -1119,7 +1119,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @throws IllegalArgumentException
      *             if any of the components is not a child of this component.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void remove(Component... components) {
@@ -1139,7 +1139,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * text content as well as child elements that have been added directly to
      * this component using the {@link Element} API.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     protected void removeAll() {
@@ -1165,7 +1165,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
@@ -1203,7 +1203,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
@@ -1230,7 +1230,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param acceptNullValues
      *            whether <code>null</code> is accepted as a model value
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinTextField(T initialValue, T defaultValue,
@@ -1258,7 +1258,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            property value, otherwise element {@code "value"} property is
      *            ignored and the initial value is set
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinTextField(T initialValue, T defaultValue,
@@ -1289,7 +1289,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
@@ -1329,7 +1329,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * @param <P>
      *            the property type
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public <P> GeneratedVaadinTextField(T initialValue, T defaultValue,
@@ -1348,7 +1348,7 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
     /**
      * Default constructor.
      *
-     * @deprecated since v23.3, deprecated classes will be removed in v24.
+     * @deprecated since v23.3, generated classes will be removed in v24.
      */
     @Deprecated
     public GeneratedVaadinTextField() {


### PR DESCRIPTION
For the deprecation notices on generated classes we specifically wanted to mention that the *generated* classes will be removed, let's clarify the notices to do so.