### PR TITLE
refactor!: remove renderer when setting item label generator

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -475,6 +475,8 @@ public class CheckboxGroup<T>
      * Sets the item label generator that is used to produce the strings shown
      * in the checkbox group for each item. By default,
      * {@link String#valueOf(Object)} is used.
+     * <p>
+     * Setting an item label generator removes any previously set item renderer.
      *
      * @param itemLabelGenerator
      *            the item label provider to use, not null
@@ -484,6 +486,7 @@ public class CheckboxGroup<T>
         Objects.requireNonNull(itemLabelGenerator,
                 "The item label generator can not be null");
         this.itemLabelGenerator = itemLabelGenerator;
+        this.itemRenderer = null;
         refreshCheckboxes();
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.data.renderer.TextRenderer;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -326,6 +327,20 @@ public class CheckboxGroupTest {
         checkboxGroup.setItemLabelGenerator(item -> item + " (Updated)");
 
         Assert.assertEquals("foo (Updated)", cb.getLabel());
+    }
+
+    @Test
+    public void setItemLabelGenerator_removesItemRenderer() {
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setItems("foo", "bar");
+        checkboxGroup.setRenderer(new TextRenderer<>());
+
+        Assert.assertTrue(
+                checkboxGroup.getItemRenderer() instanceof TextRenderer);
+
+        checkboxGroup.setItemLabelGenerator(item -> item);
+
+        Assert.assertNull(checkboxGroup.getItemRenderer());
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -354,6 +354,7 @@ public class RadioButtonGroup<T>
      * in the radio button group for each item. By default,
      * {@link String#valueOf(Object)} is used.
      * <p>
+     * Setting an item label generator removes any previously set item renderer.
      *
      * @param itemLabelGenerator
      *            the item label provider to use, not null


### PR DESCRIPTION
## Description

Changes `CheckboxGroup` to remove any previously set item renderer when setting an item label generator. This ensures that the item label generator is actually used after setting it, and aligns the behavior of the component with `RadioButtonGroup`.

Closes #4522 

## Type of change

- Breaking change
