### PR TITLE
fix(AbstractNumberField): clear possible bad input when setting an empty value (#4438) (CP: 23.3)

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.textfield.IntegerField;
+
+@Route("vaadin-integer-field/clear-value")
+public class IntegerFieldClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public IntegerFieldClearValuePage() {
+        IntegerField integerField = new IntegerField();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> integerField.clear());
+
+        add(integerField, clearButton);
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValuePage.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.textfield.NumberField;
+
+@Route("vaadin-number-field/clear-value")
+public class NumberFieldClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public NumberFieldClearValuePage() {
+        NumberField numberField = new NumberField();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> numberField.clear());
+
+        add(numberField, clearButton);
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.textfield.tests.IntegerFieldClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-integer-field/clear-value")
+public class IntegerFieldClearValueIT extends AbstractComponentIT {
+    private IntegerFieldElement integerField;
+
+    private TestBenchElement input;
+
+    @Before
+    public void init() {
+        open();
+        integerField = $(IntegerFieldElement.class).first();
+        input = integerField.$("input").first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        integerField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
+        // Native [type=number] inputs don't update their value
+        // when you are entering input that the browser is unable to parse,
+        // so we have to rely on HTML constraints to determine
+        // whether the input element is empty or not.
+        integerField.sendKeys("--2", Keys.ENTER);
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertTrue((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertFalse((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.NumberFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.textfield.tests.NumberFieldClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-number-field/clear-value")
+public class NumberFieldClearValueIT extends AbstractComponentIT {
+    private NumberFieldElement numberField;
+
+    private TestBenchElement input;
+
+    @Before
+    public void init() {
+        open();
+        numberField = $(NumberFieldElement.class).first();
+        input = numberField.$("input").first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        numberField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
+        // Native [type=number] inputs don't update their value
+        // when you are entering input that the browser is unable to parse,
+        // so we have to rely on HTML constraints to determine
+        // whether the input element is empty or not.
+        numberField.sendKeys("--2", Keys.ENTER);
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertTrue((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+        Assert.assertFalse((Boolean) executeScript(
+                "return arguments[0].validity.badInput", input));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.component.textfield;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;
@@ -342,7 +343,15 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      */
     @Override
     public void setValue(T value) {
+        T oldValue = getValue();
+
         super.setValue(value);
+
+        if (Objects.equals(oldValue, getEmptyValue())
+                && Objects.equals(value, getEmptyValue())) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The PR partially cherry-picks the following fix to `23.3`:

- #4431

> **Note**
> The new validation behavior isn't implemented for number fields in 23.3, so there are no `BasicValidationIT`, `BinderValidationIT`.

Part of https://github.com/vaadin/flow-components/issues/4395

## Type of change

- [x] Bugfix
