### PR TITLE
fix: update dialog and notification child ids on child remove

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
@@ -118,6 +118,45 @@ public class DialogChildrenTest {
                 dialog.getElement().getProperty("virtualChildNodeIds"));
     }
 
+    @Test
+    public void selfRemoveChild_virtualNodeIdsInSync() {
+        var child = new Div();
+        var child2 = new Div();
+        dialog.add(child, child2);
+        child.removeFromParent();
+        assertVirtualChildren(child2);
+    }
+
+    @Test
+    public void addSeparately_selfRemoveChild_doesNotThrow() {
+        var child = new Div();
+        var child2 = new Div();
+        dialog.add(child);
+        dialog.add(child2);
+        child.removeFromParent();
+        assertVirtualChildren(child2);
+    }
+
+    @Test
+    public void relocateChild_detachListenerRemoved() {
+        var child = new Div();
+        dialog.add(child);
+
+        // Move the child to a new parent
+        var newParent = new Div();
+        ui.add(newParent);
+        newParent.add(child);
+
+        // Should be empty of virtual children
+        assertVirtualChildren();
+        // Manually modify the virtualChildNodeIds property
+        dialog.getElement().setProperty("virtualChildNodeIds", "[-1]");
+
+        newParent.remove(child);
+        Assert.assertEquals(
+                dialog.getElement().getProperty("virtualChildNodeIds"), "[-1]");
+    }
+
     private void assertVirtualChildren(Component... components) {
         // Get a List of the node ids
         var childIds = Arrays.stream(components)

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
@@ -128,6 +128,46 @@ public class NotificationChildrenTest {
         Assert.assertNull("foo", notification.getElement().getProperty("text"));
     }
 
+    @Test
+    public void selfRemoveChild_virtualNodeIdsInSync() {
+        var child = new Div();
+        var child2 = new Div();
+        notification.add(child, child2);
+        child.removeFromParent();
+        assertVirtualChildren(child2);
+    }
+
+    @Test
+    public void addSeparately_selfRemoveChild_doesNotThrow() {
+        var child = new Div();
+        var child2 = new Div();
+        notification.add(child);
+        notification.add(child2);
+        child.removeFromParent();
+        assertVirtualChildren(child2);
+    }
+
+    @Test
+    public void relocateChild_detachListenerRemoved() {
+        var child = new Div();
+        notification.add(child);
+
+        // Move the child to a new parent
+        var newParent = new Div();
+        ui.add(newParent);
+        newParent.add(child);
+
+        // Should be empty of virtual children
+        assertVirtualChildren();
+        // Manually modify the virtualChildNodeIds property
+        notification.getElement().setProperty("virtualChildNodeIds", "[-1]");
+
+        newParent.remove(child);
+        Assert.assertEquals(
+                notification.getElement().getProperty("virtualChildNodeIds"),
+                "[-1]");
+    }
+
     private void assertVirtualChildren(Component... components) {
         // Get a List of the node ids
         var childIds = Arrays.stream(components)


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/vaadin/flow-components/pull/4499

The previous PR didn't consider that child components may be removed by calling `child.removeFromParent()` (or by adding them to another parent). This PR adds a detach listener to each child component to take care of the issue.

## Type of change

- Bugfix