### PR TITLE
refactor!: update MenuBar to use MenuBarItem component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ error-screenshots
 
 **/frontend/generated
 **/frontend/index.html
+dev-bundle

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,8 +10,8 @@
 [ "$HEADLESS" = false ] && args="$args -DdisableHeadless" && quiet="" || quiet="-q"
 
 ## Speedup installation of frontend stuff
-verify="verify -Dvaadin.pnpm.enable"
-jettyrun="jetty:run -Dvaadin.pnpm.enable"
+verify="verify -Dvaadin.pnpm.enable -Dvaadin.frontend.hotdeploy=true"
+jettyrun="jetty:run -Dvaadin.pnpm.enable -Dvaadin.frontend.hotdeploy=true"
 
 ## List all modules and ask for one to the user
 askModule() {

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -52,9 +52,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-accordion")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/accordion", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/accordion", version = "24.0.0-alpha13")
 @JsModule("@vaadin/accordion/src/vaadin-accordion.js")
 public class Accordion extends Component implements HasSize, HasStyle {
 

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
@@ -25,9 +25,9 @@ import com.vaadin.flow.component.details.Details;
  * An accordion panel which could be opened or closed.
  */
 @Tag("vaadin-accordion-panel")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/accordion", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/accordion", version = "24.0.0-alpha13")
 @JsModule("@vaadin/accordion/src/vaadin-accordion-panel.js")
 public class AccordionPanel extends Details {
 

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -52,9 +52,9 @@ import elemental.json.JsonType;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-app-layout")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/app-layout", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/app-layout", version = "24.0.0-alpha13")
 @JsModule("@vaadin/app-layout/src/vaadin-app-layout.js")
 public class AppLayout extends Component implements RouterLayout, HasStyle {
     private static final PropertyDescriptor<String, String> primarySectionProperty = PropertyDescriptors

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/DrawerToggle.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/DrawerToggle.java
@@ -30,9 +30,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * </code>
  */
 @Tag("vaadin-drawer-toggle")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/app-layout", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/app-layout", version = "24.0.0-alpha13")
 @JsModule("@vaadin/app-layout/src/vaadin-drawer-toggle.js")
 public class DrawerToggle extends Button {
 

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -53,10 +53,10 @@ import java.util.Objects;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-avatar")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/avatar/src/vaadin-avatar.js")
-@NpmPackage(value = "@vaadin/avatar", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/avatar", version = "24.0.0-alpha13")
 public class Avatar extends Component
         implements HasStyle, HasSize, HasThemeVariant<AvatarVariant> {
 

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -63,10 +63,10 @@ import java.util.stream.Stream;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-avatar-group")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/avatar-group/src/vaadin-avatar-group.js")
-@NpmPackage(value = "@vaadin/avatar-group", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/avatar-group", version = "24.0.0-alpha13")
 public class AvatarGroup extends Component implements HasOverlayClassName,
         HasStyle, HasSize, HasThemeVariant<AvatarGroupVariant> {
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
@@ -27,9 +27,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * <p>
  */
 @Tag("vaadin-board")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/board", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/board", version = "24.0.0-alpha13")
 @JsModule("@vaadin/board/vaadin-board.js")
 public class Board extends Component
         implements HasSize, HasStyle, HasOrderedComponents {

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
@@ -29,9 +29,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * <p>
  */
 @Tag("vaadin-board-row")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/board", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/board", version = "24.0.0-alpha13")
 @JsModule("@vaadin/board/vaadin-board-row.js")
 public class Row extends Component
         implements HasStyle, HasSize, HasOrderedComponents {

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -52,9 +52,9 @@ import java.util.stream.Stream;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-button")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/button", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/button", version = "24.0.0-alpha13")
 @JsModule("@vaadin/button/src/vaadin-button.js")
 public class Button extends Component implements ClickNotifier<Button>,
         Focusable<Button>, HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
@@ -86,9 +86,9 @@ import elemental.json.impl.JreJsonFactory;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-chart")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/charts", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/charts", version = "24.0.0-alpha13")
 @JsModule("@vaadin/charts/src/vaadin-chart.js")
 public class Chart extends Component implements HasStyle, HasSize, HasTheme {
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -44,9 +44,9 @@ import com.vaadin.flow.dom.PropertyChangeListener;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-checkbox")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/checkbox", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/checkbox", version = "24.0.0-alpha13")
 @JsModule("@vaadin/checkbox/src/vaadin-checkbox.js")
 public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
         implements ClickNotifier<Checkbox>, Focusable<Checkbox>, HasLabel,

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -84,9 +84,9 @@ import elemental.json.JsonArray;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-checkbox-group")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/checkbox-group", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/checkbox-group", version = "24.0.0-alpha13")
 @JsModule("@vaadin/checkbox-group/src/vaadin-checkbox-group.js")
 public class CheckboxGroup<T>
         extends AbstractSinglePropertyField<CheckboxGroup<T>, Set<T>> implements

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -59,9 +59,9 @@ import elemental.json.JsonObject;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-combo-box")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/combo-box", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/combo-box", version = "24.0.0-alpha13")
 @JsModule("@vaadin/combo-box/src/vaadin-combo-box.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./comboBoxConnector.js")

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -70,9 +70,9 @@ import java.util.Set;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-multi-select-combo-box")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/multi-select-combo-box", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/multi-select-combo-box", version = "24.0.0-alpha13")
 @JsModule("@vaadin/multi-select-combo-box/src/vaadin-multi-select-combo-box.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./comboBoxConnector.js")

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -59,9 +59,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-confirm-dialog")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/confirm-dialog", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/confirm-dialog", version = "24.0.0-alpha13")
 @JsModule("@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js")
 public class ConfirmDialog extends Component
         implements HasSize, HasStyle, HasOrderedComponents {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -49,7 +49,8 @@ import com.vaadin.flow.function.SerializableRunnable;
  */
 @SuppressWarnings("serial")
 public class ContextMenu extends ContextMenuBase<ContextMenu, MenuItem, SubMenu>
-        implements HasMenuItems, HasOverlayClassName {
+        implements HasMenuItems<ContextMenu, MenuItem, SubMenu>,
+        HasOverlayClassName {
 
     /**
      * Creates an empty context menu.

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -52,9 +52,9 @@ import elemental.json.JsonObject;
  */
 @SuppressWarnings("serial")
 @Tag("vaadin-context-menu")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/context-menu", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/context-menu", version = "24.0.0-alpha13")
 @JsModule("@vaadin/context-menu/src/vaadin-context-menu.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./contextMenuConnector.js")

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/HasMenuItems.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/HasMenuItems.java
@@ -30,7 +30,8 @@ import com.vaadin.flow.component.ComponentEventListener;
  *
  * @author Vaadin Ltd.
  */
-public interface HasMenuItems extends Serializable {
+public interface HasMenuItems<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
+        extends Serializable {
 
     /**
      * Adds a new item component with the given text content and click listener
@@ -53,8 +54,8 @@ public interface HasMenuItems extends Serializable {
      * @see ContextMenu#add(Component...)
      * @see SubMenu#add(Component...)
      */
-    MenuItem addItem(String text,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener);
+    public I addItem(String text,
+            ComponentEventListener<ClickEvent<I>> clickListener);
 
     /**
      * Adds a new item component with the given component and click listener to
@@ -77,7 +78,7 @@ public interface HasMenuItems extends Serializable {
      * @see ContextMenu#add(Component...)
      * @see SubMenu#add(Component...)
      */
-    MenuItem addItem(Component component,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener);
+    public I addItem(Component component,
+            ComponentEventListener<ClickEvent<I>> clickListener);
 
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -19,9 +19,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -42,9 +39,6 @@ import java.util.stream.Collectors;
  * @see MenuItem
  */
 @SuppressWarnings("serial")
-@Tag("vaadin-context-menu-item")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
-@JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
         extends Component implements HasText, HasComponents, HasEnabled {
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("serial")
 @Tag("vaadin-context-menu-item")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
         extends Component implements HasText, HasComponents, HasEnabled {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -59,7 +59,8 @@
         checked: child._checked,
         theme: child.__theme
       };
-      if (child.localName == 'vaadin-context-menu-item' && child._containerNodeId) {
+      // Avoid hardcoding tag name to support vaadin-menu-bar-item
+      if (child._hasVaadinItemMixin && child._containerNodeId) {
         item.children = generateItemsTree(appId, child._containerNodeId);
       }
       child._item = item;

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/src/main/java/com/vaadin/flow/component/cookieconsent/CookieConsent.java
@@ -34,9 +34,9 @@ import com.vaadin.flow.dom.Style;
  */
 @SuppressWarnings("serial")
 @Tag("vaadin-cookie-consent")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/cookie-consent", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/cookie-consent", version = "24.0.0-alpha13")
 @JsModule("@vaadin/cookie-consent/src/vaadin-cookie-consent.js")
 @JsModule("./cookieConsentConnector.js")
 public class CookieConsent extends Component implements HasStyle {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -48,9 +48,9 @@ import java.util.stream.Collectors;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-crud")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/crud", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/crud", version = "24.0.0-alpha13")
 @JsModule("@vaadin/crud/src/vaadin-crud.js")
 @JsModule("@vaadin/crud/src/vaadin-crud-edit-column.js")
 public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -51,9 +51,9 @@ import com.vaadin.flow.dom.Element;
  *            field value type
  */
 @Tag("vaadin-custom-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/custom-field", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/custom-field", version = "24.0.0-alpha13")
 @JsModule("@vaadin/custom-field/src/vaadin-custom-field.js")
 public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
         implements Focusable<CustomField<T>>, HasHelper, HasLabel, HasSize,

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -81,9 +81,9 @@ import elemental.json.JsonType;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-date-picker")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/date-picker", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/date-picker", version = "24.0.0-alpha13")
 @JsModule("@vaadin/date-picker/src/vaadin-date-picker.js")
 @JsModule("./datepickerConnector.js")
 @NpmPackage(value = "date-fns", version = "2.29.3")

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -112,9 +112,9 @@ class DateTimePickerTimePicker
  * @author Vaadin Ltd
  */
 @Tag("vaadin-date-time-picker")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/date-time-picker", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/date-time-picker", version = "24.0.0-alpha13")
 @JsModule("@vaadin/date-time-picker/src/vaadin-date-time-picker.js")
 public class DateTimePicker
         extends AbstractSinglePropertyField<DateTimePicker, LocalDateTime>

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -55,9 +55,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-details")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/details", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/details", version = "24.0.0-alpha13")
 @JsModule("@vaadin/details/src/vaadin-details.js")
 public class Details extends Component implements HasEnabled, HasSize, HasStyle,
         HasThemeVariant<DetailsVariant>, HasTooltip {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -76,9 +76,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-dialog")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/dialog", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/dialog", version = "24.0.0-alpha13")
 @JsModule("@vaadin/dialog/src/vaadin-dialog.js")
 @JsModule("./flow-component-renderer.js")
 public class Dialog extends Component implements HasComponents, HasSize,

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow/src/main/java/com/vaadin/flow/component/fieldhighlighter/FieldHighlighterInitializer.java
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow/src/main/java/com/vaadin/flow/component/fieldhighlighter/FieldHighlighterInitializer.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.Registration;
 
-@NpmPackage(value = "@vaadin/field-highlighter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/field-highlighter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/field-highlighter/src/vaadin-field-highlighter.js")
 public class FieldHighlighterInitializer {
     protected static Registration init(Element field) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.function.SerializableRunnable;
  *
  * @author Vaadin Ltd
  */
-@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha13")
 @JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 public class Tooltip implements Serializable {
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/TooltipConfiguration.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/TooltipConfiguration.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.server.VaadinService;
  *
  * @author Vaadin Ltd
  */
-@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha13")
 @JsModule("./tooltip.ts")
 public class TooltipConfiguration implements Serializable {
 

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -69,9 +69,9 @@ import elemental.json.JsonValue;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-form-layout")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/form-layout", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/form-layout", version = "24.0.0-alpha13")
 @JsModule("@vaadin/form-layout/src/vaadin-form-layout.js")
 public class FormLayout extends Component
         implements HasSize, HasStyle, HasComponents, ClickNotifier<FormLayout> {
@@ -191,9 +191,9 @@ public class FormLayout extends Component
      * @author Vaadin Ltd
      */
     @Tag("vaadin-form-item")
-    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
     @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-    @NpmPackage(value = "@vaadin/form-layout", version = "24.0.0-alpha12")
+    @NpmPackage(value = "@vaadin/form-layout", version = "24.0.0-alpha13")
     @JsModule("@vaadin/form-layout/src/vaadin-form-item.js")
     public static class FormItem extends Component
             implements HasComponents, HasStyle, ClickNotifier<FormItem> {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.dom.Element;
  */
 @JsModule("@vaadin/grid/src/vaadin-grid-column-group.js")
 @Tag("vaadin-grid-column-group")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 class ColumnGroup extends AbstractColumn<ColumnGroup> {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -205,10 +205,10 @@ import org.slf4j.LoggerFactory;
  *
  */
 @Tag("vaadin-grid")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/grid", version = "24.0.0-alpha12")
-@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/grid", version = "24.0.0-alpha13")
+@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha13")
 @JsModule("@vaadin/grid/src/vaadin-grid.js")
 @JsModule("@vaadin/grid/src/vaadin-grid-column.js")
 @JsModule("@vaadin/grid/src/vaadin-grid-sorter.js")
@@ -444,7 +444,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            type of the underlying grid this column is compatible with
      */
     @Tag("vaadin-grid-column")
-    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
     @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
     public static class Column<T> extends AbstractColumn<Column<T>> {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.function.SerializableRunnable;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-grid-flow-selection-column")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./vaadin-grid-flow-selection-column.js")
 public class GridSelectionColumn extends Component {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -45,9 +45,9 @@ import elemental.json.JsonObject;
 import org.slf4j.LoggerFactory;
 
 @Tag("vaadin-grid-pro")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/grid-pro", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/grid-pro", version = "24.0.0-alpha13")
 @JsModule("@vaadin/grid-pro/src/vaadin-grid-pro.js")
 @JsModule("@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js")
 @JsModule("./gridProConnector.js")
@@ -184,7 +184,7 @@ public class GridPro<E> extends Grid<E> {
      *            type of the underlying grid this column is compatible with
      */
     @Tag("vaadin-grid-pro-edit-column")
-    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
     @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
     public static class EditColumn<T> extends Column<T> {
 

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -33,11 +33,11 @@ import com.vaadin.flow.dom.ElementConstants;
  * @see VaadinIcon
  */
 @Tag("vaadin-icon")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/icons", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/icons", version = "24.0.0-alpha13")
 @JsModule("@vaadin/icons/vaadin-iconset.js")
-@NpmPackage(value = "@vaadin/icon", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/icon", version = "24.0.0-alpha13")
 @JsModule("@vaadin/icon/vaadin-icon.js")
 public class Icon extends Component
         implements HasStyle, ClickNotifier<Icon>, HasTooltip {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -66,9 +66,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-list-box")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/list-box", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/list-box", version = "24.0.0-alpha13")
 @JsModule("@vaadin/list-box/src/vaadin-list-box.js")
 public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, VALUE>
         extends AbstractSinglePropertyField<C, VALUE>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/VaadinItem.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/VaadinItem.java
@@ -32,9 +32,9 @@ import com.vaadin.flow.data.binder.HasItemComponents;
  *            type of the item represented by this component
  */
 @Tag("vaadin-item")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/item", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/item", version = "24.0.0-alpha13")
 @JsModule("@vaadin/item/src/vaadin-item.js")
 class VaadinItem<T> extends Component
         implements HasItemComponents.ItemComponent<T>, HasComponents {

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginForm.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginForm.java
@@ -41,9 +41,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-login-form")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/login", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/login", version = "24.0.0-alpha13")
 @JsModule("@vaadin/login/src/vaadin-login-form.js")
 public class LoginForm extends AbstractLogin implements HasStyle {
 

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
@@ -43,9 +43,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-login-overlay")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/login", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/login", version = "24.0.0-alpha13")
 @JsModule("@vaadin/login/src/vaadin-login-overlay.js")
 public class LoginOverlay extends AbstractLogin implements HasStyle {
 

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/Lumo.java
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/Lumo.java
@@ -29,10 +29,10 @@ import com.vaadin.flow.theme.AbstractTheme;
 /**
  * Lumo component theme class implementation.
  */
-@NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "24.0.0-alpha12")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "24.0.0-alpha13")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/vaadin-lumo-styles", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/vaadin-lumo-styles", version = "24.0.0-alpha13")
 @JsModule("@vaadin/vaadin-lumo-styles/color.js")
 @JsModule("@vaadin/vaadin-lumo-styles/typography.js")
 @JsModule("@vaadin/vaadin-lumo-styles/sizing.js")

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -65,7 +65,7 @@ import java.util.Objects;
  * using {@link #defineProjection(String, String)}.
  */
 @Tag("vaadin-map")
-@NpmPackage(value = "@vaadin/map", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/map", version = "24.0.0-alpha13")
 @NpmPackage(value = "proj4", version = "2.8.1")
 @JsModule("@vaadin/map/src/vaadin-map.js")
 @JsModule("./vaadin-map/mapConnector.js")

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/src/main/java/com/vaadin/flow/theme/material/Material.java
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/src/main/java/com/vaadin/flow/theme/material/Material.java
@@ -28,10 +28,10 @@ import com.vaadin.flow.theme.AbstractTheme;
 /**
  * Material component theme class implementation.
  */
-@NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "24.0.0-alpha12")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "24.0.0-alpha13")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/vaadin-material-styles", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/vaadin-material-styles", version = "24.0.0-alpha13")
 @JsModule("@vaadin/vaadin-material-styles/color.js")
 @JsModule("@vaadin/vaadin-material-styles/typography.js")
 @JsModule("./material-includes.ts")

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -15,12 +15,12 @@
  */
 package com.vaadin.flow.component.menubar.tests;
 
-import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.component.menubar.MenuBarItem;
 import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
 
@@ -40,18 +40,18 @@ public class MenuBarTestPage extends Div {
         message.setId("message");
         add(message);
 
-        MenuItem item1 = menuBar.addItem("item 1");
+        MenuBarItem item1 = menuBar.addItem("item 1");
 
-        MenuItem item2 = menuBar.addItem(new Paragraph("item 2"),
+        MenuBarItem item2 = menuBar.addItem(new Paragraph("item 2"),
                 e -> message.setText(message.getText() + "clicked item 2"));
 
         item1.getSubMenu().addItem("sub item 1",
                 e -> message.setText("clicked sub item 1"));
-        MenuItem subItem2 = item1.getSubMenu()
+        MenuBarItem subItem2 = item1.getSubMenu()
                 .addItem(new Paragraph("sub item 2"));
 
         subItem2.getSubMenu().addItem(new Paragraph("sub sub item 1"));
-        MenuItem checkable = subItem2.getSubMenu().addItem("checkable");
+        MenuBarItem checkable = subItem2.getSubMenu().addItem("checkable");
         checkable.setCheckable(true);
         checkable.addClickListener(
                 e -> message.setText(String.valueOf(checkable.isChecked())));

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarVisibilityPage.java
@@ -15,17 +15,17 @@
  */
 package com.vaadin.flow.component.menubar.tests;
 
-import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.component.menubar.MenuBarItem;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-menu-bar/menu-bar-visibility")
 public class MenuBarVisibilityPage extends Div {
     public MenuBarVisibilityPage() {
         MenuBar menuBar = new MenuBar();
-        MenuItem menuItem = menuBar.addItem("Item");
+        MenuBarItem menuItem = menuBar.addItem("Item");
 
         NativeButton toggleMenuBarVisibility = new NativeButton(
                 "Toggle menu bar visibility", (event) -> {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -31,7 +31,7 @@ import com.vaadin.testbench.TestBenchElement;
 @TestPath("vaadin-menu-bar/menu-bar-test")
 public class MenuBarPageIT extends AbstractComponentIT {
 
-    public static final String OVERLAY_TAG = "vaadin-context-menu-overlay";
+    public static final String OVERLAY_TAG = "vaadin-menu-bar-overlay";
 
     private MenuBarElement menuBar;
 
@@ -61,8 +61,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     @Test
     public void clickRootItem_subMenuRenders() {
-        menuBar.getButtons().get(0).$("vaadin-context-menu-item").first()
-                .click();
+        menuBar.getButtons().get(0).$("vaadin-menu-bar-item").first().click();
         verifyOpened();
         assertOverlayContents("sub item 1", "<p>sub item 2</p>");
     }
@@ -177,8 +176,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     @Test
     public void clickRootItemWithClickListener_listenerCalledOnce() {
-        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
-                .click();
+        menuBar.getButtons().get(1).$("vaadin-menu-bar-item").first().click();
         assertMessage("clicked item 2");
     }
 
@@ -192,8 +190,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void changeItems_clickRootItemWithClickListener_clickListenerCalledOnce() {
         click("add-root-item");
-        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
-                .click();
+        menuBar.getButtons().get(1).$("vaadin-menu-bar-item").first().click();
         assertMessage("clicked item 2");
     }
 
@@ -228,8 +225,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         clickBody();
         click("reset-width");
         waitForResizeObserver();
-        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
-                .click();
+        menuBar.getButtons().get(1).$("vaadin-menu-bar-item").first().click();
         assertMessage("clicked item 2");
     }
 
@@ -247,7 +243,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-disable");
         TestBenchElement button2 = menuBar.getButtons().get(1);
         executeScript("arguments[0].disabled=false;"
-                + "arguments[0].querySelector('vaadin-context-menu-item').disabled=false;",
+                + "arguments[0].querySelector('vaadin-menu-bar-item').disabled=false;",
                 button2);
         button2 = menuBar.getButtons().get(1);
         button2.click();
@@ -417,8 +413,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void addSubItem_clickMenuItem_clickButton_subMenuOpenedAndClosed() {
         click("add-sub-item");
-        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
-                .click();
+        menuBar.getButtons().get(1).$("vaadin-menu-bar-item").first().click();
         verifyOpened();
         menuBar.getButtons().get(1).click();
         verifyClosed();
@@ -514,9 +509,8 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     private void assertButtonContents(String... expectedInnerHTML) {
-        String[] contents = menuBar.getButtons().stream()
-                .map(button -> button.$("vaadin-context-menu-item").first()
-                        .getAttribute("innerHTML"))
+        String[] contents = menuBar.getButtons().stream().map(button -> button
+                .$("vaadin-menu-bar-item").first().getAttribute("innerHTML"))
                 .toArray(String[]::new);
         Assert.assertArrayEquals(expectedInnerHTML, contents);
     }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -56,13 +56,13 @@ import elemental.json.JsonType;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-menu-bar")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./menubarConnector.js")
 @JsModule("@vaadin/menu-bar/src/vaadin-menu-bar.js")
 @JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
-@NpmPackage(value = "@vaadin/menu-bar", version = "24.0.0-alpha12")
-@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/menu-bar", version = "24.0.0-alpha13")
+@NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha13")
 public class MenuBar extends Component
         implements HasEnabled, HasMenuItems, HasOverlayClassName, HasSize,
         HasStyle, HasThemeVariant<MenuBarVariant> {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -32,10 +32,8 @@ import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.contextmenu.HasMenuItems;
-import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.contextmenu.MenuItemsArrayGenerator;
 import com.vaadin.flow.component.contextmenu.MenuManager;
-import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
@@ -63,12 +61,13 @@ import elemental.json.JsonType;
 @JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 @NpmPackage(value = "@vaadin/menu-bar", version = "24.0.0-alpha13")
 @NpmPackage(value = "@vaadin/tooltip", version = "24.0.0-alpha13")
-public class MenuBar extends Component
-        implements HasEnabled, HasMenuItems, HasOverlayClassName, HasSize,
-        HasStyle, HasThemeVariant<MenuBarVariant> {
+public class MenuBar extends Component implements HasEnabled,
+        HasMenuItems<MenuBarMenu, MenuBarItem, MenuBarSubMenu>,
+        HasOverlayClassName, HasSize, HasStyle,
+        HasThemeVariant<MenuBarVariant> {
 
-    private MenuManager<MenuBar, MenuItem, SubMenu> menuManager;
-    private MenuItemsArrayGenerator<MenuItem> menuItemsArrayGenerator;
+    private MenuManager<MenuBar, MenuBarItem, MenuBarSubMenu> menuManager;
+    private MenuItemsArrayGenerator<MenuBarItem> menuItemsArrayGenerator;
 
     private MenuBarI18n i18n;
 
@@ -88,9 +87,10 @@ public class MenuBar extends Component
                 resetContent();
             }
         };
-        menuManager = new MenuManager<>(this, resetContent,
+        menuManager = new MenuManager<MenuBar, MenuBarItem, MenuBarSubMenu>(
+                this, resetContent,
                 (menu, contentReset) -> new MenuBarRootItem(this, contentReset),
-                MenuItem.class, null);
+                MenuBarItem.class, null);
         addAttachListener(event -> {
             String appId = event.getUI().getInternals().getAppId();
             initConnector(appId);
@@ -99,158 +99,160 @@ public class MenuBar extends Component
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided text content
-     * and adds it to the root level of this menu bar.
+     * Creates a new {@link MenuBarItem} component with the provided text
+     * content and adds it to the root level of this menu bar.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param text
      *            the text content for the new item
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
-    public MenuItem addItem(String text) {
+    public MenuBarItem addItem(String text) {
         return menuManager.addItem(text);
     }
 
     /**
-     * Creates a new {@link MenuItem} component and adds it to the root level of
-     * this menu bar. The provided component is added into the created
-     * {@link MenuItem}.
+     * Creates a new {@link MenuBarItem} component and adds it to the root level
+     * of this menu bar. The provided component is added into the created
+     * {@link MenuBarItem}.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param component
      *            the component to add inside new item
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
-    public MenuItem addItem(Component component) {
+    public MenuBarItem addItem(Component component) {
         return menuManager.addItem(component);
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided text content
-     * and click listener and adds it to the root level of this menu bar.
+     * Creates a new {@link MenuBarItem} component with the provided text
+     * content and click listener and adds it to the root level of this menu
+     * bar.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param text
      *            the text content for the new item
      * @param clickListener
      *            the handler for clicking the new item, can be {@code null} to
      *            not add listener
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
     @Override
-    public MenuItem addItem(String text,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+    public MenuBarItem addItem(String text,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
         return menuManager.addItem(text, clickListener);
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided click listener
-     * and adds it to the root level of this menu bar. The provided component is
-     * added into the created {@link MenuItem}.
+     * Creates a new {@link MenuBarItem} component with the provided click
+     * listener and adds it to the root level of this menu bar. The provided
+     * component is added into the created {@link MenuBarItem}.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param component
      *            the component to add inside the added menu item
      * @param clickListener
      *            the handler for clicking the new item, can be {@code null} to
      *            not add listener
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
     @Override
-    public MenuItem addItem(Component component,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+    public MenuBarItem addItem(Component component,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
         return menuManager.addItem(component, clickListener);
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided text content
-     * and the tooltip text and adds it to the root level of this menu bar.
+     * Creates a new {@link MenuBarItem} component with the provided text
+     * content and the tooltip text and adds it to the root level of this menu
+     * bar.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param text
      *            the text content for the new item
      * @param tooltipText
      *            the tooltip text for the new item
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
-    public MenuItem addItem(String text, String tooltipText) {
+    public MenuBarItem addItem(String text, String tooltipText) {
         var item = addItem(text);
         setTooltip(item, tooltipText);
         return item;
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided tooltip text
-     * and adds it to the root level of this menu bar. The provided component is
-     * added into the created {@link MenuItem}.
+     * Creates a new {@link MenuBarItem} component with the provided tooltip
+     * text and adds it to the root level of this menu bar. The provided
+     * component is added into the created {@link MenuBarItem}.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param component
      *            the component to add inside new item
      * @param tooltipText
      *            the tooltip text for the new item
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
-    public MenuItem addItem(Component component, String tooltipText) {
+    public MenuBarItem addItem(Component component, String tooltipText) {
         var item = addItem(component);
         setTooltip(item, tooltipText);
         return item;
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided text content
-     * and the tooltip text and click listener and adds it to the root level of
-     * this menu bar.
+     * Creates a new {@link MenuBarItem} component with the provided text
+     * content and the tooltip text and click listener and adds it to the root
+     * level of this menu bar.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param text
      *            the text content for the new item
@@ -259,27 +261,28 @@ public class MenuBar extends Component
      * @param clickListener
      *            the handler for clicking the new item, can be {@code null} to
      *            not add listener
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
-    public MenuItem addItem(String text, String tooltipText,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+    public MenuBarItem addItem(String text, String tooltipText,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
         var item = addItem(text, clickListener);
         setTooltip(item, tooltipText);
         return item;
     }
 
     /**
-     * Creates a new {@link MenuItem} component with the provided click listener
-     * and the tooltip text and adds it to the root level of this menu bar. The
-     * provided component is added into the created {@link MenuItem}.
+     * Creates a new {@link MenuBarItem} component with the provided click
+     * listener and the tooltip text and adds it to the root level of this menu
+     * bar. The provided component is added into the created
+     * {@link MenuBarItem}.
      * <p>
-     * The added {@link MenuItem} component is placed inside a button in the
+     * The added {@link MenuBarItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
-     * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via an overflow button at the end of the button row.
+     * {@link MenuBarItem} is moved out of the button, into a context menu
+     * openable via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
-     * use {@link MenuItem#getSubMenu()}.
+     * use {@link MenuBarItem#getSubMenu()}.
      *
      * @param component
      *            the component to add inside the added menu item
@@ -288,25 +291,26 @@ public class MenuBar extends Component
      * @param clickListener
      *            the handler for clicking the new item, can be {@code null} to
      *            not add listener
-     * @return the added {@link MenuItem} component
+     * @return the added {@link MenuBarItem} component
      */
-    public MenuItem addItem(Component component, String tooltipText,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+    public MenuBarItem addItem(Component component, String tooltipText,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
         var item = addItem(component, clickListener);
         setTooltip(item, tooltipText);
         return item;
     }
 
     /**
-     * Gets the {@link MenuItem} components added to the root level of the menu
-     * bar.
+     * Gets the {@link MenuBarItem} components added to the root level of the
+     * menu bar.
      * <p>
      * To manage the contents inside the sub menus, use the
-     * {@link MenuItem#getSubMenu()}.
+     * {@link MenuBarItem#getSubMenu()}.
      *
-     * @return the root level {@link MenuItem} components added to this menu bar
+     * @return the root level {@link MenuBarItem} components added to this menu
+     *         bar
      */
-    public List<MenuItem> getItems() {
+    public List<MenuBarItem> getItems() {
         return menuManager.getItems();
     }
 
@@ -320,7 +324,7 @@ public class MenuBar extends Component
      *             this menu bar
      *
      */
-    public void remove(MenuItem... items) {
+    public void remove(MenuBarItem... items) {
         menuManager.remove(items);
     }
 
@@ -496,7 +500,7 @@ public class MenuBar extends Component
      * element with a custom generator is created and added inside the menu bar
      * in case it doesn't exist.
      */
-    private void setTooltip(MenuItem item, String tooltipText) {
+    private void setTooltip(MenuBarItem item, String tooltipText) {
         if (!getElement().getChildren().anyMatch(
                 child -> "tooltip".equals(child.getAttribute("slot")))) {
             // No <vaadin-tooltip> yet added, add one

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
@@ -13,37 +13,39 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.contextmenu;
+package com.vaadin.flow.component.menubar;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.contextmenu.MenuItemBase;
 import com.vaadin.flow.function.SerializableRunnable;
 
 /**
- * Item component used inside {@link ContextMenu} and {@link SubMenu}. This
- * component can be created and added to a menu overlay with
+ * Item component used inside {@link MenuBarSubMenu}. This component can be
+ * created and added to a menu overlay with
  * {@link HasMenuItems#addItem(String, ComponentEventListener)} and similar
  * methods.
  *
  * @author Vaadin Ltd.
  */
 @SuppressWarnings("serial")
-@Tag("vaadin-context-menu-item")
-public class MenuItem extends MenuItemBase<ContextMenu, MenuItem, SubMenu>
-        implements ClickNotifier<MenuItem> {
+@Tag("vaadin-menu-bar-item")
+public class MenuBarItem
+        extends MenuItemBase<MenuBarMenu, MenuBarItem, MenuBarSubMenu>
+        implements ClickNotifier<MenuBarItem> {
 
     private final SerializableRunnable contentReset;
 
-    public MenuItem(ContextMenu contextMenu,
+    public MenuBarItem(MenuBarMenu contextMenu,
             SerializableRunnable contentReset) {
         super(contextMenu);
         this.contentReset = contentReset;
     }
 
     @Override
-    protected SubMenu createSubMenu() {
-        return new SubMenu(this, contentReset);
+    protected MenuBarSubMenu createSubMenu() {
+        return new MenuBarSubMenu(this, contentReset);
     }
 
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarMenu.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarMenu.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.contextmenu.ContextMenuBase;
+import com.vaadin.flow.component.contextmenu.HasMenuItems;
+import com.vaadin.flow.component.contextmenu.MenuManager;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.function.SerializableRunnable;
+
+/**
+ * Menu component used inside {@link MenuBar} to show items in the overlay.
+ *
+ * @author Vaadin Ltd.
+ */
+@SuppressWarnings("serial")
+public class MenuBarMenu
+        extends ContextMenuBase<MenuBarMenu, MenuBarItem, MenuBarSubMenu>
+        implements HasMenuItems<MenuBarMenu, MenuBarItem, MenuBarSubMenu> {
+
+    /**
+     * Creates an empty menu.
+     */
+    public MenuBarMenu() {
+        super();
+    }
+
+    @Override
+    public MenuBarItem addItem(String text,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
+        return getMenuManager().addItem(text, clickListener);
+    }
+
+    @Override
+    public MenuBarItem addItem(Component component,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
+        return getMenuManager().addItem(component, clickListener);
+    }
+
+    @Override
+    protected MenuManager<MenuBarMenu, MenuBarItem, MenuBarSubMenu> createMenuManager(
+            SerializableRunnable contentReset) {
+        return new MenuManager<>(this, contentReset, MenuBarItem::new,
+                MenuBarItem.class, null);
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -15,10 +15,9 @@
  */
 package com.vaadin.flow.component.menubar;
 
-import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.function.SerializableRunnable;
 
-class MenuBarRootItem extends MenuItem {
+class MenuBarRootItem extends MenuBarItem {
 
     private MenuBar menuBar;
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
@@ -13,47 +13,52 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.contextmenu;
+package com.vaadin.flow.component.menubar;
 
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.contextmenu.HasMenuItems;
+import com.vaadin.flow.component.contextmenu.MenuManager;
+import com.vaadin.flow.component.contextmenu.SubMenuBase;
 import com.vaadin.flow.function.SerializableRunnable;
 
 /**
- * API that allows adding content into the sub menus of a {@link ContextMenu} to
- * create hierarchical menus. Get it by calling {@link MenuItem#getSubMenu()} on
- * the item component that should open the sub menu. Sub menu will be rendered
- * only if content has been added inside it.
+ * API that allows adding content into the sub menus of a {@link MenuBar} to
+ * create hierarchical menus. Get it by calling {@link MenuBarItem#getSubMenu()}
+ * on the item component that should open the sub menu. Sub menu will be
+ * rendered only if content has been added inside it.
  *
  * @author Vaadin Ltd.
  */
-public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
-        implements HasMenuItems<ContextMenu, MenuItem, SubMenu> {
+public class MenuBarSubMenu
+        extends SubMenuBase<MenuBarMenu, MenuBarItem, MenuBarSubMenu>
+        implements HasMenuItems<MenuBarMenu, MenuBarItem, MenuBarSubMenu> {
 
     private final SerializableRunnable contentReset;
 
-    public SubMenu(MenuItem parentMenuItem, SerializableRunnable contentReset) {
+    public MenuBarSubMenu(MenuBarItem parentMenuItem,
+            SerializableRunnable contentReset) {
         super(parentMenuItem);
         this.contentReset = contentReset;
     }
 
     @Override
-    public MenuItem addItem(String text,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+    public MenuBarItem addItem(String text,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
         return getMenuManager().addItem(text, clickListener);
     }
 
     @Override
-    public MenuItem addItem(Component component,
-            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+    public MenuBarItem addItem(Component component,
+            ComponentEventListener<ClickEvent<MenuBarItem>> clickListener) {
         return getMenuManager().addItem(component, clickListener);
     }
 
     @Override
-    protected MenuManager<ContextMenu, MenuItem, SubMenu> createMenuManager() {
+    protected MenuManager<MenuBarMenu, MenuBarItem, MenuBarSubMenu> createMenuManager() {
         return new MenuManager<>(getParentMenuItem().getContextMenu(),
-                contentReset, MenuItem::new, MenuItem.class,
+                contentReset, MenuBarItem::new, MenuBarItem.class,
                 getParentMenuItem());
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTest.java
@@ -19,15 +19,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.component.menubar.MenuBarItem;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
 
 public class MenuBarTest {
 
     private MenuBar menuBar;
-    private MenuItem item1, item2;
+    private MenuBarItem item1, item2;
 
     @Before
     public void setup() {
@@ -50,9 +50,9 @@ public class MenuBarTest {
 
     @Test
     public void addChildrenWithClickListeners_getChildren_getItems() {
-        MenuItem item3 = menuBar.addItem("foo", e -> {
+        MenuBarItem item3 = menuBar.addItem("foo", e -> {
         });
-        MenuItem item4 = menuBar.addItem(new Span("bar"), e -> {
+        MenuBarItem item4 = menuBar.addItem(new Span("bar"), e -> {
         });
         assertChildrenAndItems(item1, item2, item3, item4);
     }
@@ -71,7 +71,7 @@ public class MenuBarTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void removeNonChildItem_throws() {
-        MenuItem item = new MenuBar().addItem("foo");
+        MenuBarItem item = new MenuBar().addItem("foo");
         menuBar.remove(item);
     }
 
@@ -88,12 +88,12 @@ public class MenuBarTest {
 
     @Test
     public void implementsHasOverlayClassName() {
-        Assert.assertTrue("ContextMenu should support overlay class name",
+        Assert.assertTrue("MenuBar should support overlay class name",
                 HasOverlayClassName.class
                         .isAssignableFrom(new MenuBar().getClass()));
     }
 
-    private void assertChildrenAndItems(MenuItem... expected) {
+    private void assertChildrenAndItems(MenuBarItem... expected) {
         Object[] menuItems = menuBar.getChildren().toArray();
         Assert.assertArrayEquals(expected, menuItems);
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
@@ -32,7 +32,7 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("vaadin-menu-bar")
 public class MenuBarElement extends TestBenchElement {
 
-    public static final String OVERLAY_TAG = "vaadin-context-menu-overlay";
+    public static final String OVERLAY_TAG = "vaadin-menu-bar-overlay";
 
     /**
      * Gets the button elements wrapping the root level items. This does not
@@ -89,7 +89,7 @@ public class MenuBarElement extends TestBenchElement {
      * @return List of TestBenchElements representing sub menu items.
      */
     public List<TestBenchElement> getSubMenuItems(TestBenchElement overlay) {
-        return overlay.$("vaadin-context-menu-item").all();
+        return overlay.$("vaadin-menu-bar-item").all();
     }
 
     /**

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
@@ -45,10 +45,10 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-message-input")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/message-input/src/vaadin-message-input.js")
-@NpmPackage(value = "@vaadin/message-input", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/message-input", version = "24.0.0-alpha13")
 public class MessageInput extends Component
         implements HasSize, HasStyle, HasEnabled, HasTooltip {
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
@@ -43,11 +43,11 @@ import elemental.json.JsonArray;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-message-list")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./messageListConnector.js")
 @JsModule("@vaadin/message-list/src/vaadin-message-list.js")
-@NpmPackage(value = "@vaadin/message-list", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/message-list", version = "24.0.0-alpha13")
 public class MessageList extends Component
         implements HasStyle, HasSize, LocaleChangeObserver {
 

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -54,9 +54,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-notification")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/notification", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/notification", version = "24.0.0-alpha13")
 @JsModule("@vaadin/notification/src/vaadin-notification.js")
 @JsModule("./flow-component-renderer.js")
 public class Notification extends Component implements HasComponents, HasStyle,

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
@@ -28,9 +28,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * it contains.
  */
 @Tag("vaadin-horizontal-layout")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/horizontal-layout", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/horizontal-layout", version = "24.0.0-alpha13")
 @JsModule("@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js")
 public class HorizontalLayout extends Component implements ThemableLayout,
         FlexComponent, ClickNotifier<HorizontalLayout> {

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
@@ -35,9 +35,9 @@ import java.util.Locale;
  * {@link #setScrollDirection(ScrollDirection)}
  */
 @Tag("vaadin-scroller")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/scroller", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/scroller", version = "24.0.0-alpha13")
 @JsModule("@vaadin/scroller/vaadin-scroller.js")
 public class Scroller extends Component
         implements HasSize, HasStyle, HasThemeVariant<ScrollerVariant> {

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
@@ -28,9 +28,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * parent component and its height is determined by the components it contains.
  */
 @Tag("vaadin-vertical-layout")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/vertical-layout", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/vertical-layout", version = "24.0.0-alpha13")
 @JsModule("@vaadin/vertical-layout/src/vaadin-vertical-layout.js")
 public class VerticalLayout extends Component implements ThemableLayout,
         FlexComponent, ClickNotifier<VerticalLayout> {

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
@@ -33,8 +33,8 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-progress-bar")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
-@NpmPackage(value = "@vaadin/progress-bar", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
+@NpmPackage(value = "@vaadin/progress-bar", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/progress-bar/src/vaadin-progress-bar.js")
 public class ProgressBar extends Component

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButton.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButton.java
@@ -34,9 +34,9 @@ import com.vaadin.flow.data.binder.HasItemComponents;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-radio-button")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/radio-group", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/radio-group", version = "24.0.0-alpha13")
 @JsModule("@vaadin/radio-group/src/vaadin-radio-button.js")
 class RadioButton<T> extends Component
         implements ClickNotifier<RadioButton<T>>, Focusable<RadioButton<T>>,

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -73,9 +73,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-radio-group")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/radio-group", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/radio-group", version = "24.0.0-alpha13")
 @JsModule("@vaadin/radio-group/src/vaadin-radio-group.js")
 public class RadioButtonGroup<T>
         extends AbstractSinglePropertyField<RadioButtonGroup<T>, T>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -54,9 +54,9 @@ import elemental.json.JsonObject;
  *
  */
 @Tag("vaadin-rich-text-editor")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/rich-text-editor", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/rich-text-editor", version = "24.0.0-alpha13")
 @JsModule("@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js")
 public class RichTextEditor
         extends AbstractSinglePropertyField<RichTextEditor, String>

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -83,9 +83,9 @@ import java.util.stream.Stream;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-select")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/select", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/select", version = "24.0.0-alpha13")
 @JsModule("@vaadin/select/src/vaadin-select.js")
 @JsModule("./selectConnector.js")
 public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
@@ -244,7 +244,7 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
      * even though that is not visible from the component level.
      */
     @Tag("vaadin-select-list-box")
-    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
     @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
     private class InternalListBox extends Component
             implements HasItemComponents<T> {

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
  *            the type of the bean
  */
 @Tag("vaadin-select-item")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 class VaadinItem<T> extends Component implements
         HasItemComponents.ItemComponent<T>, HasComponents, HasStyle, HasText {

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -42,9 +42,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-split-layout")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/split-layout", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/split-layout", version = "24.0.0-alpha13")
 @JsModule("@vaadin/split-layout/src/vaadin-split-layout.js")
 public class SplitLayout extends Component
         implements ClickNotifier<SplitLayout>, HasSize, HasStyle,

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
@@ -33,10 +33,10 @@ import com.vaadin.flow.component.shared.HasTooltip;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-tab")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/tabs/src/vaadin-tab.js")
-@NpmPackage(value = "@vaadin/tabs", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/tabs", version = "24.0.0-alpha13")
 public class Tab extends Component implements HasComponents, HasLabel, HasStyle,
         HasThemeVariant<TabVariant>, HasTooltip {
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-tabsheet")
-@NpmPackage(value = "@vaadin/tabsheet", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/tabsheet", version = "24.0.0-alpha13")
 @JsModule("@vaadin/tabsheet/src/vaadin-tabsheet.js")
 public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
         HasSuffix, HasThemeVariant<TabSheetVariant> {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -66,10 +66,10 @@ import org.slf4j.LoggerFactory;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-tabs")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/tabs/src/vaadin-tabs.js")
-@NpmPackage(value = "@vaadin/tabs", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/tabs", version = "24.0.0-alpha13")
 public class Tabs extends Component
         implements HasEnabled, HasSize, HasStyle, HasThemeVariant<TabsVariant> {
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -50,7 +50,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-big-decimal-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./vaadin-big-decimal-field.js")
 public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -43,9 +43,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-email-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/email-field", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/email-field", version = "24.0.0-alpha13")
 @JsModule("@vaadin/email-field/src/vaadin-email-field.js")
 public class EmailField extends TextFieldBase<EmailField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
@@ -28,9 +28,9 @@ import com.vaadin.flow.function.SerializableFunction;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-integer-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/integer-field", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/integer-field", version = "24.0.0-alpha13")
 @JsModule("@vaadin/integer-field/src/vaadin-integer-field.js")
 public class IntegerField extends AbstractNumberField<IntegerField, Integer>
         implements HasThemeVariant<TextFieldVariant> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
@@ -36,9 +36,9 @@ import com.vaadin.flow.function.SerializableFunction;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-number-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/number-field", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/number-field", version = "24.0.0-alpha13")
 @JsModule("@vaadin/number-field/src/vaadin-number-field.js")
 public class NumberField extends AbstractNumberField<NumberField, Double>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -38,9 +38,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-password-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/password-field", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/password-field", version = "24.0.0-alpha13")
 @JsModule("@vaadin/password-field/src/vaadin-password-field.js")
 public class PasswordField extends TextFieldBase<PasswordField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -37,9 +37,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-text-area")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/text-area", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/text-area", version = "24.0.0-alpha13")
 @JsModule("@vaadin/text-area/src/vaadin-text-area.js")
 public class TextArea extends TextFieldBase<TextArea, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextAreaVariant> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -36,9 +36,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-text-field")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/text-field", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/text-field", version = "24.0.0-alpha13")
 @JsModule("@vaadin/text-field/src/vaadin-text-field.js")
 public class TextField extends TextFieldBase<TextField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -67,9 +67,9 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-time-picker")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/time-picker", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/time-picker", version = "24.0.0-alpha13")
 @JsModule("@vaadin/time-picker/src/vaadin-time-picker.js")
 @JsModule("./vaadin-time-picker/timepickerConnector.js")
 public class TimePicker

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -63,9 +63,9 @@ import elemental.json.JsonType;
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-upload")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/upload", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/upload", version = "24.0.0-alpha13")
 @JsModule("@vaadin/upload/src/vaadin-upload.js")
 public class Upload extends Component implements HasSize, HasStyle {
 

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -66,9 +66,9 @@ import elemental.json.JsonValue;
  *            the type of the items supported by the list
  */
 @Tag("vaadin-virtual-list")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.0.0-alpha13")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-@NpmPackage(value = "@vaadin/virtual-list", version = "24.0.0-alpha12")
+@NpmPackage(value = "@vaadin/virtual-list", version = "24.0.0-alpha13")
 @JsModule("@vaadin/virtual-list/vaadin-virtual-list.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./virtualListConnector.js")


### PR DESCRIPTION
## Description

Depends on #4613

Updated `MenuBar` to use `vaadin-menu-bar-item` implemented in the web component, see https://github.com/vaadin/web-components/issues/3010.

## Type of change

- Breaking change