### PR TITLE
refactor: remove internal TemplateRenderer use from TreeGrid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPreloadIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPreloadIT.java
@@ -128,15 +128,13 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
     }
 
     @Test
-    public void firstExpanded_reExpand_shouldPreLoadDataForExpandedChildren() {
+    public void firstExpanded_reExpand_shouldUseCachedDataForExpandedChildren() {
         open(Arrays.asList(0), null, null, null, null);
         requestCountReset.click();
 
         getTreeGrid().collapseWithClick(0);
         getTreeGrid().expandWithClick(0);
-        // Expanding a recursively expanded parent doesn't yet trigger a preload
-        // so a second request is made from client.
-        Assert.assertEquals("2", requestCount.getValue());
+        Assert.assertEquals("0", requestCount.getValue());
     }
 
     @Test
@@ -149,13 +147,13 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
     }
 
     @Test
-    public void firstExpanded_reExpandChild_shouldPreLoadDataForExpandedChildren() {
+    public void firstExpanded_reExpandChild_shouldUseCachedDataForExpandedChildren() {
         open(Arrays.asList(0), null, null, null, null);
         requestCountReset.click();
 
         getTreeGrid().collapseWithClick(2);
         getTreeGrid().expandWithClick(2);
-        Assert.assertEquals("1", requestCount.getValue());
+        Assert.assertEquals("0", requestCount.getValue());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/HierarchyColumnComponentRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/HierarchyColumnComponentRenderer.java
@@ -31,6 +31,9 @@ public class HierarchyColumnComponentRenderer<COMPONENT extends Component, SOURC
                 grid.expand(List.of(item), true);
             }
         });
+
+        withProperty("children",
+                item -> grid.getDataCommunicator().hasChildren(item));
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -554,11 +554,6 @@ public class TreeGrid<T> extends Grid<T>
      * @return the created hierarchy column
      */
     public Column<T> addHierarchyColumn(ValueProvider<T, ?> valueProvider) {
-
-        // The click listener needs to check if the event gets canceled (by
-        // vaadin-grid-tree-toggle) and only invoke the callback if it does.
-        // vaadin-grid-tree-toggle will cancel the event if the user clicks on
-        // a non-focusable element inside the toggle.
         Column<T> column = addColumn(LitRenderer.<T> of(
                 "<vaadin-grid-tree-toggle @click=${onClick} .leaf=${!item.children} .expanded=${model.expanded} .level=${model.level}>"
                         + "${item.name}</vaadin-grid-tree-toggle>")


### PR DESCRIPTION
## Description

Replace `TemplateRenderer` with `LitRenderer` in `TreeGrid` 

Part of https://github.com/vaadin/flow-components/issues/4059

## Type of change

- Refactoring