### PR TITLE
refactor: add check for delta values

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -59,6 +59,26 @@ public class RichTextEditorTest {
                 rte.getElement().getProperty("value"));
     }
 
+    @Test
+    public void setValueStartingWithJsonArray_throws() {
+        RichTextEditor rte = new RichTextEditor();
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("The value starts with either '[' or '{'");
+
+        rte.setValue("[{\"insert\":\"Foo\"}]");
+    }
+
+    @Test
+    public void setValueStartingWithJsonObject_throws() {
+        RichTextEditor rte = new RichTextEditor();
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("The value starts with either '[' or '{'");
+
+        rte.setValue("{\"insert\":\"Foo\"}");
+    }
+
     // asHtml
 
     @Test
@@ -88,6 +108,19 @@ public class RichTextEditorTest {
         Assert.assertTrue(
                 "Should be possible to set required indicator to be visible on asHtml",
                 rte.isRequiredIndicatorVisible());
+    }
+
+    @Test
+    public void asHtml_setValueStartingWithJson_noException() {
+        RichTextEditor rte = new RichTextEditor();
+
+        String value = "[{\"insert\":\"Foo\"}]";
+        rte.asHtml().setValue(value);
+        Assert.assertEquals(value, rte.getValue());
+
+        value = "{\"insert\":\"Foo\"}";
+        rte.asHtml().setValue(value);
+        Assert.assertEquals(value, rte.getValue());
     }
 
     // asDelta


### PR DESCRIPTION
## Description

Adds a check to `RichTextEditor.setValue` that prevents developers from setting values in the Delta format. If the check detects a possible Delta value, an `IllegalArgumentException` is thrown. This is intended to make sure developers don't accidentally pass a Delta value after migrating to v24, which could lead to data corruption. This also un-deprecates the `AsHtml` wrapper in order to keep the legacy behavior, which allows setting HTML values starting with either `[` or `{`.

## Type of change

- Refactoring