### PR TITLE
feat: integrate client-side validation into TextArea

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BinderValidationPage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.NumberField;
-import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.Setter;
@@ -44,10 +43,6 @@ public class BinderValidationPage extends Div {
     public BinderValidationPage() {
         TextField textField = new TextField();
         addComponent(textField, Bean::getString, Bean::setString,
-                value -> value.length() > 2, field -> field.setMinLength(1));
-
-        TextArea textArea = new TextArea();
-        addComponent(textArea, Bean::getString, Bean::setString,
                 value -> value.length() > 2, field -> field.setMinLength(1));
 
         EmailField emailField = new EmailField();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextAreaPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextAreaPage.java
@@ -48,7 +48,6 @@ public class TextAreaPage extends Div {
         addBasicFeatures();
         addMaxHeightFeature();
         addMinHeightFeature();
-        addInvalidCheck();
         addHelperText();
         addHelperComponent();
     }
@@ -106,13 +105,6 @@ public class TextAreaPage extends Div {
         textArea.getStyle().set("padding", "0");
         textArea.setId("text-area-with-min-height");
         add(textArea, message);
-    }
-
-    private void addInvalidCheck() {
-        final TextArea field = new TextArea();
-        field.setMaxLength(10);
-        field.setMinLength(5);
-        TextFieldTestPageUtil.addInvalidCheck(this, field);
     }
 
     private void addHelperText() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicPage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-text-area/validation/basic")
+public class TextAreaValidationBasicPage
+        extends AbstractValidationPage<TextArea> {
+    public static final String REQUIRED_BUTTON = "required-button";
+    public static final String PATTERN_INPUT = "pattern-input";
+    public static final String MIN_LENGTH_INPUT = "min-length-input";
+    public static final String MAX_LENGTH_INPUT = "max-length-input";
+
+    public static final String ATTACH_FIELD_BUTTON = "attach-field-button";
+    public static final String DETACH_FIELD_BUTTON = "detach-field-button";
+
+    public TextAreaValidationBasicPage() {
+        super();
+
+        add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
+            testField.setRequiredIndicatorVisible(true);
+        }));
+
+        add(createInput(PATTERN_INPUT, "Set pattern", event -> {
+            testField.setPattern(event.getValue());
+        }));
+
+        add(createInput(MIN_LENGTH_INPUT, "Set min length", event -> {
+            int value = Integer.parseInt(event.getValue());
+            testField.setMinLength(value);
+        }));
+
+        add(createInput(MAX_LENGTH_INPUT, "Set max length", event -> {
+            int value = Integer.parseInt(event.getValue());
+            testField.setMaxLength(value);
+        }));
+
+        addAttachDetachControls();
+    }
+
+    private void addAttachDetachControls() {
+        NativeButton attachButton = createButton(ATTACH_FIELD_BUTTON,
+                "Attach field", event -> add(testField));
+        NativeButton detachButton = createButton(DETACH_FIELD_BUTTON,
+                "Detach field", event -> add(testField));
+
+        add(new Div(attachButton, detachButton));
+    }
+
+    protected TextArea createTestField() {
+        return new TextArea();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicPage.java
@@ -60,7 +60,7 @@ public class TextAreaValidationBasicPage
         NativeButton attachButton = createButton(ATTACH_FIELD_BUTTON,
                 "Attach field", event -> add(testField));
         NativeButton detachButton = createButton(DETACH_FIELD_BUTTON,
-                "Detach field", event -> add(testField));
+                "Detach field", event -> remove(testField));
 
         add(new Div(attachButton, detachButton));
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBinderPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBinderPage.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-text-area/validation/binder")
+public class TextAreaValidationBinderPage
+        extends AbstractValidationPage<TextArea> {
+    public static final String PATTERN_INPUT = "pattern-input";
+    public static final String MIN_LENGTH_INPUT = "min-length-input";
+    public static final String MAX_LENGTH_INPUT = "max-length-input";
+    public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
+
+    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+
+    public static class Bean {
+        private String property;
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+
+    protected Binder<Bean> binder;
+
+    private String expectedValue;
+
+    public TextAreaValidationBinderPage() {
+        super();
+
+        binder = new Binder<>(Bean.class);
+        binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
+                .withValidator(value -> value.equals(expectedValue),
+                        UNEXPECTED_VALUE_ERROR_MESSAGE)
+                .bind("property");
+
+        add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
+            expectedValue = event.getValue();
+        }));
+
+        add(createInput(PATTERN_INPUT, "Set pattern", event -> {
+            testField.setPattern(event.getValue());
+        }));
+
+        add(createInput(MIN_LENGTH_INPUT, "Set min length", event -> {
+            int value = Integer.parseInt(event.getValue());
+            testField.setMinLength(value);
+        }));
+
+        add(createInput(MAX_LENGTH_INPUT, "Set max length", event -> {
+            int value = Integer.parseInt(event.getValue());
+            testField.setMaxLength(value);
+        }));
+    }
+
+    protected TextArea createTestField() {
+        return new TextArea();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BinderValidationPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BinderValidationPageIT.java
@@ -27,7 +27,6 @@ import com.vaadin.flow.component.textfield.testbench.BigDecimalFieldElement;
 import com.vaadin.flow.component.textfield.testbench.EmailFieldElement;
 import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
 import com.vaadin.flow.component.textfield.testbench.NumberFieldElement;
-import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
@@ -59,9 +58,9 @@ public class BinderValidationPageIT extends AbstractComponentIT {
     }
 
     private List<Class<? extends TestBenchElement>> fieldClasses = Arrays
-            .asList(TextFieldElement.class, TextAreaElement.class,
-                    EmailFieldElement.class, BigDecimalFieldElement.class,
-                    IntegerFieldElement.class, NumberFieldElement.class);
+            .asList(TextFieldElement.class, EmailFieldElement.class,
+                    BigDecimalFieldElement.class, IntegerFieldElement.class,
+                    NumberFieldElement.class);
 
     @Test
     public void fields_internalValidationPass_binderValidationFail_fieldInvalid() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -152,12 +152,6 @@ public class TextAreaPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void assertCantMakeInvalidValueValidThroughClientManipulation() {
-        ValidationTestHelper.testValidation(getCommandExecutor(), getContext(),
-                $(TextAreaElement.class).id("invalid-test-field"));
-    }
-
-    @Test
     public void assertHelperText() {
         TextAreaElement textAreaElement = $(TextAreaElement.class)
                 .id("helper-text-field");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicIT.java
@@ -86,6 +86,15 @@ public class TextAreaValidationBasicIT
     }
 
     @Test
+    public void minLength_triggerInputBlur_assertValidity() {
+        $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
+
+        testField.sendKeys(Keys.TAB);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void minLength_changeInputValue_assertValidity() {
         $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
@@ -117,6 +126,15 @@ public class TextAreaValidationBasicIT
         testField.setValue("A");
         assertClientValid();
         assertServerValid();
+    }
+
+    @Test
+    public void pattern_triggerInputBlur_assertValidity() {
+        $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
+
+        testField.sendKeys(Keys.TAB);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicIT.java
@@ -21,7 +21,12 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
-import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.*;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.ATTACH_FIELD_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.DETACH_FIELD_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.MIN_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.PATTERN_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.REQUIRED_BUTTON;
 
 @TestPath("vaadin-text-area/validation/basic")
 public class TextAreaValidationBasicIT

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBasicIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBasicPage.*;
+
+@TestPath("vaadin-text-area/validation/basic")
+public class TextAreaValidationBasicIT
+        extends AbstractValidationIT<TextAreaElement> {
+    @Test
+    public void fieldIsInitiallyValid() {
+        assertClientValid();
+        assertServerValid();
+    }
+
+    @Test
+    public void onlyServerCanSetFieldToValid() {
+        $("button").id(REQUIRED_BUTTON).click();
+
+        executeScript("arguments[0].validate()", testField);
+        assertClientInvalid();
+
+        testField.sendKeys("Value");
+        executeScript("arguments[0].validate()", testField);
+        assertClientInvalid();
+
+        testField.sendKeys(Keys.TAB);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void detach_attach_onlyServerCanSetFieldToValid() {
+        $("button").id(DETACH_FIELD_BUTTON).click();
+        $("button").id(ATTACH_FIELD_BUTTON).click();
+
+        testField = getTestField();
+
+        onlyServerCanSetFieldToValid();
+    }
+
+    @Test
+    public void required_triggerInputBlur_assertValidity() {
+        $("button").id(REQUIRED_BUTTON).click();
+
+        testField.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void required_changeInputValue_assertValidity() {
+        $("button").id(REQUIRED_BUTTON).click();
+
+        testField.setValue("Value");
+        assertServerValid();
+        assertClientValid();
+
+        testField.setValue("");
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void minLength_changeInputValue_assertValidity() {
+        $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
+
+        testField.setValue("A");
+        assertClientInvalid();
+        assertServerInvalid();
+
+        testField.setValue("AA");
+        assertClientValid();
+        assertServerValid();
+
+        testField.setValue("AAA");
+        assertClientValid();
+        assertServerValid();
+    }
+
+    @Test
+    public void maxLength_changeInputValue_assertValidity() {
+        $("input").id(MAX_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
+
+        testField.setValue("AAA");
+        assertClientInvalid();
+        assertServerInvalid();
+
+        testField.setValue("AA");
+        assertClientValid();
+        assertServerValid();
+
+        testField.setValue("A");
+        assertClientValid();
+        assertServerValid();
+    }
+
+    @Test
+    public void pattern_changeInputValue_assertValidity() {
+        $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
+
+        testField.setValue("Word");
+        assertClientInvalid();
+        assertServerInvalid();
+
+        testField.setValue("1234");
+        assertClientValid();
+        assertServerValid();
+    }
+
+    protected TextAreaElement getTestField() {
+        return $(TextAreaElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBinderIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBinderIT.java
@@ -21,7 +21,12 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
-import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.*;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.MIN_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.PATTERN_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
 @TestPath("vaadin-text-area/validation/binder")
 public class TextAreaValidationBinderIT

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBinderIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaValidationBinderIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldValidationBinderPage.*;
+
+@TestPath("vaadin-text-area/validation/binder")
+public class TextAreaValidationBinderIT
+        extends AbstractValidationIT<TextAreaElement> {
+    @Test
+    public void fieldIsInitiallyValid() {
+        assertClientValid();
+        assertServerValid();
+        assertErrorMessage(null);
+    }
+
+    @Test
+    public void required_triggerInputBlur_assertValidity() {
+        testField.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void required_changeInputValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("Value", Keys.ENTER);
+
+        testField.setValue("Value");
+        assertServerValid();
+        assertClientValid();
+
+        testField.setValue("");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void minLength_changeInputValue_assertValidity() {
+        $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("AAA", Keys.ENTER);
+
+        // Constraint validation fails:
+        testField.setValue("A");
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage("");
+
+        // Binder validation fails:
+        testField.setValue("AA");
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
+
+        // Both validations pass:
+        testField.setValue("AAA");
+        assertClientValid();
+        assertServerValid();
+    }
+
+    @Test
+    public void maxLength_changeInputValue_assertValidity() {
+        $("input").id(MAX_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("A", Keys.ENTER);
+
+        // Constraint validation fails:
+        testField.setValue("AAA");
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage("");
+
+        // Binder validation fails:
+        testField.setValue("AA");
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
+
+        // Both validations pass:
+        testField.setValue("A");
+        assertClientValid();
+        assertServerValid();
+    }
+
+    @Test
+    public void pattern_changeInputValue_assertValidity() {
+        $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
+
+        // Constraint validation fails:
+        testField.setValue("Word");
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage("");
+
+        // Binder validation fails:
+        testField.setValue("12");
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
+
+        // Both validations pass:
+        testField.setValue("1234");
+        assertClientValid();
+        assertServerValid();
+    }
+
+    protected TextAreaElement getTestField() {
+        return $(TextAreaElement.class).first();
+    }
+}


### PR DESCRIPTION
## Description

Adds chained validation support to `TextArea`. For more details, please refer to https://github.com/vaadin/platform/issues/3066.

Depends on 
- https://github.com/vaadin/flow-components/pull/4263 

Closes #4213 

## Type of change

- Feature
