### PR TITLE
fix: use correct null check in setTooltipGenerator

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1043,7 +1043,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          */
         public Column<T> setTooltipGenerator(
                 SerializableFunction<T, String> tooltipGenerator) {
-            Objects.requireNonNull(classNameGenerator,
+            Objects.requireNonNull(tooltipGenerator,
                     "Tooltip generator can not be null");
 
             if (!getGrid().getElement().getChildren().anyMatch(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
@@ -71,6 +71,11 @@ public class GridTooltipTest {
         Assert.assertEquals(1, getTooltipElements(grid).count());
     }
 
+    @Test(expected = NullPointerException.class)
+    public void setNullTooltipGenerator_throws() {
+        grid.addColumn(item -> item).setTooltipGenerator(null);
+    }
+
     private Optional<Element> getTooltipElement(Grid<?> grid) {
         return getTooltipElements(grid).findFirst();
     }


### PR DESCRIPTION
## Description

The null check in `setTooltipGenerator` is incorrectly using `classNameGenerator` 🙈 

## Type of change

- Bugfix