### PR TITLE
refactor: drop unnecessary logic from RadioButtonGroup

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
@@ -24,7 +24,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.radiobutton.testbench.RadioButtonElement;
@@ -133,28 +132,16 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
         WebElement infoLabel = findElement(
                 By.id("button-group-disabled-items-info"));
 
-        Assert.assertEquals("'foo' should be selected", "foo",
+        Assert.assertEquals("'foo' should be selected server-side", "foo",
                 infoLabel.getText());
 
+        // Enable 'bar' button on client-side and click it
         executeScript("arguments[0].removeAttribute(\"disabled\");",
                 buttons.get(1));
-
         buttons.get(1).click();
 
-        try {
-            waitUntil(driver -> group
-                    .findElements(By.tagName("vaadin-radio-button")).get(1)
-                    .getAttribute("disabled") != null);
-        } catch (WebDriverException wde) {
-            Assert.fail("Server should have disabled the button again.");
-        }
-
-        Assert.assertEquals("Value 'foo' should have been re-selected", "foo",
-                infoLabel.getText());
-
-        Assert.assertTrue(
-                "Value 'foo' should have been re-selected on the client side",
-                Boolean.valueOf(buttons.get(0).getAttribute("checked")));
+        Assert.assertEquals("Value 'foo' should still be selected server-side",
+                "foo", infoLabel.getText());
     }
 
     @Test


### PR DESCRIPTION
## Description

Drops logic that tries to provide a friendly UX for hackers after they tampered with the component on the client-side, similar to what has been done for `Select` in https://github.com/vaadin/flow-components/pull/4295.

RBG had tests for restoring client-side state, which where dropped as well. Remaining tests still verify that the server-side value can not be modified.