### PR TITLE
refactor!: remove deprecated withEventHandler from LitRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -296,44 +296,6 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
     }
 
     /**
-     * Adds an event handler that can be called from within the template
-     * expression.
-     * <p>
-     * Examples:
-     *
-     * <pre>
-     * {@code
-     * // Standard event
-     * LitRenderer.of("<button @click=${handleClick}>Click me</button>")
-     *          .withEventHandler("handleClick", object -> doSomething());
-     * }
-     * </pre>
-     *
-     * The name of the event handler used in the template expression should be
-     * the name used at the eventHandlerName parameter. This name must be a
-     * valid JavaScript function name.
-     *
-     * @param eventHandlerName
-     *            the name of the event handler used inside the template
-     *            expression, must be alphanumeric and not <code>null</code>,
-     *            must not be one of the JavaScript reserved words
-     *            (https://www.w3schools.com/js/js_reserved.asp)
-     * @param handler
-     *            the handler executed when the event handler is called, not
-     *            <code>null</code>
-     * @return this instance for method chaining
-     * @see <a href=
-     *      "https://lit.dev/docs/templates/expressions/#event-listener-expressions">https://lit.dev/docs/templates/expressions/#event-listener-expressions</a>
-     *
-     * @deprecated Use {@link #withFunction(String, SerializableConsumer)}
-     *             instead.
-     */
-    public LitRenderer<SOURCE> withEventHandler(String eventHandlerName,
-            SerializableConsumer<SOURCE> handler) {
-        return withFunction(eventHandlerName, handler);
-    }
-
-    /**
      * Adds a function that can be called from within the template expression.
      * <p>
      * Examples:


### PR DESCRIPTION
## Description

Remove the deprecated `withEventHandler` from LitRenderer. The method was added [here](https://github.com/vaadin/flow-components/pull/2042).