### PR TITLE
refactor!: remove or hide deprecated setItems and getDataProvider

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/RefreshDataProviderPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/RefreshDataProviderPage.java
@@ -34,12 +34,12 @@ public class RefreshDataProviderPage extends Div {
         group.setId("group");
 
         List<String> items = new LinkedList<>(Arrays.asList("foo", "bar"));
-        group.setItems(new ListDataProvider<>(items));
+        var listDataView = group.setItems(new ListDataProvider<>(items));
 
         NativeButton button = new NativeButton("Update items", e -> {
             items.add("baz");
             items.remove(0);
-            group.getDataProvider().refreshAll();
+            listDataView.refreshAll();
         });
 
         button.setId("reset");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -320,17 +320,6 @@ public class CheckboxGroup<T>
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated Because the stream is collected to a list anyway, use
-     *             {@link HasListDataView#setItems(Collection)} instead.
-     */
-    @Deprecated
-    public void setItems(Stream<T> streamOfItems) {
-        setItems(DataProvider.fromStream(streamOfItems));
-    }
-
     private void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
         DataViewUtils.removeComponentFilterAndSortComparator(this);
@@ -402,11 +391,8 @@ public class CheckboxGroup<T>
      * Gets the data provider.
      *
      * @return the data provider, not {@code null}
-     * @deprecated use {@link #getListDataView()} or
-     *             {@link #getGenericDataView()} instead
      */
-    @Deprecated
-    public DataProvider<T, ?> getDataProvider() {
+    private DataProvider<T, ?> getDataProvider() {
         // dataProvider reference won't have been initialized before
         // calling from CheckboxGroup constructor
         return Optional.ofNullable(dataProvider).map(AtomicReference::get)

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -256,7 +256,7 @@ public class CheckboxGroupTest {
 
         item1.setLabel("etc");
         item2.setLabel("opt");
-        checkboxGroup.getDataProvider().refreshItem(item1);
+        checkboxGroup.getListDataView().refreshItem(item1);
         assertCheckboxLabels(checkboxGroup, "etc", "bar");
 
     }
@@ -277,7 +277,7 @@ public class CheckboxGroupTest {
 
         item1.setLabel("etc");
         item2.setLabel("opt");
-        checkboxGroup.getDataProvider().refreshItem(new Wrapper(1));
+        checkboxGroup.getListDataView().refreshItem(new Wrapper(1));
         assertCheckboxLabels(checkboxGroup, "etc", "bar");
 
     }
@@ -298,7 +298,7 @@ public class CheckboxGroupTest {
 
         item1.setLabel("etc");
         item2.setLabel("opt");
-        checkboxGroup.getDataProvider().refreshAll();
+        checkboxGroup.getListDataView().refreshAll();
         assertCheckboxLabels(checkboxGroup, "etc", "opt");
 
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
@@ -153,7 +153,7 @@ public class ComboBoxPage extends Div {
     private void createWithValueChangeListener() {
         ComboBox<Title> titles = new ComboBox<>();
 
-        titles.setItems(Stream.of(Title.values()));
+        titles.setItems(Title.values());
 
         titles.setId("titles");
         selectedTitle.setId("selected-titles");
@@ -164,7 +164,7 @@ public class ComboBoxPage extends Div {
     private void createWithPresetValue() {
         ComboBox<Title> titles = new ComboBox<>();
 
-        titles.setItems(Stream.of(Title.values()));
+        titles.setItems(Title.values());
         titles.setValue(Title.MRS);
 
         titles.setId("titles-with-preset-value");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/PreSelectedValuePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/PreSelectedValuePage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -29,7 +30,8 @@ public class PreSelectedValuePage extends Div {
 
     public PreSelectedValuePage() {
         ComboBox<String> comboBox = new ComboBox<>();
-        comboBox.setItems(IntStream.range(0, 20).mapToObj(i -> "Item " + i));
+        comboBox.setItems(IntStream.range(0, 20).mapToObj(i -> "Item " + i)
+                .collect(Collectors.toList()));
         comboBox.setValue(PRE_SELECTED_VALUE);
         comboBox.setId("combo");
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -669,19 +669,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
         return dataController.setItems(dataProvider);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated Because the stream is collected to a list anyway, use
-     *             {@link #setItems(Collection)} or
-     *             {@link #setItems(CallbackDataProvider.FetchCallback)}
-     *             instead.
-     */
-    @Deprecated
-    public void setItems(Stream<TItem> streamOfItems) {
-        setItems(DataProvider.fromStream(streamOfItems));
-    }
-
     // ****************************************************
     // Lazy data view implementation
     // ****************************************************


### PR DESCRIPTION
## Description

Remove the deprecated `setItems(Stream<T> streamOfItems)` method from `CheckboxGroup` and `ComboBoxBase`.
Also, make the deprecated `getDataProvider()` in `CheckboxGroup` private.