### PR TITLE
chore: update jetty to 10 (23.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
                 </project.reporting.outputEncoding>
-        <jetty.version>9.4.49.v20220914</jetty.version>
+        <jetty.version>10.0.12</jetty.version>
         <jetty.http.port>8080</jetty.http.port>
         <jetty.stop.port>9999</jetty.stop.port>
         <karaf-maven-plugin.version>4.4.0</karaf-maven-plugin.version>
@@ -313,7 +313,7 @@
                             <id>start-jetty</id>
                             <phase>pre-integration-test</phase>
                             <goals>
-                                <goal>deploy-war</goal>
+                                <goal>start-war</goal>
                             </goals>
                         </execution>
                         <execution>


### PR DESCRIPTION
keep jetty version in sync with flow 23.3 https://github.com/vaadin/flow/blob/23.3/pom.xml#L110