### PR TITLE
feat: make upload slots API work as expected

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -21,6 +21,16 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-button-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -29,7 +29,10 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.dom.DomEventListener;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
@@ -55,6 +58,16 @@ import elemental.json.JsonType;
  */
 public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
+    /**
+     * Server-side component for the default {@code <vaadin-upload>} icon.
+     */
+    @Tag("vaadin-upload-icon")
+    public static class UploadIcon extends Component {
+
+        public UploadIcon() {
+        }
+    }
+
     private StreamVariable streamVariable;
     private boolean interrupted = false;
 
@@ -62,6 +75,15 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     private boolean uploading;
 
     private UploadI18N i18n;
+
+    private Component uploadButton;
+    private Component defaultUploadButton;
+
+    private Component dropLabel;
+    private Component defaultDropLabel;
+
+    private Component dropLabelIcon;
+    private Component defaultDropLabelIcon;
 
     /**
      * The output of the upload is redirected to this receiver.
@@ -115,6 +137,15 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
                 .addEventData(elementFiles);
         getElement().addEventListener("upload-abort", allFinishedListener)
                 .addEventData(elementFiles);
+
+        defaultUploadButton = new Button();
+        setUploadButton(defaultUploadButton);
+
+        defaultDropLabel = new Span();
+        setDropLabel(defaultDropLabel);
+
+        defaultDropLabelIcon = new UploadIcon();
+        setDropLabelIcon(defaultDropLabelIcon);
     }
 
     /**
@@ -276,48 +307,60 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * Set the component as the actionable button inside the upload component,
      * that opens the dialog for choosing the files to be upload.
      *
-     * @param uploadButton
+     * @param button
      *            the component to be clicked by the user to open the dialog, or
      *            <code>null</code> to reset to the default button
      */
-    public void setUploadButton(Component uploadButton) {
+    public void setUploadButton(Component button) {
         removeElementsAtSlot("add-button");
-        if (uploadButton != null) {
-            addToAddButton(uploadButton);
+
+        if (button != null) {
+            uploadButton = button;
+        } else {
+            uploadButton = defaultUploadButton;
         }
+
+        uploadButton.getElement().setAttribute("slot", "add-button");
+        getElement().appendChild(uploadButton.getElement());
     }
 
     /**
-     * Get the component set as the upload button for the upload, if any.
+     * Get the component set as the upload button for the upload.
      *
-     * @return the actionable button, or <code>null</code> if none was set
+     * @return the actionable button, never <code>null</code>.
      */
     public Component getUploadButton() {
-        return getComponentAtSlot("add-button");
+        return uploadButton;
     }
 
     /**
      * Set the component to show as a message to the user to drop files in the
      * upload component. Despite of the name, the label can be any component.
      *
-     * @param dropLabel
+     * @param label
      *            the label to show for the users when it's possible drop files,
-     *            or <code>null</code> to clear it
+     *            or <code>null</code> to reset to the default label
      */
-    public void setDropLabel(Component dropLabel) {
+    public void setDropLabel(Component label) {
         removeElementsAtSlot("drop-label");
-        if (dropLabel != null) {
-            addToDropLabel(dropLabel);
+
+        if (label != null) {
+            dropLabel = label;
+        } else {
+            dropLabel = defaultDropLabel;
         }
+
+        dropLabel.getElement().setAttribute("slot", "drop-label");
+        getElement().appendChild(dropLabel.getElement());
     }
 
     /**
-     * Get the component set as the drop label, if any.
+     * Get the component set as the drop label.
      *
-     * @return the drop label component, or <code>null</code> if none was set
+     * @return the drop label component, never <code>null</code>.
      */
     public Component getDropLabel() {
-        return getComponentAtSlot("drop-label");
+        return dropLabel;
     }
 
     /**
@@ -325,25 +368,30 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * when the user can drop files to this upload component. Despite of the
      * name, the drop label icon can be any component.
      *
-     * @param dropLabelIcon
+     * @param icon
      *            the label icon to show for the users when it's possible to
-     *            drop files, or <code>null</code> to clear it
+     *            drop files, or <code>null</code> to reset to the default icon
      */
-    public void setDropLabelIcon(Component dropLabelIcon) {
+    public void setDropLabelIcon(Component icon) {
         removeElementsAtSlot("drop-label-icon");
-        if (dropLabelIcon != null) {
-            addToDropLabelIcon(dropLabelIcon);
+
+        if (icon != null) {
+            dropLabelIcon = icon;
+        } else {
+            dropLabelIcon = defaultDropLabelIcon;
         }
+
+        dropLabelIcon.getElement().setAttribute("slot", "drop-label-icon");
+        getElement().appendChild(dropLabelIcon.getElement());
     }
 
     /**
-     * Get the component set as the drop label icon, if any.
+     * Get the component set as the drop label icon.
      *
-     * @return the drop label icon component, or <code>null</code> if none was
-     *         set
+     * @return the drop label icon component, never <code>null</code>.
      */
     public Component getDropLabelIcon() {
-        return getComponentAtSlot("drop-label-icon");
+        return dropLabelIcon;
     }
 
     private void removeElementsAtSlot(String slot) {
@@ -351,14 +399,6 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
                 .filter(child -> slot.equals(child.getAttribute("slot")))
                 .collect(Collectors.toList())
                 .forEach(Element::removeFromParent);
-    }
-
-    private Component getComponentAtSlot(String slot) {
-        return getElement().getChildren()
-                .filter(child -> slot.equals(child.getAttribute("slot")))
-                .filter(child -> child.getComponent().isPresent())
-                .map(child -> child.getComponent().get()).findFirst()
-                .orElse(null);
     }
 
     /**

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -62,7 +62,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * Server-side component for the default {@code <vaadin-upload>} icon.
      */
     @Tag("vaadin-upload-icon")
-    public static class UploadIcon extends Component {
+    static class UploadIcon extends Component {
 
         public UploadIcon() {
         }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSlotsTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSlotsTest.java
@@ -1,0 +1,126 @@
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.upload.Upload;
+import net.jcip.annotations.NotThreadSafe;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+@NotThreadSafe
+public class UploadSlotsTest {
+
+    private UI ui;
+
+    @Before
+    public void setup() {
+        ui = new UI();
+        UI.setCurrent(ui);
+    }
+
+    @Test
+    public void getUploadButton_defaultButtonExists() {
+        Upload upload = new Upload();
+        Component button = upload.getUploadButton();
+        assertEquals("add-button", button.getElement().getAttribute("slot"));
+        assertEquals(upload, getParent(button));
+    }
+
+    @Test
+    public void setUploadButton_buttonIsAdded() {
+        Upload upload = new Upload();
+        NativeButton button = new NativeButton("Add files");
+        upload.setUploadButton(button);
+        assertEquals(button, upload.getUploadButton());
+        assertEquals("add-button", button.getElement().getAttribute("slot"));
+        assertEquals(upload, getParent(button));
+    }
+
+    @Test
+    public void setUploadButtonNull_defaultButtonIsRestored() {
+        Upload upload = new Upload();
+        Component defaultButton = upload.getUploadButton();
+
+        NativeButton button = new NativeButton("Add files");
+        upload.setUploadButton(button);
+
+        upload.setUploadButton(null);
+
+        assertEquals(defaultButton, upload.getUploadButton());
+        assertEquals(upload, getParent(defaultButton));
+    }
+
+    @Test
+    public void getDropLabel_defaultLabelExists() {
+        Upload upload = new Upload();
+        Component label = upload.getDropLabel();
+        assertEquals("drop-label", label.getElement().getAttribute("slot"));
+        assertEquals(upload, getParent(label));
+    }
+
+    @Test
+    public void setDropLabel_labelIsAdded() {
+        Upload upload = new Upload();
+        Span label = new Span("Drop files here");
+        upload.setDropLabel(label);
+        assertEquals(label, upload.getDropLabel());
+        assertEquals("drop-label", label.getElement().getAttribute("slot"));
+        assertEquals(upload, getParent(label));
+    }
+
+    @Test
+    public void setDropLabelNull_defaultLabelIsRestored() {
+        Upload upload = new Upload();
+        Component defaultLabel = upload.getDropLabel();
+
+        Span label = new Span("Drop files here");
+        upload.setDropLabel(label);
+
+        upload.setDropLabel(null);
+
+        assertEquals(defaultLabel, upload.getDropLabel());
+        assertEquals(upload, getParent(defaultLabel));
+    }
+
+    @Test
+    public void getDropLabelIcon_defaultIconExists() {
+        Upload upload = new Upload();
+        Component icon = upload.getDropLabelIcon();
+        assertEquals("drop-label-icon", icon.getElement().getAttribute("slot"));
+        assertEquals(upload, getParent(icon));
+    }
+
+    @Test
+    public void setDropLabelIcon_iconIsAdded() {
+        Upload upload = new Upload();
+        Span icon = new Span("->");
+        upload.setDropLabelIcon(icon);
+        assertEquals(icon, upload.getDropLabelIcon());
+        assertEquals("drop-label-icon", icon.getElement().getAttribute("slot"));
+        assertEquals(upload, getParent(icon));
+    }
+
+    @Test
+    public void setDropLabelIconNull_defaultIconIsRestored() {
+        Upload upload = new Upload();
+        Component defaultIcon = upload.getDropLabelIcon();
+
+        Span icon = new Span("->");
+        upload.setDropLabelIcon(icon);
+
+        upload.setDropLabelIcon(null);
+
+        assertEquals(defaultIcon, upload.getDropLabelIcon());
+        assertEquals(upload, getParent(defaultIcon));
+    }
+
+    private static Component getParent(Component component) {
+        return component.getParent().orElse(null);
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSlotsTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSlotsTest.java
@@ -7,7 +7,6 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.upload.Upload;
 import net.jcip.annotations.NotThreadSafe;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,11 +15,9 @@ import static org.junit.Assert.assertEquals;
 @NotThreadSafe
 public class UploadSlotsTest {
 
-    private UI ui;
-
     @Before
     public void setup() {
-        ui = new UI();
+        UI ui = new UI();
         UI.setCurrent(ui);
     }
 


### PR DESCRIPTION
## Description

Fixes #3542
Based on https://github.com/vaadin/web-components/pull/4857

Changed the `Upload` APIs to create slotted elements on the server side, as proposed in https://github.com/vaadin/flow-components/issues/3542#issuecomment-1200823976.
This makes the following methods return correct components by default, instead of `null`:

- `getUploadButton()`
- `getDropLabel()`
- `getDropLabelIcon()`

## Type of change

- Feature