### PR TITLE
fix(TimePicker): clear possible bad input when setting an empty value (#4430) (CP: 23.3)

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/ClearValuePage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/ClearValuePage.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-time-picker/clear-value")
+public class ClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public ClearValuePage() {
+        TimePicker timePicker = new TimePicker();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> timePicker.clear());
+
+        add(timePicker, clearButton);
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBasicPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBasicPage.java
@@ -17,6 +17,7 @@ public class TimePickerValidationBasicPage
     public static final String REQUIRED_BUTTON = "required-button";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public TimePickerValidationBasicPage() {
         super();
@@ -33,6 +34,10 @@ public class TimePickerValidationBasicPage
         add(createInput(MAX_INPUT, "Set max time", event -> {
             LocalTime value = LocalTime.parse(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
 
         addAttachDetachControls();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBinderPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBinderPage.java
@@ -13,6 +13,7 @@ public class TimePickerValidationBinderPage
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
@@ -55,6 +56,10 @@ public class TimePickerValidationBinderPage
         add(createInput(MAX_INPUT, "Set max time", event -> {
             LocalTime value = LocalTime.parse(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.timepicker.tests.ClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-time-picker/clear-value")
+public class ClearValueIT extends AbstractComponentIT {
+    private TimePickerElement timePicker;
+
+    @Before
+    public void init() {
+        open();
+        timePicker = $(TimePickerElement.class).first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        timePicker.selectByText("12:00 PM");
+        Assert.assertEquals("12:00 PM", timePicker.getTimePickerInputValue());
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", timePicker.getTimePickerInputValue());
+    }
+
+    @Test
+    public void setBadInputValue_clearValue_inputValueIsEmpty() {
+        timePicker.selectByText("INVALID");
+        Assert.assertEquals("INVALID", timePicker.getTimePickerInputValue());
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", timePicker.getTimePickerInputValue());
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBasicIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBasicIT.java
@@ -12,6 +12,7 @@ import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerVa
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBasicPage.MIN_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBasicPage.MAX_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBasicPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBasicPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-time-picker/validation/basic")
 public class TimePickerValidationBasicIT
@@ -117,6 +118,17 @@ public class TimePickerValidationBasicIT
         testField.selectByText("INVALID");
         assertServerInvalid();
         assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.selectByText("INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     protected TimePickerElement getTestField() {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBinderIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/TimePickerValidationBinderIT.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.Keys;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBinderPage.MIN_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBinderPage.MAX_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBinderPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBinderPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBinderPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.timepicker.tests.validation.TimePickerValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -108,6 +109,19 @@ public class TimePickerValidationBinderIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        testField.selectByText("INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     protected TimePickerElement getTestField() {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -236,7 +236,19 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         if (value != null) {
             value = value.truncatedTo(ChronoUnit.MILLIS);
         }
+
+        LocalTime oldValue = getValue();
+
         super.setValue(value);
+
+        if (Objects.equals(oldValue, getEmptyValue())
+                && Objects.equals(value, getEmptyValue())
+                && isInputValuePresent()) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+            getElement().setProperty("_hasInputValue", false);
+            fireEvent(new ClientValidatedEvent(this, false, true));
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The PR cherry-picks the following fix to `23.3`:

- #4430

> **Note**
> There were a few conflicts due to the new test naming and structure that we introduced in `24.0` but that we didn't backport to `23.3`.

Part of https://github.com/vaadin/flow-components/issues/4395

## Type of change

- [x] Bugfix
