### PR TITLE
chore: align year in LICENSE files and headers

### DIFF
--- a/vaadin-accordion-flow-parent/LICENSE
+++ b/vaadin-accordion-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-app-layout-flow-parent/LICENSE
+++ b/vaadin-app-layout-flow-parent/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2018 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-avatar-flow-parent/LICENSE
+++ b/vaadin-avatar-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-button-flow-parent/LICENSE
+++ b/vaadin-button-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipDefaultsPage.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipDefaultsPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipDefaultsIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipDefaultsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-checkbox-flow-parent/LICENSE
+++ b/vaadin-checkbox-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-combo-box-flow-parent/LICENSE
+++ b/vaadin-combo-box-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-confirm-dialog-flow-parent/LICENSE
+++ b/vaadin-confirm-dialog-flow-parent/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-context-menu-flow-parent/LICENSE
+++ b/vaadin-context-menu-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-custom-field-flow-parent/LICENSE
+++ b/vaadin-custom-field-flow-parent/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2017 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-date-picker-flow-parent/LICENSE
+++ b/vaadin-date-picker-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-date-time-picker-flow-parent/LICENSE
+++ b/vaadin-date-time-picker-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-details-flow-parent/LICENSE
+++ b/vaadin-details-flow-parent/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2018 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-dialog-flow-parent/LICENSE
+++ b/vaadin-dialog-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-field-highlighter-flow-parent/LICENSE
+++ b/vaadin-field-highlighter-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/TooltipConfiguration.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/TooltipConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-form-layout-flow-parent/LICENSE
+++ b/vaadin-form-layout-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-grid-flow-parent/LICENSE
+++ b/vaadin-grid-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-icons-flow-parent/LICENSE
+++ b/vaadin-icons-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-list-box-flow-parent/LICENSE
+++ b/vaadin-list-box-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-login-flow-parent/LICENSE
+++ b/vaadin-login-flow-parent/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2017 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-menu-bar-flow-parent/LICENSE
+++ b/vaadin-menu-bar-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSerializationIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSerializationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-messages-flow-parent/LICENSE
+++ b/vaadin-messages-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-notification-flow-parent/LICENSE
+++ b/vaadin-notification-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-ordered-layout-flow-parent/LICENSE
+++ b/vaadin-ordered-layout-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-progress-bar-flow-parent/LICENSE
+++ b/vaadin-progress-bar-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-radio-button-flow-parent/LICENSE
+++ b/vaadin-radio-button-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-renderer-flow-parent/LICENSE
+++ b/vaadin-renderer-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-select-flow-parent/LICENSE
+++ b/vaadin-select-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-split-layout-flow-parent/LICENSE
+++ b/vaadin-split-layout-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-tabs-flow-parent/LICENSE
+++ b/vaadin-tabs-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/main/java/com/vaadin/flow/component/tabs/tests/TabSheetPage.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/main/java/com/vaadin/flow/component/tabs/tests/TabSheetPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetIT.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabSheetElement.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabSheetElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/vaadin-text-field-flow-parent/LICENSE
+++ b/vaadin-text-field-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-time-picker-flow-parent/LICENSE
+++ b/vaadin-time-picker-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-upload-flow-parent/LICENSE
+++ b/vaadin-upload-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vaadin-virtual-list-flow-parent/LICENSE
+++ b/vaadin-virtual-list-flow-parent/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Vaadin Ltd.
+   Copyright 2000-2022 Vaadin Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Updated year in LICENSE files and comments to use `2000-2022` for consistency.

## Type of change

- Internal change