### PR TITLE
docs: document the purpose of HasTooltip interface better

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -15,10 +15,22 @@
  */
 package com.vaadin.flow.component.shared;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 
 /**
- * Mixin interface for components that support a tooltip.
+ * Mixin interface for components that have special handling for tooltips on the
+ * Web Component level.
+ * <p>
+ * Components that implement this interface get a
+ * <code>&lt;vaadin-tooltip slot="tooltip"&gt;</code> element added inside the
+ * component's light DOM and are expected to handle it appropriately on the
+ * client-side.
+ * <p>
+ * Use this interface only if you are implementing a new component that also has
+ * a Web Component counterpart with a custom tooltip support. Otherwise, use
+ * {@link Tooltip#forComponent(Component)} instead.
+ *
  *
  * @author Vaadin Ltd
  */


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/4293

The `HasTooltip` interface has caused some confusion among users because of its poor documentation. This PR improves the interface's Javadoc to make it better understandable.

## Type of change

- Documentation