### PR TITLE
refactor!: remove deprecated remove and removeAll from ComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -29,7 +28,6 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableBiPredicate;
 
 import elemental.json.Json;
@@ -327,41 +325,5 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     @Override
     public T getEmptyValue() {
         return null;
-    }
-
-    /**
-     * Removes the given child components from this component.
-     *
-     * @param components
-     *            The components to remove.
-     * @throws IllegalArgumentException
-     *             if any of the components is not a child of this component.
-     * @deprecated since v23.3
-     */
-    @Deprecated
-    protected void remove(Component... components) {
-        for (Component component : components) {
-            if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
-                getElement().removeChild(component.getElement());
-            } else {
-                throw new IllegalArgumentException("The given component ("
-                        + component + ") is not a child of this component");
-            }
-        }
-    }
-
-    /**
-     * Removes all contents from this component, this includes child components,
-     * text content as well as child elements that have been added directly to
-     * this component using the {@link Element} API.
-     *
-     * @deprecated since v23.3
-     */
-    @Deprecated
-    protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
-        getElement().removeAllChildren();
     }
 }


### PR DESCRIPTION
## Description

Remove the ComboBox `remove(Component... components)` and `removeAll()` API that was [deprecated in 23.3](https://github.com/vaadin/flow-components/pull/4115)