### PR TITLE
fix: do not access dialog internals before the element is ready

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/CloseListenerReopenDialogIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/CloseListenerReopenDialogIT.java
@@ -113,6 +113,15 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
                 1, findElements(By.className("sub")).size());
     }
 
+    @Test
+    public void openDialog_shouldNotThrow() {
+        open();
+
+        findElement(By.id("open")).click();
+
+        checkLogsForErrors();
+    }
+
     private void closeDialog() {
         new Actions(getDriver()).sendKeys(Keys.ESCAPE).build().perform();
     }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -985,8 +985,9 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     private void setDimension(String dimension, String value) {
-        getElement().executeJs(OVERLAY_LOCATOR_JS + ".$.overlay.style[$0]=$1",
-                dimension, value);
+        getElement().executeJs("requestAnimationFrame(e => "
+                + OVERLAY_LOCATOR_JS + ".$.overlay.style[$0]=$1)", dimension,
+                value);
     }
 
     private void attachComponentRenderer() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/resources/META-INF/resources/frontend/dialogConnector.js
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/resources/META-INF/resources/frontend/dialogConnector.js
@@ -32,7 +32,14 @@
         attributeFilter: ['class']
       });
 
-      copyClassName(dialog);
+      // On connector init, the <vaadin-dialog> may not yet be ready,
+      // so we need to check if it has the $ property which gets accessed
+      // in copyClassName.
+      // Also, the class name does not need to be copied if the dialog
+      // is not initially opened.
+      if (dialog.opened && dialog.$) {
+        copyClassName(dialog);
+      }
     }
   };
 })();


### PR DESCRIPTION
## Description

Avoid client-side errors on init when a `Dialog` is added as a child of another `Dialog`.

![Screenshot 2023-01-12 at 10 27 28](https://user-images.githubusercontent.com/1222264/212025439-73732b15-2b93-4bf0-a5a4-06c4947c8edc.png)

## Type of change

- Bugfix