### PR TITLE
fix: restore backward compatibility of new event classes

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -775,13 +775,13 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
 
     @Override
     public Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent> listener) {
+            ComponentEventListener<OpenedChangeEvent<DatePicker>> listener) {
         return super.addOpenedChangeListener(listener);
     }
 
     @Override
     public Registration addInvalidChangeListener(
-            ComponentEventListener<InvalidChangeEvent> listener) {
+            ComponentEventListener<InvalidChangeEvent<DatePicker>> listener) {
         return super.addInvalidChangeListener(listener);
     }
 
@@ -1185,16 +1185,16 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         }
     }
 
-    public static class InvalidChangeEvent
-            extends GeneratedVaadinDatePicker.InvalidChangeEvent<DatePicker> {
-        public InvalidChangeEvent(DatePicker source, boolean fromClient) {
+    public static class InvalidChangeEvent<T extends GeneratedVaadinDatePicker<T, ?>>
+            extends GeneratedVaadinDatePicker.InvalidChangeEvent<T> {
+        public InvalidChangeEvent(T source, boolean fromClient) {
             super(source, fromClient);
         }
     }
 
-    public static class OpenedChangeEvent
-            extends GeneratedVaadinDatePicker.OpenedChangeEvent<DatePicker> {
-        public OpenedChangeEvent(DatePicker source, boolean fromClient) {
+    public static class OpenedChangeEvent<T extends GeneratedVaadinDatePicker<T, ?>>
+            extends GeneratedVaadinDatePicker.OpenedChangeEvent<T> {
+        public OpenedChangeEvent(T source, boolean fromClient) {
             super(source, fromClient);
         }
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1162,10 +1162,10 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
-            ComponentEventListener<DatePicker.InvalidChangeEvent> listener) {
+            ComponentEventListener<DatePicker.InvalidChangeEvent<DatePicker>> listener) {
         return getElement().addPropertyChangeListener("invalid",
                 event -> listener.onComponentEvent(
-                        new DatePicker.InvalidChangeEvent((DatePicker) this,
+                        new DatePicker.InvalidChangeEvent<>((DatePicker) this,
                                 event.isUserOriginated())));
     }
 
@@ -1200,10 +1200,10 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
-            ComponentEventListener<DatePicker.OpenedChangeEvent> listener) {
+            ComponentEventListener<DatePicker.OpenedChangeEvent<DatePicker>> listener) {
         return getElement().addPropertyChangeListener("opened",
                 event -> listener.onComponentEvent(
-                        new DatePicker.OpenedChangeEvent((DatePicker) this,
+                        new DatePicker.OpenedChangeEvent<>((DatePicker) this,
                                 event.isUserOriginated())));
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -853,7 +853,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      */
     @Override
     public Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent> listener) {
+            ComponentEventListener<OpenedChangeEvent<Dialog>> listener) {
         return super.addOpenedChangeListener(listener);
     }
 
@@ -965,9 +965,9 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 "Dialog does not support adding styles to overlay");
     }
 
-    public static class OpenedChangeEvent
-            extends GeneratedVaadinDialog.OpenedChangeEvent<Dialog> {
-        public OpenedChangeEvent(Dialog source, boolean fromClient) {
+    public static class OpenedChangeEvent<T extends GeneratedVaadinDialog<T>>
+            extends GeneratedVaadinDialog.OpenedChangeEvent<T> {
+        public OpenedChangeEvent(T source, boolean fromClient) {
             super(source, fromClient);
         }
     }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -171,11 +171,10 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
-            ComponentEventListener<Dialog.OpenedChangeEvent> listener) {
-        return getElement()
-                .addPropertyChangeListener("opened",
-                        event -> listener.onComponentEvent(
-                                new Dialog.OpenedChangeEvent((Dialog) this,
-                                        event.isUserOriginated())));
+            ComponentEventListener<Dialog.OpenedChangeEvent<Dialog>> listener) {
+        return getElement().addPropertyChangeListener("opened",
+                event -> listener.onComponentEvent(
+                        new Dialog.OpenedChangeEvent<>((Dialog) this,
+                                event.isUserOriginated())));
     }
 }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -279,10 +279,11 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      */
     @Deprecated
     protected Registration addOpenedChangeListener(
-            ComponentEventListener<Notification.OpenedChangeEvent> listener) {
+            ComponentEventListener<Notification.OpenedChangeEvent<Notification>> listener) {
         return getElement().addPropertyChangeListener("opened",
-                event -> listener.onComponentEvent(
-                        new Notification.OpenedChangeEvent((Notification) this,
+                event -> listener
+                        .onComponentEvent(new Notification.OpenedChangeEvent<>(
+                                (Notification) this,
                                 event.isUserOriginated())));
     }
 }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -487,7 +487,7 @@ public class Notification extends GeneratedVaadinNotification<Notification>
 
     @Override
     public Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent> listener) {
+            ComponentEventListener<OpenedChangeEvent<Notification>> listener) {
         return super.addOpenedChangeListener(listener);
     }
 
@@ -620,9 +620,9 @@ public class Notification extends GeneratedVaadinNotification<Notification>
                 "Notification does not support adding styles to card element");
     }
 
-    public static class OpenedChangeEvent extends
-            GeneratedVaadinNotification.OpenedChangeEvent<Notification> {
-        public OpenedChangeEvent(Notification source, boolean fromClient) {
+    public static class OpenedChangeEvent<T extends GeneratedVaadinNotification<T>>
+            extends GeneratedVaadinNotification.OpenedChangeEvent<T> {
+        public OpenedChangeEvent(T source, boolean fromClient) {
             super(source, fromClient);
         }
     }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -327,8 +327,9 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
     @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addSplitterDragendListener(
-            ComponentEventListener<SplitLayout.SplitterDragendEvent> listener) {
-        return addListener(SplitLayout.SplitterDragendEvent.class, listener);
+            ComponentEventListener<SplitLayout.SplitterDragendEvent<SplitLayout>> listener) {
+        return addListener(SplitLayout.SplitterDragendEvent.class,
+                (ComponentEventListener) listener);
     }
 
     /**

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -305,7 +305,7 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      */
     @Override
     public Registration addSplitterDragendListener(
-            ComponentEventListener<SplitterDragendEvent> listener) {
+            ComponentEventListener<SplitterDragendEvent<SplitLayout>> listener) {
         return super.addSplitterDragendListener(listener);
     }
 
@@ -344,9 +344,9 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
         super.removeThemeVariants(variants);
     }
 
-    public static class SplitterDragendEvent extends
-            GeneratedVaadinSplitLayout.SplitterDragendEvent<SplitLayout> {
-        public SplitterDragendEvent(SplitLayout source, boolean fromClient) {
+    public static class SplitterDragendEvent<T extends GeneratedVaadinSplitLayout<T>>
+            extends GeneratedVaadinSplitLayout.SplitterDragendEvent<T> {
+        public SplitterDragendEvent(T source, boolean fromClient) {
             super(source, fromClient);
         }
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -871,10 +871,10 @@ public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePic
      */
     @Deprecated
     protected Registration addInvalidChangeListener(
-            ComponentEventListener<TimePicker.InvalidChangeEvent> listener) {
+            ComponentEventListener<TimePicker.InvalidChangeEvent<TimePicker>> listener) {
         return getElement().addPropertyChangeListener("invalid",
                 event -> listener.onComponentEvent(
-                        new TimePicker.InvalidChangeEvent((TimePicker) this,
+                        new TimePicker.InvalidChangeEvent<>((TimePicker) this,
                                 event.isUserOriginated())));
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -442,7 +442,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
 
     @Override
     public Registration addInvalidChangeListener(
-            ComponentEventListener<TimePicker.InvalidChangeEvent> listener) {
+            ComponentEventListener<TimePicker.InvalidChangeEvent<TimePicker>> listener) {
         return super.addInvalidChangeListener(listener);
     }
 
@@ -762,9 +762,9 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         return FeatureFlags.get(service.getContext()).isEnabled(feature);
     }
 
-    public static class InvalidChangeEvent
-            extends GeneratedVaadinTimePicker.InvalidChangeEvent<TimePicker> {
-        public InvalidChangeEvent(TimePicker source, boolean fromClient) {
+    public static class InvalidChangeEvent<T extends GeneratedVaadinTimePicker<T, ?>>
+            extends GeneratedVaadinTimePicker.InvalidChangeEvent<T> {
+        public InvalidChangeEvent(T source, boolean fromClient) {
             super(source, fromClient);
         }
     }


### PR DESCRIPTION
## Description

When sub-classing components, and using an implicit import for events such as `SplitterDragendEvent`, then the event classes introduced as an alternative to the deprecated events in generated classes can cause compilation errors. The problem is that the newly introduced event class now shadows the deprecated class, and the new class does not have the generic type param of the deprecated class.

Fixed this by adding a generic type param to the new event classes as well. The param will be dropped in v24, which will require developers to update their code during migration accordingly. The breaking change should be mentioned in the release notes, and in the migration guide.

Fixes https://github.com/vaadin/flow-components/issues/4286

## Type of change

- Bugfix
