### PR TITLE
refactor!: remove deprecated Select constructor

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -150,22 +150,6 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     }
 
     /**
-     * Constructs a select with the given items.
-     *
-     * @param items
-     *            the items for the select
-     * @see #setItems(Object...)
-     * @deprecated as of 23.1. Please use {@link #setItems(Object[])} instead.
-     */
-    @Deprecated
-    @SafeVarargs
-    public Select(T... items) {
-        this();
-
-        setItems(items);
-    }
-
-    /**
      * Constructs a select with the initial value change listener.
      *
      * @param listener

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -128,7 +128,7 @@ public class SelectTest {
         Assert.assertEquals("Invalid number of items", 0,
                 getListBox().getChildren().count());
 
-        select = new Select<>("foo", "bar", "baz");
+        select = new Select<>("label", null, "foo", "bar", "baz");
 
         Assert.assertEquals("Invalid number of items", 3,
                 getListBox().getChildren().count());


### PR DESCRIPTION
## Description

Fixes #1275

Removing the constructor that has been deprecated since 23.1 - see https://github.com/vaadin/flow-components/issues/1275#issuecomment-1104824035

## Type of change

- Breaking change