### PR TITLE
fix(DateTimePicker): clear possible bad input when setting an empty value (#4431) (CP: 23.3)

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/ClearValuePage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/ClearValuePage.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-date-time-picker/clear-value")
+public class ClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public ClearValuePage() {
+        DateTimePicker datePicker = new DateTimePicker();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> datePicker.clear());
+
+        add(datePicker, clearButton);
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBasicPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBasicPage.java
@@ -17,6 +17,7 @@ public class DateTimePickerValidationBasicPage
     public static final String REQUIRED_BUTTON = "required-button";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public DateTimePickerValidationBasicPage() {
         super();
@@ -33,6 +34,10 @@ public class DateTimePickerValidationBasicPage
         add(createInput(MAX_INPUT, "Set max date time", event -> {
             var value = LocalDateTime.parse(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
 
         addAttachDetachControls();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBinderPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBinderPage.java
@@ -13,6 +13,7 @@ public class DateTimePickerValidationBinderPage
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
+    public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
@@ -56,6 +57,10 @@ public class DateTimePickerValidationBinderPage
         add(createInput(MAX_INPUT, "Set max date time", event -> {
             var value = LocalDateTime.parse(event.getValue());
             testField.setMax(value);
+        }));
+
+        add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
+            testField.clear();
         }));
     }
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/ClearValueIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/ClearValueIT.java
@@ -1,0 +1,88 @@
+package com.vaadin.flow.component.datetimepicker;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.datetimepicker.testbench.DateTimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.datetimepicker.ClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-date-time-picker/clear-value")
+public class ClearValueIT extends AbstractComponentIT {
+    private DateTimePickerElement dateTimePicker;
+    private TestBenchElement dateInput;
+    private TestBenchElement timeInput;
+
+    @Before
+    public void init() {
+        open();
+        dateTimePicker = $(DateTimePickerElement.class).first();
+        dateInput = dateTimePicker.$("input").first();
+        timeInput = dateTimePicker.$("input").last();
+    }
+
+    @Test
+    public void setDateInputValue_clearValue_inputValueIsEmpty() {
+        dateInput.sendKeys("1/1/2022", Keys.ENTER);
+        Assert.assertEquals("1/1/2022", dateInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", dateInput.getPropertyString("value"));
+    }
+
+    @Test
+    public void setTimeInputValue_clearValue_inputValueIsEmpty() {
+        timeInput.sendKeys("12:00 PM", Keys.ENTER);
+        Assert.assertEquals("12:00 PM", timeInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", timeInput.getPropertyString("value"));
+    }
+
+    @Test
+    public void setDateAndTimeInputValue_clearValue_inputValueIsEmpty() {
+        dateInput.sendKeys("1/1/2022", Keys.ENTER);
+        timeInput.sendKeys("12:00 PM", Keys.ENTER);
+        Assert.assertEquals("1/1/2022", dateInput.getPropertyString("value"));
+        Assert.assertEquals("12:00 PM", timeInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", dateInput.getPropertyString("value"));
+        Assert.assertEquals("", timeInput.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setDateInputValue_clearValue_inputValueIsEmpty() {
+        dateInput.sendKeys("INVALID", Keys.ENTER);
+        Assert.assertEquals("INVALID", dateInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", dateInput.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setTimeInputValue_clearValue_inputValueIsEmpty() {
+        timeInput.sendKeys("INVALID", Keys.ENTER);
+        Assert.assertEquals("INVALID", timeInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", timeInput.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setDateAndTimeInputValue_clearValue_inputValueIsEmpty() {
+        dateInput.sendKeys("INVALID", Keys.ENTER);
+        timeInput.sendKeys("INVALID", Keys.ENTER);
+        Assert.assertEquals("INVALID", dateInput.getPropertyString("value"));
+        Assert.assertEquals("INVALID", timeInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", dateInput.getPropertyString("value"));
+        Assert.assertEquals("", timeInput.getPropertyString("value"));
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBasicIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBasicIT.java
@@ -14,6 +14,7 @@ import static com.vaadin.flow.component.datetimepicker.validation.DateTimePicker
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBasicPage.MIN_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBasicPage.MAX_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBasicPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBasicPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-date-time-picker/validation/basic")
 public class DateTimePickerValidationBasicIT
@@ -168,6 +169,78 @@ public class DateTimePickerValidationBasicIT
         setInputValue(timeInput, "13:00");
         assertClientValid();
         assertServerValid();
+    }
+
+    @Test
+    public void badInput_changeValue_assertValidity() {
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+
+        setInputValue(dateInput, "1/1/2000");
+        setInputValue(timeInput, "10:00");
+        assertServerValid();
+        assertClientValid();
+
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setDateInputValue_blur_assertValidity() {
+        setInputValue(dateInput, "INVALID");
+        dateInput.sendKeys(Keys.TAB);
+        timeInput.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setTimeInputValue_blur_assertValidity() {
+        setInputValue(timeInput, "INVALID");
+        timeInput.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void badInput_setDateInputValue_blur_clearValue_assertValidity() {
+        setInputValue(dateInput, "INVALID");
+        dateInput.sendKeys(Keys.TAB);
+        timeInput.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void badInput_setTimeInputValue_blur_clearValue_assertValidity() {
+        setInputValue(timeInput, "INVALID");
+        timeInput.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     protected DateTimePickerElement getTestField() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBinderIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBinderIT.java
@@ -75,7 +75,7 @@ public class DateTimePickerValidationBinderIT
     }
 
     @Test
-    public void min_changeValue_assertValidity() {
+    public void min_changeInputValue_assertValidity() {
         $("input").id(MIN_INPUT).sendKeys("2000-02-02T12:00", Keys.ENTER);
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2000-03-03T11:00",
                 Keys.ENTER);

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBinderIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/DateTimePickerValidationBinderIT.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.Keys;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBinderPage.MIN_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBinderPage.MAX_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBinderPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBinderPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBinderPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.DateTimePickerValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -74,49 +75,7 @@ public class DateTimePickerValidationBinderIT
     }
 
     @Test
-    public void required_badInput_setDateInputValue_blur_assertValidity() {
-        setInputValue(dateInput, "INVALID");
-        dateInput.sendKeys(Keys.TAB);
-        timeInput.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage("");
-    }
-
-    @Test
-    public void required_badInput_setTimeInputValue_blur_assertValidity() {
-        setInputValue(timeInput, "INVALID");
-        timeInput.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage("");
-    }
-
-    @Test
-    public void badInput_changeInputValue_assertValidity() {
-        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2000-01-01T10:00",
-                Keys.ENTER);
-
-        setInputValue(dateInput, "INVALID");
-        setInputValue(timeInput, "INVALID");
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage("");
-
-        setInputValue(dateInput, "1/1/2000");
-        setInputValue(timeInput, "10:00");
-        assertServerValid();
-        assertClientValid();
-
-        setInputValue(dateInput, "INVALID");
-        setInputValue(timeInput, "INVALID");
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage("");
-    }
-
-    @Test
-    public void min_changeInputValue_assertValidity() {
+    public void min_changeValue_assertValidity() {
         $("input").id(MIN_INPUT).sendKeys("2000-02-02T12:00", Keys.ENTER);
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2000-03-03T11:00",
                 Keys.ENTER);
@@ -185,6 +144,43 @@ public class DateTimePickerValidationBinderIT
         setInputValue(timeInput, "13:00");
         assertClientValid();
         assertServerValid();
+    }
+
+    @Test
+    public void badInput_changeValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2000-01-01T10:00",
+                Keys.ENTER);
+
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        setInputValue(dateInput, "1/1/2000");
+        setInputValue(timeInput, "10:00");
+        assertServerValid();
+        assertClientValid();
+
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+    }
+
+    @Test
+    public void badInput_setValue_clearValue_assertValidity() {
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     protected DateTimePickerElement getTestField() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -22,8 +22,6 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;
@@ -57,6 +55,13 @@ class DateTimePickerDatePicker
 
     void passThroughPresentationValue(LocalDate newPresentationValue) {
         super.setPresentationValue(newPresentationValue);
+
+        if (Objects.equals(newPresentationValue, getEmptyValue())
+                && isInputValuePresent()) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+            getElement().setProperty("_hasInputValue", false);
+        }
     }
 
     @Synchronize(property = "_hasInputValue", value = "has-input-value-changed")
@@ -77,6 +82,13 @@ class DateTimePickerTimePicker
 
     void passThroughPresentationValue(LocalTime newPresentationValue) {
         super.setPresentationValue(newPresentationValue);
+
+        if (Objects.equals(newPresentationValue, getEmptyValue())
+                && isInputValuePresent()) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+            getElement().setProperty("_hasInputValue", false);
+        }
     }
 
     @Synchronize(property = "_hasInputValue", value = "has-input-value-changed")
@@ -299,9 +311,23 @@ public class DateTimePicker
      */
     @Override
     public void setValue(LocalDateTime value) {
+        LocalDateTime oldValue = getValue();
+
         value = sanitizeValue(value);
         super.setValue(value);
-        synchronizeChildComponentValues(value);
+
+        boolean isInputValuePresent = timePicker.isInputValuePresent()
+                || datePicker.isInputValuePresent();
+        boolean isValueRemainedEmpty = Objects.equals(oldValue, getEmptyValue())
+                && Objects.equals(value, getEmptyValue());
+        if (isValueRemainedEmpty && isInputValuePresent) {
+            // Clear the input elements from possible bad input.
+            synchronizeChildComponentValues(value);
+            fireEvent(new ClientValidatedEvent(this, false, true));
+        } else {
+            synchronizeChildComponentValues(value);
+        }
+
     }
 
     /**

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -22,6 +22,8 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;


### PR DESCRIPTION
## Description

The PR cherry-picks the following fix to `23.3`:

- #4431

> **Note**
> There were a few conflicts due to the new test naming and structure that we introduced in `24.0` but that we didn't backport to `23.3`.

Part of https://github.com/vaadin/flow-components/issues/4395

## Type of change

- [x] Bugfix
