### PR TITLE
fix: avoid deprecation notice in Eclipse for button theme variant methods

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -425,4 +425,13 @@ public class Button extends GeneratedVaadinButton<Button>
         initDisableOnClick();
     }
 
+    @Override
+    public void addThemeVariants(ButtonVariant... variants) {
+        super.addThemeVariants(variants);
+    }
+
+    @Override
+    public void removeThemeVariants(ButtonVariant... variants) {
+        super.removeThemeVariants(variants);
+    }
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -276,6 +276,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
     // Override is only required to keep binary compatibility with other 23.x
     // minor versions, will be removed with the method in v24
     @Override
+    @Deprecated
     public void addThemeVariants(ButtonVariant... variants) {
         HasThemeVariant.super.addThemeVariants(variants);
     }
@@ -283,6 +284,7 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
     // Override is only required to keep binary compatibility with other 23.x
     // minor versions, will be removed with the method in v24
     @Override
+    @Deprecated
     public void removeThemeVariants(ButtonVariant... variants) {
         HasThemeVariant.super.removeThemeVariants(variants);
     }


### PR DESCRIPTION
## Description

From a [Discord thread](https://discord.com/channels/732335336448852018/1053292376036212857/1053292376036212857), it seems that Eclipse marks `Button.addThemeVariant`, `Button.removeThemeVariant` as deprecated, even though the methods are not deprecated - only the `GeneratedVaadinButton` class that defines them is.

Let's add overrides for these methods to `Button` like we have done for other components. It seems that for every other component we already have an override for these methods.
