### PR TITLE
fix: make sure tooltip attaches to the current UI

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -85,11 +85,13 @@ public class Tooltip implements Serializable {
         // Create a new Tooltip handle instance
         var tooltip = new Tooltip();
 
-        // The host under which the <vaadin-tooltip> element is auto-attached
-        var tooltipHost = UI.getCurrent().getElement();
-
         // Handle target attach
         SerializableRunnable onTargetAttach = () -> {
+            // Remove the tooltip from its current state tree
+            tooltip.tooltipElement.removeFromTree();
+            
+            // The host under which the <vaadin-tooltip> element is auto-attached
+            var tooltipHost = UI.getCurrent().getElement();
             tooltipHost.appendChild(tooltip.tooltipElement);
             tooltip.tooltipElement.executeJs("this.target = $0;", element);
         };

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -53,6 +53,20 @@ public class TooltipTest {
     }
 
     @Test
+    public void addComponent_createTooltip_changeUI_tooltipAttached() {
+        ui.add(component);
+        Tooltip.forComponent(component);
+        
+        // Create a new UI and move the component to it (@PreserveOnRefresh)
+        ui = new UI();
+        UI.setCurrent(ui);
+        component.getElement().removeFromTree();
+        ui.add(component);
+
+        Assert.assertTrue(getTooltipElement().isPresent());
+    }
+
+    @Test
     public void createTooltip_setText() {
         var tooltip = Tooltip.forComponent(component);
         tooltip.setText("foo");


### PR DESCRIPTION
## Description

The `tooltipHost` in `Tooltip.forElement` always referred to the initial UI instance. This PR fixes the attach listener to make it always use the current UI.

Fixes https://github.com/vaadin/flow-components/issues/4288

## Type of change

Bugfix