### PR TITLE
refactor!: remove deprecated IronResizeEvent API

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -151,13 +151,6 @@ import com.vaadin.flow.shared.Registration;
  * 150px;&quot;&gt;First&lt;/div&gt; &lt;div&gt;Second&lt;/div&gt;
  * &lt;/vaadin-split-layout&gt;
  * </p>
- * <h3>Resize Notification</h3>
- * <p>
- * This element implements {@code IronResizableBehavior} to notify the nested
- * resizables when the splitter is dragged. In order to define a resizable and
- * receive that notification in a nested element, include
- * {@code IronResizableBehavior} and listen for the {@code iron-resize} event.
- * </p>
  * <h3>Styling</h3>
  * <p>
  * The following shadow DOM parts are available for styling:
@@ -252,32 +245,6 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
     protected void setOrientation(String orientation) {
         getElement().setProperty("orientation",
                 orientation == null ? "" : orientation);
-    }
-
-    @DomEvent("iron-resize")
-    @Deprecated
-    public static class IronResizeEvent<R extends GeneratedVaadinSplitLayout<R>>
-            extends ComponentEvent<R> {
-        public IronResizeEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code iron-resize} events fired by the webcomponent.
-     *
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     *
-     * @deprecated Since 23.2, this API is deprecated.
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Deprecated
-    protected Registration addIronResizeListener(
-            ComponentEventListener<IronResizeEvent<R>> listener) {
-        return addListener(IronResizeEvent.class,
-                (ComponentEventListener) listener);
     }
 
     @DomEvent("splitter-dragend")


### PR DESCRIPTION
## Description

Removed `IronResizeEvent` API from `GeneratedSplitLayout`, previously deprecated in #3545.

## Type of change

- Breaking change