### PR TITLE
refactor: replace template with renderer function in dialog

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -76,14 +76,13 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/dialog", version = "24.0.0-alpha7")
 @JsModule("@vaadin/dialog/src/vaadin-dialog.js")
-@JsModule("@vaadin/polymer-legacy-adapter/template-renderer.js")
 @JsModule("./dialogConnector.js")
 @JsModule("./flow-component-renderer.js")
 public class Dialog extends Component implements HasComponents, HasSize,
         HasStyle, HasThemeVariant<DialogVariant> {
 
     private static final String OVERLAY_LOCATOR_JS = "this.$.overlay";
-    private Element template;
+
     private Element container;
     private boolean autoAddedToTheUi;
     private int onCloseConfigured;
@@ -102,11 +101,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * Creates an empty dialog.
      */
     public Dialog() {
-        getElement().setAttribute("suppress-template-warning", true);
-
-        template = new Element("template");
-        getElement().appendChild(template);
-
         container = new Element("div");
         container.getClassList().add("draggable");
         container.getClassList().add("draggable-leaf-only");
@@ -975,7 +969,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
         String renderer = String.format(
                 "<flow-component-renderer appid=\"%s\" nodeid=\"%s\" style=\"display: flex; height: 100%%;\"></flow-component-renderer>",
                 appId, nodeId);
-        template.setProperty("innerHTML", renderer);
+        getElement().executeJs("this.renderer = root => root.innerHTML = $0",
+                renderer);
 
         setDimension(ElementConstants.STYLE_WIDTH, width);
         setDimension(ElementConstants.STYLE_MIN_WIDTH, minWidth);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -969,7 +969,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
         String renderer = String.format(
                 "<flow-component-renderer appid=\"%s\" nodeid=\"%s\" style=\"display: flex; height: 100%%;\"></flow-component-renderer>",
                 appId, nodeId);
-        getElement().executeJs("this.renderer = root => root.innerHTML = $0",
+        getElement().executeJs(
+                "this.renderer = (root) => { if (!root.firstChild) { root.innerHTML = $0 } }",
                 renderer);
 
         setDimension(ElementConstants.STYLE_WIDTH, width);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -97,14 +97,6 @@ public class DialogTest {
         Assert.assertEquals(dialog.getHeight(), "100px");
     }
 
-    @Test
-    public void templateWarningSuppressed() {
-        Dialog dialog = new Dialog();
-
-        Assert.assertTrue("Template warning is not suppressed",
-                dialog.getElement().hasAttribute("suppress-template-warning"));
-    }
-
     @Test(expected = IllegalStateException.class)
     public void setOpened_noUi() {
         UI.setCurrent(null);
@@ -123,7 +115,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations(8);
+        assertInvocations(9);
     }
 
     @Test
@@ -132,7 +124,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertEquals(7, flushInvocations().size());
+        Assert.assertEquals(8, flushInvocations().size());
 
         dialog.addDialogCloseActionListener(event -> {
         });
@@ -156,7 +148,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertEquals(7, flushInvocations().size());
+        Assert.assertEquals(8, flushInvocations().size());
     }
 
     @Test
@@ -171,7 +163,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertEquals(7, flushInvocations().size());
+        Assert.assertEquals(8, flushInvocations().size());
     }
 
     @Test
@@ -204,7 +196,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations(8);
+        assertInvocations(9);
     }
 
     @Test
@@ -222,7 +214,7 @@ public class DialogTest {
 
         registration.remove();
 
-        assertInvocations(8);
+        assertInvocations(9);
     }
 
     @Test


### PR DESCRIPTION
## Description

The `Dialog` component currently uses a `<template>` tag internally to add the `flow-component-renderer` inside its overlay. This PR
- replaces the `<template>` with a `renderer` function
- removes the dependency to `@vaadin/polymer-legacy-adapter/template-renderer.js`
- removes the `suppress-template-warning` attribute from the `<vaadin-dialog>` element

## Type of change

Refactor