### PR TITLE
refactor!: removed non-serializable constructors from LocalDateRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateRenderer.java
@@ -154,27 +154,6 @@ public class LocalDateRenderer<SOURCE>
      *            not <code>null</code>
      * @param formatter
      *            the formatter to use, not <code>null</code>
-     * @deprecated Via this constructor renderer is not serializable, use
-     *             {@link LocalDateRenderer(ValueProvider,
-     *             SerializableSupplier)} instead.
-     */
-    @Deprecated
-    public LocalDateRenderer(ValueProvider<SOURCE, LocalDate> valueProvider,
-            DateTimeFormatter formatter) {
-        this(valueProvider, () -> formatter, "");
-    }
-
-    /**
-     * Creates a new LocalDateRenderer.
-     * <p>
-     * The renderer is configured to render with the given formatter, with an
-     * empty string as its null representation.
-     *
-     * @param valueProvider
-     *            the callback to provide a {@link LocalDate} to the renderer,
-     *            not <code>null</code>
-     * @param formatter
-     *            the formatter to use, not <code>null</code>
      */
     public LocalDateRenderer(ValueProvider<SOURCE, LocalDate> valueProvider,
             SerializableSupplier<DateTimeFormatter> formatter) {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateTimeRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LocalDateTimeRenderer.java
@@ -74,56 +74,11 @@ public class LocalDateTimeRenderer<SOURCE>
      *            renderer, not <code>null</code>
      * @param formatter
      *            the formatter to use, not <code>null</code>
-     * @deprecated Via this constructor renderer is not serializable, use
-     *             {@link LocalDateTimeRenderer(ValueProvider,
-     *             SerializableSupplier)} instead.
-     */
-    @Deprecated
-    public LocalDateTimeRenderer(
-            ValueProvider<SOURCE, LocalDateTime> valueProvider,
-            DateTimeFormatter formatter) {
-        this(valueProvider, () -> formatter, "");
-    }
-
-    /**
-     * Creates a new LocalDateTimeRenderer.
-     * <p>
-     * The renderer is configured to render with the given formatter, with the
-     * empty string as its null representation.
-     *
-     * @param valueProvider
-     *            the callback to provide a {@link LocalDateTime} to the
-     *            renderer, not <code>null</code>
-     * @param formatter
-     *            the formatter to use, not <code>null</code>
      */
     public LocalDateTimeRenderer(
             ValueProvider<SOURCE, LocalDateTime> valueProvider,
             SerializableSupplier<DateTimeFormatter> formatter) {
         this(valueProvider, formatter, "");
-    }
-
-    /**
-     * Creates a new LocalDateTimeRenderer.
-     * <p>
-     * The renderer is configured to render with the given formatter.
-     *
-     * @param valueProvider
-     *            the callback to provide a {@link LocalDateTime} to the
-     *            renderer, not <code>null</code>
-     * @param formatter
-     *            the formatter to use, not <code>null</code>
-     * @param nullRepresentation
-     *            the textual representation of the <code>null</code> value
-     * @deprecated Via this constructor renderer is not serializable, use
-     *             {@link LocalDateTimeRenderer(ValueProvider,
-     *             SerializableSupplier, String)} instead.
-     */
-    @Deprecated
-    public LocalDateTimeRenderer(
-            ValueProvider<SOURCE, LocalDateTime> valueProvider,
-            DateTimeFormatter formatter, String nullRepresentation) {
-        this(valueProvider, () -> formatter, nullRepresentation);
     }
 
     /**


### PR DESCRIPTION
chore: removed non-serializable constructors from LocalDateRenderer and LocalDateTimeRenderer

Part of #4536