### PR TITLE
fix!: retain checkbox group value on item label generator change

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDemoPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDemoPage.java
@@ -93,16 +93,10 @@ public class CheckboxGroupDemoPage extends Div {
                 "Checkbox group value changed from '%s' to '%s'",
                 getNames(event.getOldValue()), getNames(event.getValue()))));
 
-        NativeButton updateLabelGeneratorButton = new NativeButton(
-                "Update label generator", event -> group.setItemLabelGenerator(
-                        person -> person.getName() + " (Updated)"));
-        updateLabelGeneratorButton.setId("update-label-generator");
-
         group.setId("checkbox-group-with-item-generator");
         message.setId("checkbox-group-gen-value");
 
-        addCard("Checkbox group with label generator", group,
-                updateLabelGeneratorButton, message);
+        addCard("Checkbox group with label generator", group, message);
     }
 
     private void addDisabled() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDemoPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDemoPage.java
@@ -93,10 +93,16 @@ public class CheckboxGroupDemoPage extends Div {
                 "Checkbox group value changed from '%s' to '%s'",
                 getNames(event.getOldValue()), getNames(event.getValue()))));
 
+        NativeButton updateLabelGeneratorButton = new NativeButton(
+                "Update label generator", event -> group.setItemLabelGenerator(
+                        person -> person.getName() + " (Updated)"));
+        updateLabelGeneratorButton.setId("update-label-generator");
+
         group.setId("checkbox-group-with-item-generator");
         message.setId("checkbox-group-gen-value");
 
-        addCard("Checkbox group with label generator", group, message);
+        addCard("Checkbox group with label generator", group,
+                updateLabelGeneratorButton, message);
     }
 
     private void addDisabled() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -86,6 +86,18 @@ public class CheckboxGroupIT extends AbstractComponentIT {
     }
 
     @Test
+    public void updateItemLabelGenerator() {
+        CheckboxGroupElement group = $(CheckboxGroupElement.class)
+                .id("checkbox-group-with-item-generator");
+        Assert.assertEquals("Joe", group.getCheckboxes().get(0).getLabel());
+
+        layout.findElement(By.id("update-label-generator")).click();
+
+        Assert.assertEquals("Joe (Updated)",
+                group.getCheckboxes().get(0).getLabel());
+    }
+
+    @Test
     public void disabledGroup() {
         CheckboxGroupElement group = $(CheckboxGroupElement.class)
                 .id("checkbox-group-disabled");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -86,18 +86,6 @@ public class CheckboxGroupIT extends AbstractComponentIT {
     }
 
     @Test
-    public void updateItemLabelGenerator() {
-        CheckboxGroupElement group = $(CheckboxGroupElement.class)
-                .id("checkbox-group-with-item-generator");
-        Assert.assertEquals("Joe", group.getCheckboxes().get(0).getLabel());
-
-        layout.findElement(By.id("update-label-generator")).click();
-
-        Assert.assertEquals("Joe (Updated)",
-                group.getCheckboxes().get(0).getLabel());
-    }
-
-    @Test
     public void disabledGroup() {
         CheckboxGroupElement group = $(CheckboxGroupElement.class)
                 .id("checkbox-group-disabled");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -140,16 +140,13 @@ public class CheckboxGroupIT extends AbstractComponentIT {
         Assert.assertEquals("", valueInfo.getText());
 
         // make the group not read-only
-        WebElement switchReadOnly = findElement(By.id("switch-read-only"));
-        new Actions(getDriver()).moveToElement(switchReadOnly).click().build()
-                .perform();
+        findElement(By.id("switch-read-only")).click();
 
         group.selectByText("bar");
         Assert.assertEquals("[bar]", valueInfo.getText());
 
         // make it read-only again
-        new Actions(getDriver()).moveToElement(switchReadOnly).click().build()
-                .perform();
+        findElement(By.id("switch-read-only")).click();
 
         // click to the first item
         group.selectByText("foo");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -484,7 +484,7 @@ public class CheckboxGroup<T>
         Objects.requireNonNull(itemLabelGenerator,
                 "The item label generator can not be null");
         this.itemLabelGenerator = itemLabelGenerator;
-        reset();
+        refreshCheckboxes();
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -303,6 +303,19 @@ public class CheckboxGroupTest {
     }
 
     @Test
+    public void selectItem_setItemLabelGenerator_selectionIsRetained() {
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setItems("foo", "bar");
+
+        checkboxGroup.setValue(Set.of("foo"));
+        Assert.assertEquals(Set.of("foo"), checkboxGroup.getValue());
+
+        checkboxGroup.setItemLabelGenerator(item -> item + " (Updated)");
+
+        Assert.assertEquals(Set.of("foo"), checkboxGroup.getValue());
+    }
+
+    @Test
     public void addSelectionListener_selectionEventIsFired() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -316,6 +316,19 @@ public class CheckboxGroupTest {
     }
 
     @Test
+    public void selectItem_setItemLabelGenerator_labelIsUpdated() {
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setItems("foo", "bar");
+
+        Checkbox cb = (Checkbox) checkboxGroup.getChildren().findFirst().get();
+        Assert.assertEquals("foo", cb.getLabel());
+
+        checkboxGroup.setItemLabelGenerator(item -> item + " (Updated)");
+
+        Assert.assertEquals("foo (Updated)", cb.getLabel());
+    }
+
+    @Test
     public void addSelectionListener_selectionEventIsFired() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -316,7 +316,7 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void selectItem_setItemLabelGenerator_labelIsUpdated() {
+    public void setItemLabelGenerator_labelIsUpdated() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");
 


### PR DESCRIPTION
## Description

Calling `setItemLabelGenerator` for `CheckboxGroup` used to clear the selected values.

This PR makes the `CheckboxGroup` retain the selection by refreshing the checkboxes instead of resetting the `CheckboxGroup` when `setItemLabelGenerator` is called.

This is a breaking change.

Fixes #3131 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.