### PR TITLE
refactor: remove internal TemplateRenderer use from VirtualList

### DIFF
--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.virtuallist.tests;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -100,11 +101,11 @@ public class VirtualListIT extends AbstractComponentIT {
             Assert.assertEquals(String.valueOf(i + 1),
                     items.getObject(i).getString("key"));
             Assert.assertEquals("Person " + (i + 1),
-                    items.getObject(i).getString("lr_0_name"));
+                    getPropertyString(items.getObject(i), "name"));
             Assert.assertEquals(String.valueOf(i + 1),
-                    items.getObject(i).getString("lr_0_age"));
+                    getPropertyString(items.getObject(i), "age"));
             Assert.assertEquals("person_" + (i + 1),
-                    items.getObject(i).getString("lr_0_user"));
+                    getPropertyString(items.getObject(i), "user"));
         }
 
         WebElement update = findElement(
@@ -113,8 +114,10 @@ public class VirtualListIT extends AbstractComponentIT {
         scrollIntoViewAndClick(update);
         items = getItems(getDriver(), list);
         JsonObject person = items.getObject(0);
-        Assert.assertEquals("Person 1 Updated", person.getString("lr_0_name"));
-        Assert.assertEquals("person_1_updated", person.getString("lr_0_user"));
+        Assert.assertEquals("Person 1 Updated",
+                getPropertyString(person, "name"));
+        Assert.assertEquals("person_1_updated",
+                getPropertyString(person, "user"));
     }
 
     @Ignore("https://github.com/vaadin/flow-components/issues/3222")
@@ -447,7 +450,8 @@ public class VirtualListIT extends AbstractComponentIT {
         Assert.assertEquals(length, items.length());
         for (int i = 0; i < items.length(); i++) {
             JsonObject obj = items.getObject(i);
-            Assert.assertEquals("Person " + (i + 1), obj.getString("label"));
+            Assert.assertEquals("Person " + (i + 1),
+                    getPropertyString(obj, "label"));
         }
     }
 
@@ -459,8 +463,9 @@ public class VirtualListIT extends AbstractComponentIT {
                     "Object at index " + i + " is null, when it shouldn't be",
                     items.get(i),
                     CoreMatchers.not(CoreMatchers.instanceOf(JsonNull.class)));
+            System.out.println(items.getObject(i));
             Assert.assertEquals(itemLabelprefix + (i + 1),
-                    items.getObject(i).getString("label"));
+                    getPropertyString(items.getObject(i), "label"));
         }
     }
 
@@ -498,8 +503,14 @@ public class VirtualListIT extends AbstractComponentIT {
                     "The label of the initial object at the index " + i
                             + " of the list '" + listId + "' is wrong",
                     itemLabelPrefixForSecondSet + (i + 1),
-                    items.getObject(i).getString("label"));
+                    getPropertyString(items.getObject(i), "label"));
         }
+    }
+
+    private String getPropertyString(JsonObject json, String propertyName) {
+        var keyForLabel = Arrays.stream(json.keys())
+                .filter(key -> key.endsWith(propertyName)).findFirst().get();
+        return json.getString(keyForLabel);
     }
 
     private void clickToSet3Items_listIsUpdated(String listId,
@@ -516,7 +527,7 @@ public class VirtualListIT extends AbstractComponentIT {
                     "The label of the updated object at the index " + i
                             + " of the list '" + listId + "' is wrong",
                     itemLabelPrefixForFirstSet + (i + 1),
-                    items.getObject(i).getString("label"));
+                    getPropertyString(items.getObject(i), "label"));
         }
     }
 

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -463,7 +463,6 @@ public class VirtualListIT extends AbstractComponentIT {
                     "Object at index " + i + " is null, when it shouldn't be",
                     items.get(i),
                     CoreMatchers.not(CoreMatchers.instanceOf(JsonNull.class)));
-            System.out.println(items.getObject(i));
             Assert.assertEquals(itemLabelprefix + (i + 1),
                     getPropertyString(items.getObject(i), "label"));
         }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -507,9 +507,9 @@ public class VirtualListIT extends AbstractComponentIT {
     }
 
     private String getPropertyString(JsonObject json, String propertyName) {
-        var keyForLabel = Arrays.stream(json.keys())
+        var keyForProperty = Arrays.stream(json.keys())
                 .filter(key -> key.endsWith(propertyName)).findFirst().get();
-        return json.getString(keyForLabel);
+        return json.getString(keyForProperty);
     }
 
     private void clickToSet3Items_listIsUpdated(String listId,

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -39,7 +39,6 @@ import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.Rendering;
-import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.ValueProvider;
@@ -190,7 +189,7 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
     public void setRenderer(ValueProvider<T, String> valueProvider) {
         Objects.requireNonNull(valueProvider,
                 "The valueProvider must not be null");
-        this.setRenderer(TemplateRenderer.<T> of("[[item.label]]")
+        this.setRenderer(LitRenderer.<T> of("${item.label}")
                 .withProperty("label", valueProvider));
     }
 


### PR DESCRIPTION
## Description

Replace `TemplateRenderer` with `LitRenderer` in `VirtualList` 

Part of https://github.com/vaadin/flow-components/issues/4059

## Type of change

- Refactoring