### PR TITLE
chore: fix Grid testbench selectors to work on macOS

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/src/main/java/com/vaadin/flow/component/gridpro/testbench/GridTHTDElement.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/src/main/java/com/vaadin/flow/component/gridpro/testbench/GridTHTDElement.java
@@ -29,11 +29,10 @@ public class GridTHTDElement extends TestBenchElement {
 
     @Override
     public String getText() {
-        // The first child element of a cell is a slot. The following JS finds
-        // the elements assigned to that slot and then joins the `textContent`
-        // of the elements slots
+        // The following JS finds the elements assigned to a cell's slot and
+        // then joins their `textContent`
         String text = (String) executeScript("var cell = arguments[0];"
-                + "return Array.from(cell.firstElementChild.assignedNodes()).map(function(node) { return node.textContent;}).join('');",
+                + "return Array.from(cell.querySelector('slot').assignedNodes()).map(function(node) { return node.textContent;}).join('');",
                 this);
         if (text.trim().isEmpty()) {
             return "";
@@ -43,11 +42,10 @@ public class GridTHTDElement extends TestBenchElement {
     }
 
     public String getInnerHTML() {
-        // The first child element of a cell is a slot. The following JS finds
-        // the elements assigned to that slot and then joins the `innerHTML`
-        // of the elements slots
+        // The following JS finds the elements assigned to a cell's slot and
+        // then joins their `innerHTML`
         String text = (String) executeScript("var cell = arguments[0];"
-                + "return Array.from(cell.firstElementChild.assignedNodes()).map(function(node) { return node.innerHTML;}).join('');",
+                + "return Array.from(cell.querySelector('slot').assignedNodes()).map(function(node) { return node.innerHTML;}).join('');",
                 this);
         if (text.trim().isEmpty()) {
             return "";
@@ -93,7 +91,7 @@ public class GridTHTDElement extends TestBenchElement {
     @Override
     public SearchContext getContext() {
         return (SearchContext) executeScript(
-                "return arguments[0].firstElementChild.assignedNodes()[0];",
+                "return arguments[0].querySelector('slot').assignedNodes()[0];",
                 this);
     }
 }


### PR DESCRIPTION
## Description

As part of https://github.com/vaadin/web-components/pull/4260 we changed GridPro cells to wrap their slot in a button element, when run on macOS. This causes GridPro ITs to fail when run on macOS, as TestBench selectors currently expect the slot to be the direct child of the cell.

This change modifies these selectors to query for the slot instead.
