### PR TITLE
docs: clean up references to TemplateRenderer in comments

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java
@@ -77,7 +77,7 @@ class ComboBoxRenderManager<TItem> implements Serializable {
             rendering = renderer.render(comboBox.getElement(),
                     comboBox.getDataCommunicator().getKeyMapper());
         } else {
-            // TemplateRenderer or ComponentRenderer
+            // TemplateRenderer
             if (template == null) {
                 template = new Element("template");
             }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewUsingTemplatesPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewUsingTemplatesPage.java
@@ -76,7 +76,7 @@ public class GridViewUsingTemplatesPage extends LegacyTestView {
 
         grid.setSelectionMode(SelectionMode.NONE);
         grid.setId("template-renderer");
-        addCard("Using templates", "Grid with columns using template renderer",
+        addCard("Using templates", "Grid with columns using Lit renderer",
                 grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1392,8 +1392,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private SerializableSupplier<Editor<T>> editorFactory = this::createEditor;
 
-    private boolean verticalScrollingEnabled = true;
-
     private SerializableFunction<T, String> classNameGenerator = item -> null;
     private SerializableFunction<T, String> partNameGenerator = item -> null;
     private SerializablePredicate<T> dropFilter = item -> true;
@@ -1735,7 +1733,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * {@link ComponentRenderer}.
      * <p>
      * <em>NOTE:</em> Using {@link ComponentRenderer} is not as efficient as the
-     * built in renderers or using {@link TemplateRenderer}.
+     * built in renderers or using {@link LitRenderer}.
      * </p>
      * <p>
      * Every added column sends data to the client side regardless of its
@@ -1797,12 +1795,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <p>
      * See implementations of the {@link Renderer} interface for built-in
      * renderer options with type safe APIs. For a renderer using template
-     * binding, use {@link TemplateRenderer#of(String)}.
+     * binding, use {@link LitRenderer#of(String)}.
      * <p>
      * <em>NOTE:</em> You can add component columns easily using the
      * {@link #addComponentColumn(ValueProvider)}, but using
      * {@link ComponentRenderer} is not as efficient as the built in renderers
-     * or using {@link TemplateRenderer}.
+     * or using {@link LitRenderer}.
      * </p>
      * <p>
      * Every added column sends data to the client side regardless of its
@@ -1819,7 +1817,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @return the created column
      *
      * @see #getDefaultColumnFactory()
-     * @see TemplateRenderer#of(String)
+     * @see LitRenderer#of(String)
      * @see #addComponentColumn(ValueProvider)
      * @see #removeColumn(Column)
      * @see #addColumn(Renderer, BiFunction)
@@ -1835,12 +1833,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <p>
      * See implementations of the {@link Renderer} interface for built-in
      * renderer options with type safe APIs. For a renderer using template
-     * binding, use {@link TemplateRenderer#of(String)}.
+     * binding, use {@link LitRenderer#of(String)}.
      * <p>
      * <em>NOTE:</em> You can add component columns easily using the
      * {@link #addComponentColumn(ValueProvider)}, but using
      * {@link ComponentRenderer} is not as efficient as the built in renderers
-     * or using {@link TemplateRenderer}.
+     * or using {@link LitRenderer}.
      * </p>
      * <p>
      * Every added column sends data to the client side regardless of its
@@ -1856,7 +1854,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @return the created column
      *
      * @see #addColumn(Renderer)
-     * @see TemplateRenderer#of(String)
+     * @see LitRenderer#of(String)
      * @see #addComponentColumn(ValueProvider)
      * @see #removeColumn(Column)
      */
@@ -1940,7 +1938,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <em>NOTE:</em> You can add component columns easily using the
      * {@link #addComponentColumn(ValueProvider)}, but using
      * {@link ComponentRenderer} is not as efficient as the built in renderers
-     * or using {@link TemplateRenderer}.
+     * or using {@link LitRenderer}.
      * <p>
      *
      * Every added column sends data to the client side regardless of its
@@ -1982,7 +1980,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <em>NOTE:</em> You can add component columns easily using the
      * {@link #addComponentColumn(ValueProvider)}, but using
      * {@link ComponentRenderer} is not as efficient as the built in renderers
-     * or using {@link TemplateRenderer}.
+     * or using {@link LitRenderer}.
      *
      * <p>
      * Every added column sends data to the client side regardless of its
@@ -2957,7 +2955,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             rendering = ((LitRenderer<T>) renderer).render(getElement(),
                     dataCommunicator.getKeyMapper(), "rowDetailsRenderer");
         } else {
-            // TemplateRenderer or ComponentRenderer
+            // TemplateRenderer
             if (detailsTemplate == null) {
                 rendering = renderer.render(getElement(),
                         getDataCommunicator().getKeyMapper());

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
@@ -49,8 +49,8 @@ public abstract class BasicRenderer<SOURCE, TARGET>
     private final ValueProvider<SOURCE, TARGET> valueProvider;
 
     /**
-     * Builds a new template renderer using the value provider as the source of
-     * values to be rendered.
+     * Builds a new renderer using the value provider as the source of values to
+     * be rendered.
      *
      * @param valueProvider
      *            the callback to provide a objects to the renderer, not

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateRenderer.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.function.ValueProvider;
 
 /**
- * A template renderer for presenting date values.
+ * A renderer for presenting date values.
  *
  * @author Vaadin Ltd
  *

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateTimeRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateTimeRenderer.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.function.ValueProvider;
 
 /**
  *
- * A template renderer for presenting {@code LocalDateTime} objects.
+ * A renderer for presenting {@code LocalDateTime} objects.
  *
  * @author Vaadin Ltd
  *

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NativeButtonRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NativeButtonRenderer.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.shared.Registration;
 
 /**
  *
- * A template renderer to create a clickable button.
+ * A renderer to create a clickable button.
  * <p>
  * {@link ItemClickListener}s are notified when the rendered buttons are either
  * clicked or tapped (in touch devices).

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NumberRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NumberRenderer.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.function.ValueProvider;
 
 /**
  *
- * A template renderer for presenting number values.
+ * A renderer for presenting number values.
  *
  * @author Vaadin Ltd
  *

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
@@ -64,7 +64,7 @@ public class ComponentRendererTest {
     }
 
     @Test
-    public void templateRenderered_parentAttachedBeforeChild() {
+    public void componentRenderer_parentAttachedBeforeChild() {
         UI ui = new TestUI();
         TestUIInternals internals = (TestUIInternals) ui.getInternals();
 
@@ -77,7 +77,7 @@ public class ComponentRendererTest {
         KeyMapper<String> keyMapper = new KeyMapper<>();
 
         Rendering<String> rendering = renderer.render(container, keyMapper);
-        // simulate a call from the grid to refresh data - template is not setup
+        // simulate a call from the grid to refresh data
         containerParent.getNode()
                 .runWhenAttached(ui2 -> ui2.getInternals().getStateTree()
                         .beforeClientResponse(containerParent.getNode(),
@@ -99,7 +99,7 @@ public class ComponentRendererTest {
     }
 
     @Test
-    public void templateRenderered_childAttachedBeforeParent() {
+    public void componentRenderer_childAttachedBeforeParent() {
         UI ui = new TestUI();
         TestUIInternals internals = (TestUIInternals) ui.getInternals();
 

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -217,7 +217,7 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
             rendering = renderer.render(getElement(),
                     dataCommunicator.getKeyMapper());
         } else {
-            // TemplateRenderer or ComponentRenderer
+            // TemplateRenderer
             if (template.getParent() == null) {
                 getElement().appendChild(template);
             }


### PR DESCRIPTION
Follow up for https://github.com/vaadin/flow-components/pull/4148

Extracted from https://github.com/vaadin/flow-components/pull/4224

Clean up outdated references to "template renderer" in code comments and test names