### PR TITLE
refactor: extract common logic to HasValidationProperties

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -46,6 +45,7 @@ import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.binder.HasValidator;
@@ -91,9 +91,9 @@ import elemental.json.JsonArray;
 public class CheckboxGroup<T>
         extends AbstractSinglePropertyField<CheckboxGroup<T>, Set<T>> implements
         HasClientValidation, HasDataView<T, Void, CheckboxGroupDataView<T>>,
-        HasHelper, HasItemComponents<T>, HasLabel,
-        HasListDataView<T, CheckboxGroupListDataView<T>>, HasSize, HasStyle,
-        HasThemeVariant<CheckboxGroupVariant>, HasTooltip, HasValidation,
+        HasHelper, HasItemComponents<T>, HasLabel, HasSize, HasStyle,
+        HasListDataView<T, CheckboxGroupListDataView<T>>, HasTooltip,
+        HasThemeVariant<CheckboxGroupVariant>, HasValidationProperties,
         HasValidator<Set<T>>, MultiSelect<CheckboxGroup<T>, T> {
 
     private static final String VALUE = "value";
@@ -517,26 +517,6 @@ public class CheckboxGroup<T>
     }
 
     /**
-     * Sets the error message to display when the value is invalid.
-     *
-     * @param errorMessage
-     *            the String value to set
-     */
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the current error message from the checkbox group.
-     *
-     * @return the current error message
-     */
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
-    /**
      * Specifies that the user must fill in a value.
      *
      * @param required
@@ -556,20 +536,6 @@ public class CheckboxGroup<T>
      */
     public boolean isRequired() {
         return getElement().getProperty("required", false);
-    }
-
-    /**
-     * Whether the component has an invalid value or not.
-     */
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
-    }
-
-    /**
-     * Sets whether the component has an invalid value or not.
-     */
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasTheme;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.UI;
@@ -42,6 +41,7 @@ import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
 import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
@@ -88,7 +88,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
         HasDataView<TItem, String, ComboBoxDataView<TItem>>, HasHelper,
         HasLabel, HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>,
         HasListDataView<TItem, ComboBoxListDataView<TItem>>, HasSize, HasStyle,
-        HasTheme, HasTooltip, HasValidation, HasValidator<TValue> {
+        HasTheme, HasTooltip, HasValidationProperties, HasValidator<TValue> {
 
     /**
      * Registration for custom value listeners that disallows entering custom
@@ -325,20 +325,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     }
 
     /**
-     * Whether the component has an invalid value or not.
-     */
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
-    }
-
-    /**
-     * Sets whether the component has an invalid value or not.
-     */
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    /**
      * Sets whether the component requires a value to be considered in a valid
      * state.
      *
@@ -356,23 +342,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      */
     public void setRequired(boolean required) {
         super.setRequiredIndicatorVisible(required);
-    }
-
-    /**
-     * The error message that should be displayed when the component becomes
-     * invalid
-     */
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
-    /**
-     * Sets the error message that should be displayed when the component
-     * becomes invalid
-     */
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
     }
 
     /**

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.AbstractField;
@@ -33,7 +34,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasTheme;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.Element;
@@ -56,8 +56,8 @@ import com.vaadin.flow.dom.Element;
 @NpmPackage(value = "@vaadin/custom-field", version = "24.0.0-alpha10")
 @JsModule("@vaadin/custom-field/src/vaadin-custom-field.js")
 public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
-        implements Focusable<CustomField<T>>, HasHelper, HasSize, HasValidation,
-        HasLabel, HasTheme, HasStyle, HasTooltip {
+        implements Focusable<CustomField<T>>, HasHelper, HasLabel, HasSize,
+        HasStyle, HasTheme, HasTooltip, HasValidationProperties {
 
     /**
      * Default constructor.
@@ -173,41 +173,6 @@ public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
                         + component + ") is not a child of this component");
             }
         }
-    }
-
-    /**
-     * <p>
-     * This property is set to true when the control value is invalid.
-     * </p>
-     *
-     * @return the {@code invalid} property from the webcomponent
-     */
-    @Override
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
-    }
-
-    /**
-     * <p>
-     * This property is set to true when the control value is invalid.
-     * </p>
-     *
-     * @param invalid
-     *            the boolean value to set
-     */
-    @Override
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    @Override
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage", errorMessage);
-    }
-
-    @Override
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
@@ -50,6 +49,7 @@ import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.ValidationResult;
@@ -91,8 +91,8 @@ public class DatePicker
         extends AbstractSinglePropertyField<DatePicker, LocalDate>
         implements Focusable<DatePicker>, HasAllowedCharPattern, HasAutoOpen,
         HasClearButton, HasClientValidation, HasHelper, HasLabel,
-        HasOverlayClassName, HasPrefix, HasSize, HasStyle,
-        HasThemeVariant<DatePickerVariant>, HasTooltip, HasValidation,
+        HasOverlayClassName, HasPrefix, HasSize, HasStyle, HasTooltip,
+        HasThemeVariant<DatePickerVariant>, HasValidationProperties,
         HasValidator<LocalDate> {
 
     private DatePickerI18n i18n;
@@ -481,27 +481,6 @@ public class DatePicker
                 .beforeClientResponse(this, context -> command.accept(ui)));
     }
 
-    /**
-     * Sets the error message that should be displayed when the component
-     * becomes invalid.
-     *
-     * @param errorMessage
-     *            the String value to set
-     */
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the current error message from the datepicker.
-     *
-     * @return the current error message
-     */
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
     @Override
     public Validator<LocalDate> getDefaultValidator() {
         return (value, context) -> checkValidity(value);
@@ -514,27 +493,6 @@ public class DatePicker
                 event -> listener.validationStatusChanged(
                         new ValidationStatusChangeEvent<LocalDate>(this,
                                 !isInvalid())));
-    }
-
-    /**
-     * Sets whether the component has an invalid value or not.
-     *
-     * @param invalid
-     *            {@code true} for invalid, {@code false} for valid
-     */
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    /**
-     * Gets the validity of the datepicker output.
-     * <p>
-     * return true, if the value is invalid.
-     *
-     * @return the {@code validity} property from the datepicker
-     */
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
     }
 
     private ValidationResult checkValidity(LocalDate value) {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -40,6 +39,7 @@ import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.component.timepicker.StepsUtil;
@@ -123,7 +123,7 @@ public class DateTimePicker extends
         AbstractSinglePropertyField<DateTimePicker, LocalDateTime> implements
         Focusable<DateTimePicker>, HasAutoOpen, HasClientValidation, HasHelper,
         HasLabel, HasSize, HasStyle, HasThemeVariant<DateTimePickerVariant>,
-        HasTooltip, HasValidation, HasValidator<LocalDateTime> {
+        HasTooltip, HasValidationProperties, HasValidator<LocalDateTime> {
 
     private final DateTimePickerDatePicker datePicker = new DateTimePickerDatePicker();
     private final DateTimePickerTimePicker timePicker = new DateTimePickerTimePicker();
@@ -627,43 +627,6 @@ public class DateTimePicker extends
     public void removeThemeNames(String... themeNames) {
         HasThemeVariant.super.removeThemeNames(themeNames);
         synchronizeTheme();
-    }
-
-    /**
-     * Sets the error message to display when the input is invalid.
-     */
-    @Override
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the error message to display when the input is invalid.
-     *
-     * @return the current error message
-     */
-    @Override
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
-    /**
-     * Sets the validity indication of the date time picker output.
-     */
-    @Override
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    /**
-     * Gets the validity indication of the date time picker output.
-     *
-     * @return the current validity indication.
-     */
-    @Override
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
     }
 
     @Override

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HasValidation;
+
+/**
+ * Mixin interface for components that provide properties for setting invalid
+ * state and error message string to show when invalid.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasValidationProperties extends HasElement, HasValidation {
+
+    /**
+     * Sets the error message to show to the user when the component is invalid.
+     *
+     * @param errorMessage
+     *            the error message or {@code null} to clear it
+     */
+    @Override
+    default void setErrorMessage(String errorMessage) {
+        getElement().setProperty("errorMessage",
+                errorMessage == null ? "" : errorMessage);
+    }
+
+    /**
+     * Gets the error message to show to the when the component is invalid.
+     *
+     * @return the error message or {@code null} if not set
+     */
+    @Override
+    default String getErrorMessage() {
+        return getElement().getProperty("errorMessage", "");
+    }
+
+    /**
+     * Sets the invalid state of the component.
+     *
+     * @param invalid
+     *            {@code true} for invalid, {@code false} for valid
+     */
+    @Override
+    default void setInvalid(boolean invalid) {
+        getElement().setProperty("invalid", invalid);
+    }
+
+    /**
+     * Gets whether the component is currently in invalid state.
+     *
+     * @return {@code true} for invalid, {@code false} for valid
+     */
+    @Override
+    default boolean isInvalid() {
+        return getElement().getProperty("invalid", false);
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -45,7 +45,7 @@ public interface HasValidationProperties extends HasElement, HasValidation {
      */
     @Override
     default String getErrorMessage() {
-        return getElement().getProperty("errorMessage", "");
+        return getElement().getProperty("errorMessage");
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasValidationPropertiesTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasValidationPropertiesTest.java
@@ -18,7 +18,7 @@ public class HasValidationPropertiesTest {
 
     @Test
     public void initialErrorMessage() {
-        Assert.assertEquals(component.getErrorMessage(), "");
+        Assert.assertEquals(component.getErrorMessage(), null);
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasValidationPropertiesTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasValidationPropertiesTest.java
@@ -1,0 +1,56 @@
+package com.vaadin.flow.component.shared;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+public class HasValidationPropertiesTest {
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void initialErrorMessage() {
+        Assert.assertEquals(component.getErrorMessage(), "");
+    }
+
+    @Test
+    public void changeErrorMessage() {
+        component.setErrorMessage("This field is required");
+        Assert.assertEquals(component.getElement().getProperty("errorMessage"),
+                "This field is required");
+
+        component.setErrorMessage(null);
+        Assert.assertEquals(component.getElement().getProperty("errorMessage"),
+                "");
+    }
+
+    @Test
+    public void initialInvalid() {
+        Assert.assertFalse(component.isInvalid());
+    }
+
+    @Test
+    public void changeInvalid() {
+        component.setInvalid(true);
+        Assert.assertTrue(component.isInvalid());
+        Assert.assertTrue(component.getElement().getProperty("invalid", false));
+
+        component.setInvalid(false);
+        Assert.assertFalse(component.isInvalid());
+        Assert.assertFalse(
+                component.getElement().getProperty("invalid", false));
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements HasValidationProperties {
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -43,6 +42,7 @@ import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
@@ -82,7 +82,7 @@ public class RadioButtonGroup<T>
         implements HasClientValidation,
         HasDataView<T, Void, RadioButtonGroupDataView<T>>, HasHelper, HasLabel,
         HasListDataView<T, RadioButtonGroupListDataView<T>>, HasSize, HasStyle,
-        HasThemeVariant<RadioGroupVariant>, HasTooltip, HasValidation,
+        HasThemeVariant<RadioGroupVariant>, HasTooltip, HasValidationProperties,
         HasValidator<T>, SingleSelect<RadioButtonGroup<T>, T> {
 
     private final KeyMapper<T> keyMapper = new KeyMapper<>();
@@ -512,26 +512,6 @@ public class RadioButtonGroup<T>
     }
 
     /**
-     * Sets the error message to display when the value is invalid.
-     *
-     * @param errorMessage
-     *            the String value to set
-     */
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the current error message from the radio button group.
-     *
-     * @return the current error message
-     */
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
-    /**
      * Sets the label for the field.
      *
      * @param label
@@ -548,25 +528,6 @@ public class RadioButtonGroup<T>
      */
     public String getLabel() {
         return getElement().getProperty("label");
-    }
-
-    /**
-     * Whether the component has an invalid value or not.
-     *
-     * @return {@code true} for invalid, {@code false} for valid
-     */
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
-    }
-
-    /**
-     * Sets whether the component has an invalid value or not.
-     *
-     * @param invalid
-     *            {@code true} for invalid, {@code false} for valid
-     */
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
     }
 
     @SuppressWarnings("unchecked")

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -27,21 +27,21 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.select.data.SelectDataView;
 import com.vaadin.flow.component.select.data.SelectListDataView;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasPrefix;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.binder.HasValidator;
@@ -94,7 +94,7 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         HasDataView<T, Void, SelectDataView<T>>, HasItemComponents<T>,
         HasHelper, HasLabel, HasListDataView<T, SelectListDataView<T>>,
         HasOverlayClassName, HasPrefix, HasSize, HasStyle,
-        HasThemeVariant<SelectVariant>, HasTooltip, HasValidation,
+        HasThemeVariant<SelectVariant>, HasTooltip, HasValidationProperties,
         HasValidator<T>, SingleSelect<Select<T>, T> {
 
     public static final String LABEL_ATTRIBUTE = "label";
@@ -628,49 +628,6 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     @Override
     public boolean isRequiredIndicatorVisible() {
         return getElement().getProperty("required", false);
-    }
-
-    /**
-     * Sets the error message to show to the user on invalid selection.
-     *
-     * @param errorMessage
-     *            the error message or {@code null} to clear it
-     */
-    @Override
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the error message to show to the user on invalid selection
-     *
-     * @return the error message or {@code null} if not set
-     */
-    @Override
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
-    /**
-     * Sets the select to show as invalid state and display error message.
-     *
-     * @param invalid
-     *            {@code true} for invalid, {@code false} for valid
-     */
-    @Override
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    /**
-     * Gets whether the select is currently in invalid state.
-     *
-     * @return {@code true} for invalid, {@code false} for valid
-     */
-    @Override
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/InternalFieldBase.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/InternalFieldBase.java
@@ -23,12 +23,12 @@ import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
 import com.vaadin.flow.component.KeyNotifier;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.value.HasValueChangeMode;
@@ -50,7 +50,7 @@ public abstract class InternalFieldBase<TComponent extends InternalFieldBase<TCo
         implements CompositionNotifier, Focusable<TComponent>,
         HasAutocapitalize, HasAutocomplete, HasAutocorrect, HasClearButton,
         HasClientValidation, HasHelper, HasLabel, HasPrefixAndSuffix, HasSize,
-        HasStyle, HasTooltip, HasValidation, HasValidator<TValue>,
+        HasStyle, HasTooltip, HasValidationProperties, HasValidator<TValue>,
         HasValueChangeMode, InputNotifier, KeyNotifier {
 
     private ValueChangeMode currentMode;
@@ -111,27 +111,6 @@ public abstract class InternalFieldBase<TComponent extends InternalFieldBase<TCo
      */
     public String getPlaceholder() {
         return getElement().getProperty("placeholder");
-    }
-
-    /**
-     * Sets the error message that should be displayed when the component
-     * becomes invalid.
-     *
-     * @param errorMessage
-     *            the String value to set
-     */
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the current error message from the web component.
-     *
-     * @return the current error message
-     */
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
     }
 
     /**
@@ -196,25 +175,6 @@ public abstract class InternalFieldBase<TComponent extends InternalFieldBase<TCo
      */
     public void setAutoselect(boolean autoselect) {
         getElement().setProperty("autoselect", autoselect);
-    }
-
-    /**
-     * Sets whether the component has an invalid value or not.
-     *
-     * @param invalid
-     *            {@code true} for invalid, {@code false} for valid
-     */
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    /**
-     * Whether the component has an invalid value or not.
-     *
-     * @return the {@code invalid} property from the web component
-     */
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
@@ -47,6 +46,7 @@ import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.ValidationResult;
@@ -76,8 +76,9 @@ public class TimePicker
         extends AbstractSinglePropertyField<TimePicker, LocalTime>
         implements Focusable<TimePicker>, HasAllowedCharPattern, HasAutoOpen,
         HasClearButton, HasClientValidation, HasHelper, HasLabel, HasPrefix,
-        HasOverlayClassName, HasSize, HasStyle, HasTooltip, HasValidation,
-        HasThemeVariant<TimePickerVariant>, HasValidator<LocalTime> {
+        HasOverlayClassName, HasSize, HasStyle, HasTooltip,
+        HasThemeVariant<TimePickerVariant>, HasValidationProperties,
+        HasValidator<LocalTime> {
 
     private static final SerializableFunction<String, LocalTime> PARSER = valueFromClient -> {
         return valueFromClient == null || valueFromClient.isEmpty() ? null
@@ -269,48 +270,6 @@ public class TimePicker
      */
     public String getLabel() {
         return getElement().getProperty("label");
-    }
-
-    /**
-     * Sets the error message that should be displayed when the component
-     * becomes invalid.
-     *
-     * @param errorMessage
-     *            the String value to set
-     */
-    public void setErrorMessage(String errorMessage) {
-        getElement().setProperty("errorMessage",
-                errorMessage == null ? "" : errorMessage);
-    }
-
-    /**
-     * Gets the current error message from the time picker.
-     *
-     * @return the current error message
-     */
-    public String getErrorMessage() {
-        return getElement().getProperty("errorMessage");
-    }
-
-    /**
-     * Sets whether the component has an invalid value or not.
-     *
-     * @param invalid
-     *            {@code true} for invalid, {@code false} for valid
-     */
-    public void setInvalid(boolean invalid) {
-        getElement().setProperty("invalid", invalid);
-    }
-
-    /**
-     * Gets the validity of the time picker output.
-     * <p>
-     * return true, if the value is invalid.
-     *
-     * @return the {@code invalid} property from the time picker
-     */
-    public boolean isInvalid() {
-        return getElement().getProperty("invalid", false);
     }
 
     @Override


### PR DESCRIPTION
## Description

1. Added `HasValidationProperties` interface which is based on [`HasValidation`](https://github.com/vaadin/flow/blob/fd04f545ee3f13b0cf3cdf2b694c6d9ab215c689/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java#L27) and provides same method signatures. 
The difference is that this interface actually sets / gets corresponding properties: `invalid` and `errorMessage`.
2. Updated all the components that provide these methods to use the new interface instead of `HasValidation`.

## Type of change

- Refactor