### PR TITLE
refactor: add setSlot helper, check for adding Text

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -338,8 +338,7 @@ public class ConfirmDialog extends Component
      *            the element to display instead of default Reject button
      */
     public void setRejectButton(Element element) {
-        SlotUtils.clearSlot(this, "reject-button");
-        SlotUtils.addToSlot(this, "reject-button", element);
+        SlotUtils.setSlot(this, "reject-button", element);
     }
 
     /**
@@ -392,8 +391,7 @@ public class ConfirmDialog extends Component
      *            the element to display instead of default Cancel button
      */
     public void setCancelButton(Element element) {
-        SlotUtils.clearSlot(this, "cancel-button");
-        SlotUtils.addToSlot(this, "cancel-button", element);
+        SlotUtils.setSlot(this, "cancel-button", element);
     }
 
     /**
@@ -445,8 +443,7 @@ public class ConfirmDialog extends Component
      *            the element to display instead of default Confirm button
      */
     public void setConfirmButton(Element element) {
-        SlotUtils.clearSlot(this, "confirm-button");
-        SlotUtils.addToSlot(this, "confirm-button", element);
+        SlotUtils.setSlot(this, "confirm-button", element);
     }
 
     /**
@@ -569,8 +566,7 @@ public class ConfirmDialog extends Component
      *            the element to display instead of default header text
      */
     public void setHeader(Element element) {
-        SlotUtils.clearSlot(this, "header");
-        SlotUtils.addToSlot(this, "header", element);
+        SlotUtils.setSlot(this, "header", element);
     }
 
     /**

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -502,8 +502,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
      *            the content to be set
      */
     public void setToolbar(Component... components) {
-        SlotUtils.clearSlot(this, "toolbar");
-        SlotUtils.addToSlot(this, "toolbar", components);
+        SlotUtils.setSlot(this, "toolbar", components);
     }
 
     /**
@@ -564,13 +563,8 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
      * @param button
      */
     public void setNewButton(Component button) {
-        SlotUtils.clearSlot(this, "new-button");
-
         newButton = button;
-
-        if (button != null) {
-            SlotUtils.addToSlot(this, "new-button", button);
-        }
+        SlotUtils.setSlot(this, "new-button", button);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/SlotUtils.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/SlotUtils.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.shared;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.dom.Element;
 
 import java.util.Objects;
@@ -85,16 +86,25 @@ public class SlotUtils {
      *            the name of the slot inside the parent, not {@code null}
      * @param components
      *            components to add to the specified slot.
+     * @throws IllegalArgumentException
+     *             if any of the components is a {@link Text} component.
      * @throws NullPointerException
-     *             if any of the components is null or if the components array
-     *             is null.
+     *             if the components array is null.
      */
     public static void addToSlot(HasElement parent, String slot,
             Component... components) {
         Objects.requireNonNull(parent, "Parent cannot be null");
 
         for (Component component : components) {
-            addElementToSlot(parent, component.getElement(), slot);
+            if (component != null) {
+                if (component instanceof Text) {
+                    throw new IllegalArgumentException("Text as a " + slot
+                            + " slot content is not supported. "
+                            + "Consider wrapping the Text inside a Div.");
+                }
+
+                addElementToSlot(parent, component.getElement(), slot);
+            }
         }
     }
 
@@ -108,16 +118,59 @@ public class SlotUtils {
      * @param elements
      *            elements to add to the specified slot.
      * @throws NullPointerException
-     *             if any of the elements is null or if the elements array is
-     *             null.
+     *             if the elements array is null.
      */
     public static void addToSlot(HasElement parent, String slot,
             Element... elements) {
         Objects.requireNonNull(parent, "Parent cannot be null");
 
         for (Element element : elements) {
-            addElementToSlot(parent, element, slot);
+            if (element != null) {
+                addElementToSlot(parent, element, slot);
+            }
         }
+    }
+
+    /**
+     * Clears the specific slot in the parent component and adds components to
+     * it.
+     *
+     * @param parent
+     *            the parent component to add the components to, not
+     *            {@code null}
+     * @param slot
+     *            the name of the slot inside the parent, not {@code null}
+     * @param components
+     *            components to add to the specified slot.
+     * @throws NullPointerException
+     *             if the components array is null.
+     */
+    public static void setSlot(HasElement parent, String slot,
+            Component... components) {
+        Objects.requireNonNull(parent, "Parent cannot be null");
+
+        clearSlot(parent, slot);
+        addToSlot(parent, slot, components);
+    }
+
+    /**
+     * Clears the specific slot in the parent component and adds elements to it.
+     *
+     * @param parent
+     *            the parent component to add the elements to, not {@code null}
+     * @param slot
+     *            the name of the slot inside the parent, not {@code null}
+     * @param elements
+     *            elements to add to the specified slot.
+     * @throws NullPointerException
+     *             if the elements array is null.
+     */
+    public static void setSlot(HasElement parent, String slot,
+            Element... elements) {
+        Objects.requireNonNull(parent, "Parent cannot be null");
+
+        clearSlot(parent, slot);
+        addToSlot(parent, slot, elements);
     }
 
     private static void addElementToSlot(HasElement parent, Element element,

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -145,11 +145,8 @@ public class Tooltip implements Serializable {
      * @return the tooltip handle
      */
     static Tooltip forHasTooltip(HasTooltip hasTooltip) {
-        // Clear any existing tooltip
-        SlotUtils.clearSlot(hasTooltip, "tooltip");
-
         var tooltip = new Tooltip();
-        SlotUtils.addToSlot(hasTooltip, "tooltip", tooltip.tooltipElement);
+        SlotUtils.setSlot(hasTooltip, "tooltip", tooltip.tooltipElement);
         elementTooltips.put(hasTooltip.getElement(), tooltip);
         return tooltip;
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/SlotUtilsTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/SlotUtilsTest.java
@@ -54,8 +54,24 @@ public class SlotUtilsTest {
     }
 
     @Test
+    public void addToSlot_elementIsAdded() {
+        SlotUtils.addToSlot(parent, TEST_SLOT, new Element("div"));
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+    }
+
+    @Test
     public void setSlot_componentIsAdded() {
         SlotUtils.setSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+    }
+
+    @Test
+    public void setSlot_elementIsAdded() {
+        SlotUtils.setSlot(parent, TEST_SLOT, new Element("div"));
 
         Assert.assertEquals(1,
                 SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/SlotUtilsTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/SlotUtilsTest.java
@@ -15,11 +15,14 @@
  */
 package com.vaadin.flow.component.shared;
 
-import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.dom.ElementFactory;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -27,33 +30,110 @@ import org.junit.Test;
  */
 public class SlotUtilsTest {
 
+    @Tag("div")
+    private static class TestComponent extends Component
+            implements HasComponents {
+    }
+
     private static final String TEST_SLOT = "testSlot";
     private static final String OTHER_SLOT = "otherSlot";
 
-    @Test
-    public void clearSlotShouldOnlyRemoveElementsFromMatchingSlot() {
-        Element div = ElementFactory.createDiv();
-        div.appendChild(span(TEST_SLOT));
-        div.appendChild(span(OTHER_SLOT));
+    private TestComponent parent;
 
-        HasElement hasElement = () -> div;
-
-        Assert.assertEquals(1,
-                SlotUtils.getElementsInSlot(hasElement, TEST_SLOT).count());
-        Assert.assertEquals(1,
-                SlotUtils.getElementsInSlot(hasElement, OTHER_SLOT).count());
-
-        SlotUtils.clearSlot(hasElement, TEST_SLOT);
-
-        Assert.assertEquals(0,
-                SlotUtils.getElementsInSlot(hasElement, TEST_SLOT).count());
-        Assert.assertEquals(1,
-                SlotUtils.getElementsInSlot(hasElement, OTHER_SLOT).count());
+    @Before
+    public void setup() {
+        parent = new TestComponent();
     }
 
-    private static Element span(String slot) {
-        Element span = ElementFactory.createSpan();
-        span.setAttribute("slot", slot);
-        return span;
+    @Test
+    public void addToSlot_componentIsAdded() {
+        SlotUtils.addToSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+    }
+
+    @Test
+    public void setSlot_componentIsAdded() {
+        SlotUtils.setSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+    }
+
+    @Test
+    public void addToSlot_oldComponentIsNotRemoved() {
+        SlotUtils.addToSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+
+        SlotUtils.addToSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(2,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+    }
+
+    @Test
+    public void setSlot_oldComponentIsRemoved() {
+        SlotUtils.setSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+
+        SlotUtils.setSlot(parent, TEST_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+    }
+
+    @Test
+    public void clearSlot_onlyMatchingSlotChildIsRemoved() {
+        SlotUtils.addToSlot(parent, TEST_SLOT, new TestComponent());
+        SlotUtils.addToSlot(parent, OTHER_SLOT, new TestComponent());
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, OTHER_SLOT).count());
+
+        SlotUtils.clearSlot(parent, TEST_SLOT);
+
+        Assert.assertEquals(0,
+                SlotUtils.getElementsInSlot(parent, TEST_SLOT).count());
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(parent, OTHER_SLOT).count());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addToSlot_textNodeAsComponent_throws() {
+        Text textNode = new Text("Text");
+        SlotUtils.addToSlot(parent, TEST_SLOT, textNode);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSlot_textNodeAsComponent_throws() {
+        Text textNode = new Text("Text");
+        SlotUtils.setSlot(parent, TEST_SLOT, textNode);
+    }
+
+    @Test
+    public void addToSlot_nullAsComponent_doesNotThrow() {
+        SlotUtils.addToSlot(parent, TEST_SLOT, new TestComponent(), null);
+    }
+
+    @Test
+    public void setSlot_nullAsComponent_doesNotThrow() {
+        SlotUtils.setSlot(parent, TEST_SLOT, new TestComponent(), null);
+    }
+
+    @Test
+    public void addToSlot_nullAsElement_doesNotThrow() {
+        SlotUtils.addToSlot(parent, TEST_SLOT, new Element("div"), null);
+    }
+
+    @Test
+    public void setSlot_nullAsElement_doesNotThrow() {
+        SlotUtils.setSlot(parent, TEST_SLOT, new Element("div"), null);
     }
 }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -290,16 +290,7 @@ public class TabSheet extends Component
      *            prefix component
      */
     public void setPrefixComponent(Component component) {
-        SlotUtils.clearSlot(this, "prefix");
-
-        if (component != null) {
-            if (component instanceof Text) {
-                throw new IllegalArgumentException(
-                        "Text as a prefix is not supported. Consider wrapping the Text inside a Div.");
-            }
-
-            SlotUtils.addToSlot(this, "prefix", component);
-        }
+        SlotUtils.setSlot(this, "prefix", component);
     }
 
     /**
@@ -325,16 +316,7 @@ public class TabSheet extends Component
      *            suffix component
      */
     public void setSuffixComponent(Component component) {
-        SlotUtils.clearSlot(this, "suffix");
-
-        if (component != null) {
-            if (component instanceof Text) {
-                throw new IllegalArgumentException(
-                        "Text as a suffix is not supported. Consider wrapping the Text inside a Div.");
-            }
-
-            SlotUtils.addToSlot(this, "suffix", component);
-        }
+        SlotUtils.setSlot(this, "suffix", component);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/HasPrefixAndSuffix.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/HasPrefixAndSuffix.java
@@ -39,11 +39,7 @@ public interface HasPrefixAndSuffix extends HasElement {
      *            prefix component
      */
     default void setPrefixComponent(Component component) {
-        SlotUtils.clearSlot(this, "prefix");
-
-        if (component != null) {
-            SlotUtils.addToSlot(this, "prefix", component);
-        }
+        SlotUtils.setSlot(this, "prefix", component);
     }
 
     /**
@@ -69,11 +65,7 @@ public interface HasPrefixAndSuffix extends HasElement {
      *            suffix component
      */
     default void setSuffixComponent(Component component) {
-        SlotUtils.clearSlot(this, "suffix");
-
-        if (component != null) {
-            SlotUtils.addToSlot(this, "suffix", component);
-        }
+        SlotUtils.setSlot(this, "suffix", component);
     }
 
     /**

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -327,15 +327,13 @@ public class Upload extends Component implements HasSize, HasStyle {
      *            <code>null</code> to reset to the default button
      */
     public void setUploadButton(Component button) {
-        SlotUtils.clearSlot(this, "add-button");
-
         if (button != null) {
             uploadButton = button;
         } else {
             uploadButton = defaultUploadButton;
         }
 
-        SlotUtils.addToSlot(this, "add-button", uploadButton);
+        SlotUtils.setSlot(this, "add-button", uploadButton);
     }
 
     /**
@@ -356,15 +354,13 @@ public class Upload extends Component implements HasSize, HasStyle {
      *            or <code>null</code> to reset to the default label
      */
     public void setDropLabel(Component label) {
-        SlotUtils.clearSlot(this, "drop-label");
-
         if (label != null) {
             dropLabel = label;
         } else {
             dropLabel = defaultDropLabel;
         }
 
-        SlotUtils.addToSlot(this, "drop-label", dropLabel);
+        SlotUtils.setSlot(this, "drop-label", dropLabel);
     }
 
     /**
@@ -386,15 +382,13 @@ public class Upload extends Component implements HasSize, HasStyle {
      *            drop files, or <code>null</code> to reset to the default icon
      */
     public void setDropLabelIcon(Component icon) {
-        SlotUtils.clearSlot(this, "drop-label-icon");
-
         if (icon != null) {
             dropLabelIcon = icon;
         } else {
             dropLabelIcon = defaultDropLabelIcon;
         }
 
-        SlotUtils.addToSlot(this, "drop-label-icon", dropLabelIcon);
+        SlotUtils.setSlot(this, "drop-label-icon", dropLabelIcon);
     }
 
     /**


### PR DESCRIPTION
## Description

Follow-up to #4427 inspired by https://github.com/vaadin/flow-components/pull/4427#discussion_r1057763912 - once again thanks @knoobie for the idea 🙇‍♂️ 

Related to #1574 - there will be a proper exception now for `Text`, like the one in `TabSheet`:
https://github.com/vaadin/flow-components/blob/35154825bca56b8b91dc0e92e7e3178ff0d0bfb7/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java#L297-L300

Also added missing unit tests for `addToSlot` as well as for the newly added `setSlot`.

## Type of change

- Refactor