### PR TITLE
refactor: deprecate RTE value property in favor of asDelta (#4087)

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/tests/RichTextEditorAsDeltaPage.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/tests/RichTextEditorAsDeltaPage.java
@@ -1,0 +1,105 @@
+package com.vaadin.flow.component.richtexteditor.tests;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.richtexteditor.RichTextEditor;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.BinderValidationStatus;
+import com.vaadin.flow.data.binder.BindingValidationStatus;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.function.SerializablePredicate;
+import com.vaadin.flow.router.Route;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Route(value = "vaadin-rich-text-editor/as-delta")
+public class RichTextEditorAsDeltaPage extends VerticalLayout {
+
+    public RichTextEditorAsDeltaPage() {
+        createSimpleRichTextEditor();
+        createRichTextEditorWithBinder();
+    }
+
+    private void createSimpleRichTextEditor() {
+        RichTextEditor rte = new RichTextEditor();
+        rte.setId("simple-rte");
+        rte.setValueChangeMode(ValueChangeMode.EAGER);
+
+        Div simpleOutput = new Div();
+        simpleOutput.setId("simple-output");
+
+        rte.asDelta().addValueChangeListener(e -> {
+            simpleOutput.setText(e.getValue());
+        });
+
+        Button setValueButton = new Button("Set server value");
+        setValueButton.setId("set-server-value");
+        setValueButton.addClickListener(
+                event -> rte.asDelta().setValue("[{\"insert\":\"Foo\"}]"));
+
+        add(rte, setValueButton, simpleOutput);
+    }
+
+    private void createRichTextEditorWithBinder() {
+        RichTextEditor rte = new RichTextEditor();
+        rte.setId("binder-rte");
+        rte.setValueChangeMode(ValueChangeMode.EAGER);
+        rte.setRequiredIndicatorVisible(true);
+
+        Div binderOutput = new Div();
+        binderOutput.setId("binder-output");
+
+        // Configure Binder
+        SerializablePredicate<String> notEmptyPredicate = value -> !rte
+                .asDelta().getValue().trim().isEmpty();
+
+        TestBean testBean = new TestBean();
+        Binder<TestBean> binder = new Binder<>();
+        binder.forField(rte.asDelta())
+                .withValidator(notEmptyPredicate,
+                        "Delta value should contain something")
+                .bind(TestBean::getDeltaValue, TestBean::setDeltaValue);
+
+        // Create action buttons
+        Button save = new Button("Save");
+        save.setId("binder-save");
+        save.addClickListener(event -> {
+            if (binder.writeBeanIfValid(testBean)) {
+                binderOutput.setText("Saved: " + testBean.getDeltaValue());
+            } else {
+                BinderValidationStatus<TestBean> validate = binder.validate();
+                String errorText = validate.getFieldValidationStatuses()
+                        .stream().filter(BindingValidationStatus::isError)
+                        .map(BindingValidationStatus::getMessage)
+                        .map(Optional::get).distinct()
+                        .collect(Collectors.joining(", "));
+                binderOutput.setText("There are errors: " + errorText);
+            }
+        });
+
+        Button reset = new Button("Reset");
+        reset.setId("binder-reset");
+        reset.addClickListener(event -> {
+            // clear fields by setting null
+            binder.readBean(null);
+            binderOutput.setText("");
+        });
+
+        add(rte, new Div(save, reset), binderOutput);
+    }
+
+    private static class TestBean implements Serializable {
+        private String deltaValue = "";
+
+        public String getDeltaValue() {
+            return deltaValue;
+        }
+
+        public void setDeltaValue(String deltaValue) {
+            this.deltaValue = deltaValue;
+        }
+    }
+}

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/tests/RichTextEditorAsDeltaIT.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/tests/RichTextEditorAsDeltaIT.java
@@ -1,0 +1,92 @@
+package com.vaadin.flow.component.richtexteditor.tests;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.richtexteditor.testbench.RichTextEditorElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-rich-text-editor/as-delta")
+public class RichTextEditorAsDeltaIT extends AbstractComponentIT {
+
+    private RichTextEditorElement simpleRte;
+    private TestBenchElement simpleOutput;
+
+    private RichTextEditorElement binderRte;
+    private TestBenchElement binderOutput;
+    private ButtonElement binderSave;
+    private ButtonElement binderReset;
+
+    @Before
+    public void init() {
+        open();
+        simpleRte = $(RichTextEditorElement.class).id("simple-rte");
+        simpleOutput = $(TestBenchElement.class).id("simple-output");
+
+        binderRte = $(RichTextEditorElement.class).id("binder-rte");
+        binderOutput = $(TestBenchElement.class).id("binder-output");
+        binderSave = $(ButtonElement.class).id("binder-save");
+        binderReset = $(ButtonElement.class).id("binder-reset");
+    }
+
+    @Test
+    public void simple_setServerValue() {
+        $(ButtonElement.class).id("set-server-value").click();
+
+        Assert.assertEquals("<p>Foo</p>",
+                simpleRte.getEditor().getProperty("innerHTML"));
+    }
+
+    @Test
+    public void simple_enterValue() {
+        simpleRte.getEditor().sendKeys("Foo");
+
+        waitUntil(e -> !simpleOutput.getText().isEmpty());
+
+        Assert.assertEquals("[{\"insert\":\"Foo\\n\"}]",
+                simpleOutput.getText());
+    }
+
+    @Test
+    public void binder_emptyValue_error() {
+        binderSave.click();
+
+        waitUntil(e -> !binderOutput.getText().isEmpty());
+
+        Assert.assertEquals(
+                "There are errors: Delta value should contain something",
+                binderOutput.getText());
+    }
+
+    @Test
+    public void binder_enterValue_saved() {
+        binderRte.getEditor().sendKeys("Foo");
+
+        waitUntil(e -> {
+            binderSave.click();
+            return !binderOutput.getText().startsWith("There are errors");
+        });
+
+        Assert.assertEquals("Saved: [{\"insert\":\"Foo\\n\"}]",
+                binderOutput.getText());
+    }
+
+    @Test
+    public void binder_enterValue_reset_empty() {
+        binderRte.getEditor().sendKeys("Foo");
+        Assert.assertEquals("<p>Foo</p>",
+                binderRte.getEditor().getProperty("innerHTML"));
+
+        waitUntil(e -> {
+            binderSave.click();
+            return !binderOutput.getText().startsWith("There are errors");
+        });
+        binderReset.click();
+
+        Assert.assertEquals("<p><br></p>",
+                binderRte.getEditor().getProperty("innerHTML"));
+    }
+}

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -38,14 +38,19 @@ import elemental.json.JsonObject;
  * format and style your text using boldface, italics, headings, lists, images,
  * links etc.
  * <p>
- * The value of the rich text editor is in
- * <a href="https://github.com/quilljs/delta">Delta</a> format. The
+ * The value of the rich text editor is in the
+ * <a href="https://github.com/quilljs/delta">Quill Delta</a> format. The
  * {@link #setValue(String) setValue} and {@link #getValue() getValue} methods
- * deal with the default Delta format, but it is also possible to get and set
- * the value as an HTML string using
- * <code>rte.{@link #asHtml()}.{@link AsHtml#getValue() getValue()}</code>,
- * <code>rte.{@link #asHtml()}.{@link AsHtml#setValue(String) setValue()}</code>
- * and {@link #getHtmlValue()}.
+ * use the delta format by default.
+ * <p>
+ * Note that the default use of the delta format has been deprecated in 23.3,
+ * and from 24 onwards, the component will use the HTML format as default. To
+ * keep using the delta format, use {@link #asDelta()},
+ * {@link AsDelta#getValue()} and {@link AsDelta#setValue(String)}.
+ *
+ * <p>
+ * To get and set the value in HTML format, use {@link #asHtml},
+ * {@link AsHtml#getValue()} and {@link AsHtml#setValue(String)}.
  *
  * @author Vaadin Ltd
  *
@@ -63,6 +68,7 @@ public class RichTextEditor
     private ValueChangeMode currentMode;
     private RichTextEditorI18n i18n;
     private AsHtml asHtml;
+    private AsDelta asDelta;
     private HtmlSetRequest htmlSetRequest;
 
     /**
@@ -163,8 +169,11 @@ public class RichTextEditor
      * @see AsHtml#setValue(String)
      * @param value
      *            the new value in Delta format, not {@code null}
+     * @deprecated since 23.3, from 24 onwards the value will be in HTML format.
+     *             Use {@link #asDelta()} instead.
      */
     @Override
+    @Deprecated
     public void setValue(String value) {
         super.setValue(value);
     }
@@ -186,8 +195,11 @@ public class RichTextEditor
      * @see #asHtml()
      * @see AsHtml#getValue()
      * @return the current value.
+     * @deprecated since 23.3, from 24 onwards the value will be in HTML format.
+     *             Use {@link #asDelta()} instead.
      */
     @Override
+    @Deprecated
     public String getValue() {
         return super.getValue();
     }
@@ -750,8 +762,8 @@ public class RichTextEditor
     }
 
     /**
-     * Gets an instance of {@code HasValue} for binding the html value of the
-     * editor with {@code Binder}.
+     * Gets an instance of {@code HasValue} for the editor in the HTML format.
+     * Can be used for binding the value with {@link Binder}.
      *
      * @return an instance of {@code HasValue}
      */
@@ -760,6 +772,20 @@ public class RichTextEditor
             asHtml = new AsHtml();
         }
         return asHtml;
+    }
+
+    /**
+     * Gets an instance of {@code HasValue} for the editor in the
+     * <a href="https://github.com/quilljs/delta">Quill Delta</a> format. Can be
+     * used for binding the value with {@link Binder}.
+     *
+     * @return an instance of {@code HasValue}
+     */
+    public HasValue<ValueChangeEvent<String>, String> asDelta() {
+        if (asDelta == null) {
+            asDelta = new AsDelta();
+        }
+        return asDelta;
     }
 
     /**
@@ -961,4 +987,76 @@ public class RichTextEditor
         }
     }
 
+    private class AsDelta
+            implements HasValue<ValueChangeEvent<String>, String> {
+        /**
+         * Sets the value of this editor in the
+         * <a href="https://github.com/quilljs/delta">Quill Delta</a> format. If
+         * the new value is not equal to {@code getValue()}, fires a value
+         * change event. Throws {@code NullPointerException}, if the value is
+         * null.
+         * <p>
+         * Note: {@link Binder} will take care of the {@code null} conversion
+         * when integrates with the editor, as long as no new converter is
+         * defined.
+         *
+         * @param value
+         *            the new value in Delta format, not {@code null}
+         */
+        @Override
+        public void setValue(String value) {
+            RichTextEditor.this.setValue(value);
+        }
+
+        /**
+         * Returns the current value of this editor in the
+         * <a href="https://github.com/quilljs/delta">Quill Delta</a> format. By
+         * default, the empty editor will return an empty string.
+         *
+         * @return the current value.
+         */
+        @Override
+        public String getValue() {
+            return RichTextEditor.this.getValue();
+        }
+
+        @Override
+        public Registration addValueChangeListener(
+                ValueChangeListener<? super ValueChangeEvent<String>> valueChangeListener) {
+            return RichTextEditor.this
+                    .addValueChangeListener(valueChangeListener);
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) {
+            RichTextEditor.this.setReadOnly(readOnly);
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return RichTextEditor.this.isReadOnly();
+        }
+
+        @Override
+        public void setRequiredIndicatorVisible(
+                boolean requiredIndicatorVisible) {
+            RichTextEditor.this
+                    .setRequiredIndicatorVisible(requiredIndicatorVisible);
+        }
+
+        @Override
+        public boolean isRequiredIndicatorVisible() {
+            return RichTextEditor.this.isRequiredIndicatorVisible();
+        }
+
+        @Override
+        public String getEmptyValue() {
+            return RichTextEditor.this.getEmptyValue();
+        }
+
+        @Override
+        public void clear() {
+            RichTextEditor.this.clear();
+        }
+    }
 }

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -228,6 +228,60 @@ public class RichTextEditorTest {
                 rte.isRequiredIndicatorVisible());
     }
 
+    // asDelta
+
+    @Test
+    public void asDelta_setValue_getValue() {
+        String deltaValue = "[{\"insert\":\"Foo\"}]";
+        RichTextEditor rte = new RichTextEditor();
+        HasValue<ValueChangeEvent<String>, String> asDelta = rte.asDelta();
+        asDelta.setValue(deltaValue);
+
+        Assert.assertEquals("Should set value property", deltaValue,
+                rte.getElement().getProperty("value"));
+        Assert.assertEquals("Should get the same value as it was set",
+                deltaValue, asDelta.getValue());
+    }
+
+    @Test
+    public void asDelta_setReadOnly_rteIsReadonly() {
+        RichTextEditor rte = new RichTextEditor();
+        HasValue<ValueChangeEvent<String>, String> asDelta = rte.asDelta();
+        asDelta.setReadOnly(true);
+        Assert.assertTrue("Should be possible to set readonly on asDelta",
+                rte.isReadOnly());
+    }
+
+    @Test
+    public void asDelta_setRequiredIndicatorVisible_rteRequiredIndicatorVisible() {
+        RichTextEditor rte = new RichTextEditor();
+        HasValue<ValueChangeEvent<String>, String> asDelta = rte.asDelta();
+        asDelta.setRequiredIndicatorVisible(true);
+        Assert.assertTrue(
+                "Should be possible to set required indicator to be visible on asDelta",
+                rte.isRequiredIndicatorVisible());
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void asDelta_addChangeListener() {
+        String deltaValue = "[{\"insert\":\"Foo\"}]";
+        RichTextEditor rte = new RichTextEditor();
+        HasValue<ValueChangeEvent<String>, String> asDelta = rte.asDelta();
+
+        HasValue.ValueChangeListener valueChangeListenerMock = Mockito
+                .mock(HasValue.ValueChangeListener.class);
+        asDelta.addValueChangeListener(valueChangeListenerMock);
+
+        rte.asDelta().setValue(deltaValue);
+        Mockito.verify(valueChangeListenerMock, Mockito.times(1))
+                .valueChanged(Mockito.any());
+
+        rte.setValue("");
+        Mockito.verify(valueChangeListenerMock, Mockito.times(2))
+                .valueChanged(Mockito.any());
+    }
+
     @Test
     public void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
         Element element = new Element("vaadin-rich-text-editor");


### PR DESCRIPTION
Cherry-pick of #4087 to `master` / v24.

Adding this as a basis for switching the default format to HTML to hopefully reduce the changes from [that PR](https://github.com/vaadin/flow-components/pull/4521) a bit.

Part of https://github.com/vaadin/flow-components/issues/1063

## Type of change

- Refactoring