### PR TITLE
refactor: deprecate Grid.setVerticalScrollingEnabled

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingPage.java
@@ -19,6 +19,7 @@ public class EditorVerticalScrollingPage extends Div {
 
     private Grid<Person> grid = new Grid<>();
 
+    @SuppressWarnings("deprecation")
     public EditorVerticalScrollingPage() {
         setSizeFull();
         grid.setSelectionMode(SelectionMode.NONE);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3867,7 +3867,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @param enabled
      *            <code>true</code> to enable vertical scrolling,
      *            <code>false</code> to disabled it
+     * @deprecated since v23.3
      */
+    @Deprecated
     public void setVerticalScrollingEnabled(boolean enabled) {
         if (isVerticalScrollingEnabled() == enabled) {
             return;
@@ -3882,7 +3884,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *
      * @return <code>true</code> if the vertical scrolling is enabled,
      *         <code>false</code> otherwise
+     * @deprecated since v23.3
      */
+    @Deprecated
     public boolean isVerticalScrollingEnabled() {
         return verticalScrollingEnabled;
     }


### PR DESCRIPTION
## Description

Deprecates the `Grid.setVerticalScrollingEnabled` method, which is scheduled to be removed in v24.

Part of #4168 