### PR TITLE
chore: upgrade jetty-maven-plugin and properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
                 </project.reporting.outputEncoding>
-        <jetty.version>11.0.8</jetty.version>
+        <jetty.version>11.0.13</jetty.version>
         <jetty.http.port>8080</jetty.http.port>
         <jetty.stop.port>9999</jetty.stop.port>
         <karaf-maven-plugin.version>4.4.3</karaf-maven-plugin.version>
@@ -107,8 +107,7 @@
                             <configuration>
                                 <systemProperties>
                                     <systemProperty>
-                                        <name>vaadin.productionMode</name>
-                                        <value>true</value>
+                                        <vaadin.productionMode>true</vaadin.productionMode>
                                     </systemProperty>
                                 </systemProperties>
                             </configuration>
@@ -290,18 +289,10 @@
                         <stopKey>foo</stopKey>
                         <systemProperties>
                             <force>true</force>
-                            <systemProperty>
-                                <name>project.basedir</name>
-                                <value>${project.basedir}</value>
-                            </systemProperty>
-                            <systemProperty>
-                                <name>vaadin.productionMode</name>
-                                <value>false</value>
-                            </systemProperty>
-                            <systemProperty>
-                                <name>vaadin.reuseDevServer</name>
-                                <value>true</value>
-                            </systemProperty>
+                            <project.basedir>${project.basedir}</project.basedir>
+                            <vaadin.productionMode>false</vaadin.productionMode>
+                            <vaadin.reuseDevServer>true</vaadin.reuseDevServer>
+                            <vaadin.frontend.hotdeploy>true</vaadin.frontend.hotdeploy>
                         </systemProperties>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -106,9 +106,7 @@
                             <artifactId>jetty-maven-plugin</artifactId>
                             <configuration>
                                 <systemProperties>
-                                    <systemProperty>
-                                        <vaadin.productionMode>true</vaadin.productionMode>
-                                    </systemProperty>
+                                    <vaadin.productionMode>true</vaadin.productionMode>
                                 </systemProperties>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
also enable the `vaadin.frontend.hotdeploy`