### PR TITLE
refactor!: remove deprecated GridElement.findInShadowRoot

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -308,20 +308,6 @@ public class GridElement extends TestBenchElement {
     }
 
     /**
-     * Find all {@link WebElement}s using the given {@link By} selector.
-     *
-     * @deprecated this method will not working for Chrome 96+, because of the
-     *             breaking changes in ChromeDriver.
-     * @param by
-     *            the selector used to find elements
-     * @return a list of found elements
-     */
-    @Deprecated
-    public List<WebElement> findInShadowRoot(By by) {
-        return getShadowRoot().findElements(by);
-    }
-
-    /**
      * Gets the footer cell for the given visible column index.
      *
      * @param columnIndex


### PR DESCRIPTION
## Description

Removed the deprecated and no longer working method from TestBench API for Grid.
Its usage was previously removed - see e.g. https://github.com/vaadin/vaadin-grid-flow/pull/1138

## Type of change

- Breaking change