### PR TITLE
refactor: replace template with renderer function in notification

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -281,7 +281,8 @@ public class Notification extends Component implements HasComponents, HasStyle,
      */
     public void setText(String text) {
         removeAll();
-        this.getElement().setProperty("text", HtmlUtils.escape(text));
+        this.getElement().setProperty("text",
+                text != null ? HtmlUtils.escape(text) : null);
         this.getElement().callJsFunction("requestContentUpdate");
     }
 

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -39,7 +39,6 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.dom.Style;
-import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.HtmlUtils;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.router.NavigationTrigger;
@@ -56,7 +55,6 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/notification", version = "24.0.0-alpha8")
 @JsModule("@vaadin/notification/src/vaadin-notification.js")
-@JsModule("@vaadin/polymer-legacy-adapter/template-renderer.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./notificationConnector.js")
 public class Notification extends Component implements HasComponents, HasStyle,
@@ -65,32 +63,10 @@ public class Notification extends Component implements HasComponents, HasStyle,
     private static final int DEFAULT_DURATION = 5000;
     private static final Position DEFAULT_POSITION = Position.BOTTOM_START;
 
-    private static final SerializableConsumer<UI> NO_OP = ui -> {
-    };
-
     private final Element container = ElementFactory.createDiv();
-    private final Element templateElement = new Element("template");
     private boolean autoAddedToTheUi = false;
 
     private Registration afterProgrammaticNavigationListenerRegistration;
-
-    private SerializableConsumer<UI> configureTemplate = new ConfigureComponentRenderer();
-
-    private class ConfigureComponentRenderer
-            implements SerializableConsumer<UI> {
-
-        @Override
-        public void accept(UI ui) {
-            if (this == configureTemplate) {
-                String appId = ui.getInternals().getAppId();
-                int nodeId = container.getNode().getId();
-                String template = String.format(
-                        "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
-                        appId, nodeId);
-                templateElement.setProperty("innerHTML", template);
-            }
-        }
-    }
 
     /**
      * Enumeration of all available positions for notification component
@@ -129,6 +105,37 @@ public class Notification extends Component implements HasComponents, HasStyle,
                     : Position.valueOf(clientName.replace('-', '_')
                             .toUpperCase(Locale.ENGLISH));
         }
+    }
+
+    /**
+     * Assigns a renderer function to the notification.
+     *
+     * If the Web Component has {@code text} property defined, it will be used
+     * as the text content of the notification.
+     *
+     * Otherwise, {@code this.container} will be included in the notification
+     * with {@code <flow-component-renderer>}
+     */
+    private void configureRenderer() {
+        String appId = UI.getCurrent() != null
+                ? UI.getCurrent().getInternals().getAppId()
+                : "ROOT";
+        int nodeId = container.getNode().getId();
+        String template = String.format(
+                "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
+                appId, nodeId);
+
+        getElement().executeJs(
+        //@formatter:off
+        "this.renderer = (root, notification) => {" +
+        "  if (notification.text) {" +
+        "    root.textContent = notification.text;" +
+        "  } else if (!root.firstElementChild) {" +
+        "    root.innerHTML = $0;" +
+        "  }" +
+        "}",
+        //@formatter:on
+                template);
     }
 
     /**
@@ -209,9 +216,6 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     private void initBaseElementsAndListeners() {
-        getElement().setAttribute("suppress-template-warning", true);
-
-        getElement().appendChild(templateElement);
         getElement().appendVirtualChild(container);
 
         getElement().addEventListener("opened-changed",
@@ -277,8 +281,8 @@ public class Notification extends Component implements HasComponents, HasStyle,
      */
     public void setText(String text) {
         removeAll();
-        configureTemplate = NO_OP;
-        templateElement.setProperty("innerHTML", HtmlUtils.escape(text));
+        this.getElement().setProperty("text", HtmlUtils.escape(text));
+        this.getElement().callJsFunction("requestContentUpdate");
     }
 
     /**
@@ -572,16 +576,15 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     private void configureComponentRenderer() {
-        configureTemplate = new ConfigureComponentRenderer();
-        getElement().getNode()
-                .runWhenAttached(ui -> configureTemplate.accept(ui));
+        this.getElement().removeProperty("text");
+        this.getElement().callJsFunction("requestContentUpdate");
     }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
-        configureTemplate.accept(attachEvent.getUI());
+        configureRenderer();
     }
 
     @Override

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -125,17 +125,17 @@ public class Notification extends Component implements HasComponents, HasStyle,
                 "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
                 appId, nodeId);
 
-        getElement().executeJs(
         //@formatter:off
-        "this.renderer = (root, notification) => {" +
-        "  if (notification.text) {" +
-        "    root.textContent = notification.text;" +
-        "  } else if (!root.firstElementChild) {" +
-        "    root.innerHTML = $0;" +
-        "  }" +
-        "}",
+        getElement().executeJs(
+            "this.renderer = (root, notification) => {" +
+            "  if (notification.text) {" +
+            "    root.textContent = notification.text;" +
+            "  } else if (!root.firstElementChild) {" +
+            "    root.innerHTML = $0;" +
+            "  }" +
+            "}",
+            template);
         //@formatter:on
-                template);
     }
 
     /**

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.notification.Notification.Position;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinSession;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -143,14 +142,6 @@ public class NotificationTest {
         }
     }
 
-    @Test
-    public void templateWarningSuppressed() {
-        Notification notification = new Notification();
-
-        Assert.assertTrue("Template warning is not suppressed", notification
-                .getElement().hasAttribute("suppress-template-warning"));
-    }
-
     @Test(expected = IllegalStateException.class)
     public void setOpened_noUiInstance() {
         UI.setCurrent(null);
@@ -178,43 +169,6 @@ public class NotificationTest {
 
         Assert.assertEquals(Position.BOTTOM_START, notification.getPosition());
         Assert.assertEquals(5000, notification.getDuration());
-    }
-
-    @Test
-    public void setText_notificationHasAddedComponents_innerHtmlIsTextValue() {
-        Notification notification = new Notification();
-
-        notification.add(new Div());
-        notification.setText("foo");
-
-        notification.open();
-
-        flushBeforeClientResponse();
-
-        Element templateElement = notification.getElement().getChildren()
-                .findFirst().get();
-
-        String innerHtml = templateElement.getProperty("innerHTML");
-        Assert.assertEquals("foo", innerHtml);
-    }
-
-    @Test
-    public void add_notificationHasText_innerHtmlIsTemplateValue() {
-        Notification notification = new Notification();
-
-        notification.setText("foo");
-        notification.add(new Div());
-
-        notification.open();
-
-        flushBeforeClientResponse();
-
-        Element templateElement = notification.getElement().getChildren()
-                .findFirst().get();
-
-        String innerHtml = templateElement.getProperty("innerHTML");
-        Assert.assertThat(innerHtml,
-                CoreMatchers.startsWith("<flow-component-renderer"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.notification.Notification.Position;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinSession;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -169,6 +170,39 @@ public class NotificationTest {
 
         Assert.assertEquals(Position.BOTTOM_START, notification.getPosition());
         Assert.assertEquals(5000, notification.getDuration());
+    }
+
+    @Test
+    public void addComponent_setText_notificationHasText() {
+        Notification notification = new Notification();
+
+        notification.add(new Div());
+        notification.setText("foo");
+
+        Assert.assertEquals("foo",
+                notification.getElement().getProperty("text"));
+    }
+
+    @Test
+    public void setText_addComponent_notificationDoesNotHaveText() {
+        Notification notification = new Notification();
+
+        notification.setText("foo");
+        notification.add(new Div());
+
+        Assert.assertEquals(null,
+                notification.getElement().getProperty("text"));
+    }
+
+    @Test
+    public void setText_setTextNull_notificationDoesNotHaveText() {
+        Notification notification = new Notification();
+
+        notification.setText("foo");
+        notification.setText(null);
+
+        Assert.assertEquals(null,
+                notification.getElement().getProperty("text"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## Description

The `Notification` component currently uses a `<template>` tag internally to populate its overlay. This PR
- replaces the `<template>` with a `renderer` function
- removes the dependency to `@vaadin/polymer-legacy-adapter/template-renderer.js`
- removes the `suppress-template-warning` attribute from the `<vaadin-dialog>` element

## Type of change

Refactor