### PR TITLE
chore: use a static getter for spreadsheet styles

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
@@ -18,7 +18,9 @@ const overlayStyles = (() => {
 })();
 
 export class VaadinSpreadsheet extends LitElement {
-  static styles = spreadsheetStyles;
+  static get styles() {
+    return spreadsheetStyles;
+  }
 
   static get properties() {
     return {


### PR DESCRIPTION
Fixes an issue with frontend compilation in docs:
<img width="987" alt="Screenshot 2022-11-24 at 12 41 32" src="https://user-images.githubusercontent.com/1222264/203764070-6673b4f4-bad0-48dc-8654-160634f006d7.png">
