### PR TITLE
fix: use Lumo colors for popup button overlay

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet-styles.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet-styles.js
@@ -104,6 +104,7 @@ export const spreadsheetStyles = css`
     border: none;
     color: #474747;
     outline: none;
+    background-color: initial;
   }
   .v-spreadsheet .functionbar .arrow {
     position: absolute;
@@ -1252,7 +1253,7 @@ export const spreadsheetOverlayStyles = css`
   #spreadsheet-overlays .v-spreadsheet-popupbutton-overlay {
     padding: 4px 4px;
     border-radius: 4px;
-    background-color: white;
+    background-color: var(--lumo-base-color, #fff);
     color: #474747;
     box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1), 0 3px 5px 0 rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.091);
     -webkit-backface-visibility: hidden;
@@ -1289,7 +1290,6 @@ export const spreadsheetOverlayStyles = css`
     gap: 4px;
   }
   #spreadsheet-overlays .v-spreadsheet-popupbutton-overlay-header {
-    background: white;
     height: 18px;
     position: relative;
     width: 100%;
@@ -1321,5 +1321,6 @@ export const spreadsheetOverlayStyles = css`
     height: 18px;
     line-height: 18px;
     text-align: center;
+    color: var(--lumo-body-text-color);
   }
 `;


### PR DESCRIPTION
## Description

Use Lumo colors for the popup button overlay

Fixes https://github.com/vaadin/flow-components/issues/4266

Before:

![Screenshot 2022-11-30 at 13 39 53](https://user-images.githubusercontent.com/1222264/204787493-b90580d0-faa2-4c16-b761-94d32a59342a.png)

After:

![Screenshot 2022-11-30 at 13 37 54](https://user-images.githubusercontent.com/1222264/204787534-ffe2e2bb-5ec8-43a8-be59-5b4f9173467f.png)

![Screenshot 2022-11-30 at 13 41 25](https://user-images.githubusercontent.com/1222264/204787556-104eb905-f487-4442-9800-5c9ae009c360.png)



## Type of change

Bugfix