### PR TITLE
refactor!: remove deprecated UploadI18N.setCancel

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadTestsI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadTestsI18N.java
@@ -31,7 +31,6 @@ class UploadTestsI18N {
                     .setMany("Добавить файлы"))
             .setFile(new UploadI18N.File().setStart("Загрузить")
                     .setRetry("Повторить").setRemove("Удалить"))
-            .setCancel("Отменить")
             .setError(new UploadI18N.Error()
                     .setTooManyFiles("Слишком много файлов.")
                     .setFileIsTooBig("Слишком большой файл.")

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -643,35 +643,6 @@ public class UploadI18N implements Serializable {
     }
 
     /**
-     * Get cancel translation.
-     *
-     * @return translation string
-     *
-     * @deprecated since Vaadin 22, {@link #getCancel()} is deprecated as the
-     *             `cancel` translation is not used anywhere.
-     */
-    @Deprecated
-    public String getCancel() {
-        return cancel;
-    }
-
-    /**
-     * Set cancel translation.
-     *
-     * @param cancel
-     *            translation string
-     * @return i18n translations
-     *
-     * @deprecated since Vaadin 22, {@link #setCancel(String)} is deprecated as
-     *             the `cancel` translation is not used anywhere.
-     */
-    @Deprecated
-    public UploadI18N setCancel(String cancel) {
-        this.cancel = cancel;
-        return this;
-    }
-
-    /**
      * Get error translations.
      *
      * @return error translations


### PR DESCRIPTION
## Description

Removed no longer needed `UploadI18N` API that was deprecated in https://github.com/vaadin/flow-components/pull/2215.

## Type of change

- Breaking change