### PR TITLE
fix: use microtask when setting i18n object to date-picker

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -152,6 +152,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           const formatterAndParser = createFormatterAndParser(usedFormats);
 
           // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
+          // Defer setting I18N property into microtask as a workaround for: https://github.com/vaadin/flow-components/issues/4500
           queueMicrotask(() => {
             datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
           });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -152,7 +152,9 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           const formatterAndParser = createFormatterAndParser(usedFormats);
 
           // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
-          datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
+          queueMicrotask(() => {
+            datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
+          });
         });
       })(datepicker)
   };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-date-time-picker-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-text-field-flow</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -130,6 +135,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-select-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-date-time-picker-testbench</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDateTimePickerPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDateTimePickerPage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.time.LocalDateTime;
+
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
+import com.vaadin.flow.component.datetimepicker.DateTimePicker;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/date-time-picker")
+public class GridDateTimePickerPage extends Div {
+
+    public GridDateTimePickerPage() {
+        var grid = new Grid<Meeting>();
+        grid.setItems(
+                new Meeting("Meeting 1", LocalDateTime.of(2000, 6, 13, 12, 0)));
+
+        grid.addColumn(Meeting::getName).setHeader("Name");
+
+        grid.addComponentColumn(meeting -> {
+            DateTimePicker dateTime = new DateTimePicker();
+            DatePickerI18n i18n = new DatePickerI18n();
+            i18n.setDateFormat("dd.MM.yyyy");
+            dateTime.setDatePickerI18n(i18n);
+            dateTime.setValue(meeting.getDate());
+            return dateTime;
+        }).setHeader("Date and time");
+
+        add(grid);
+    }
+
+    private class Meeting {
+        private String name;
+        private LocalDateTime date;
+
+        public Meeting(String name, LocalDateTime date) {
+            this.name = name;
+            this.date = date;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public LocalDateTime getDate() {
+            return date;
+        }
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDateTimePickerIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDateTimePickerIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.datetimepicker.testbench.DateTimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+
+@TestPath("vaadin-grid/date-time-picker")
+public class GridDateTimePickerIT extends AbstractComponentIT {
+
+    @Test
+    public void shouldHaveI18nApplied() {
+        open();
+
+        Assert.assertEquals("13.06.2000",
+                $(DateTimePickerElement.class).first().getDatePresentation());
+    }
+}


### PR DESCRIPTION
## Description

This was a difficult one to debug. It seems to have something to do with the old `ComponentRenderer` relying on a `<template>` and Polymer Templatizer to populate the cell content.

For some reason, this setup lead to a timing where setting the `<vaadin-date-picker>`'s `i18n` property synchronously in the connector wouldn't invoke any effects in the Web Component but instead, got soon after overridden by the default value. Setting the value in microtask timing works around the issue.

Note that the issue didn't produce with a `<vaadin-date-picker>`, but required a `<vaadin-date-time-picker>`.

Fixes https://github.com/vaadin/flow-components/issues/4500

## Type of change

- Bugfix