### PR TITLE
fix(DatePicker): clear possible bad input when setting an empty value (#4413) (CP: 23.3)

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/ClearValuePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/ClearValuePage.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-date-picker/clear-value")
+public class ClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public ClearValuePage() {
+        DatePicker datePicker = new DatePicker();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> datePicker.clear());
+
+        add(datePicker, clearButton);
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBasicPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBasicPage.java
@@ -17,6 +17,7 @@ public class DatePickerValidationBasicPage
     public static final String REQUIRED_BUTTON = "required-button";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public DatePickerValidationBasicPage() {
         super();
@@ -33,6 +34,10 @@ public class DatePickerValidationBasicPage
         add(createInput(MAX_INPUT, "Set max date", event -> {
             LocalDate value = LocalDate.parse(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
 
         addAttachDetachControls();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBinderPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBinderPage.java
@@ -12,6 +12,7 @@ public class DatePickerValidationBinderPage
         extends AbstractValidationPage<DatePicker> {
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
@@ -55,6 +56,10 @@ public class DatePickerValidationBinderPage
         add(createInput(MAX_INPUT, "Set max date", event -> {
             LocalDate value = LocalDate.parse(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/ClearValueIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/ClearValueIT.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.component.datepicker;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.datepicker.ClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-date-picker/clear-value")
+public class ClearValueIT extends AbstractComponentIT {
+    private DatePickerElement datePicker;
+
+    @Before
+    public void init() {
+        open();
+        datePicker = $(DatePickerElement.class).first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        datePicker.sendKeys("1/1/2022", Keys.ENTER);
+        Assert.assertEquals("1/1/2022", datePicker.getInputValue());
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", datePicker.getInputValue());
+    }
+
+    @Test
+    public void setBadInputValue_clearValue_inputValueIsEmpty() {
+        datePicker.sendKeys("INVALID", Keys.ENTER);
+        Assert.assertEquals("INVALID", datePicker.getInputValue());
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", datePicker.getInputValue());
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBasicIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBasicIT.java
@@ -12,6 +12,7 @@ import static com.vaadin.flow.component.datepicker.validation.DatePickerValidati
 import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBasicPage.MIN_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBasicPage.MAX_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBasicPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBasicPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-date-picker/validation/basic")
 public class DatePickerValidationBasicIT
@@ -117,6 +118,17 @@ public class DatePickerValidationBasicIT
         testField.setInputValue("INVALID");
         assertServerInvalid();
         assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.setInputValue("INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     protected DatePickerElement getTestField() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBinderIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/DatePickerValidationBinderIT.java
@@ -12,6 +12,7 @@ import static com.vaadin.flow.component.datepicker.validation.DatePickerValidati
 import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBinderPage.EXPECTED_VALUE_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBinderPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datepicker.validation.DatePickerValidationBinderPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-date-picker/validation/binder")
 public class DatePickerValidationBinderIT
@@ -108,6 +109,19 @@ public class DatePickerValidationBinderIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.setInputValue("INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     protected DatePickerElement getTestField() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -572,6 +572,22 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         return getElement().getProperty("_hasInputValue", false);
     }
 
+    @Override
+    public void setValue(LocalDate value) {
+        LocalDate oldValue = getValue();
+
+        super.setValue(value);
+
+        if (Objects.equals(oldValue, getEmptyValue())
+                && Objects.equals(value, getEmptyValue())
+                && isInputValuePresent()) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+            getElement().setProperty("_hasInputValue", false);
+            fireEvent(new ClientValidatedEvent(this, false, true));
+        }
+    }
+
     /**
      * Sets the label for the datepicker.
      *

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -18,15 +18,6 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
 
         datepicker.$connector = {};
 
-        datepicker.addEventListener(
-          'blur',
-          tryCatchWrapper((e) => {
-            if (!e.target.value && e.target.invalid) {
-              console.warn('Invalid value in the DatePicker.');
-            }
-          })
-        );
-
         const createLocaleBasedDateFormat = function (locale) {
           try {
             // Check whether the locale is supported or not


### PR DESCRIPTION
## Description

The PR cherry-picks the following fix to `23.3`:

- #4413

> **Note**
> There were a few conflicts due to the new test naming and structure that we introduced in `24.0` but that we didn't backport to `23.3`.

Part of https://github.com/vaadin/flow-components/issues/4395

## Type of change

- [x] Bugfix
