### PR TITLE
fix: map virtual-list placeholder item with data generator

### DIFF
--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
@@ -141,7 +141,20 @@ public class VirtualListViewIT extends AbstractComponentIT {
         WebElement list = findElement(By
                 .id("list-of-people-with-dataprovider-and-component-renderer"));
         validateListSize(list, 500);
-        validatePlaceholderObject(list);
+
+        // Get the text content of a placeholder component
+        var obj = (Map<String, Long>) executeScript(
+                "return arguments[0].$connector.placeholderItem;", list);
+        var nodeId = obj.entrySet().stream()
+                .filter(entry -> entry.getKey().endsWith("nodeid")).findFirst()
+                .get().getValue();
+        var text = (String) executeScript(
+                "return Vaadin.Flow.clients.ROOT.getByNodeId(arguments[0]).textContent",
+                nodeId);
+        Assert.assertEquals("The placeholder component of the '"
+                + list.getAttribute("id")
+                + "' virtual-list should have the '-----' as text content",
+                "-----", text);
     }
 
     @Test
@@ -193,10 +206,13 @@ public class VirtualListViewIT extends AbstractComponentIT {
     private void validatePlaceholderObject(WebElement list) {
         Map<String, String> obj = (Map<String, String>) executeScript(
                 "return arguments[0].$connector.placeholderItem;", list);
+        // Find the mapped key for "firstName" property
+        var keyForDisabled = obj.keySet().stream()
+                .filter(key -> key.endsWith("firstName")).findFirst().get();
         Assert.assertEquals("The placeholderItem object of the '"
                 + list.getAttribute("id")
                 + "' virtual-list should have the '-----' as firstName property",
-                "-----", obj.get("firstName"));
+                "-----", obj.get(keyForDisabled));
     }
 
 }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
@@ -207,12 +207,12 @@ public class VirtualListViewIT extends AbstractComponentIT {
         Map<String, String> obj = (Map<String, String>) executeScript(
                 "return arguments[0].$connector.placeholderItem;", list);
         // Find the mapped key for "firstName" property
-        var keyForDisabled = obj.keySet().stream()
+        var keyForFirstName = obj.keySet().stream()
                 .filter(key -> key.endsWith("firstName")).findFirst().get();
         Assert.assertEquals("The placeholderItem object of the '"
                 + list.getAttribute("id")
                 + "' virtual-list should have the '-----' as firstName property",
-                "-----", obj.get(keyForDisabled));
+                "-----", obj.get(keyForFirstName));
     }
 
 }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.virtuallist.paging.PagelessDataCommunicator;
@@ -271,7 +272,11 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
             if (placeholderItem != null) {
                 dataGenerator.generateData(placeholderItem, json);
             }
-            getElement().callJsFunction("$connector.setPlaceholderItem", json);
+            var appId = UI.getCurrent() != null
+                    ? UI.getCurrent().getInternals().getAppId()
+                    : "";
+            getElement().callJsFunction("$connector.setPlaceholderItem", json,
+                    appId);
         });
 
         registerTemplateUpdate();

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -240,6 +240,11 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
         registerTemplateUpdate();
 
         getDataCommunicator().reset();
+
+        // Changing the renderer may also affect how the placeholder item is
+        // processed by the data generator. Call setPlaceholderItem to make sure
+        // the sent placeholder item is up to date.
+        this.setPlaceholderItem(this.placeholderItem);
     }
 
     /**
@@ -267,11 +272,16 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
 
         runBeforeClientResponse(() -> {
             var json = Json.createObject();
-            // Use the renderer's data generator to create the final placeholder
-            // item which should be sent sent to the client
+
             if (placeholderItem != null) {
+                // Use the renderer's data generator to create the final
+                // placeholder item which should be sent to the client. In the
+                // case of ComponentRenderer, the generator also creates a
+                // placeholder element which is automatically sent to the client
+                // and the resulting json object will include its nodeid.
                 dataGenerator.generateData(placeholderItem, json);
             }
+
             var appId = UI.getCurrent() != null
                     ? UI.getCurrent().getInternals().getAppId()
                     : "";

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -268,7 +268,7 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
         runBeforeClientResponse(() -> {
             var json = Json.createObject();
             // Use the renderer's data generator to create the final placeholder
-            // item which shoul be sent send to the client
+            // item which should be sent sent to the client
             if (placeholderItem != null) {
                 dataGenerator.generateData(placeholderItem, json);
             }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
@@ -59,11 +59,30 @@ window.Vaadin.Flow.virtualListConnector = {
         root.__virtualListIndex = model.index;
 
         if (model.item === undefined) {
-          originalRenderer.call(list, root, list, {
-            ...model,
-            item: list.$connector.placeholderItem
-          });
+          if (list.$connector.placeholderElement) {
+            // ComponentRenderer
+            if (!root.__hasComponentRendererPlaceholder) {
+              // The root was previously rendered by the ComponentRenderer. Clear and add a placeholder.
+              root.innerHTML = '';
+              delete root._$litPart$;
+              root.appendChild(list.$connector.placeholderElement.cloneNode(true));
+              root.__hasComponentRendererPlaceholder = true;
+            }
+          } else {
+            // LitRenderer
+            originalRenderer.call(list, root, list, {
+              ...model,
+              item: list.$connector.placeholderItem
+            });
+          }
         } else {
+          if (root.__hasComponentRendererPlaceholder) {
+            // The root was previously populated with a placeholder. Clear it.
+            root.innerHTML = '';
+            delete root._$litPart$;
+            root.__hasComponentRendererPlaceholder = false;
+          }
+
           originalRenderer.call(list, root, list, model);
         }
 
@@ -122,9 +141,11 @@ window.Vaadin.Flow.virtualListConnector = {
       }
     };
 
-    list.$connector.setPlaceholderItem = function (placeholderItem = {}) {
+    list.$connector.setPlaceholderItem = function (placeholderItem = {}, appId) {
       placeholderItem.__placeholder = true;
       list.$connector.placeholderItem = placeholderItem;
+      const nodeId = Object.entries(placeholderItem).find(([key]) => key.endsWith('_nodeid'));
+      list.$connector.placeholderElement = nodeId ? Vaadin.Flow.clients[appId].getByNodeId(nodeId[1]) : null;
     };
   }
 };

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
@@ -79,7 +79,6 @@ window.Vaadin.Flow.virtualListConnector = {
           if (root.__hasComponentRendererPlaceholder) {
             // The root was previously populated with a placeholder. Clear it.
             root.innerHTML = '';
-            delete root._$litPart$;
             root.__hasComponentRendererPlaceholder = false;
           }
 


### PR DESCRIPTION
Follow-up for https://github.com/vaadin/flow-components/pull/4148

This PR fixes an issue where a LitRenderer-based VirtualList would not show the placeholder item. This is because the placeholder item wasn't mapped by the renderer's data generator. Just like all the other virtual list items, the data generator should process the placeholder item before sending it to the client.

In LitRenderer's case, the data generator prefixes the item properties with an instance-specific namespace identifier.

In ComponentRenderer's case, processing the placeholder item with the [data generator](https://github.com/vaadin/flow-components/blob/master/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentDataGenerator.java) results in a Component getting created to be transmitted to the client. We modified the `virtualListConnector` to use clones of this element as placeholders.