### PR TITLE
fix(BigDecimalField): clear possible bad input when setting an empty value (#4442) (CP: 23.3)

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.textfield.BigDecimalField;
+
+@Route("vaadin-big-decimal-field/clear-value")
+public class BigDecimalFieldClearValuePage extends Div {
+    public static final String CLEAR_BUTTON = "clear-button";
+
+    public BigDecimalFieldClearValuePage() {
+        BigDecimalField bigDecimalField = new BigDecimalField();
+
+        NativeButton clearButton = new NativeButton("Clear value");
+        clearButton.setId(CLEAR_BUTTON);
+        clearButton.addClickListener(event -> bigDecimalField.clear());
+
+        add(bigDecimalField, clearButton);
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
@@ -1,0 +1,45 @@
+package com.vaadin.flow.component.textfield.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.BigDecimalFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.textfield.tests.BigDecimalFieldClearValuePage.CLEAR_BUTTON;
+
+@TestPath("vaadin-big-decimal-field/clear-value")
+public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
+    private BigDecimalFieldElement bigDecimalField;
+
+    private TestBenchElement input;
+
+    @Before
+    public void init() {
+        open();
+        bigDecimalField = $(BigDecimalFieldElement.class).first();
+        input = bigDecimalField.$("input").first();
+    }
+
+    @Test
+    public void setInputValue_clearValue_inputValueIsEmpty() {
+        bigDecimalField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
+        bigDecimalField.sendKeys("--2", Keys.ENTER);
+        Assert.assertEquals("--2", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_BUTTON).click();
+        Assert.assertEquals("", input.getPropertyString("value"));
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -373,7 +373,6 @@ public class BigDecimalField
                 && Objects.equals(value, getEmptyValue())) {
             // Clear the input element from possible bad input.
             getElement().executeJs("this.inputElement.value = ''");
-            getElement().setProperty("_hasInputValue", false);
         }
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -365,7 +365,16 @@ public class BigDecimalField
      */
     @Override
     public void setValue(BigDecimal value) {
+        BigDecimal oldValue = getValue();
+
         super.setValue(value);
+
+        if (Objects.equals(oldValue, getEmptyValue())
+                && Objects.equals(value, getEmptyValue())) {
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this.inputElement.value = ''");
+            getElement().setProperty("_hasInputValue", false);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The PR partially cherry-picks the following fix to `23.3`:

- #4442

> **Note**
> The new validation behavior isn't implemented for number fields in 23.3, so there are no `BasicValidationIT`, `BinderValidationIT`.

Part of https://github.com/vaadin/flow-components/issues/4395

## Type of change

- [x] Bugfix
