### PR TITLE
fix(AbstractNumberField): clear possible bad input when setting an empty value

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.textfield.IntegerField;
+
+@Route("vaadin-integer-field/clear-value")
+public class IntegerFieldClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public IntegerFieldClearValuePage() {
+        IntegerField integerField = new IntegerField();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> integerField.clear());
+
+        add(integerField, clearButton);
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValuePage.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.textfield.NumberField;
+
+@Route("vaadin-number-field/clear-value")
+public class NumberFieldClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public NumberFieldClearValuePage() {
+        NumberField numberField = new NumberField();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> numberField.clear());
+
+        add(numberField, clearButton);
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValidationBasicPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValidationBasicPage.java
@@ -26,6 +26,7 @@ public class IntegerFieldValidationBasicPage
     public static final String STEP_INPUT = "step-input";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public IntegerFieldValidationBasicPage() {
         super();
@@ -47,6 +48,10 @@ public class IntegerFieldValidationBasicPage
         add(createInput(MAX_INPUT, "Set max", event -> {
             int value = Integer.parseInt(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValidationBinderPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValidationBinderPage.java
@@ -27,6 +27,7 @@ public class IntegerFieldValidationBinderPage
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
@@ -73,6 +74,10 @@ public class IntegerFieldValidationBinderPage
         add(createInput(MAX_INPUT, "Set max", event -> {
             int value = Integer.parseInt(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationPage.java
@@ -26,6 +26,7 @@ public class NumberFieldBasicValidationPage
     public static final String STEP_INPUT = "step-input";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public NumberFieldBasicValidationPage() {
         super();
@@ -47,6 +48,10 @@ public class NumberFieldBasicValidationPage
         add(createInput(MAX_INPUT, "Set max", event -> {
             double value = Double.parseDouble(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationPage.java
@@ -27,6 +27,7 @@ public class NumberFieldBinderValidationPage
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
@@ -73,6 +74,10 @@ public class NumberFieldBinderValidationPage
         add(createInput(MAX_INPUT, "Set max", event -> {
             double value = Double.parseDouble(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.textfield.tests.IntegerFieldClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-integer-field/clear-value")
+public class IntegerFieldClearValueIT extends AbstractComponentIT {
+    private IntegerFieldElement integerField;
+
+    private TestBenchElement input;
+
+    @Before
+    public void init() {
+        open();
+        integerField = $(IntegerFieldElement.class).first();
+        input = integerField.$("input").first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        integerField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
+        // Native [type=number] inputs don't update their value
+        // when you are entering input that the browser is unable to parse,
+        // so we have to rely on HTML constraints to determine
+        // whether the input element is empty or not.
+        integerField.sendKeys("--2", Keys.ENTER);
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertTrue((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertFalse((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.NumberFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.textfield.tests.NumberFieldClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-number-field/clear-value")
+public class NumberFieldClearValueIT extends AbstractComponentIT {
+    private NumberFieldElement numberField;
+
+    private TestBenchElement input;
+
+    @Before
+    public void init() {
+        open();
+        numberField = $(NumberFieldElement.class).first();
+        input = numberField.$("input").first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        numberField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
+        // Native [type=number] inputs don't update their value
+        // when you are entering input that the browser is unable to parse,
+        // so we have to rely on HTML constraints to determine
+        // whether the input element is empty or not.
+        numberField.sendKeys("--2", Keys.ENTER);
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertTrue((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertFalse((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -26,6 +26,7 @@ import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldV
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.MAX_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.STEP_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-integer-field/validation/basic")
 public class IntegerFieldBasicValidationIT
@@ -156,6 +157,17 @@ public class IntegerFieldBasicValidationIT
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.sendKeys("--2", Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -26,6 +26,7 @@ import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldV
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.MIN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.MAX_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -147,6 +148,19 @@ public class IntegerFieldBinderValidationIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.sendKeys("--2", Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
@@ -26,6 +26,7 @@ import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBa
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBasicValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBasicValidationPage.STEP_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBasicValidationPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-number-field/validation/basic")
 public class NumberFieldBasicValidationIT
@@ -156,6 +157,17 @@ public class NumberFieldBasicValidationIT
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.sendKeys("--2", Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
@@ -26,6 +26,7 @@ import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBi
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.MIN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -147,6 +148,19 @@ public class NumberFieldBinderValidationIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.sendKeys("--2", Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     protected NumberFieldElement getTestField() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -134,7 +134,18 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      */
     @Override
     public void setValue(T value) {
+        T oldValue = getValue();
+
         super.setValue(value);
+
+        if (Objects.equals(oldValue, getEmptyValue())
+                && Objects.equals(value, getEmptyValue())
+                && isInputValuePresent()) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+            getElement().setProperty("_hasInputValue", false);
+            fireEvent(new ClientValidatedEvent(this, false, true));
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The PR overrides AbstractNumberField's `setValue()` to support clearing the input element from possible bad input when setting an empty value in the case the previous value was already empty. Or, in other words, this PR guarantees that bad input won't remain in the field after you assign an *empty* Binder bean that in fact relates to *another* record.

The PR targets both NumberField and IntegerField.

Part of https://github.com/vaadin/flow-components/issues/4395

## Type of change

- [x] Bugfix
