### PR TITLE
feat: set labels for map markers

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureLabelPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureLabelPage.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.map;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
 import com.vaadin.flow.router.Route;
 
@@ -11,19 +12,34 @@ public class FeatureLabelPage extends Div {
         Map map = new Map();
         map.getFeatureLayer().setId("feature-layer");
 
-        MarkerFeature marker = new MarkerFeature();
-        marker.setLabel("Marker label");
-        map.getFeatureLayer().addFeature(marker);
+        MarkerFeature marker1 = new MarkerFeature();
+        marker1.setId("marker1");
+        marker1.setLabel("Marker label 1");
+        map.getFeatureLayer().addFeature(marker1);
+
+        MarkerFeature marker2 = new MarkerFeature(new Coordinate(30, 0));
+        marker2.setId("marker2");
+        marker2.setLabel("Marker label 2");
+        map.getFeatureLayer().addFeature(marker2);
+
+        MarkerFeature marker3 = new MarkerFeature(new Coordinate(60, 0));
+        marker3.setId("marker3");
+        marker3.setLabel("Marker label 3");
+        map.getFeatureLayer().addFeature(marker3);
 
         NativeButton updateLabelText = new NativeButton("Update label text",
                 e -> {
-                    marker.setLabel("Updated label");
+                    marker1.setLabel("Updated label 1");
+                    marker2.setLabel("Updated label 2");
+                    marker3.setLabel("Updated label 3");
                 });
         updateLabelText.setId("update-label-text");
 
-        NativeButton removeLabelText = new NativeButton("Remove label text",
+        NativeButton removeLabelText = new NativeButton("Remove label texts",
                 e -> {
-                    marker.setLabel(null);
+                    marker1.setLabel(null);
+                    marker2.setLabel(null);
+                    marker3.setLabel(null);
                 });
         removeLabelText.setId("remove-label-text");
 

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureLabelPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureLabelPage.java
@@ -1,0 +1,33 @@
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/feature-label")
+public class FeatureLabelPage extends Div {
+    public FeatureLabelPage() {
+        Map map = new Map();
+        map.getFeatureLayer().setId("feature-layer");
+
+        MarkerFeature marker = new MarkerFeature();
+        marker.setLabel("Marker label");
+        map.getFeatureLayer().addFeature(marker);
+
+        NativeButton updateLabelText = new NativeButton("Update label text",
+                e -> {
+                    marker.setLabel("Updated label");
+                });
+        updateLabelText.setId("update-label-text");
+
+        NativeButton removeLabelText = new NativeButton("Remove label text",
+                e -> {
+                    marker.setLabel(null);
+                });
+        removeLabelText.setId("remove-label-text");
+
+        add(map);
+        add(new Div(updateLabelText, removeLabelText));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureLabelIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureLabelIT.java
@@ -24,9 +24,8 @@ public class FeatureLabelIT extends AbstractComponentIT {
 
     @Test
     public void defaultLabelStyle() {
-        MapElement.TextReference text = getMarkerTextStyle();
+        MapElement.TextReference text = getMarkerTextStyle("marker1");
 
-        Assert.assertEquals("Marker label", text.getText());
         Assert.assertEquals("13px sans-serif", text.getFont());
         Assert.assertEquals("#333", text.getFill().getColor());
         Assert.assertEquals("#fff", text.getStroke().getColor());
@@ -36,27 +35,42 @@ public class FeatureLabelIT extends AbstractComponentIT {
     }
 
     @Test
-    public void updateLabel() {
-        updateLabelText.click();
-
-        MapElement.TextReference text = getMarkerTextStyle();
-        Assert.assertEquals("Updated label", text.getText());
+    public void initialLabels() {
+        Assert.assertEquals("Marker label 1",
+                getMarkerTextStyle("marker1").getText());
+        Assert.assertEquals("Marker label 2",
+                getMarkerTextStyle("marker2").getText());
+        Assert.assertEquals("Marker label 3",
+                getMarkerTextStyle("marker3").getText());
     }
 
     @Test
-    public void removeLabel() {
-        removeLabelText.click();
+    public void updateLabels() {
+        updateLabelText.click();
 
-        MapElement.TextReference text = getMarkerTextStyle();
-        Assert.assertNull(text.getText());
+        Assert.assertEquals("Updated label 1",
+                getMarkerTextStyle("marker1").getText());
+        Assert.assertEquals("Updated label 2",
+                getMarkerTextStyle("marker2").getText());
+        Assert.assertEquals("Updated label 3",
+                getMarkerTextStyle("marker3").getText());
     }
 
-    private MapElement.TextReference getMarkerTextStyle() {
+    @Test
+    public void removeLabels() {
+        removeLabelText.click();
+
+        Assert.assertNull(getMarkerTextStyle("marker1").getText());
+        Assert.assertNull(getMarkerTextStyle("marker2").getText());
+        Assert.assertNull(getMarkerTextStyle("marker3").getText());
+    }
+
+    private MapElement.TextReference getMarkerTextStyle(String markerId) {
         MapElement.MapReference mapReference = map.getMapReference();
         MapElement.VectorSourceReference vectorSource = mapReference.getLayers()
                 .getLayer("feature-layer").getSource().asVectorSource();
         MapElement.FeatureReference feature = vectorSource.getFeatures()
-                .getFeature(0);
+                .getFeature(markerId);
         return feature.getStyle().getText();
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureLabelIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureLabelIT.java
@@ -1,0 +1,62 @@
+package com.vaadin.flow.components.map;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-map/feature-label")
+public class FeatureLabelIT extends AbstractComponentIT {
+    private MapElement map;
+    private TestBenchElement updateLabelText;
+    private TestBenchElement removeLabelText;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+        updateLabelText = $(TestBenchElement.class).id("update-label-text");
+        removeLabelText = $(TestBenchElement.class).id("remove-label-text");
+    }
+
+    @Test
+    public void defaultLabelStyle() {
+        MapElement.TextReference text = getMarkerTextStyle();
+
+        Assert.assertEquals("Marker label", text.getText());
+        Assert.assertEquals("13px sans-serif", text.getFont());
+        Assert.assertEquals("#333", text.getFill().getColor());
+        Assert.assertEquals("#fff", text.getStroke().getColor());
+        Assert.assertEquals(3, text.getStroke().getWidth());
+        Assert.assertEquals(0, text.getOffsetX());
+        Assert.assertEquals(10, text.getOffsetY());
+    }
+
+    @Test
+    public void updateLabel() {
+        updateLabelText.click();
+
+        MapElement.TextReference text = getMarkerTextStyle();
+        Assert.assertEquals("Updated label", text.getText());
+    }
+
+    @Test
+    public void removeLabel() {
+        removeLabelText.click();
+
+        MapElement.TextReference text = getMarkerTextStyle();
+        Assert.assertNull(text.getText());
+    }
+
+    private MapElement.TextReference getMarkerTextStyle() {
+        MapElement.MapReference mapReference = map.getMapReference();
+        MapElement.VectorSourceReference vectorSource = mapReference.getLayers()
+                .getLayer("feature-layer").getSource().asVectorSource();
+        MapElement.FeatureReference feature = vectorSource.getFeatures()
+                .getFeature(0);
+        return feature.getStyle().getText();
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Feature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Feature.java
@@ -27,6 +27,7 @@ public abstract class Feature extends AbstractConfigurationObject {
 
     private SimpleGeometry geometry;
     private Style style;
+    private String label;
     private boolean draggable;
 
     @Override
@@ -81,6 +82,27 @@ public abstract class Feature extends AbstractConfigurationObject {
         removeChild(this.style);
         this.style = style;
         addChild(style);
+    }
+
+    /**
+     * The label that should be displayed next to the feature.
+     *
+     * @return the label string
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Sets the label that should be displayed next to the feature. Set to
+     * {@code null} to remove the label.
+     *
+     * @param label
+     *            the new label string, or {@code null} to remove the label
+     */
+    public void setLabel(String label) {
+        this.label = label;
+        markAsDirty();
     }
 
     /**

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
@@ -9,6 +9,9 @@
  */
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
+import Fill from 'ol/style/Fill';
+import Stroke from 'ol/style/Stroke';
+import Text from 'ol/style/Text';
 import View from 'ol/View';
 import { synchronizeImageLayer, synchronizeTileLayer, synchronizeVectorLayer } from './layers.js';
 import {
@@ -20,6 +23,16 @@ import {
 } from './sources.js';
 import { synchronizeIcon, synchronizeFill, synchronizeStroke, synchronizeStyle } from './styles.js';
 import { convertToCoordinateArray, synchronizeCollection } from './util.js';
+
+/**
+ * Fallback text style to use for features that don't have a custom one
+ */
+const fallbackTextStyle = new Text({
+  font: '13px sans-serif',
+  offsetY: 10,
+  fill: new Fill({ color: '#333' }),
+  stroke: new Stroke({ color: '#fff', width: 3 })
+});
 
 function synchronizeMap(target, source, context) {
   if (!target) {
@@ -62,7 +75,31 @@ function synchronizeFeature(target, source, context) {
   }
 
   target.setGeometry(context.lookup.get(source.geometry));
-  target.setStyle(context.lookup.get(source.style));
+
+  // Define style function is run before rendering each feature. The function
+  // supports using a fallback text style for rendering labels in case the
+  // feature doesn't define its own text style.
+  // Acquire reference to style instance outside of style function, otherwise
+  // there would be no reference to the instance, and it might get garbage
+  // collected.
+  const style = context.lookup.get(source.style);
+  target.setStyle(() => {
+    if (!style) {
+      return undefined;
+    }
+    // If feature has a label but no custom text style, then use default text
+    // style
+    if (source.label && !style.getText()) {
+      style.setText(fallbackTextStyle);
+    }
+    // Set the feature's label on the text style. This is safe even when using
+    // the default text style instance, as for each feature using the default
+    // text style, this function will be called again before rendering.
+    if (style.getText()) {
+      style.getText().setText(source.label);
+    }
+    return style;
+  });
   target.draggable = source.draggable;
 
   return target;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
@@ -76,9 +76,9 @@ function synchronizeFeature(target, source, context) {
 
   target.setGeometry(context.lookup.get(source.geometry));
 
-  // Define style function is run before rendering each feature. The function
-  // supports using a fallback text style for rendering labels in case the
-  // feature doesn't define its own text style.
+  // Define style function that is run before rendering each feature. The
+  // function supports using a fallback text style for rendering labels in case
+  // the feature doesn't define its own text style.
   // Acquire reference to style instance outside of style function, otherwise
   // there would be no reference to the instance, and it might get garbage
   // collected.

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -480,6 +480,12 @@ public class MapElement extends TestBenchElement {
         public FeatureReference getFeature(int index) {
             return new FeatureReference(executor, path("item(%s)", index));
         }
+
+        public FeatureReference getFeature(String featureId) {
+            return new FeatureReference(executor,
+                    path("getArray().find(feature => feature.id === '%s')",
+                            featureId));
+        }
     }
 
     public static class FeatureReference extends ConfigurationObjectReference {

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -493,7 +493,7 @@ public class MapElement extends TestBenchElement {
         }
 
         public StyleReference getStyle() {
-            return new StyleReference(executor, path("getStyle()"));
+            return new StyleReference(executor, path("getStyle()()"));
         }
     }
 
@@ -504,6 +504,10 @@ public class MapElement extends TestBenchElement {
 
         public IconReference getImage() {
             return new IconReference(executor, path("getImage()"));
+        }
+
+        public TextReference getText() {
+            return new TextReference(executor, path("getText()"));
         }
     }
 
@@ -552,6 +556,61 @@ public class MapElement extends TestBenchElement {
 
         public String getSrc() {
             return getString("getSrc()");
+        }
+    }
+
+    public static class TextReference extends ConfigurationObjectReference {
+        private TextReference(ExpressionExecutor executor, String expression) {
+            super(executor, expression);
+        }
+
+        public String getText() {
+            return getString("getText()");
+        }
+
+        public String getFont() {
+            return getString("getFont()");
+        }
+
+        public int getOffsetX() {
+            return getInt("getOffsetX()");
+        }
+
+        public int getOffsetY() {
+            return getInt("getOffsetY()");
+        }
+
+        public FillReference getFill() {
+            return new FillReference(executor, path("getFill()"));
+        }
+
+        public StrokeReference getStroke() {
+            return new StrokeReference(executor, path("getStroke()"));
+        }
+    }
+
+    public static class FillReference extends ConfigurationObjectReference {
+        private FillReference(ExpressionExecutor executor, String expression) {
+            super(executor, expression);
+        }
+
+        public String getColor() {
+            return getString("getColor()");
+        }
+    }
+
+    public static class StrokeReference extends ConfigurationObjectReference {
+        private StrokeReference(ExpressionExecutor executor,
+                String expression) {
+            super(executor, expression);
+        }
+
+        public String getColor() {
+            return getString("getColor()");
+        }
+
+        public Number getWidth() {
+            return getInt("getWidth()");
         }
     }
 }


### PR DESCRIPTION
## Description

Allows to set and remove text labels for map markers. Labels are rendered with a default style for now, I'll add customization of the marker's label style in a follow-up PR.

Part of: https://github.com/vaadin/flow-components/issues/2898
AC: https://github.com/vaadin/platform/issues/3533
Research: https://github.com/vaadin/flow-components/issues/4278#issuecomment-1411810550

## Type of change

- Feature
