### PR TITLE
refactor: extract OverlayClassListProxy to shared package

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -16,10 +16,8 @@
 package com.vaadin.flow.component.dialog;
 
 import java.io.Serializable;
-import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -41,6 +39,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.InternalOverlayClassListProxy;
 import com.vaadin.flow.dom.ClassList;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
@@ -993,7 +992,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     @Override
     public ClassList getClassNames() {
-        return new OverlayClassListProxy(this);
+        return new InternalOverlayClassListProxy(this);
     }
 
     /**
@@ -1004,62 +1003,5 @@ public class Dialog extends Component implements HasComponents, HasSize,
     public Style getStyle() {
         throw new UnsupportedOperationException(
                 "Dialog does not support adding styles to overlay");
-    }
-
-    static class OverlayClassListProxy extends AbstractSet<String>
-            implements ClassList {
-        private final HasStyle hasStyle;
-        private final ClassList classList;
-
-        public OverlayClassListProxy(HasStyle hasStyle) {
-            this.hasStyle = hasStyle;
-            this.classList = hasStyle.getElement().getClassList();
-        }
-
-        private void updateOverlayClass() {
-            hasStyle.getElement().setProperty("overlayClass",
-                    hasStyle.getClassName());
-        }
-
-        @Override
-        public Iterator<String> iterator() {
-            return new IteratorProxy(classList.iterator());
-        }
-
-        @Override
-        public int size() {
-            return classList.size();
-        }
-
-        @Override
-        public boolean add(String s) {
-            boolean result = classList.add(s);
-            updateOverlayClass();
-            return result;
-        }
-
-        private class IteratorProxy implements Iterator<String> {
-            private final Iterator<String> iterator;
-
-            public IteratorProxy(Iterator<String> iterator) {
-                this.iterator = iterator;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
-
-            @Override
-            public String next() {
-                return iterator.next();
-            }
-
-            @Override
-            public void remove() {
-                iterator.remove();
-                updateOverlayClass();
-            }
-        }
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogHasStyleTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogHasStyleTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.shared.InternalOverlayClassListProxy;
 import com.vaadin.flow.server.VaadinSession;
 
 public class DialogHasStyleTest {
@@ -115,7 +116,7 @@ public class DialogHasStyleTest {
 
     @Test
     public void getClassNames_usesProxy() {
-        Assert.assertTrue(
-                dialog.getClassNames() instanceof Dialog.OverlayClassListProxy);
+        Assert.assertTrue(dialog
+                .getClassNames() instanceof InternalOverlayClassListProxy);
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogSerializableTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogSerializableTest.java
@@ -2,12 +2,5 @@ package com.vaadin.flow.component.dialog;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-import java.util.stream.Stream;
-
 public class DialogSerializableTest extends ClassesSerializableTest {
-    @Override
-    protected Stream<String> getExcludedPatterns() {
-        return Stream.concat(super.getExcludedPatterns(), Stream.of(
-                "com\\.vaadin\\.flow\\.component\\.shared\\.InternalOverlayClassListProxy\\$IteratorProxy"));
-    }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogSerializableTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogSerializableTest.java
@@ -8,6 +8,6 @@ public class DialogSerializableTest extends ClassesSerializableTest {
     @Override
     protected Stream<String> getExcludedPatterns() {
         return Stream.concat(super.getExcludedPatterns(), Stream.of(
-                "com\\.vaadin\\.flow\\.component\\.dialog\\.Dialog\\$OverlayClassListProxy\\$IteratorProxy"));
+                "com\\.vaadin\\.flow\\.component\\.shared\\.InternalOverlayClassListProxy\\$IteratorProxy"));
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InternalOverlayClassListProxy.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InternalOverlayClassListProxy.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.shared;
 
+import java.io.Serializable;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import com.vaadin.flow.component.HasStyle;
@@ -57,7 +58,7 @@ public class InternalOverlayClassListProxy extends AbstractSet<String>
         return result;
     }
 
-    private class IteratorProxy implements Iterator<String> {
+    private class IteratorProxy implements Serializable, Iterator<String> {
         private final Iterator<String> iterator;
 
         public IteratorProxy(Iterator<String> iterator) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InternalOverlayClassListProxy.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InternalOverlayClassListProxy.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.dom.ClassList;
+
+/**
+ * Internal class that provides shared functionality for setting CSS class names
+ * to overlay only components that support {@link HasStyle}, such as
+ * {@link Dialog}. Not intended to be used publicly.
+ */
+public class InternalOverlayClassListProxy extends AbstractSet<String>
+        implements ClassList {
+    private final HasStyle hasStyle;
+    private final ClassList classList;
+
+    public InternalOverlayClassListProxy(HasStyle hasStyle) {
+        this.hasStyle = hasStyle;
+        this.classList = hasStyle.getElement().getClassList();
+    }
+
+    private void updateOverlayClass() {
+        hasStyle.getElement().setProperty("overlayClass",
+                hasStyle.getClassName());
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return new IteratorProxy(classList.iterator());
+    }
+
+    @Override
+    public int size() {
+        return classList.size();
+    }
+
+    @Override
+    public boolean add(String s) {
+        boolean result = classList.add(s);
+        updateOverlayClass();
+        return result;
+    }
+
+    private class IteratorProxy implements Iterator<String> {
+        private final Iterator<String> iterator;
+
+        public IteratorProxy(Iterator<String> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public String next() {
+            return iterator.next();
+        }
+
+        @Override
+        public void remove() {
+            iterator.remove();
+            updateOverlayClass();
+        }
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/InternalOverlayClassListProxyTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/InternalOverlayClassListProxyTest.java
@@ -1,23 +1,24 @@
-package com.vaadin.flow.component.dialog;
-
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Tag;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+package com.vaadin.flow.component.shared;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class OverlayClassListProxyTest {
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Tag;
+
+public class InternalOverlayClassListProxyTest {
     private TestComponent component;
-    private Dialog.OverlayClassListProxy proxy;
+    private InternalOverlayClassListProxy proxy;
 
     @Before
     public void setup() {
         component = new TestComponent();
-        proxy = new Dialog.OverlayClassListProxy(component);
+        proxy = new InternalOverlayClassListProxy(component);
     }
 
     @Test


### PR DESCRIPTION
## Description

Follow-up to #4549. 

Moved the class into shared package and added `Internal` prefix with appropriate JavaDoc, as discussed.

## Type of change

- Refactor