### PR TITLE
fix: set correct flag on the default slotted elements

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -149,9 +149,13 @@ public class Upload extends Component implements HasSize, HasStyle {
                 .addEventData(elementFiles);
 
         defaultUploadButton = new Button();
+        // Ensure the flag is set before the element is added to the slot
+        defaultUploadButton.getElement().setProperty("_isDefault", true);
         setUploadButton(defaultUploadButton);
 
         defaultDropLabel = new Span();
+        // Ensure the flag is set before the element is added to the slot
+        defaultDropLabel.getElement().setProperty("_isDefault", true);
         setDropLabel(defaultDropLabel);
 
         defaultDropLabelIcon = new UploadIcon();
@@ -652,24 +656,6 @@ public class Upload extends Component implements HasSize, HasStyle {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-
-        if (uploadButton == defaultUploadButton) {
-            // FIXME: the "_isDefault" flag is being set too late,
-            // so we have to trigger the slot controller manually
-            getElement().executeJs(
-                    "$0._addButton = null; $1._isDefault = true;"
-                            + "$0._addButtonController.initNode($1)",
-                    getElement(), defaultUploadButton.getElement());
-        }
-
-        if (dropLabel == defaultDropLabel) {
-            // FIXME: the "_isDefault" flag is being set too late,
-            // so we have to trigger the slot controller manually
-            getElement().executeJs(
-                    "$0._dropLabel = null; $1._isDefault = true;"
-                            + "$0._dropLabelController.initNode($1)",
-                    getElement(), defaultDropLabel.getElement());
-        }
 
         // Element state is not persisted across attach/detach
         if (this.i18n != null) {


### PR DESCRIPTION
## Description

Replaced an ugly workaround in https://github.com/vaadin/flow-components/pull/4436/commits/449083a6c68eb34cbfe2ed0a74f3591d7a28519d with a proper fix - thanks @vursen for the help 🙏 

## Type of change

- Bugfix