### PR TITLE
refactor!: remove deprecated setMinTime and setMaxTime

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -595,21 +595,6 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     }
 
     /**
-     * Sets the minimum time in the time picker. Times before that will be
-     * disabled in the popup.
-     *
-     * @deprecated Since 22.0, this API is deprecated in favor of
-     *             {@link TimePicker#setMin(LocalTime)}
-     * @param min
-     *            the minimum time that is allowed to be selected, or
-     *            <code>null</code> to remove any minimum constraints
-     */
-    @Deprecated
-    public void setMinTime(LocalTime min) {
-        this.setMin(min);
-    }
-
-    /**
      * Gets the minimum time in the time picker. Time before that will be
      * disabled in the popup.
      *
@@ -618,21 +603,6 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      */
     public LocalTime getMin() {
         return this.min;
-    }
-
-    /**
-     * Gets the minimum time in the time picker. Time before that will be
-     * disabled in the popup.
-     *
-     * @deprecated Since 22.0, this API is deprecated in favor of
-     *             {@link TimePicker#getMin()}
-     *
-     * @return the minimum time that is allowed to be selected, or
-     *         <code>null</code> if there's no minimum
-     */
-    @Deprecated
-    public LocalTime getMinTime() {
-        return this.getMin();
     }
 
     /**
@@ -649,22 +619,6 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     }
 
     /**
-     * Sets the maximum time in the time picker. Times after that will be
-     * disabled in the popup.
-     *
-     * @deprecated Since 22.0, this API is deprecated in favor of
-     *             {@link TimePicker#setMax(LocalTime)}
-     *
-     * @param max
-     *            the maximum time that is allowed to be selected, or
-     *            <code>null</code> to remove any maximum constraints
-     */
-    @Deprecated
-    public void setMaxTime(LocalTime max) {
-        this.setMax(max);
-    }
-
-    /**
      * Gets the maximum time in the time picker. Times after that will be
      * disabled in the popup.
      *
@@ -673,21 +627,6 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      */
     public LocalTime getMax() {
         return this.max;
-    }
-
-    /**
-     * Gets the maximum time in the time picker. Times after that will be
-     * disabled in the popup.
-     *
-     * @deprecated Since 22.0, this API is deprecated in favor of
-     *             {@link TimePicker#getMax()}
-     *
-     * @return the maximum time that is allowed to be selected, or
-     *         <code>null</code> if there's no maximum
-     */
-    @Deprecated
-    public LocalTime getMaxTime() {
-        return this.getMax();
     }
 
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -174,41 +174,11 @@ public class TimePickerTest {
     }
 
     @Test
-    public void setMinTime_getMin() {
-        TimePicker timePicker = new TimePicker();
-        final String min = "12:00";
-        LocalTime minTime = LocalTime.parse(min);
-        timePicker.setMinTime(minTime);
-        assertEquals(minTime, timePicker.getMin());
-        assertEquals(minTime, timePicker.getMinTime());
-    }
-
-    @Test
     public void setMin_getMin_null() {
         TimePicker timePicker = new TimePicker();
         assertEquals(null, timePicker.getMin());
         timePicker.setMin(null);
         assertEquals(null, timePicker.getMin());
-        assertEquals(null, timePicker.getMinTime());
-    }
-
-    @Test
-    public void setMinTime_getMin_null() {
-        TimePicker timePicker = new TimePicker();
-        assertEquals(null, timePicker.getMinTime());
-        timePicker.setMinTime(null);
-        assertEquals(null, timePicker.getMin());
-        assertEquals(null, timePicker.getMinTime());
-    }
-
-    @Test
-    public void setMaxTime_getMax() {
-        TimePicker timePicker = new TimePicker();
-        final String max = "12:00";
-        LocalTime maxTime = LocalTime.parse(max);
-        timePicker.setMaxTime(maxTime);
-        assertEquals(maxTime, timePicker.getMax());
-        assertEquals(maxTime, timePicker.getMaxTime());
     }
 
     @Test
@@ -217,16 +187,6 @@ public class TimePickerTest {
         assertEquals(null, timePicker.getMax());
         timePicker.setMax(null);
         assertEquals(null, timePicker.getMax());
-        assertEquals(null, timePicker.getMaxTime());
-    }
-
-    @Test
-    public void setMaxTime_getMax_null() {
-        TimePicker timePicker = new TimePicker();
-        assertEquals(null, timePicker.getMaxTime());
-        timePicker.setMaxTime(null);
-        assertEquals(null, timePicker.getMax());
-        assertEquals(null, timePicker.getMaxTime());
     }
 
     @Test


### PR DESCRIPTION
## Description

Removed `TimePicker` APIs that have been deprecated in https://github.com/vaadin/flow-components/pull/2246.

## Type of change

- Breaking change