### PR TITLE
chore: improve flaky combo box test

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
@@ -157,7 +157,9 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
     @Test
     public void addItemCountChangeListener_newItemAdded_itemCountChanged() {
         // Add custom value
-        firstComboBox.sendKeys(NEW_PERSON_NAME, Keys.ENTER);
+        firstComboBox.sendKeys(NEW_PERSON_NAME);
+        waitUntil(driver -> !firstComboBox.getPropertyBoolean("loading"));
+        firstComboBox.sendKeys(Keys.ENTER);
         verifyNotifiedItemCount(
                 "Expected item count = 251 after adding a new item", 251);
         // Erase input field's text, because it can be treated as a filter


### PR DESCRIPTION
The `addItemCountChangeListener_newItemAdded_itemCountChanged` IT fails regularly in CI and [snapshot validation](https://bender.vaadin.com/buildConfiguration/FlowComponents_Snapshot/356410?expandBuildProblemsSection=true&hideProblemsFromDependencies=false&hideTestsFromDependencies=false), as well as when debugging locally. There seems to be an actual issue with committing a value or changing the underlying data while the component is loading. Modified the test to wait until loading has finished before committing the value.
