### PR TITLE
refactor!: drop the div wrapper from dialog and notification

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.dialog;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
@@ -102,12 +103,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     public Dialog() {
         container = new Element("div");
-        container.getClassList().add("draggable");
-        container.getClassList().add("draggable-leaf-only");
-        container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
-        container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
-        container.getStyle().set("display", "inline-block");
-
+        this.container.addAttachListener(event -> {
+            this.container.executeJs(
+                    "Vaadin.FlowComponentHost.patchVirtualContainer(this)");
+        });
         getElement().appendVirtualChild(container);
 
         // Needs to be updated on each
@@ -359,6 +358,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
                     "Component to add cannot be null");
             container.appendChild(component.getElement());
         }
+
+        updateVirtualChildNodeIds();
     }
 
     @Override
@@ -374,11 +375,15 @@ public class Dialog extends Component implements HasComponents, HasSize,
                         + component + ") is not a child of this component");
             }
         }
+
+        updateVirtualChildNodeIds();
     }
 
     @Override
     public void removeAll() {
         container.removeAllChildren();
+
+        updateVirtualChildNodeIds();
     }
 
     /**
@@ -404,6 +409,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
         // The case when the index is bigger than the children count is handled
         // inside the method below
         container.insertChild(index, component.getElement());
+
+        updateVirtualChildNodeIds();
     }
 
     /**
@@ -902,6 +909,15 @@ public class Dialog extends Component implements HasComponents, HasSize,
         return super.addDetachListener(listener);
     }
 
+    private void updateVirtualChildNodeIds() {
+        this.getElement().setPropertyList("virtualChildNodeIds",
+                container.getChildren()
+                        .map(element -> element.getNode().getId())
+                        .collect(Collectors.toList()));
+
+        this.getElement().callJsFunction("requestContentUpdate");
+    }
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
@@ -912,6 +928,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
         Shortcuts.setShortcutListenOnElement(OVERLAY_LOCATOR_JS, this);
         initConnector();
         initHeaderFooterRenderer();
+        updateVirtualChildNodeIds();
     }
 
     /**
@@ -966,11 +983,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     private void attachComponentRenderer() {
         String appId = UI.getCurrent().getInternals().getAppId();
-        int nodeId = container.getNode().getId();
 
         getElement().executeJs(
-                "this.renderer = (root) => Vaadin.FlowComponentHost.setChildNodes($0, [$1], root)",
-                appId, nodeId);
+                "this.renderer = (root) => Vaadin.FlowComponentHost.setChildNodes($0, this.virtualChildNodeIds, root)",
+                appId);
 
         setDimension(ElementConstants.STYLE_WIDTH, width);
         setDimension(ElementConstants.STYLE_MIN_WIDTH, minWidth);

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.notification;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
@@ -113,23 +114,23 @@ public class Notification extends Component implements HasComponents, HasStyle,
      * If the Web Component has {@code text} property defined, it will be used
      * as the text content of the notification.
      *
-     * Otherwise, {@code this.container} will be included in the notification.
+     * Otherwise, {@code the child nodes of this.container} will be included in
+     * the notification.
      */
     private void configureRenderer() {
         String appId = UI.getCurrent() != null
                 ? UI.getCurrent().getInternals().getAppId()
                 : "ROOT";
-        int nodeId = container.getNode().getId();
 
         //@formatter:off
         getElement().executeJs(
-            "this.renderer = (root, notification) => {" +
-            "  if (notification.text) {" +
-            "    root.textContent = notification.text;" +
-            "  } else if (!root.firstElementChild) {" +
-            "    Vaadin.FlowComponentHost.setChildNodes($0, [$1], root)" +
+            "this.renderer = (root) => {" +
+            "  if (this.text) {" +
+            "    root.textContent = this.text;" +
+            "  } else {" +
+            "    Vaadin.FlowComponentHost.setChildNodes($0, this.virtualChildNodeIds, root)" +
             "  }" +
-            "}", appId, nodeId);
+            "}", appId);
         //@formatter:on
     }
 
@@ -211,6 +212,10 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     private void initBaseElementsAndListeners() {
+        this.container.addAttachListener(event -> {
+            this.container.executeJs(
+                    "Vaadin.FlowComponentHost.patchVirtualContainer(this)");
+        });
         getElement().appendVirtualChild(container);
 
         getElement().addEventListener("opened-changed",
@@ -379,6 +384,7 @@ public class Notification extends Component implements HasComponents, HasStyle,
                         + component + ") is not a child of this component");
             }
         }
+        configureComponentRenderer();
     }
 
     /**
@@ -418,6 +424,8 @@ public class Notification extends Component implements HasComponents, HasStyle,
     @Override
     public void removeAll() {
         container.removeAllChildren();
+
+        configureComponentRenderer();
     }
 
     @Override
@@ -573,7 +581,16 @@ public class Notification extends Component implements HasComponents, HasStyle,
 
     private void configureComponentRenderer() {
         this.getElement().removeProperty("text");
+        updateVirtualChildNodeIds();
+
         this.getElement().callJsFunction("requestContentUpdate");
+    }
+
+    private void updateVirtualChildNodeIds() {
+        this.getElement().setPropertyList("virtualChildNodeIds",
+                container.getChildren()
+                        .map(element -> element.getNode().getId())
+                        .collect(Collectors.toList()));
     }
 
     @Override
@@ -581,6 +598,7 @@ public class Notification extends Component implements HasComponents, HasStyle,
         super.onAttach(attachEvent);
         initConnector();
         configureRenderer();
+        updateVirtualChildNodeIds();
     }
 
     @Override


### PR DESCRIPTION
## Description

Follow-up PR for https://github.com/vaadin/flow-components/pull/4483
Fixes https://github.com/vaadin/flow-components/issues/1876

This PR drops the internal `<div>` containers from `Notification` and `Dialog` overlays, aligning the DOM structure with that of the Web Component counterparts.

### Breaking changes

- The `<div>` container is no longer in the DOM hierarchy of `Notification` and `Dialog` overlays

## Type of change

- Refactor
