### PR TITLE
refactor: move OverlayClassListProxy to the internal namespace

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -39,7 +39,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
-import com.vaadin.flow.component.shared.InternalOverlayClassListProxy;
+import com.vaadin.flow.component.shared.internal.OverlayClassListProxy;
 import com.vaadin.flow.dom.ClassList;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
@@ -992,7 +992,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     @Override
     public ClassList getClassNames() {
-        return new InternalOverlayClassListProxy(this);
+        return new OverlayClassListProxy(this);
     }
 
     /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogHasStyleTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogHasStyleTest.java
@@ -23,7 +23,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.shared.InternalOverlayClassListProxy;
+import com.vaadin.flow.component.shared.internal.OverlayClassListProxy;
 import com.vaadin.flow.server.VaadinSession;
 
 public class DialogHasStyleTest {
@@ -116,7 +116,7 @@ public class DialogHasStyleTest {
 
     @Test
     public void getClassNames_usesProxy() {
-        Assert.assertTrue(dialog
-                .getClassNames() instanceof InternalOverlayClassListProxy);
+        Assert.assertTrue(
+                dialog.getClassNames() instanceof OverlayClassListProxy);
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayClassListProxy.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayClassListProxy.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.shared;
+package com.vaadin.flow.component.shared.internal;
 
 import java.io.Serializable;
 import java.util.AbstractSet;
@@ -26,12 +26,12 @@ import com.vaadin.flow.dom.ClassList;
  * to overlay only components that support {@link HasStyle}, such as
  * {@link Dialog}. Not intended to be used publicly.
  */
-public class InternalOverlayClassListProxy extends AbstractSet<String>
+public class OverlayClassListProxy extends AbstractSet<String>
         implements ClassList {
     private final HasStyle hasStyle;
     private final ClassList classList;
 
-    public InternalOverlayClassListProxy(HasStyle hasStyle) {
+    public OverlayClassListProxy(HasStyle hasStyle) {
         this.hasStyle = hasStyle;
         this.classList = hasStyle.getElement().getClassList();
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/internal/OverlayClassListProxyTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/internal/OverlayClassListProxyTest.java
@@ -1,4 +1,4 @@
-package com.vaadin.flow.component.shared;
+package com.vaadin.flow.component.shared.internal;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,14 +11,14 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 
-public class InternalOverlayClassListProxyTest {
+public class OverlayClassListProxyTest {
     private TestComponent component;
-    private InternalOverlayClassListProxy proxy;
+    private OverlayClassListProxy proxy;
 
     @Before
     public void setup() {
         component = new TestComponent();
-        proxy = new InternalOverlayClassListProxy(component);
+        proxy = new OverlayClassListProxy(component);
     }
 
     @Test


### PR DESCRIPTION
## Description

Moved the class as suggested by https://github.com/vaadin/flow-components/pull/4576#discussion_r1082421277.

## Type of change

- Refactor