### PR TITLE
chore: update vaadin-date-picker web component to 4.5.0

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-date-picker</artifactId>
-            <version>4.4.5</version>
+            <version>4.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -255,7 +255,7 @@ import elemental.json.JsonObject;
  */
 @Tag("vaadin-date-picker")
 @HtmlImport("frontend://bower_components/vaadin-date-picker/src/vaadin-date-picker.html")
-@NpmPackage(value = "@vaadin/vaadin-date-picker", version = "4.4.5")
+@NpmPackage(value = "@vaadin/vaadin-date-picker", version = "4.5.0")
 @JsModule("@vaadin/vaadin-date-picker/src/vaadin-date-picker.js")
 public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePicker<R, T>, T>
         extends AbstractSinglePropertyField<R, T>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-date-picker</artifactId>
-            <version>4.4.5</version>
+            <version>4.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
## Description

Updated `vaadin-date-picker` to the new minor with `referenceDate` functionality.

## Type of change

- Version bump