### PR TITLE
refactor: drop unnecessary logic from CheckboxGroup

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -29,7 +29,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -112,23 +111,13 @@ public class CheckboxGroupIT extends AbstractComponentIT {
         WebElement infoLabel = layout
                 .findElement(By.id("checkbox-group-disabled-items-info"));
 
-        Assert.assertEquals("'foo' should be selected", "[foo]",
+        Assert.assertEquals("'foo' should be selected server-side", "[foo]",
                 infoLabel.getText());
 
         group.selectByText("bar");
 
-        try {
-            waitUntil(driver -> !group.getCheckboxes().get(1).isChecked());
-        } catch (WebDriverException wde) {
-            Assert.fail("Server should have disabled the checkbox again.");
-        }
-
-        Assert.assertEquals("Value 'foo' should have been re-selected", "[foo]",
-                infoLabel.getText());
-
-        Assert.assertTrue(
-                "Value 'foo' should have been re-selected on the client side",
-                checkboxes.get(0).isChecked());
+        Assert.assertEquals("Still only 'foo' should be selected server-side",
+                "[foo]", infoLabel.getText());
     }
 
     @Test


### PR DESCRIPTION
## Description

Drops logic that tries to provide a friendly UX for hackers after they tampered with the component on the client-side, similar to what has been done for `Select` in https://github.com/vaadin/flow-components/pull/4295.

CBG had tests for restoring client-side state, which where dropped as well. Remaining tests still verify that the server-side value can not be modified.