### PR TITLE
refactor: deprecate RadioButtonGroup implementation of HasItemComponents

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDemoPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDemoPage.java
@@ -258,6 +258,7 @@ public class RadioButtonGroupDemoPage extends Div {
         return person.getName();
     }
 
+    @SuppressWarnings("deprecation")
     private void addComponentAfterItems() {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
         group.setItems("foo", "bar", "baz");
@@ -271,6 +272,7 @@ public class RadioButtonGroupDemoPage extends Div {
         addCard("Add component to group", group);
     }
 
+    @SuppressWarnings("deprecation")
     private void insertComponentsBetweenItems() {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
 
@@ -289,6 +291,7 @@ public class RadioButtonGroupDemoPage extends Div {
         addCard("Insert component after item in group", group);
     }
 
+    @SuppressWarnings("deprecation")
     private void prependAndInsertComponents() {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
 
@@ -308,6 +311,7 @@ public class RadioButtonGroupDemoPage extends Div {
 
     private Label below;
 
+    @SuppressWarnings("deprecation")
     private void dynamicComponents() {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -751,6 +751,7 @@ public class RadioButtonGroup<T>
     public void removeThemeVariants(RadioGroupVariant... variants) {
         super.removeThemeVariants(variants);
     }
+
     /**
      * @deprecated since v23.3. This component is not intended to be used as a
      *             generic component container, and its implementation of

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
@@ -749,5 +750,137 @@ public class RadioButtonGroup<T>
     @Override
     public void removeThemeVariants(RadioGroupVariant... variants) {
         super.removeThemeVariants(variants);
+    }
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+
+    @Override
+    @Deprecated
+    public void add(Component... components) {
+        HasItemComponents.super.add(components);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void add(Collection<Component> components) {
+        HasItemComponents.super.add(components);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void add(String text) {
+        HasItemComponents.super.add(text);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void remove(Component... components) {
+        HasItemComponents.super.remove(components);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void remove(Collection<Component> components) {
+        HasItemComponents.super.remove(components);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void removeAll() {
+        HasItemComponents.super.removeAll();
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void addComponentAtIndex(int index, Component component) {
+        HasItemComponents.super.addComponentAtIndex(index, component);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void addComponentAsFirst(Component component) {
+        HasItemComponents.super.addComponentAsFirst(component);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void addComponents(T afterItem, Component... components) {
+        HasItemComponents.super.addComponents(afterItem, components);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public void prependComponents(T beforeItem, Component... components) {
+        HasItemComponents.super.prependComponents(beforeItem, components);
+    }
+
+    /**
+     * @deprecated since v23.3. This component is not intended to be used as a
+     *             generic component container, and its implementation of
+     *             {@link HasComponents} and {@link HasItemComponents} will be
+     *             removed in v24.
+     */
+    @Override
+    @Deprecated
+    public int getItemPosition(T item) {
+        return HasItemComponents.super.getItemPosition(item);
     }
 }


### PR DESCRIPTION
## Description

Deprecates the `RadioButtonGroup` implementation of `HasItemComponents` and `HasComponents`, as the component is not intended to be used as a generic component container.

Part of #4194

## Type of change

- Refactoring