### PR TITLE
refactor: rename confusing elementContainers parameter

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
@@ -177,9 +177,9 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
     }
 
     /**
-     * Sets an alignment for individual element container inside the layout.
-     * This individual alignment for the element container overrides any
-     * alignment set at the {@link #setAlignItems(Alignment)}.
+     * Sets an alignment for individual components inside the layout. This
+     * individual alignment for the component overrides any alignment set at the
+     * {@link #setAlignItems(Alignment)}.
      * <p>
      * It effectively sets the {@code "alignSelf"} style value.
      * <p>
@@ -189,20 +189,19 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
      * @param alignment
      *            the individual alignment for the children components. Setting
      *            <code>null</code> will reset the alignment to its default
-     * @param elementContainers
-     *            The element containers (components) to which the individual
-     *            alignment should be set
+     * @param components
+     *            The components to which the individual alignment should be set
      */
     default public void setAlignSelf(Alignment alignment,
-            HasElement... elementContainers) {
+            HasElement... components) {
         if (alignment == null) {
-            for (HasElement container : elementContainers) {
-                container.getElement().getStyle()
+            for (HasElement component : components) {
+                component.getElement().getStyle()
                         .remove(FlexConstants.ALIGN_SELF_CSS_PROPERTY);
             }
         } else {
-            for (HasElement container : elementContainers) {
-                container.getElement().getStyle().set(
+            for (HasElement component : components) {
+                component.getElement().getStyle().set(
                         FlexConstants.ALIGN_SELF_CSS_PROPERTY,
                         alignment.getFlexValue());
             }
@@ -210,18 +209,17 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
     }
 
     /**
-     * Gets the individual alignment of a given element container.
+     * Gets the individual alignment of a given component.
      * <p>
-     * The default alignment for individual element containers is
+     * The default alignment for individual components is
      * {@link Alignment#AUTO}.
      *
-     * @param container
-     *            The element container (component) which individual layout
-     *            should be read
-     * @return the alignment of the container, never <code>null</code>
+     * @param component
+     *            The component which individual layout should be read
+     * @return the alignment of the component, never <code>null</code>
      */
-    default public Alignment getAlignSelf(HasElement container) {
-        return Alignment.toAlignment(container.getElement().getStyle()
+    default public Alignment getAlignSelf(HasElement component) {
+        return Alignment.toAlignment(component.getElement().getStyle()
                 .get(FlexConstants.ALIGN_SELF_CSS_PROPERTY), Alignment.AUTO);
     }
 
@@ -238,28 +236,27 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
      * other components, and so on.
      * <p>
      * Setting to flex grow property value 0 disables the expansion of the
-     * element container. Negative values are not allowed.
+     * component. Negative values are not allowed.
      *
      * @param flexGrow
-     *            the proportion of the available space the element container
-     *            should take up
-     * @param elementContainers
-     *            the containers (components) to apply the flex grow property
+     *            the proportion of the available space the component should
+     *            take up
+     * @param components
+     *            the components to apply the flex grow property
      */
-    default public void setFlexGrow(double flexGrow,
-            HasElement... elementContainers) {
+    default public void setFlexGrow(double flexGrow, HasElement... components) {
         if (flexGrow < 0) {
             throw new IllegalArgumentException(
                     "Flex grow property cannot be negative");
         }
         if (flexGrow == 0) {
-            for (HasElement container : elementContainers) {
-                container.getElement().getStyle()
+            for (HasElement component : components) {
+                component.getElement().getStyle()
                         .remove(FlexConstants.FLEX_GROW_CSS_PROPERTY);
             }
         } else {
-            for (HasElement container : elementContainers) {
-                container.getElement().getStyle().set(
+            for (HasElement component : components) {
+                component.getElement().getStyle().set(
                         FlexConstants.FLEX_GROW_CSS_PROPERTY,
                         String.valueOf(flexGrow));
             }
@@ -267,14 +264,14 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
     }
 
     /**
-     * Gets the flex grow property of a given element container.
+     * Gets the flex grow property of a given component.
      *
-     * @param elementContainer
-     *            the element container to read the flex grow property from
+     * @param component
+     *            the component to read the flex grow property from
      * @return the flex grow property, or 0 if none was set
      */
-    default public double getFlexGrow(HasElement elementContainer) {
-        String ratio = elementContainer.getElement().getStyle()
+    default public double getFlexGrow(HasElement component) {
+        String ratio = component.getElement().getStyle()
                 .get(FlexConstants.FLEX_GROW_CSS_PROPERTY);
         if (ratio == null || ratio.isEmpty()) {
             return 0;
@@ -283,7 +280,7 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
             return Double.parseDouble(ratio);
         } catch (Exception e) {
             throw new IllegalStateException(
-                    "The flex grow property of the element container is not parseable to double: "
+                    "The flex grow property of the component is not parseable to double: "
                             + ratio,
                     e);
         }
@@ -301,32 +298,32 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
      * @param flexShrink
      *            how much the component will shrink relative to the rest of the
      *            components
-     * @param elementContainers
-     *            the containers (components) to apply the flex shrink property
+     * @param components
+     *            the components to apply the flex shrink property
      */
     default public void setFlexShrink(double flexShrink,
-            HasElement... elementContainers) {
+            HasElement... components) {
         if (flexShrink < 0) {
             throw new IllegalArgumentException(
                     "Flex shrink property cannot be negative");
         }
 
-        for (HasElement container : elementContainers) {
-            container.getElement().getStyle().set(
+        for (HasElement component : components) {
+            component.getElement().getStyle().set(
                     FlexConstants.FLEX_SHRINK_CSS_PROPERTY,
                     String.valueOf(flexShrink));
         }
     }
 
     /**
-     * Gets the flex shrink property of a given element container.
+     * Gets the flex shrink property of a given component.
      *
-     * @param elementContainer
-     *            the element container to read the flex shrink property from
+     * @param component
+     *            the component to read the flex shrink property from
      * @return the flex shrink property, or 1 if none was set
      */
-    default public double getFlexShrink(HasElement elementContainer) {
-        String ratio = elementContainer.getElement().getStyle()
+    default public double getFlexShrink(HasElement component) {
+        String ratio = component.getElement().getStyle()
                 .get(FlexConstants.FLEX_SHRINK_CSS_PROPERTY);
         if (ratio == null || ratio.isEmpty()) {
             return 1;
@@ -336,7 +333,7 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
             return Double.parseDouble(ratio);
         } catch (Exception e) {
             throw new IllegalStateException(
-                    "The flex shrink property of the element container is not parseable to double: "
+                    "The flex shrink property of the component is not parseable to double: "
                             + ratio,
                     e);
         }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexLayout.java
@@ -271,17 +271,17 @@ public class FlexLayout extends Component
      * @param width
      *            the width for the components. Setting <code>null</code> will
      *            remove the flex basis property
-     * @param elementContainers
-     *            the containers (components) to apply the flex basis property
+     * @param components
+     *            the components to apply the flex basis property
      */
-    public void setFlexBasis(String width, HasElement... elementContainers) {
+    public void setFlexBasis(String width, HasElement... components) {
         if (width == null) {
-            for (HasElement element : elementContainers) {
+            for (HasElement element : components) {
                 element.getElement().getStyle()
                         .remove(FlexConstants.FLEX_BASIS_CSS_PROPERTY);
             }
         } else {
-            for (HasElement element : elementContainers) {
+            for (HasElement element : components) {
                 element.getElement().getStyle()
                         .set(FlexConstants.FLEX_BASIS_CSS_PROPERTY, width);
             }
@@ -289,14 +289,14 @@ public class FlexLayout extends Component
     }
 
     /**
-     * Gets the flex basis property of a given element container.
+     * Gets the flex basis property of a given component.
      *
-     * @param elementContainer
-     *            the element container to read the flex basis property from
+     * @param component
+     *            the component to read the flex basis property from
      * @return the flex grow property
      */
-    public String getFlexBasis(HasElement elementContainer) {
-        return elementContainer.getElement().getStyle()
+    public String getFlexBasis(HasElement component) {
+        return component.getElement().getStyle()
                 .get(FlexConstants.FLEX_BASIS_CSS_PROPERTY);
     }
 
@@ -345,27 +345,27 @@ public class FlexLayout extends Component
      *
      * @param order
      *            the order for the component
-     * @param elementContainer
-     *            the container (component) to apply the order property
+     * @param component
+     *            the component to apply the order property
      */
-    public void setOrder(int order, HasElement elementContainer) {
+    public void setOrder(int order, HasElement component) {
         if (order == 0) {
-            elementContainer.getElement().getStyle()
+            component.getElement().getStyle()
                     .remove(FlexConstants.ORDER_CSS_PROPERTY);
         }
-        elementContainer.getElement().getStyle()
-                .set(FlexConstants.ORDER_CSS_PROPERTY, String.valueOf(order));
+        component.getElement().getStyle().set(FlexConstants.ORDER_CSS_PROPERTY,
+                String.valueOf(order));
     }
 
     /**
-     * Gets the order property of a given element container.
+     * Gets the order property of a given component.
      *
-     * @param elementContainer
-     *            the element container to read the order property from
+     * @param component
+     *            the component to read the order property from
      * @return the order property, or 0 if none was set
      */
-    public int getOrder(HasElement elementContainer) {
-        String order = elementContainer.getElement().getStyle()
+    public int getOrder(HasElement component) {
+        String order = component.getElement().getStyle()
                 .get(FlexConstants.ORDER_CSS_PROPERTY);
 
         if (order == null || order.isEmpty()) {
@@ -375,7 +375,7 @@ public class FlexLayout extends Component
             return Integer.parseInt(order);
         } catch (Exception e) {
             throw new IllegalStateException(
-                    "The order property of the element container is not parseable to integer: "
+                    "The order property of the component is not parseable to integer: "
                             + order,
                     e);
         }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
@@ -186,33 +186,30 @@ public class HorizontalLayout extends Component implements ThemableLayout,
      * @param alignment
      *            the individual alignment for the children components. Setting
      *            <code>null</code> will reset the alignment to its default
-     * @param elementContainers
-     *            The element containers (components) to which the individual
-     *            alignment should be set
+     * @param components
+     *            The components to which the individual alignment should be set
      * @see #setVerticalComponentAlignment(Alignment, Component...)
      */
     @Override
-    public void setAlignSelf(Alignment alignment,
-            HasElement... elementContainers) {
+    public void setAlignSelf(Alignment alignment, HasElement... components) {
         // this method is overridden to have javadocs that point to the method
         // that should be used and has better javadocs.
-        FlexComponent.super.setAlignSelf(alignment, elementContainers);
+        FlexComponent.super.setAlignSelf(alignment, components);
     }
 
     /**
      * This is the same as {@link #getVerticalComponentAlignment(Component)}.
      *
-     * @param container
-     *            The element container (component) which individual layout
-     *            should be read
-     * @return the alignment of the container, never <code>null</code>
+     * @param component
+     *            The component which individual layout should be read
+     * @return the alignment of the component, never <code>null</code>
      * @see #getVerticalComponentAlignment(Component)
      */
     @Override
-    public Alignment getAlignSelf(HasElement container) {
+    public Alignment getAlignSelf(HasElement component) {
         // this method is overridden to have javadocs that point to the method
         // that should be used and has better javadocs.
-        return FlexComponent.super.getAlignSelf(container);
+        return FlexComponent.super.getAlignSelf(component);
     }
 
     /**

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
@@ -194,33 +194,30 @@ public class VerticalLayout extends Component implements ThemableLayout,
      * @param alignment
      *            the individual alignment for the children components. Setting
      *            <code>null</code> will reset the alignment to its default
-     * @param elementContainers
-     *            The element containers (components) to which the individual
-     *            alignment should be set
+     * @param components
+     *            The components to which the individual alignment should be set
      * @see #setHorizontalComponentAlignment(Alignment, Component...)
      */
     @Override
-    public void setAlignSelf(Alignment alignment,
-            HasElement... elementContainers) {
+    public void setAlignSelf(Alignment alignment, HasElement... components) {
         // this method is overridden to have javadocs that point to the method
         // that should be used and has better javadocs.
-        FlexComponent.super.setAlignSelf(alignment, elementContainers);
+        FlexComponent.super.setAlignSelf(alignment, components);
     }
 
     /**
      * This is the same as {@link #getHorizontalComponentAlignment(Component)}.
      *
-     * @param container
-     *            The element container (component) which individual layout
-     *            should be read
-     * @return the alignment of the container, never <code>null</code>
+     * @param component
+     *            The component which individual layout should be read
+     * @return the alignment of the component, never <code>null</code>
      * @see #getHorizontalComponentAlignment(Component)
      */
     @Override
-    public Alignment getAlignSelf(HasElement container) {
+    public Alignment getAlignSelf(HasElement component) {
         // this method is overridden to have javadocs that point to the method
         // that should be used and has better javadocs.
-        return FlexComponent.super.getAlignSelf(container);
+        return FlexComponent.super.getAlignSelf(component);
     }
 
     /**


### PR DESCRIPTION
## Description

Addresses https://github.com/vaadin/flow-components/pull/4541#discussion_r1071911284

Rename the confusing `elementContainers` parameter used in number of methods of the `ordered-layout` module.

## Type of change

Refactor