### PR TITLE
test: reset UI in teardown for Upload slot tests

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSlotsTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSlotsTest.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.upload.Upload;
 import net.jcip.annotations.NotThreadSafe;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,6 +20,11 @@ public class UploadSlotsTest {
     public void setup() {
         UI ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test


### PR DESCRIPTION
## Description

There is a problem with unit tests introduced in #4207 and now it causes snapshot and other PRs to fail.
Apparently, unit tests for Upload module are not configured correctly adn don't run with ITs. 

Here is the error, it's unclear to me why it happens but at least `@After` block is missing.

```
java.lang.NullPointerException: Cannot invoke "com.vaadin.flow.component.UI.getUIId()" because the return value of "com.vaadin.flow.component.UI.getCurrent()" is null
  at com.vaadin.flow.component.upload.tests.UploadSlotsTest.setDropLabelNull_defaultLabelIsRestored(UploadSlotsTest.java:76)
  ```

## Type of change

- Tests