### PR TITLE
fix: restore incorrectly removed setRequired override

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -206,6 +206,22 @@ public class EmailField extends InternalFieldBase<EmailField, String>
     }
 
     /**
+     * <p>
+     * Specifies that the user must fill in a value.
+     * </p>
+     * NOTE: The required indicator will not be visible, if there is no
+     * {@code label} property set for the textfield.
+     *
+     * @param required
+     *            the boolean value to set
+     */
+    @Override
+    public void setRequired(boolean required) {
+        super.setRequired(required);
+        getValidationSupport().setRequired(required);
+    }
+
+    /**
      * Sets a regular expression for the value to pass on the client-side. The
      * pattern must be a valid JavaScript Regular Expression that matches the
      * entire value, not just some subset.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -231,6 +231,22 @@ public class TextArea extends InternalFieldBase<TextArea, String>
     }
 
     /**
+     * <p>
+     * Specifies that the user must fill in a value.
+     * </p>
+     * NOTE: The required indicator will not be visible, if there is no
+     * {@code label} property set for the textfield.
+     *
+     * @param required
+     *            the boolean value to set
+     */
+    @Override
+    public void setRequired(boolean required) {
+        super.setRequired(required);
+        getValidationSupport().setRequired(required);
+    }
+
+    /**
      * Sets a regular expression for the value to pass on the client-side. The
      * pattern must be a valid JavaScript Regular Expression that matches the
      * entire value, not just some subset.


### PR DESCRIPTION
## Description

Fixed a regression from the [accidental removal](https://github.com/vaadin/flow-components/pull/4377/files#diff-fea9ce1496969ddcbb3608e138125a5eb86e8d86050a9ce106f7fb622bd2a2d9L410-L422) of `setRequired` in #4337 - somehow I missed that 😞 
Also added this override to `EmailField` that has `getValidationSupport` but didn't have this. 

See internal discussion: https://vaadin.slack.com/archives/C3TGRP4HY/p1671547876459429

## Type of change

- Bugfix