### PR TITLE
feat: move flex-shrink API to FlexComponent

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
@@ -290,6 +290,59 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
     }
 
     /**
+     * Sets the flex shrink property of the components inside the layout. The
+     * flex shrink property specifies how the item will shrink relative to the
+     * rest of the components inside the same layout.
+     *
+     * Negative values are not allowed.
+     *
+     * The default value is 1.
+     *
+     * @param flexShrink
+     *            how much the component will shrink relative to the rest of the
+     *            components
+     * @param elementContainers
+     *            the containers (components) to apply the flex shrink property
+     */
+    default public void setFlexShrink(double flexShrink,
+            HasElement... elementContainers) {
+        if (flexShrink < 0) {
+            throw new IllegalArgumentException(
+                    "Flex shrink property cannot be negative");
+        }
+
+        for (HasElement container : elementContainers) {
+            container.getElement().getStyle().set(
+                    FlexConstants.FLEX_SHRINK_CSS_PROPERTY,
+                    String.valueOf(flexShrink));
+        }
+    }
+
+    /**
+     * Gets the flex shrink property of a given element container.
+     *
+     * @param elementContainer
+     *            the element container to read the flex shrink property from
+     * @return the flex shrink property, or 1 if none was set
+     */
+    default public double getFlexShrink(HasElement elementContainer) {
+        String ratio = elementContainer.getElement().getStyle()
+                .get(FlexConstants.FLEX_SHRINK_CSS_PROPERTY);
+        if (ratio == null || ratio.isEmpty()) {
+            return 1;
+        }
+
+        try {
+            return Double.parseDouble(ratio);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "The flex shrink property of the element container is not parseable to double: "
+                            + ratio,
+                    e);
+        }
+    }
+
+    /**
      * Sets the {@link JustifyContentMode} used by this layout.
      * <p>
      * The default justify content mode is {@link JustifyContentMode#START}.

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
@@ -293,9 +293,9 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
      * Sets the flex shrink property of the components inside the layout. The
      * flex shrink property specifies how the item will shrink relative to the
      * rest of the components inside the same layout.
-     *
+     * <p>
      * Negative values are not allowed.
-     *
+     * <p>
      * The default value is 1.
      *
      * @param flexShrink

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
@@ -336,59 +336,6 @@ public class FlexLayout extends Component
     }
 
     /**
-     * Sets the flex shrink property of the components inside the layout. The
-     * flex shrink property specifies how the item will shrink relative to the
-     * rest of the components inside the same layout.
-     *
-     * Negative values are not allowed.
-     *
-     * The default value is 1.
-     *
-     * @param flexShrink
-     *            how much the component will shrink relative to the rest of the
-     *            components
-     * @param elementContainers
-     *            the containers (components) to apply the flex shrink property
-     */
-    public void setFlexShrink(double flexShrink,
-            HasElement... elementContainers) {
-        if (flexShrink < 0) {
-            throw new IllegalArgumentException(
-                    "Flex shrink property cannot be negative");
-        }
-
-        for (HasElement container : elementContainers) {
-            container.getElement().getStyle().set(
-                    FlexConstants.FLEX_SHRINK_CSS_PROPERTY,
-                    String.valueOf(flexShrink));
-        }
-    }
-
-    /**
-     * Gets the flex shrink property of a given element container.
-     *
-     * @param elementContainer
-     *            the element container to read the flex shrink property from
-     * @return the flex shrink property, or 1 if none was set
-     */
-    public double getFlexShrink(HasElement elementContainer) {
-        String ratio = elementContainer.getElement().getStyle()
-                .get(FlexConstants.FLEX_SHRINK_CSS_PROPERTY);
-        if (ratio == null || ratio.isEmpty()) {
-            return 1;
-        }
-
-        try {
-            return Double.parseDouble(ratio);
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "The flex shrink property of the element container is not parseable to double: "
-                            + ratio,
-                    e);
-        }
-    }
-
-    /**
      * Sets the order property of the component inside the layout. The order
      * property specifies the order of a component relative to the rest of the
      * components inside the same layout.

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexComponentTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexComponentTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.orderedlayout.tests;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FlexComponentTest {
+
+    @Test
+    public void setFlexShrink() {
+        TestComponent component = new TestComponent();
+        Div div = new Div();
+        component.add(div);
+        component.setFlexShrink(2, div);
+
+        Assert.assertEquals("should set flex-shrink",
+                component.getFlexShrink(div), 2, 0);
+    }
+
+    @Test
+    public void getFlexShrink_returnOneIfNotSet() {
+        TestComponent component = new TestComponent();
+        Div div = new Div();
+        component.add(div);
+
+        Assert.assertEquals("should return 1 if flex-shirk not set",
+                component.getFlexShrink(div), 1, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setFlexShrink_throwExceptionIfNegative() {
+        TestComponent component = new TestComponent();
+        Div div = new Div();
+        component.add(div);
+        component.setFlexShrink(-1, div);
+    }
+
+    @Tag("test")
+    private static class TestComponent extends Component
+            implements FlexComponent {
+    }
+}

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexLayoutTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexLayoutTest.java
@@ -111,35 +111,6 @@ public class FlexLayoutTest {
     }
 
     @Test
-    public void testFlexLayout_setFlexShrink() {
-        FlexLayout layout = new FlexLayout();
-        Div div = new Div();
-        layout.add(div);
-        layout.setFlexShrink(2, div);
-
-        Assert.assertEquals("should set flex-shrink", layout.getFlexShrink(div),
-                2, 0);
-    }
-
-    @Test
-    public void testFlexLayout_getFlexShrink_returnOneIfNotSet() {
-        FlexLayout layout = new FlexLayout();
-        Div div = new Div();
-        layout.add(div);
-
-        Assert.assertEquals("should return 1 if flex-shirk not set",
-                layout.getFlexShrink(div), 1, 0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testFlexLayout_setFlexShrink_throwExceptionIfNegative() {
-        FlexLayout layout = new FlexLayout();
-        Div div = new Div();
-        layout.add(div);
-        layout.setFlexShrink(-1, div);
-    }
-
-    @Test
     public void testFlexLayout_setAndUnsetOrder() {
         FlexLayout layout = new FlexLayout();
         Div div = new Div();


### PR DESCRIPTION
## Description

Closes https://github.com/vaadin/flow-components/issues/3772

Move the `setFlexShrink` and `getFlexShrink` methods from `FlexLayout` to `FlexComponent`, effectively making them available for `HorizontalLayout` and `VerticalLayout` also.

Relates to https://github.com/vaadin/web-components/pull/5281: `"Should introduce HorizontalLayout/VerticalLayout.setFlexShrink so Flow devs can easily revert the flex-shrink change in Button and badge"`

## Type of change

- Feature