### PR TITLE
feat: add HasPrefix and HasSuffix shared interfaces

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasPrefix.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasPrefix.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * Mixin interface for components that have a prefix slot.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasPrefix extends HasElement {
+    /**
+     * Adds the given component into this field before the content, replacing
+     * any existing prefix component.
+     * <p>
+     * This is most commonly used to add a simple icon or static text into the
+     * field.
+     *
+     * @param component
+     *            the component to set, can be {@code null} to remove existing
+     *            prefix component
+     */
+    default void setPrefixComponent(Component component) {
+        SlotUtils.setSlot(this, "prefix", component);
+    }
+
+    /**
+     * Gets the component in the prefix slot of this field.
+     *
+     * @return the prefix component of this field, or {@code null} if no prefix
+     *         component has been set
+     * @see #setPrefixComponent(Component)
+     */
+    default Component getPrefixComponent() {
+        return SlotUtils.getChildInSlot(this, "prefix");
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasSuffix.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasSuffix.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * Mixin interface for components that have a suffix slot.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasSuffix extends HasElement {
+    /**
+     * Adds the given component into this field after the content, replacing any
+     * existing suffix component.
+     * <p>
+     * This is most commonly used to add a simple icon or static text into the
+     * field.
+     *
+     * @param component
+     *            the component to set, can be {@code null} to remove existing
+     *            suffix component
+     */
+    default void setSuffixComponent(Component component) {
+        SlotUtils.setSlot(this, "suffix", component);
+    }
+
+    /**
+     * Gets the component in the suffix slot of this field.
+     *
+     * @return the suffix component of this field, or {@code null} if no suffix
+     *         component has been set
+     * @see #setPrefixComponent(Component)
+     */
+    default Component getSuffixComponent() {
+        return SlotUtils.getChildInSlot(this, "suffix");
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasPrefixTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasPrefixTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+public class HasPrefixTest {
+
+    @Tag("test")
+    private static class TestComponent extends Component implements HasPrefix {
+    }
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void getPrefix_noComponentByDefault() {
+        Assert.assertNull(component.getPrefixComponent());
+    }
+
+    @Test
+    public void setPrefix_replacesPrefix() {
+        TestComponent foo = new TestComponent();
+        component.setPrefixComponent(foo);
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(component, "prefix").count());
+        Assert.assertEquals(foo, component.getPrefixComponent());
+
+        TestComponent bar = new TestComponent();
+        component.setPrefixComponent(bar);
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(component, "prefix").count());
+        Assert.assertEquals(bar, component.getPrefixComponent());
+    }
+
+    @Test
+    public void setPrefix_setPrefixNull_prefixRemoved() {
+        component.setPrefixComponent(new TestComponent());
+        component.setPrefixComponent(null);
+
+        Assert.assertNull(component.getPrefixComponent());
+        Assert.assertEquals(0,
+                SlotUtils.getElementsInSlot(component, "prefix").count());
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasSuffixTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasSuffixTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+public class HasSuffixTest {
+
+    @Tag("test")
+    private static class TestComponent extends Component implements HasSuffix {
+    }
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void getSuffix_noComponentByDefault() {
+        Assert.assertNull(component.getSuffixComponent());
+    }
+
+    @Test
+    public void setSuffix_replacesSuffix() {
+        TestComponent foo = new TestComponent();
+        component.setSuffixComponent(foo);
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(component, "suffix").count());
+        Assert.assertEquals(foo, component.getSuffixComponent());
+
+        TestComponent bar = new TestComponent();
+        component.setSuffixComponent(bar);
+
+        Assert.assertEquals(1,
+                SlotUtils.getElementsInSlot(component, "suffix").count());
+        Assert.assertEquals(bar, component.getSuffixComponent());
+    }
+
+    @Test
+    public void setSuffix_setSuffixNull_suffixRemoved() {
+        component.setSuffixComponent(new TestComponent());
+        component.setSuffixComponent(null);
+
+        Assert.assertNull(component.getSuffixComponent());
+        Assert.assertEquals(0,
+                SlotUtils.getElementsInSlot(component, "suffix").count());
+    }
+}


### PR DESCRIPTION
## Description

Inspired by https://github.com/vaadin/flow-components/pull/4377#discussion_r1050102495 

Pre-requisite for #1594

Created two separate interfaces: `HasPrefix` and `HasSuffix` based on the `HasPrefixAndSuffix` interface.
I will create a separate PR to update `TextField` and other components to use these new interfaces.

After all the components are updated, we could probably drop `HasPrefixAndSuffix` as no longer needed.

## Type of change

- Internal feature