### PR TITLE
feat: add HasOverlayClassName interface to MultiSelectComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
-import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
@@ -69,8 +68,8 @@ import elemental.json.JsonObject;
 @JsModule("@vaadin/polymer-legacy-adapter/template-renderer.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./comboBoxConnector.js")
-public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T> implements
-        HasOverlayClassName, HasPrefix, HasThemeVariant<ComboBoxVariant> {
+public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
+        implements HasPrefix, HasThemeVariant<ComboBoxVariant> {
 
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
@@ -84,7 +85,7 @@ import java.util.stream.Stream;
 public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, TItem, TValue>, TItem, TValue>
         extends AbstractSinglePropertyField<TComponent, TValue>
         implements Focusable<TComponent>, HasAllowedCharPattern, HasAutoOpen,
-        HasClearButton, HasClientValidation,
+        HasClearButton, HasClientValidation, HasOverlayClassName,
         HasDataView<TItem, String, ComboBoxDataView<TItem>>, HasHelper,
         HasLabel, HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>,
         HasListDataView<TItem, ComboBoxListDataView<TItem>>, HasSize, HasStyle,

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -17,9 +17,10 @@ package com.vaadin.flow.component.combobox;
 
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasLabel;
-import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
+import com.vaadin.flow.component.shared.HasAllowedCharPattern;
+import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
@@ -65,6 +66,13 @@ public abstract class ComboBoxBaseTest {
     public void implementsHasAllowedCharPattern() {
         Assert.assertTrue("ComboBox should support allowed char pattern",
                 HasAllowedCharPattern.class.isAssignableFrom(
+                        createComboBox(String.class).getClass()));
+    }
+
+    @Test
+    public void implementsHasOverlayClassName() {
+        Assert.assertTrue("ComboBox should support overlay class name",
+                HasOverlayClassName.class.isAssignableFrom(
                         createComboBox(String.class).getClass()));
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -20,7 +20,6 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
@@ -184,13 +183,6 @@ public class ComboBoxTest extends ComboBoxBaseTest {
                 .thenAnswer(invocation -> new ComboBox());
         ComboBox field = Component.from(element, ComboBox.class);
         Assert.assertEquals("foo", field.getElement().getPropertyRaw("value"));
-    }
-
-    @Test
-    public void implementsHasOverlayClassName() {
-        Assert.assertTrue("ComboBox should support overlay class name",
-                HasOverlayClassName.class.isAssignableFrom(
-                        createComboBox(String.class).getClass()));
     }
 
     @Test


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/3593

Based on #4502

Note, the `HasOverlayClassName` is now moved to `ComboBoxBase` where other shared interfaces are placed.

## Type of change

- Feature