### PR TITLE
refactor!: remove deprecated setItems method from Grid

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerInAGridHeaderPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerInAGridHeaderPage.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.util.Locale;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -34,7 +35,8 @@ public class DatePickerInAGridHeaderPage extends Div {
         header.setId("date-picker");
 
         grid.addColumn(ValueProvider.identity()).setHeader(header);
-        grid.setItems(IntStream.range(0, 100).mapToObj(i -> "Item " + i));
+        grid.setItems(IntStream.range(0, 100).mapToObj(i -> "Item " + i)
+                .collect(Collectors.toList()));
 
         add(grid);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -49,7 +50,8 @@ public class ContextMenuGridPage extends Div {
         grid.addColumn(Person::getFirstName).setHeader("Name").setId("Name-Id");
         grid.addColumn(Person::getAge).setHeader("Born").setId("Born-Id");
         grid.setItems(IntStream.range(0, 77)
-                .mapToObj(i -> new Person("Person " + i, 1900 + i)));
+                .mapToObj(i -> new Person("Person " + i, 1900 + i))
+                .collect(Collectors.toList()));
 
         GridContextMenu<Person> contextMenu = grid.addContextMenu();
         addItems(contextMenu);
@@ -87,8 +89,8 @@ public class ContextMenuGridPage extends Div {
         GridInATemplate template = new GridInATemplate();
         Grid<String> gridInATemplate = template.getGrid();
         gridInATemplate.addColumn(s -> s).setHeader("Item");
-        gridInATemplate
-                .setItems(IntStream.range(0, 26).mapToObj(i -> "Item " + i));
+        gridInATemplate.setItems(IntStream.range(0, 26)
+                .mapToObj(i -> "Item " + i).collect(Collectors.toList()));
 
         GridContextMenu<String> contextMenu = gridInATemplate.addContextMenu();
         contextMenu.addItem("Show name of context menu target item",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -35,7 +36,8 @@ public class DynamicContextMenuGridPage extends Div {
         grid.addColumn(Person::getAge).setHeader("Born").setId("Born-Id");
 
         grid.setItems(IntStream.range(0, 50)
-                .mapToObj(i -> new Person("Person " + i, i)));
+                .mapToObj(i -> new Person("Person " + i, i))
+                .collect(Collectors.toList()));
 
         GridContextMenu<Person> contextMenu = grid.addContextMenu();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.grid.it;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -90,8 +91,8 @@ public class GridMultiSelectionColumnPage extends Div {
 
     private void createInMemoryGrid() {
         Grid<String> grid = new Grid<>();
-        grid.setItems(
-                IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString));
+        grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
+                .collect(Collectors.toList()));
         setUp(grid);
         grid.setId(IN_MEMORY_GRID_ID);
         add(new H2("In-memory grid"), grid);
@@ -138,8 +139,8 @@ public class GridMultiSelectionColumnPage extends Div {
 
     private void createBasicGridFromSingleToMultiBeforeAttached() {
         Grid<String> grid = new Grid<>();
-        grid.setItems(
-                IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString));
+        grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
+                .collect(Collectors.toList()));
         setUp(grid);
         grid.setId("in-testing-multi-selection-mode-grid");
         add(new H2("in-testing-multi-selection-mode-grid"), grid);
@@ -151,8 +152,8 @@ public class GridMultiSelectionColumnPage extends Div {
 
     private void createBasicGridFromMultiToSingleBeforeAttached() {
         Grid<String> grid = new Grid<>();
-        grid.setItems(
-                IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString));
+        grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
+                .collect(Collectors.toList()));
         setUp(grid);
         grid.setId("in-testing-multi-selection-mode-grid-single");
         add(new H2("in-testing-multi-selection-mode-grid-single"), grid);
@@ -164,8 +165,8 @@ public class GridMultiSelectionColumnPage extends Div {
 
     private void setAutoWidthIsTrueOfSelectionColumn() {
         Grid<String> grid = new Grid<>();
-        grid.setItems(
-                IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString));
+        grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
+                .collect(Collectors.toList()));
         setUp(grid);
         grid.setId("set-auto-width-true");
         add(new H2("In-set-auto-width-true"), grid);
@@ -177,7 +178,8 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createBasicGridMultiAllRowsSelected() {
         Grid<String> grid = new Grid<>();
         grid.setId(MULTI_SELECT_GRID_ALL_SELECTED_GRID_ID);
-        grid.setItems(IntStream.range(0, 2).mapToObj(Integer::toString));
+        grid.setItems(IntStream.range(0, 2).mapToObj(Integer::toString)
+                .collect(Collectors.toList()));
         grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length())).setHeader("length");
         grid.setSelectionMode(Grid.SelectionMode.MULTI);
@@ -198,7 +200,8 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createBasicGridMultiOneRowDeSelected() {
         Grid<String> grid = new Grid<>();
         grid.setId(MULTI_SELECT_GRID_ONE_NOT_SELECTED_GRID_ID);
-        grid.setItems(IntStream.range(0, 2).mapToObj(Integer::toString));
+        grid.setItems(IntStream.range(0, 2).mapToObj(Integer::toString)
+                .collect(Collectors.toList()));
         grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length())).setHeader("length");
         grid.setSelectionMode(Grid.SelectionMode.MULTI);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -15,7 +16,8 @@ public class GridScrollToPage extends Div {
         Grid<String> grid = new Grid<>();
         grid.setId("data-grid");
 
-        grid.setItems(IntStream.rangeClosed(0, 1000).mapToObj(String::valueOf));
+        grid.setItems(IntStream.rangeClosed(0, 1000).mapToObj(String::valueOf)
+                .collect(Collectors.toList()));
 
         grid.addColumn(item -> item).setHeader("Data");
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.button.Button;
@@ -65,7 +66,8 @@ public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
         Grid<String> grid = new Grid<>();
         grid.addColumn(string -> String.valueOf(Math.random())) // NOSONAR
                 .setHeader("column 1");
-        grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf));
+        grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf)
+                .collect(Collectors.toList()));
         grid.setAllRowsVisible(true);
         if (!deselectAllowed) {
             ((GridSingleSelectionModel) grid.getSelectionModel())
@@ -79,7 +81,8 @@ public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
     private Grid<String> setItemsGrid(Grid grid, String id) {
         grid.addColumn(string -> String.valueOf(Math.random())) // NOSONAR
                 .setHeader("column 1");
-        grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf));
+        grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf)
+                .collect(Collectors.toList()));
         grid.setAllRowsVisible(true);
         grid.setId(id);
         return grid;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestScrollingOver100kLines.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestScrollingOver100kLines.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.time.LocalDate;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -46,8 +47,8 @@ public class GridTestScrollingOver100kLines extends Div {
         grid.setWidth("100%");
         grid.setHeight("300px");
 
-        grid.setItems(
-                IntStream.rangeClosed(1, 100500).mapToObj(String::valueOf));
+        grid.setItems(IntStream.rangeClosed(1, 100500).mapToObj(String::valueOf)
+                .collect(Collectors.toList()));
         add(grid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -34,13 +35,13 @@ public class ToggleVisibilityPage extends Div {
 
     public ToggleVisibilityPage() {
         Grid<String> grid1 = new Grid<>();
-        grid1.setItems(
-                IntStream.range(0, 100).mapToObj(i -> "Grid1 Item " + i));
+        grid1.setItems(IntStream.range(0, 100).mapToObj(i -> "Grid1 Item " + i)
+                .collect(Collectors.toList()));
         grid1.addColumn(ValueProvider.identity());
 
         Grid<String> grid2 = new Grid<>();
-        grid2.setItems(
-                IntStream.range(0, 100).mapToObj(i -> "Grid2 Item " + i));
+        grid2.setItems(IntStream.range(0, 100).mapToObj(i -> "Grid2 Item " + i)
+                .collect(Collectors.toList()));
         grid2.addColumn(ValueProvider.identity());
 
         Div parent1 = new Div(grid1);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2450,19 +2450,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @deprecated Because the stream is collected to a list anyway, use
-     *             {@link HasListDataView#setItems(Collection)} or
-     *             {@link #setItems(CallbackDataProvider.FetchCallback)}
-     *             instead.
-     */
-    @Deprecated
-    public void setItems(Stream<T> streamOfItems) {
-        setItems(DataProvider.fromStream(streamOfItems));
-    }
-
-    /**
      * Returns the data provider of this grid.
      * <p>
      * To get information and control over the items in the grid, use either


### PR DESCRIPTION
## Description

Remove the deprecated `setItems(Stream<T> streamOfItems)` method from `Grid`