### PR TITLE
chore: stop logging registerRpc in spreadsheet

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1177,7 +1177,6 @@ public class Spreadsheet extends Component
     }
 
     private void registerRpc(SpreadsheetHandlerImpl spreadsheetHandler) {
-        LOGGER.info("Spreadsheet.registerRpc()");
         addListener(SpreadsheetEvent.class,
                 new SpreadsheetEventListener(spreadsheetHandler));
     }


### PR DESCRIPTION
## Description

The `Spreadsheet` logs `Spreadsheet.registerRpc()` for each new instance which adds unnecessary noise to CI logs etc.

## Type of change

- Chore