### PR TITLE
fix: add dialog and notification children to host element

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -16,18 +16,16 @@
 package com.vaadin.flow.component.dialog;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.Stream.Builder;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
@@ -346,35 +344,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
      *            the components to add
      */
     @Override
-    public void add(Component... components) {
-        Objects.requireNonNull(components, "Components should not be null");
-        for (Component component : components) {
-            Objects.requireNonNull(component,
-                    "Component to add cannot be null");
-            getElement().appendChild(component.getElement());
-        }
+    public void add(Collection<Component> components) {
+        HasComponents.super.add(components);
 
         updateVirtualChildNodeIds();
-    }
-
-    @Override
-    public void remove(Component... components) {
-        Objects.requireNonNull(components, "Components should not be null");
-        for (Component component : components) {
-            Objects.requireNonNull(component,
-                    "Component to remove cannot be null");
-            if (getElement().equals(component.getElement().getParent())) {
-                getElement().removeChild(component.getElement());
-            } else {
-                throw new IllegalArgumentException("The given component ("
-                        + component + ") is not a child of this component");
-            }
-        }
-    }
-
-    @Override
-    public void removeAll() {
-        getElement().removeAllChildren();
     }
 
     /**
@@ -392,14 +365,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     @Override
     public void addComponentAtIndex(int index, Component component) {
-        Objects.requireNonNull(component, "Component should not be null");
-        if (index < 0) {
-            throw new IllegalArgumentException(
-                    "Cannot add a component with a negative index");
-        }
-        // The case when the index is bigger than the children count is handled
-        // inside the method below
-        getElement().insertChild(index, component.getElement());
+        HasComponents.super.addComponentAtIndex(index, component);
 
         updateVirtualChildNodeIds();
     }
@@ -851,14 +817,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
         if (isAttached()) {
             getUI().ifPresent(ui -> ui.setChildComponentModal(this, modal));
         }
-    }
-
-    @Override
-    public Stream<Component> getChildren() {
-        Builder<Component> childComponents = Stream.builder();
-        getElement().getChildren().forEach(childElement -> ComponentUtil
-                .findComponents(childElement, childComponents::add));
-        return childComponents.build();
     }
 
     /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.dialog;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.After;
@@ -70,6 +71,23 @@ public class DialogChildrenTest {
         dialog.add(child);
         dialog.add(child2);
         assertVirtualChildren(child, child2);
+    }
+
+    @Test
+    public void addCollection_virtualNodeIdsInSync() {
+        var child = new Div();
+        var child2 = new Div();
+        dialog.add(List.of(child, child2));
+        assertVirtualChildren(child, child2);
+    }
+
+    @Test
+    public void addComponentAsFirst_virtualNodeIdsInSync() {
+        var child = new Div();
+        var child2 = new Div();
+        dialog.add(child);
+        dialog.addComponentAsFirst(child2);
+        assertVirtualChildren(child2, child);
     }
 
     @Test

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NestedNotificationPage.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NestedNotificationPage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.notification.tests;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-notification/nested")
+public class NestedNotificationPage extends Div {
+
+    public NestedNotificationPage() {
+        var parent = new Notification();
+
+        var child = new Notification();
+        child.setText("Child text");
+
+        parent.add(child);
+        parent.add(new NativeButton("Open child", e -> child.open()));
+
+        var openParentButton = new NativeButton("Open parent",
+                e -> parent.open());
+        openParentButton.setId("open");
+        add(openParentButton);
+    }
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NestedNotificationIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NestedNotificationIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.notification.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-notification/nested")
+public class NestedNotificationIT extends AbstractComponentIT {
+
+    @Test
+    public void openNotification_shouldNotThrow() {
+        open();
+
+        findElement(By.id("open")).click();
+
+        checkLogsForErrors();
+    }
+
+}

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -15,20 +15,18 @@
  */
 package com.vaadin.flow.component.notification;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.Stream.Builder;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
@@ -41,7 +39,6 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementDetachListener;
-import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.internal.HtmlUtils;
 import com.vaadin.flow.internal.StateTree;
@@ -352,34 +349,10 @@ public class Notification extends Component implements HasComponents, HasStyle,
      *            the components to add
      */
     @Override
-    public void add(Component... components) {
-        Objects.requireNonNull(components, "Components should not be null");
-        for (Component component : components) {
-            Objects.requireNonNull(component,
-                    "Component to add cannot be null");
-            getElement().appendChild(component.getElement());
-        }
-        configureComponentRenderer();
-    }
+    public void add(Collection<Component> components) {
+        HasComponents.super.add(components);
 
-    /**
-     * Remove the given components from this notification.
-     *
-     * @param components
-     *            the components to remove
-     */
-    @Override
-    public void remove(Component... components) {
-        for (Component component : components) {
-            Objects.requireNonNull(component,
-                    "Component to remove cannot be null");
-            if (getElement().equals(component.getElement().getParent())) {
-                getElement().removeChild(component.getElement());
-            } else {
-                throw new IllegalArgumentException("The given component ("
-                        + component + ") is not a child of this component");
-            }
-        }
+        configureComponentRenderer();
     }
 
     /**
@@ -401,32 +374,9 @@ public class Notification extends Component implements HasComponents, HasStyle,
      */
     @Override
     public void addComponentAtIndex(int index, Component component) {
-        Objects.requireNonNull(component, "Component should not be null");
-        if (index < 0) {
-            throw new IllegalArgumentException(
-                    "Cannot add a component with a negative index");
-        }
-        // The case when the index is bigger than the children count is handled
-        // inside the method below
-        getElement().insertChild(index, component.getElement());
+        HasComponents.super.addComponentAtIndex(index, component);
 
         configureComponentRenderer();
-    }
-
-    /**
-     * Remove all the components from this notification.
-     */
-    @Override
-    public void removeAll() {
-        getElement().removeAllChildren();
-    }
-
-    @Override
-    public Stream<Component> getChildren() {
-        Builder<Component> childComponents = Stream.builder();
-        getElement().getChildren().forEach(childElement -> ComponentUtil
-                .findComponents(childElement, childComponents::add));
-        return childComponents.build();
     }
 
     /**

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.notification;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.After;
@@ -70,6 +71,23 @@ public class NotificationChildrenTest {
         notification.add(child);
         notification.add(child2);
         assertVirtualChildren(child, child2);
+    }
+
+    @Test
+    public void addCollection_virtualNodeIdsInSync() {
+        var child = new Div();
+        var child2 = new Div();
+        notification.add(List.of(child, child2));
+        assertVirtualChildren(child, child2);
+    }
+
+    @Test
+    public void addComponentAsFirst_virtualNodeIdsInSync() {
+        var child = new Div();
+        var child2 = new Div();
+        notification.add(child);
+        notification.addComponentAsFirst(child2);
+        assertVirtualChildren(child2, child);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes the regression discovered in https://github.com/vaadin/flow-components/pull/4538#discussion_r1072032428.

The issue occurred when scheduled JS executions would trigger for a virtual child component before it was actually added to the DOM. The PR fixes the issue by appending the child components as regular elements to the `<vaadin-notification>` and `<vaadin-dialog>` hosts. The script which teleports the child components inside the overlay still works as before.

## Type of change

Bugfix