### PR TITLE
test: use a valid email field value in a test case

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
@@ -91,6 +91,7 @@ public class ValueChangeModeIT extends AbstractComponentIT {
     @Test
     public void testValueChangeModesForEmailField()
             throws InterruptedException {
+        emailField.sendKeys("foo@test.com");
         testValueChangeModes(emailField, "emailfield");
     }
 


### PR DESCRIPTION
## Description

There's currently a test case which keeps failing because it uses invalid text input value (`"11111"`) for `EmailField` while testing value change modes.

This change sets an initial value for the email field so that appending "1"s in the test case still keeps the field value valid (`"foo@test.com11111"`)