### PR TITLE
fix: Fix NPE if component renderer returns null

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentDataGenerator.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentDataGenerator.java
@@ -83,6 +83,9 @@ public class ComponentDataGenerator<T>
             nodeId = oldRenderedComponent.getElement().getNode().getId();
         } else {
             Component renderedComponent = createComponent(item);
+            if (renderedComponent == null) {
+                return;
+            }
             if (renderedComponent.getParent().isPresent()) {
                 LoggerFactory.getLogger(ComponentDataGenerator.class).warn(
                         "The 'createComponent' method returned a component '{}' which already has a parent."

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
@@ -140,6 +140,44 @@ public class ComponentRendererTest {
 
     }
 
+    @Test
+    public void allowNullValues() {
+        UI ui = new TestUI();
+        TestUIInternals internals = (TestUIInternals) ui.getInternals();
+
+        ComponentRenderer<TestDiv, String> nullRenderer = new ComponentRenderer<>(
+                e -> null);
+
+        Element containerParent = new Element("div");
+        Element container = new Element("div");
+        KeyMapper<String> keyMapper = new KeyMapper<>();
+
+        ComponentDataGenerator<String> rendering = (ComponentDataGenerator<String>) nullRenderer
+                .render(container, keyMapper);
+
+        containerParent.getNode()
+                .runWhenAttached(ui2 -> ui2.getInternals().getStateTree()
+                        .beforeClientResponse(containerParent.getNode(),
+                                context -> {
+                                    // if nodeid is null then the component
+                                    // won't be rendered correctly
+                                    Assert.assertNotNull(
+                                            "NodeIdPropertyName should not be null",
+                                            rendering.getNodeIdPropertyName());
+                                    JsonObject value = Json.createObject();
+                                    rendering.generateData("item", value);
+                                    Assert.assertEquals(
+                                            "generateData should not add elements in the jsonobject",
+                                            0, value.keys().length);
+                                }));
+        // attach the child (ex: container) before the parent (ex: grid)
+        attachElement(ui, container);
+        attachElement(ui, containerParent);
+
+        internals.getStateTree().runExecutionsBeforeClientResponse();
+
+    }
+
     private void attachElement(UI ui, Element contentTemplate) {
         ui.getElement().appendChild(contentTemplate);
     }


### PR DESCRIPTION
## Description

Users (including myself couple of times) intuitively return null for e.g. Grid cells that shouldn't contain component and consider this a bug. It is common that only some rows contain e.g. an edit button (for example based on permissions).

Currently we throw a nasty NPE from the internals. With this simple fix we do a null check instead and render nothing.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
