### PR TITLE
fix: select custom editor text after value is set

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.gridpro.GridPro;
@@ -34,6 +35,13 @@ public class MainView extends VerticalLayout {
 
         Div eventsPanel = new Div();
         eventsPanel.setId("events-panel");
+
+        Div selectionPanel = new Div();
+        selectionPanel.setId("selection-panel");
+
+        UI.getCurrent().getElement().executeJs(
+                "document.addEventListener('selectionchange', () => $0.textContent = document.getSelection().toString())",
+                selectionPanel.getElement());
 
         GridPro<Person> grid = new GridPro<>();
         Button disableGrid = new Button("Disable Grid");
@@ -112,7 +120,7 @@ public class MainView extends VerticalLayout {
         disableGrid.addClickListener(click -> grid.setEnabled(false));
 
         add(grid, itemDisplayPanel, subPropertyDisplayPanel, eventsPanel,
-                disableGrid);
+                selectionPanel, disableGrid);
     }
 
     protected void createBeanGridWithEditColumns() {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
+import org.w3c.dom.Document;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -256,6 +257,24 @@ public class BasicIT extends AbstractParallelTest {
         TestBenchElement textField = cell.$("vaadin-text-field").first();
         // should have converted integer model value into string editor value
         Assert.assertEquals("2019", textField.getProperty("value"));
+    }
+
+    @Test
+    public void gridWithCustomEditors_navigateToWithTabKey_textIsSelected() {
+        var cell_0_4 = grid.getCell(0, 4);
+        assertCellEnterEditModeOnDoubleClick(0, 4, "vaadin-combo-box");
+
+        waitUntil(e -> cell_0_4.$("vaadin-combo-box").exists());
+        var input = cell_0_4.$("vaadin-combo-box").first();
+        input.sendKeys(Keys.TAB);
+
+        Assert.assertEquals("person1@vaadin.com",
+                getPanelText("selection-panel"));
+
+        var cell_0_5 = grid.getCell(0, 5);
+        input = cell_0_5.$("input").first();
+        input.sendKeys(Keys.TAB);
+        Assert.assertEquals("2019", getPanelText("selection-panel"));
     }
 
     private void assertCellEnterEditModeOnDoubleClick(Integer rowIndex,

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasValueAndElement;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.grid.ColumnPathRenderer;
@@ -141,6 +142,9 @@ public class GridPro<E> extends Grid<E> {
             if (column.getEditorType().equals("custom")) {
                 column.getEditorField()
                         .setValue(column.getValueProvider().apply(e.getItem()));
+                UI.getCurrent().getPage().executeJs(
+                        "window.Vaadin.Flow.gridProConnector.focusCustomEditor($0)",
+                        column.getEditorField().getElement());
             }
         });
     }

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -17,6 +17,13 @@
   }
 
   window.Vaadin.Flow.gridProConnector = {
+    focusCustomEditor: (editor) => {
+      if (editor instanceof HTMLInputElement) {
+        editor.select();
+      } else if (editor.focusElement && editor.focusElement instanceof HTMLInputElement) {
+        editor.focusElement.select();
+      }
+    },
     setEditModeRenderer: (column, component) =>
       tryCatchWrapper(function (column, component) {
         column.editModeRenderer = tryCatchWrapper(function editModeRenderer(root, _, rowData) {


### PR DESCRIPTION
## Description

When the user enters a cell with a custom editor, the GridPro calls the `setValue()` method, which makes the field loses the selected text that is performed by the web component. 

This change adds a method to `gridProConnector` that does the same logic present on the web component to select the text on the opened editor _only for the columns with a custom editor_.

Fixes #4305

## Type of change

- [X] Bugfix
- [ ] Feature
