### PR TITLE
refactor!: stop implementing and retain functionality of hascomponents

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/main/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/main/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
@@ -68,7 +68,8 @@ public class SelectedTabPage extends Div {
         setSelectedTab.setId("set-selected-tab");
 
         NativeButton deleteFirst = new NativeButton("Delete first tab",
-                event -> tabs.remove(tabs.getChildren().findFirst().get()));
+                event -> tabs
+                        .remove((Tab) tabs.getChildren().findFirst().get()));
         deleteFirst.setId("delete-first");
 
         NativeButton addFirstWithElementAPI = new NativeButton(

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/main/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/main/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
@@ -56,7 +56,7 @@ public class SelectedTabPage extends Div {
         delete.setId("delete");
 
         NativeButton addFirst = new NativeButton("Add new tab as the first",
-                event -> tabs.addComponentAsFirst(new Tab("baz")));
+                event -> tabs.addTabAsFirst(new Tab("baz")));
         addFirst.setId("add-first");
 
         NativeButton setSelectedIndex = new NativeButton("setSelectedIndex(1)",

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -131,7 +131,7 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
         if (position < 0) {
             tabs.add(tab);
         } else {
-            tabs.addComponentAtIndex(position, tab);
+            tabs.addTabAtIndex(position, tab);
         }
 
         // Make sure possible old content related to the same tab gets removed
@@ -242,7 +242,7 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
     /**
      * Returns the tab at the given position.
      *
-     * @param index
+     * @param position
      *            the position of the tab, must be greater than or equals to 0
      *            and less than the number of tabs
      * @return The tab at the given index
@@ -251,7 +251,7 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
      *             number of tabs
      */
     public Tab getTabAt(int position) {
-        return (Tab) tabs.getComponentAt(position);
+        return tabs.getTabAt(position);
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
@@ -70,7 +71,7 @@ import org.slf4j.LoggerFactory;
 @JsModule("@vaadin/tabs/src/vaadin-tabs.js")
 @NpmPackage(value = "@vaadin/tabs", version = "24.0.0-alpha8")
 public class Tabs extends Component
-        implements HasSize, HasStyle, HasThemeVariant<TabsVariant> {
+        implements HasEnabled, HasSize, HasStyle, HasThemeVariant<TabsVariant> {
 
     private static final String SELECTED = "selected";
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -141,6 +141,32 @@ public class Tabs extends Component
      * selection change listener has been added before adding the tabs, it will
      * be notified with the auto-selected tab.
      *
+     * @param components
+     *            the tabs to enclose
+     * @deprecated since 24.0, use {@link #add(Tab...)} instead.
+     */
+    @Deprecated
+    public void add(Component... components) {
+        Objects.requireNonNull(components, "Tabs should not be null");
+        boolean allComponentsAreTabs = Arrays.stream(components).map(
+                tab -> Objects.requireNonNull(tab, "Tab to add cannot be null"))
+                .allMatch(component -> component instanceof Tab);
+        if (!allComponentsAreTabs) {
+            throw new IllegalArgumentException(
+                    "Adding a component other than a Tab is not supported.");
+        }
+        add((Tab[]) components);
+    }
+
+    /**
+     * Adds the given tabs to the component.
+     * <p>
+     * The first added {@link Tab} component will be automatically selected,
+     * unless auto-selection is explicitly disabled with
+     * {@link #Tabs(boolean, Tab...)}, or {@link #setAutoselect(boolean)}. If a
+     * selection change listener has been added before adding the tabs, it will
+     * be notified with the auto-selected tab.
+     *
      * @param tabs
      *            the tabs to enclose
      */
@@ -164,6 +190,36 @@ public class Tabs extends Component
     /**
      * Removes the given child tabs from this component.
      *
+     * @param components
+     *            the tabs to remove
+     * @throws IllegalArgumentException
+     *             if there is a tab whose non {@code null} parent is not this
+     *             component
+     *             <p>
+     *             Removing tabs before the selected tab will decrease the
+     *             {@link #getSelectedIndex() selected index} to avoid changing
+     *             the selected tab. Removing the selected tab will select the
+     *             next available tab if autoselect is true, otherwise no tab
+     *             will be selected.
+     * @deprecated since 24.0, use {@link #remove(Tab...)} instead.
+     */
+    @Deprecated
+    public void remove(Component... components) {
+        Objects.requireNonNull(components, "Tabs should not be null");
+        boolean allComponentsAreTabs = Arrays.stream(components)
+                .map(tab -> Objects.requireNonNull(tab,
+                        "Tab to remove cannot be null"))
+                .allMatch(component -> component instanceof Tab);
+        if (!allComponentsAreTabs) {
+            throw new IllegalArgumentException(
+                    "Adding a component other than a Tab is not supported.");
+        }
+        remove((Tab[]) components);
+    }
+
+    /**
+     * Removes the given child tabs from this component.
+     *
      * @param tabs
      *            the tabs to remove
      * @throws IllegalArgumentException
@@ -181,7 +237,7 @@ public class Tabs extends Component
         int lowerIndices = (int) Stream.of(tabs).map(this::indexOf)
                 .filter(index -> index >= 0 && index < selectedIndex).count();
 
-        Tab selectedTab = getComponentAt(selectedIndex);
+        Tab selectedTab = getTabAt(selectedIndex);
         boolean isSelectedTab = selectedTab == null
                 || Stream.of(tabs).anyMatch(selectedTab::equals);
 
@@ -251,6 +307,33 @@ public class Tabs extends Component
      * @param index
      *            the index, where the tab will be added. The index must be
      *            non-negative and may not exceed the children count
+     * @param component
+     *            the tab to add, value should not be null
+     *            <p>
+     *            Adding a tab before the currently selected tab will increment
+     *            the {@link #getSelectedIndex() selected index} to avoid
+     *            changing the selected tab.
+     * @deprecated since 24.0, use {@link #addTabAtIndex(int, Tab)} instead.
+     */
+    @Deprecated
+    public void addComponentAtIndex(int index, Component component) {
+        Objects.requireNonNull(component, "Tab should not be null");
+        if (!(component instanceof Tab)) {
+            throw new IllegalArgumentException(
+                    "Adding a component other than a Tab is not supported.");
+        }
+        addTabAtIndex(index, (Tab) component);
+    }
+
+    /**
+     * Adds the given tab as child of this tab at the specific index.
+     * <p>
+     * In case the specified tab has already been added to another parent, it
+     * will be removed from there and added to this one.
+     *
+     * @param index
+     *            the index, where the tab will be added. The index must be
+     *            non-negative and may not exceed the children count
      * @param tab
      *            the tab to add, value should not be null
      *            <p>
@@ -258,7 +341,7 @@ public class Tabs extends Component
      *            the {@link #getSelectedIndex() selected index} to avoid
      *            changing the selected tab.
      */
-    public void addComponentAtIndex(int index, Tab tab) {
+    public void addTabAtIndex(int index, Tab tab) {
         Objects.requireNonNull(tab, "Tab should not be null");
         if (index < 0) {
             throw new IllegalArgumentException(
@@ -436,7 +519,7 @@ public class Tabs extends Component
         if (selectedIndex < 0) {
             return null;
         }
-        return getComponentAt(selectedIndex);
+        return getTabAt(selectedIndex);
     }
 
     /**
@@ -586,6 +669,24 @@ public class Tabs extends Component
     /**
      * Returns the index of the given tab.
      *
+     * @param component
+     *            the tab to look up, can not be <code>null</code>
+     * @return the index of the tab or -1 if the tab is not a child
+     * @deprecated since 24.0, use {@link #indexOf(Tab)} instead.
+     */
+    @Deprecated
+    public int indexOf(Component component) {
+        Objects.requireNonNull(component, "Tab should not be null");
+        if (!(component instanceof Tab)) {
+            throw new IllegalArgumentException(
+                    "Adding a component other than a Tab is not supported.");
+        }
+        return indexOf((Tab) component);
+    }
+
+    /**
+     * Returns the index of the given tab.
+     *
      * @param tab
      *            the tab to look up, can not be <code>null</code>
      * @return the index of the tab or -1 if the tab is not a child
@@ -626,8 +727,25 @@ public class Tabs extends Component
      * @throws IllegalArgumentException
      *             if the index is less than 0 or greater than or equals to the
      *             number of children tabs
+     * @deprecated since 24.0, use {@link #getTabAt(int)} instead.
      */
-    public Tab getComponentAt(int index) {
+    @Deprecated
+    public Component getComponentAt(int index) {
+        return getTabAt(index);
+    }
+
+    /**
+     * Returns the tab at the given position.
+     *
+     * @param index
+     *            the position of the tab, must be greater than or equals to 0
+     *            and less than the number of children tabs
+     * @return The tab at the given index
+     * @throws IllegalArgumentException
+     *             if the index is less than 0 or greater than or equals to the
+     *             number of children tabs
+     */
+    public Tab getTabAt(int index) {
         if (index < 0) {
             throw new IllegalArgumentException(
                     "The 'index' argument should be greater than or equal to 0. It was: "
@@ -645,10 +763,30 @@ public class Tabs extends Component
      * In case the specified tab has already been added to another parent, it
      * will be removed from there and added to this one.
      *
+     * @param component
+     *            the tab to add, value should not be null
+     * @deprecated since 24.0, use {@link #addTabAsFirst(Tab)} instead.
+     */
+    @Deprecated
+    public void addComponentAsFirst(Component component) {
+        Objects.requireNonNull(component, "Tab should not be null");
+        if (!(component instanceof Tab)) {
+            throw new IllegalArgumentException(
+                    "Adding a component other than a Tab is not supported.");
+        }
+        addTabAsFirst((Tab) component);
+    }
+
+    /**
+     * Adds the given tab as the first child of this component.
+     * <p>
+     * In case the specified tab has already been added to another parent, it
+     * will be removed from there and added to this one.
+     *
      * @param tab
      *            the tab to add, value should not be null
      */
-    public void addComponentAsFirst(Tab tab) {
-        addComponentAtIndex(0, tab);
+    public void addTabAsFirst(Tab tab) {
+        addTabAtIndex(0, tab);
     }
 }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -367,6 +367,41 @@ public class Tabs extends Component
      * are already in the container, their positions are swapped. Tab attach and
      * detach events should be taken care as with add and remove.
      *
+     * @param oldComponent
+     *            the old tab that will be replaced. Can be <code>null</code>,
+     *            which will make the newTab to be added to the layout without
+     *            replacing any other
+     *
+     * @param newComponent
+     *            the new tab to be replaced. Can be <code>null</code>, which
+     *            will make the oldTab to be removed from the layout without
+     *            adding any other
+     *            <p>
+     *            Replacing the currently selected tab will make the new tab
+     *            selected.
+     * @deprecated since 24.0, use {@link #replace(Tab, Tab)} instead.
+     */
+    @Deprecated
+    public void replace(Component oldComponent, Component newComponent) {
+        if (oldComponent != null && !(oldComponent instanceof Tab)) {
+            throw new IllegalArgumentException(
+                    "Removing a component other than a Tab is not supported.");
+        }
+        if (newComponent != null && !(newComponent instanceof Tab)) {
+            throw new IllegalArgumentException(
+                    "Adding a component other than a Tab is not supported.");
+        }
+        replace((Tab) oldComponent, (Tab) newComponent);
+    }
+
+    /**
+     * Replaces the tab in the container with another one without changing
+     * position. This method replaces tab with another one is such way that the
+     * new tab overtakes the position of the old tab. If the old tab is not in
+     * the container, the new tab is added to the container. If the both tabs
+     * are already in the container, their positions are swapped. Tab attach and
+     * detach events should be taken care as with add and remove.
+     *
      * @param oldTab
      *            the old tab that will be replaced. Can be <code>null</code>,
      *            which will make the newTab to be added to the layout without

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
@@ -157,7 +157,7 @@ public class SelectionEventTest {
 
     @Test
     public void addTabs_selectionNotChanged() {
-        tabs.addComponentAsFirst(new Tab());
+        tabs.addTabAsFirst(new Tab());
         tabs.add(new Tab());
 
         Assert.assertEquals(
@@ -310,7 +310,7 @@ public class SelectionEventTest {
         tabs = new Tabs();
         addSelectedChangeListener(tabs);
 
-        tabs.addComponentAtIndex(0, tab1);
+        tabs.addTabAtIndex(0, tab1);
 
         Assert.assertEquals(
                 "Unexpected selected index after adding the first tab.", 0,
@@ -327,8 +327,8 @@ public class SelectionEventTest {
         tabs = new Tabs();
         addSelectedChangeListener(tabs);
 
-        tabs.addComponentAtIndex(0, tab1);
-        tabs.addComponentAtIndex(0, tab2);
+        tabs.addTabAtIndex(0, tab1);
+        tabs.addTabAtIndex(0, tab2);
 
         Assert.assertEquals(
                 "Unexpected selected index after adding the first tab.", 1,
@@ -346,7 +346,7 @@ public class SelectionEventTest {
         tabs = new Tabs(false);
         addSelectedChangeListener(tabs);
 
-        tabs.addComponentAtIndex(0, tab1);
+        tabs.addTabAtIndex(0, tab1);
 
         Assert.assertEquals(
                 "Unexpected selected index after adding the first tab.", -1,


### PR DESCRIPTION
## Description

`Tabs` used to implement `HasOrderedComponents` and `HasComponents`. However, it does not support adding arbitrary content. This PR removes these interfaces from `Tabs` while retaining the functionality using `Tab` instead of `Component` in parameters.

This is a breaking change.

Fixes #1636 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.