### PR TITLE
refactor!: relocate Renderer API with custom function name

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnPathRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnPathRenderer.java
@@ -61,7 +61,7 @@ public class ColumnPathRenderer<SOURCE> extends Renderer<SOURCE> {
 
     @Override
     public Rendering<SOURCE> render(Element container,
-            DataKeyMapper<SOURCE> keyMapper) {
+            DataKeyMapper<SOURCE> keyMapper, String rendererName) {
         container.setProperty("path", property);
 
         // disables the automatic creation of headers when the path is used

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -121,7 +121,6 @@ import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -2865,22 +2864,20 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             return;
         }
 
-        if (renderer instanceof LitRenderer) {
-            var rendering = ((LitRenderer<T>) renderer).render(getElement(),
-                    dataCommunicator.getKeyMapper(), "rowDetailsRenderer");
+        var rendering = renderer.render(getElement(),
+                dataCommunicator.getKeyMapper(), "rowDetailsRenderer");
 
-            rendering.getDataGenerator().ifPresent(renderingDataGenerator -> {
-                itemDetailsDataGenerator = renderingDataGenerator;
-                Registration detailsRenderingDataGeneratorRegistration = () -> {
-                    detailsManager.destroyAllData();
-                    itemDetailsDataGenerator = null;
-                };
-                detailsRenderingRegistrations
-                        .add(detailsRenderingDataGeneratorRegistration);
-            });
+        rendering.getDataGenerator().ifPresent(renderingDataGenerator -> {
+            itemDetailsDataGenerator = renderingDataGenerator;
+            Registration detailsRenderingDataGeneratorRegistration = () -> {
+                detailsManager.destroyAllData();
+                itemDetailsDataGenerator = null;
+            };
+            detailsRenderingRegistrations
+                    .add(detailsRenderingDataGeneratorRegistration);
+        });
 
-            detailsRenderingRegistrations.add(rendering.getRegistration());
-        }
+        detailsRenderingRegistrations.add(rendering.getRegistration());
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
@@ -137,7 +137,8 @@ public class EditorRenderer<T> extends Renderer<T> implements DataGenerator<T> {
     }
 
     @Override
-    public Rendering<T> render(Element container, DataKeyMapper<T> keyMapper) {
+    public Rendering<T> render(Element container, DataKeyMapper<T> keyMapper,
+            String rendererName) {
         /*
          * The virtual container is needed as the parent of all editor
          * components. Editor components need a parent in order to have a proper

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -680,7 +680,7 @@ public class GridPro<E> extends Grid<E> {
                 DataKeyMapper<SOURCE> keyMapper, String rendererName) {
 
             Rendering<SOURCE> columnPathRendering = super.render(container,
-                    keyMapper);
+                    keyMapper, rendererName);
             Rendering<SOURCE> representationRendering = representationRenderer
                     .render(container, keyMapper);
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -677,7 +677,7 @@ public class GridPro<E> extends Grid<E> {
 
         @Override
         public Rendering<SOURCE> render(Element container,
-                DataKeyMapper<SOURCE> keyMapper) {
+                DataKeyMapper<SOURCE> keyMapper, String rendererName) {
 
             Rendering<SOURCE> columnPathRendering = super.render(container,
                     keyMapper);

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -69,8 +69,6 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
 
     private final String templateExpression;
 
-    private final String DEFAULT_RENDERER_NAME = "renderer";
-
     private final String propertyNamespace;
 
     private final Map<String, ValueProvider<SOURCE, ?>> valueProviders = new HashMap<>();
@@ -142,44 +140,7 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         return new LitRenderer<>(templateExpression);
     }
 
-    /**
-     * Sets up rendering of model objects inside a given
-     * {@code Element container} element. The model objects are rendered using
-     * the Lit template literal provided when creating this LitRenderer
-     * instance, and the Vaadin-default JS renderer function name.
-     *
-     * @param container
-     *            the DOM element that supports setting a renderer function
-     * @param keyMapper
-     *            mapper used internally to fetch items by key and to provide
-     *            keys for given items. It is required when either functions or
-     *            {@link DataGenerator} are supported
-     * @return the context of the rendering, that can be used by the components
-     *         to provide extra customization
-     */
     @Override
-    public Rendering<SOURCE> render(Element container,
-            DataKeyMapper<SOURCE> keyMapper) {
-        return this.render(container, keyMapper, DEFAULT_RENDERER_NAME);
-    }
-
-    /**
-     * Sets up rendering of model objects inside a given
-     * {@code Element container} element. The model objects are rendered using
-     * the Lit template literal provided when creating this LitRenderer
-     * instance, and a given {@code String rendererName} JS renderer function.
-     *
-     * @param container
-     *            the DOM element that supports setting a renderer function
-     * @param keyMapper
-     *            mapper used internally to fetch items by key and to provide
-     *            keys for given items. It is required when either functions or
-     *            {@link DataGenerator} are supported
-     * @param rendererName
-     *            name of the renderer function the container element accepts
-     * @return the context of the rendering, that can be used by the components
-     *         to provide extra customization
-     */
     public Rendering<SOURCE> render(Element container,
             DataKeyMapper<SOURCE> keyMapper, String rendererName) {
         DataGenerator<SOURCE> dataGenerator = createDataGenerator();

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -36,6 +36,8 @@ import com.vaadin.flow.function.ValueProvider;
  */
 public abstract class Renderer<SOURCE> implements Serializable {
 
+    private final String DEFAULT_RENDERER_NAME = "renderer";
+
     /**
      * Registers a renderer function to the given container element. Creates the
      * setup to handle rendering of individual data items as requested by the
@@ -46,11 +48,30 @@ public abstract class Renderer<SOURCE> implements Serializable {
      *            the element which accepts the renderer function on the client.
      * @param keyMapper
      *            mapper used internally to fetch items by key and to provide
-     *            keys for given items. It is required when either event
-     *            handlers or {@link DataGenerator} are supported
+     *            keys for given items.
+     * @return the context of the rendering, that can be used by the components
+     *         to provide extra customization
+     */
+    public Rendering<SOURCE> render(Element container,
+            DataKeyMapper<SOURCE> keyMapper) {
+        return render(container, keyMapper, DEFAULT_RENDERER_NAME);
+    }
+
+    /**
+     * Registers a renderer function with the given name to the given container
+     * element. Creates the setup to handle rendering of individual data items
+     * as requested by the renderer function invocation.
+     *
+     * @param container
+     *            the element which accepts the renderer function on the client.
+     * @param keyMapper
+     *            mapper used internally to fetch items by key and to provide
+     *            keys for given items.
+     * @param rendererName
+     *            name of the renderer function the container element accepts
      * @return the context of the rendering, that can be used by the components
      *         to provide extra customization
      */
     public abstract Rendering<SOURCE> render(Element container,
-            DataKeyMapper<SOURCE> keyMapper);
+            DataKeyMapper<SOURCE> keyMapper, String rendererName);
 }


### PR DESCRIPTION
## Description

Follow-up for https://github.com/vaadin/flow-components/pull/4224

Moves the `render(Element container, DataKeyMapper<SOURCE> keyMapper, String rendererName)` API from `LitRenderer` to `Renderer`. Every type of `Renderer` should accept a custom name for the renderer function.

Example:
Before the change, `Grid` [needed to cast the renderer](https://github.com/vaadin/flow-components/blob/cea5c82ea950a600e4a2b65acd4db58ae15c524b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java#L2868-L2869) passed to `setItemDetailsRenderer` as a `LitRenderer` to make it plug into the `rowDetailsRenderer` function on the Web Component. After the change, since the API is defined on the `Renderer`, casting is no longer necessary and any `Renderer` can be passed as an item details renderer.

## Type of change

- Refactoring