### PR TITLE
Revert "chore: bump ci-sauce from 1.166 to 1.167 (#4575)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <failIfNoTests>false</failIfNoTests>
         <vaadin.pnpm.enable>false</vaadin.pnpm.enable>
         <sauce-connect.version>2.1.25</sauce-connect.version>
-        <ci-sauce.version>1.167</ci-sauce.version>
+        <ci-sauce.version>1.166</ci-sauce.version>
         <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>
         <osgi.bundle.license>http://www.apache.org/licenses/LICENSE-2.0</osgi.bundle.license>
         <osgi.export.package>default</osgi.export.package>


### PR DESCRIPTION
This reverts commit 2d0b5e8887d6753036a9d3030e8c2389021040ff.

