### PR TITLE
refactor: extract HasAutoOpen interface to shared module

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -39,6 +39,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
+import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.ValidationUtil;
@@ -82,12 +83,12 @@ import java.util.stream.Stream;
  */
 public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, TItem, TValue>, TItem, TValue>
         extends AbstractSinglePropertyField<TComponent, TValue>
-        implements HasStyle, Focusable<TComponent>, HasSize, HasValidation,
-        HasHelper, HasTheme, HasLabel, HasClearButton, HasAllowedCharPattern,
-        HasDataView<TItem, String, ComboBoxDataView<TItem>>,
-        HasListDataView<TItem, ComboBoxListDataView<TItem>>,
-        HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>, HasTooltip,
-        HasValidator<TValue>, HasClientValidation {
+        implements Focusable<TComponent>, HasAllowedCharPattern, HasAutoOpen,
+        HasClearButton, HasClientValidation,
+        HasDataView<TItem, String, ComboBoxDataView<TItem>>, HasHelper,
+        HasLabel, HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>,
+        HasListDataView<TItem, ComboBoxListDataView<TItem>>, HasSize, HasStyle,
+        HasTheme, HasTooltip, HasValidation, HasValidator<TValue> {
 
     /**
      * Registration for custom value listeners that disallows entering custom
@@ -394,28 +395,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     public void setPlaceholder(String placeholder) {
         getElement().setProperty("placeholder",
                 placeholder == null ? "" : placeholder);
-    }
-
-    /**
-     * Gets whether dropdown will open automatically or not.
-     *
-     * @return {@code true} if enabled, {@code false} otherwise
-     */
-    public boolean isAutoOpen() {
-        return !getElement().getProperty("autoOpenDisabled", false);
-    }
-
-    /**
-     * Enables or disables the dropdown opening automatically. If {@code false}
-     * the dropdown is only opened when clicking the toggle button or pressing
-     * Up or Down arrow keys.
-     *
-     * @param autoOpen
-     *            {@code false} to prevent the dropdown from opening
-     *            automatically
-     */
-    public void setAutoOpen(boolean autoOpen) {
-        getElement().setProperty("autoOpenDisabled", !autoOpen);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -86,12 +87,10 @@ import elemental.json.JsonType;
 @NpmPackage(value = "date-fns", version = "2.29.3")
 public class DatePicker
         extends AbstractSinglePropertyField<DatePicker, LocalDate>
-        implements Focusable<DatePicker>, HasAllowedCharPattern, HasClearButton,
-        HasClientValidation, HasHelper, HasLabel, HasSize, HasStyle,
-        HasThemeVariant<DatePickerVariant>, HasTooltip, HasValidation,
+        implements Focusable<DatePicker>, HasAllowedCharPattern, HasAutoOpen,
+        HasClearButton, HasClientValidation, HasHelper, HasLabel, HasSize,
+        HasStyle, HasThemeVariant<DatePickerVariant>, HasTooltip, HasValidation,
         HasValidator<LocalDate> {
-
-    private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 
     private DatePickerI18n i18n;
 
@@ -759,28 +758,6 @@ public class DatePicker
      */
     public String getName() {
         return getElement().getProperty("name");
-    }
-
-    /**
-     * When auto open is enabled, the dropdown will open when the field is
-     * clicked.
-     *
-     * @param autoOpen
-     *            Value for the auto open property,
-     */
-    public void setAutoOpen(boolean autoOpen) {
-        getElement().setProperty(PROP_AUTO_OPEN_DISABLED, !autoOpen);
-    }
-
-    /**
-     * When auto open is enabled, the dropdown will open when the field is
-     * clicked.
-     *
-     * @return {@code true} if auto open is enabled. {@code false} otherwise.
-     *         Default is {@code true}
-     */
-    public boolean isAutoOpen() {
-        return !getElement().getProperty(PROP_AUTO_OPEN_DISABLED, false);
     }
 
     /**

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
+import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
@@ -97,13 +98,11 @@ class DateTimePickerTimePicker
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/date-time-picker", version = "24.0.0-alpha6")
 @JsModule("@vaadin/date-time-picker/src/vaadin-date-time-picker.js")
-public class DateTimePicker
-        extends AbstractSinglePropertyField<DateTimePicker, LocalDateTime>
-        implements Focusable<DateTimePicker>, HasClientValidation, HasHelper,
+public class DateTimePicker extends
+        AbstractSinglePropertyField<DateTimePicker, LocalDateTime> implements
+        Focusable<DateTimePicker>, HasAutoOpen, HasClientValidation, HasHelper,
         HasLabel, HasSize, HasStyle, HasThemeVariant<DateTimePickerVariant>,
         HasTooltip, HasValidation, HasValidator<LocalDateTime> {
-
-    private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 
     private final DateTimePickerDatePicker datePicker = new DateTimePickerDatePicker();
     private final DateTimePickerTimePicker timePicker = new DateTimePickerTimePicker();
@@ -799,20 +798,9 @@ public class DateTimePicker
      *            Value for the auto open property,
      */
     public void setAutoOpen(boolean autoOpen) {
-        getElement().setProperty(PROP_AUTO_OPEN_DISABLED, !autoOpen);
+        getElement().setProperty("autoOpenDisabled", !autoOpen);
         datePicker.setAutoOpen(autoOpen);
         timePicker.setAutoOpen(autoOpen);
-    }
-
-    /**
-     * When auto open is enabled, the dropdown will open when the field is
-     * clicked.
-     *
-     * @return {@code true} if auto open is enabled. {@code false} otherwise.
-     *         Default is {@code true}
-     */
-    public boolean isAutoOpen() {
-        return !getElement().getProperty(PROP_AUTO_OPEN_DISABLED, false);
     }
 
     @Override

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasAutoOpen.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasAutoOpen.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * Mixin interface for field components that support setting auto open to
+ * control whether the overlay should open on input click or not.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasAutoOpen extends HasElement {
+
+    /**
+     * Gets whether dropdown will open automatically or not.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    default boolean isAutoOpen() {
+        return !getElement().getProperty("autoOpenDisabled", false);
+    }
+
+    /**
+     * Enables or disables the dropdown opening automatically. If {@code false}
+     * the dropdown is only opened when clicking the toggle button or pressing
+     * Up or Down arrow keys.
+     *
+     * @param autoOpen
+     *            {@code false} to prevent the dropdown from opening
+     *            automatically
+     */
+    default void setAutoOpen(boolean autoOpen) {
+        getElement().setProperty("autoOpenDisabled", !autoOpen);
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasAutoOpenTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasAutoOpenTest.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.component.shared;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+public class HasAutoOpenTest {
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void initialValue() {
+        Assert.assertTrue(component.isAutoOpen());
+    }
+
+    @Test
+    public void changeValue() {
+        component.setAutoOpen(false);
+        Assert.assertFalse(component.isAutoOpen());
+        Assert.assertTrue(
+                component.getElement().getProperty("autoOpenDisabled", true));
+
+        component.setAutoOpen(true);
+        Assert.assertTrue(component.isAutoOpen());
+        Assert.assertFalse(
+                component.getElement().getProperty("autoOpenDisabled", false));
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasAutoOpen {
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -71,9 +72,9 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("./vaadin-time-picker/timepickerConnector.js")
 public class TimePicker
         extends AbstractSinglePropertyField<TimePicker, LocalTime>
-        implements Focusable<TimePicker>, HasAllowedCharPattern, HasClearButton,
-        HasClientValidation, HasHelper, HasLabel, HasSize, HasStyle,
-        HasThemeVariant<TimePickerVariant>, HasTooltip, HasValidation,
+        implements Focusable<TimePicker>, HasAllowedCharPattern, HasAutoOpen,
+        HasClearButton, HasClientValidation, HasHelper, HasLabel, HasSize,
+        HasStyle, HasThemeVariant<TimePickerVariant>, HasTooltip, HasValidation,
         HasValidator<LocalTime> {
 
     private static final SerializableFunction<String, LocalTime> PARSER = valueFromClient -> {
@@ -84,8 +85,6 @@ public class TimePicker
     private static final SerializableFunction<LocalTime, String> FORMATTER = valueFromModel -> {
         return valueFromModel == null ? "" : valueFromModel.toString();
     };
-
-    private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
 
     private Locale locale;
 
@@ -650,28 +649,6 @@ public class TimePicker
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, context -> command.accept(ui)));
-    }
-
-    /**
-     * Enables or disables the dropdown opening automatically. If {@code false}
-     * the dropdown is only opened when clicking the toggle button or pressing
-     * Up or Down arrow keys.
-     *
-     * @param autoOpen
-     *            {@code false} to prevent the dropdown from opening
-     *            automatically
-     */
-    public void setAutoOpen(boolean autoOpen) {
-        getElement().setProperty(PROP_AUTO_OPEN_DISABLED, !autoOpen);
-    }
-
-    /**
-     * Gets whether dropdown will open automatically or not.
-     *
-     * @return {@code true} if enabled, {@code false} otherwise
-     */
-    public boolean isAutoOpen() {
-        return !getElement().getProperty(PROP_AUTO_OPEN_DISABLED, false);
     }
 
     /**


### PR DESCRIPTION
## Description

Extracted `HasAutoOpen` interface to be used by following components:

- `ComboBox`
- `MultiSelectComboBox`
- `DatePicker`
- `DateTimePicker`
- `TimePicker`

## Type of change

- Refactor