### PR TITLE
fix: lambda expression was refactored into an anonymous class

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarSerializationPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarSerializationPage.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+@Route("vaadin-menu-bar/serialization")
+public class MenuBarSerializationPage extends Div {
+
+    private MenuBar menuBar;
+    private NativeButton serializeAndDeserializeUiButton;
+    private Span exceptionMessageSpan;
+
+    public MenuBarSerializationPage() {
+        menuBar = new MenuBar();
+        menuBar.addItem("Menu item");
+
+        serializeAndDeserializeUiButton = new NativeButton(
+                "Serialize&Deserialize UI");
+        serializeAndDeserializeUiButton
+                .addClickListener(event -> serializeAndDeserialize());
+        serializeAndDeserializeUiButton.setId("serialize-and-deserialize-ui");
+
+        exceptionMessageSpan = new Span();
+        exceptionMessageSpan.setId("exception-message-span");
+
+        add(serializeAndDeserializeUiButton, menuBar, exceptionMessageSpan);
+    }
+
+    private void serializeAndDeserialize() {
+        ByteArrayOutputStream bs = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bs)) {
+            out.writeObject(UI.getCurrent());
+        } catch (IOException ex) {
+            exceptionMessageSpan.setText(ex.getMessage());
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bs.toByteArray()))) {
+            in.readObject();
+        } catch (IOException | ClassNotFoundException | ClassCastException ex) {
+            exceptionMessageSpan.setText(ex.getMessage());
+        }
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSerializationIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSerializationIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-menu-bar/serialization")
+public class MenuBarSerializationIT extends AbstractComponentIT {
+    private MenuBarElement menuBar;
+
+    @Before
+    public void init() {
+        open();
+        menuBar = $(MenuBarElement.class).waitForFirst();
+    }
+
+    @Test
+    public void serializeAndDeserializeUi_noExceptionIsThrown() {
+        $("button").id("serialize-and-deserialize-ui").click();
+        Assert.assertEquals("",
+                $("span").id("exception-message-span").getText());
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.JsonSerializer;
 
 import elemental.json.JsonObject;
@@ -76,7 +77,14 @@ public class MenuBar extends Component
      */
     public MenuBar() {
         menuItemsArrayGenerator = new MenuItemsArrayGenerator<>(this);
-        menuManager = new MenuManager<>(this, this::resetContent,
+        // Not a lambda because of UI serialization purposes
+        SerializableRunnable resetContent = new SerializableRunnable() {
+            @Override
+            public void run() {
+                resetContent();
+            }
+        };
+        menuManager = new MenuManager<>(this, resetContent,
                 (menu, contentReset) -> new MenuBarRootItem(this, contentReset),
                 MenuItem.class, null);
         addAttachListener(event -> {


### PR DESCRIPTION
## Description

Deserialization of a UI containing a `MenuBar` component failed with a `ClassCastException`. 

This PR changes the lambda expression `this::resetContent` and adds an anonymous class instead.

Fixes #4056 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.