### PR TITLE
chore: align license header for core components

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -1,9 +1,3 @@
-package com.vaadin.flow.component.accordion;
-
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
-
 /*
  * Copyright 2000-2022 Vaadin Ltd.
  *
@@ -19,6 +13,11 @@ import java.util.OptionalInt;
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.flow.component.accordion;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
@@ -1,5 +1,3 @@
-package com.vaadin.flow.component.accordion;
-
 /*
  * Copyright 2000-2022 Vaadin Ltd.
  *
@@ -15,6 +13,7 @@ package com.vaadin.flow.component.accordion;
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.flow.component.accordion;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;

--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
@@ -1,5 +1,3 @@
-package com.vaadin.flow.component.accordion.testbench;
-
 /*
  * Copyright 2000-2022 Vaadin Ltd.
  *
@@ -15,6 +13,7 @@ package com.vaadin.flow.component.accordion.testbench;
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.flow.component.accordion.testbench;
 
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;

--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionPanelElement.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionPanelElement.java
@@ -1,5 +1,3 @@
-package com.vaadin.flow.component.accordion.testbench;
-
 /*
  * Copyright 2000-2022 Vaadin Ltd.
  *
@@ -15,6 +13,7 @@ package com.vaadin.flow.component.accordion.testbench;
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.flow.component.accordion.testbench;
 
 import com.vaadin.testbench.elementsbase.Element;
 import com.vaadin.flow.component.details.testbench.DetailsElement;

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -1,28 +1,23 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.applayout;
 
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
-
-/*
- * #%L
- * Vaadin App Layout
- * %%
- * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/DrawerToggle.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/DrawerToggle.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.applayout;
-
 /*
- * #%L
- * Vaadin App Layout
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.applayout;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutElement.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutElement.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.applayout.testbench;
-
 /*
- * #%L
- * Vaadin App Layout Testbench API
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.applayout.testbench;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/DrawerToggleElement.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/DrawerToggleElement.java
@@ -1,27 +1,22 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.applayout.testbench;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
-
-/*
- * #%L
- * Vaadin App Layout Testbench API
- * %%
- * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
 
 @Element("vaadin-drawer-toggle")
 public class DrawerToggleElement extends TestBenchElement {

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.customfield;
-
 /*
- * #%L
- * Vaadin CustomField for Vaadin 10
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.customfield;
 
 import java.util.Objects;
 import java.util.stream.Collectors;

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/src/main/java/com/vaadin/flow/component/customfield/testbench/CustomFieldElement.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/src/main/java/com/vaadin/flow/component/customfield/testbench/CustomFieldElement.java
@@ -1,26 +1,21 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.customfield.testbench;
 
 import com.vaadin.testbench.ElementQuery;
-
-/*
- * #%L
- * Vaadin CustomField Testbench API
- * %%
- * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
 
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.TestBenchElement;

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.details;
-
 /*
- * #%L
- * Details for Vaadin Flow
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.details;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/DetailsVariant.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/DetailsVariant.java
@@ -1,31 +1,25 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.details;
 
 import com.vaadin.flow.component.shared.ThemeVariant;
 
-/*
- * #%L
- * Details for Vaadin Flow
- * %%
- * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
-
 /**
  * The set of theme variants applicable to the {@code vaadin-details} component.
  */
-
 public enum DetailsVariant implements ThemeVariant {
 
     FILLED("filled"), REVERSE("reverse"), SMALL("small");

--- a/vaadin-details-flow-parent/vaadin-details-testbench/src/main/java/com/vaadin/flow/component/details/testbench/DetailsElement.java
+++ b/vaadin-details-flow-parent/vaadin-details-testbench/src/main/java/com/vaadin/flow/component/details/testbench/DetailsElement.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.details.testbench;
-
 /*
- * #%L
- * Vaadin Details Testbench API
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.details.testbench;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login;
-
 /*
- * #%L
- * Login for Vaadin Flow
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginForm.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginForm.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login;
-
 /*
- * #%L
- * Login for Vaadin Flow
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login;
 
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginI18n.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginI18n.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login;
-
 /*
- * #%L
- * Login for Vaadin Flow
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login;
 
 import com.vaadin.flow.internal.JsonSerializer;
 import elemental.json.JsonFactory;

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login;
-
 /*
- * #%L
- * Login for Vaadin Flow
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;

--- a/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/Login.java
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/Login.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login.testbench;
-
 /*
- * #%L
- * Vaadin Login Testbench API
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login.testbench;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;

--- a/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginFormElement.java
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginFormElement.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login.testbench;
-
 /*
- * #%L
- * Vaadin Login Testbench API
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login.testbench;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;

--- a/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginOverlayElement.java
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginOverlayElement.java
@@ -1,24 +1,19 @@
-package com.vaadin.flow.component.login.testbench;
-
 /*
- * #%L
- * Vaadin Login Testbench API
- * %%
  * Copyright 2000-2022 Vaadin Ltd.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+package com.vaadin.flow.component.login.testbench;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;


### PR DESCRIPTION
## Description

Updated license header for the Flow components originally created by Pro team:

- `AppLayout`
- `CustomField`
- `Details`
- `Login`

Also updated `Accordion` that has the correct comment - just moved it to the first line.
The license is still the same (Apache 2.0), only the comment style has changed.

## Type of change

- Internal change