### PR TITLE
fix: use the same cell reference constructor in order to ensure consistency

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/PopupButtonFixture.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/PopupButtonFixture.java
@@ -26,8 +26,9 @@ public class PopupButtonFixture implements SpreadsheetFixture {
             }
             List<String> values = new ArrayList<>(VALUES);
             CellReference ref = event.getSelectedCellReference();
-            CellReference newRef = new CellReference(ref.getRow(),
-                    ref.getCol());
+            CellReference newRef = new CellReference(
+                    spreadsheet.getActiveSheet().getSheetName(), ref.getRow(),
+                    ref.getCol(), false, false);
             DataValidationButton popupButton = new DataValidationButton(
                     spreadsheet, values);
             popupButton.setUp();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionManager.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionManager.java
@@ -116,7 +116,9 @@ public class CellSelectionManager implements Serializable {
     }
 
     boolean isCellInsideSelection(int row, int column) {
-        CellReference cellReference = new CellReference(row - 1, column - 1);
+        CellReference cellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), row - 1,
+                column - 1, false, false);
         boolean inside = cellReference.equals(selectedCellReference)
                 || individualSelectedCells.contains(cellReference);
         if (!inside) {
@@ -173,7 +175,9 @@ public class CellSelectionManager implements Serializable {
      */
     protected void onCellSelected(int row, int column,
             boolean discardOldRangeSelection) {
-        CellReference cellReference = new CellReference(row - 1, column - 1);
+        CellReference cellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), row - 1,
+                column - 1, false, false);
         CellReference previousCellReference = selectedCellReference;
         if (!cellReference.equals(previousCellReference)
                 || discardOldRangeSelection && (!cellRangeAddresses.isEmpty()
@@ -217,8 +221,9 @@ public class CellSelectionManager implements Serializable {
                             region.col1 - 1, region.col2 - 1);
                 }
                 handleCellRangeSelection(cra);
-                selectedCellReference = new CellReference(cra.getFirstRow(),
-                        cra.getFirstColumn());
+                selectedCellReference = new CellReference(
+                        spreadsheet.getActiveSheet().getSheetName(),
+                        cra.getFirstRow(), cra.getFirstColumn(), false, false);
                 paintedCellRange = cra;
                 cellRangeAddresses.clear();
                 cellRangeAddresses.add(cra);
@@ -234,8 +239,10 @@ public class CellSelectionManager implements Serializable {
                             .createCorrectCellRangeAddress(region.row1,
                                     region.col1, region.row2, region.col2);
                     handleCellRangeSelection(cra);
-                    selectedCellReference = new CellReference(cra.getFirstRow(),
-                            cra.getFirstColumn());
+                    selectedCellReference = new CellReference(
+                            spreadsheet.getActiveSheet().getSheetName(),
+                            cra.getFirstRow(), cra.getFirstColumn(), false,
+                            false);
                     paintedCellRange = cra;
                     cellRangeAddresses.clear();
                     cellRangeAddresses.add(cra);
@@ -382,8 +389,9 @@ public class CellSelectionManager implements Serializable {
 
     protected void handleCellRangeSelection(String name, CellRangeAddress cra) {
 
-        final CellReference firstCell = new CellReference(cra.getFirstRow(),
-                cra.getFirstColumn());
+        final CellReference firstCell = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), cra.getFirstRow(),
+                cra.getFirstColumn(), false, false);
 
         handleCellRangeSelection(name, firstCell, cra, true);
     }
@@ -463,8 +471,9 @@ public class CellSelectionManager implements Serializable {
         cellRangeAddresses.clear();
         individualSelectedCells.clear();
 
-        selectedCellReference = new CellReference(selectedCellRow - 1,
-                selectedCellColumn - 1);
+        selectedCellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(),
+                selectedCellRow - 1, selectedCellColumn - 1, false, false);
 
         CellRangeAddress cra = spreadsheet.createCorrectCellRangeAddress(row1,
                 col1, row2, col2);
@@ -507,7 +516,9 @@ public class CellSelectionManager implements Serializable {
             individualSelectedCells.add(selectedCellReference);
         }
         handleCellSelection(row, column);
-        selectedCellReference = new CellReference(row - 1, column - 1);
+        selectedCellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), row - 1,
+                column - 1, false, false);
         spreadsheet.loadCustomEditorOnSelectedCell();
         if (individualSelectedCells.contains(selectedCellReference)) {
             individualSelectedCells.remove(
@@ -558,8 +569,9 @@ public class CellSelectionManager implements Serializable {
      */
     protected void onRowSelected(int row, int firstColumnIndex) {
         handleCellSelection(row, firstColumnIndex);
-        selectedCellReference = new CellReference(row - 1,
-                firstColumnIndex - 1);
+        selectedCellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), row - 1,
+                firstColumnIndex - 1, false, false);
         spreadsheet.loadCustomEditorOnSelectedCell();
         cellRangeAddresses.clear();
         individualSelectedCells.clear();
@@ -592,8 +604,9 @@ public class CellSelectionManager implements Serializable {
             individualSelectedCells.add(selectedCellReference);
         }
         handleCellSelection(row, firstColumnIndex);
-        selectedCellReference = new CellReference(row - 1,
-                firstColumnIndex - 1);
+        selectedCellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), row - 1,
+                firstColumnIndex - 1, false, false);
         spreadsheet.loadCustomEditorOnSelectedCell();
         cellRangeAddresses.add(spreadsheet.createCorrectCellRangeAddress(row, 1,
                 row, spreadsheet.getColumns()));
@@ -612,8 +625,9 @@ public class CellSelectionManager implements Serializable {
      */
     protected void onColumnSelected(int firstRowIndex, int column) {
         handleCellSelection(firstRowIndex, column);
-        selectedCellReference = new CellReference(firstRowIndex - 1,
-                column - 1);
+        selectedCellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), firstRowIndex - 1,
+                column - 1, false, false);
         spreadsheet.loadCustomEditorOnSelectedCell();
         cellRangeAddresses.clear();
         individualSelectedCells.clear();
@@ -646,8 +660,9 @@ public class CellSelectionManager implements Serializable {
             individualSelectedCells.add(selectedCellReference);
         }
         handleCellSelection(firstRowIndex, column);
-        selectedCellReference = new CellReference(firstRowIndex - 1,
-                column - 1);
+        selectedCellReference = new CellReference(
+                spreadsheet.getActiveSheet().getSheetName(), firstRowIndex - 1,
+                column - 1, false, false);
         spreadsheet.loadCustomEditorOnSelectedCell();
         cellRangeAddresses.add(spreadsheet.createCorrectCellRangeAddress(1,
                 column, spreadsheet.getRows(), column));
@@ -676,8 +691,10 @@ public class CellSelectionManager implements Serializable {
                 handleCellAddressChange(region.getFirstRow() + 1,
                         region.getFirstColumn() + 1, false);
             }
-            selectedCellReference = new CellReference(region.getFirstRow(),
-                    region.getFirstColumn());
+            selectedCellReference = new CellReference(
+                    spreadsheet.getActiveSheet().getSheetName(),
+                    region.getFirstRow(), region.getFirstColumn(), false,
+                    false);
             fire = true;
         }
         for (Iterator<CellRangeAddress> i = cellRangeAddresses.iterator(); i

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionShifter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionShifter.java
@@ -141,7 +141,9 @@ public class CellSelectionShifter implements Serializable {
         for (int x = region.getFirstColumn(); x <= region
                 .getLastColumn(); x++) {
             for (int y = region.getFirstRow(); y <= region.getLastRow(); y++) {
-                cells.add(new CellReference(y, x));
+                cells.add(new CellReference(
+                        spreadsheet.getActiveSheet().getSheetName(), y, x,
+                        false, false));
             }
         }
         spreadsheet.fireEvent(new CellValueChangeEvent(spreadsheet, cells));
@@ -399,8 +401,10 @@ public class CellSelectionShifter implements Serializable {
                     if (!SpreadsheetUtil.isCellInRange(selectedCellReference,
                             newPaintedCellRange)) {
                         selectedCellReference = new CellReference(
+                                spreadsheet.getActiveSheet().getSheetName(),
                                 newPaintedCellRange.getFirstRow(),
-                                newPaintedCellRange.getFirstColumn());
+                                newPaintedCellRange.getFirstColumn(), false,
+                                false);
                     }
                     getCellSelectionManager().handleCellRangeSelection(
                             selectedCellReference, newPaintedCellRange, false);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
@@ -602,7 +602,9 @@ public class CellValueManager implements Serializable {
 
         // capture cell value to history
         CellValueCommand command = new CellValueCommand(spreadsheet);
-        command.captureCellValues(new CellReference(row - 1, col - 1));
+        command.captureCellValues(
+                new CellReference(spreadsheet.getActiveSheet().getSheetName(),
+                        row - 1, col - 1, false, false));
         spreadsheet.getSpreadsheetHistoryManager().addCommand(command);
         boolean updateHyperlinks = false;
         boolean formulaChanged = false;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -643,7 +643,8 @@ public class Spreadsheet extends Component
     void onPopupButtonClick(int row, int column) {
         PopupButton popup = sheetPopupButtons
                 .get(SpreadsheetUtil.relativeToAbsolute(this,
-                        new CellReference(row - 1, column - 1)));
+                        new CellReference(getActiveSheet().getSheetName(),
+                                row - 1, column - 1, false, false)));
         if (popup != null) {
             popup.openPopup();
         }
@@ -652,7 +653,8 @@ public class Spreadsheet extends Component
     void onPopupClose(int row, int column) {
         PopupButton popup = sheetPopupButtons
                 .get(SpreadsheetUtil.relativeToAbsolute(this,
-                        new CellReference(row - 1, column - 1)));
+                        new CellReference(getActiveSheet().getSheetName(),
+                                row - 1, column - 1, false, false)));
 
         if (popup != null) {
             popup.closePopup();
@@ -2922,7 +2924,8 @@ public class Spreadsheet extends Component
                 } else if (numberOfRowsAboveWasChanged(row, last, first)) {
                     int newRow = cell.getRow() + n;
                     int col = cell.getCol();
-                    CellReference newCell = new CellReference(newRow, col, true,
+                    CellReference newCell = new CellReference(
+                            getActiveSheet().getSheetName(), newRow, col, true,
                             true);
                     pbutton.setCellReference(newCell);
                     updated.put(newCell, pbutton);
@@ -4760,7 +4763,8 @@ public class Spreadsheet extends Component
      *            removes the pop-up button for the target cell.
      */
     public void setPopup(int row, int col, PopupButton popupButton) {
-        setPopup(new CellReference(row, col), popupButton);
+        setPopup(new CellReference(getActiveSheet().getSheetName(), row, col,
+                false, false), popupButton);
     }
 
     /**
@@ -5184,7 +5188,9 @@ public class Spreadsheet extends Component
 
                 for (int x = a.getFirstColumn(); x <= a.getLastColumn(); x++) {
                     for (int y = a.getFirstRow(); y <= a.getLastRow(); y++) {
-                        cells.add(new CellReference(y, x));
+                        cells.add(new CellReference(
+                                selectedCellReference.getSheetName(), y, x,
+                                false, false));
                     }
                 }
             }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetHandlerImpl.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetHandlerImpl.java
@@ -334,7 +334,9 @@ public class SpreadsheetHandlerImpl implements SpreadsheetServerRpc {
         for (int x = region.getFirstColumn(); x <= region
                 .getLastColumn(); x++) {
             for (int y = region.getFirstRow(); y <= region.getLastRow(); y++) {
-                cells.add(new CellReference(y, x));
+                cells.add(new CellReference(
+                        spreadsheet.getActiveSheet().getSheetName(), y, x,
+                        false, false));
             }
         }
         fireCellValueChangeEvent(cells);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/CellShiftValuesCommand.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/CellShiftValuesCommand.java
@@ -52,8 +52,10 @@ public class CellShiftValuesCommand extends CellValueCommand {
                 .isCellInRange(selectedCellReference, paintedCellRange)) {
             return selectedCellReference;
         } else {
-            return new CellReference(paintedCellRange.getFirstRow(),
-                    paintedCellRange.getFirstColumn());
+            return new CellReference(
+                    spreadsheet.getActiveSheet().getSheetName(),
+                    paintedCellRange.getFirstRow(),
+                    paintedCellRange.getFirstColumn(), false, false);
         }
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/CellValueCommand.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/CellValueCommand.java
@@ -148,7 +148,8 @@ public class CellValueCommand extends SpreadsheetCommand
 
     @Override
     public CellReference getSelectedCellReference() {
-        return new CellReference(selectedCellRow, selectedcellCol);
+        return new CellReference(spreadsheet.getActiveSheet().getSheetName(),
+                selectedCellRow, selectedcellCol, false, false);
     }
 
     @Override
@@ -339,13 +340,15 @@ public class CellValueCommand extends SpreadsheetCommand
         for (Object o : values) {
             if (o instanceof CellValue) {
                 CellValue cellValue = (CellValue) o;
-                changedCells
-                        .add(new CellReference(cellValue.row, cellValue.col));
+                changedCells.add(new CellReference(
+                        spreadsheet.getActiveSheet().getSheetName(),
+                        cellValue.row, cellValue.col, false, false));
             } else {
                 CellRangeValue cellRangeValue = (CellRangeValue) o;
                 for (int r = cellRangeValue.row1; r <= cellRangeValue.row2; r++) {
                     for (int c = cellRangeValue.col1; c <= cellRangeValue.col2; c++) {
-                        changedCells.add(new CellReference(r, c));
+                        changedCells.add(new CellReference(
+                                getSheet().getSheetName(), r, c, false, false));
                     }
                 }
             }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/RowInsertOrDeleteCommand.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/RowInsertOrDeleteCommand.java
@@ -44,7 +44,8 @@ public class RowInsertOrDeleteCommand extends SpreadsheetCommand {
 
     @Override
     public CellReference getSelectedCellReference() {
-        return new CellReference(row, 0);
+        return new CellReference(spreadsheet.getActiveSheet().getSheetName(),
+                row, 0, false, false);
     }
 
     @Override


### PR DESCRIPTION
## Description

In Apache POI, `CellReference` has multiple constructors. In the version that Vaadin V8 used, the constructor `CellReference(Cell cell)` did not use the sheet name from the `Cell` object. However, while having the same signature, this constructor started using the sheet name in the new versions. This creates inconsistencies when checking equality for `CellReference`s since we use different constructors in various locations. 

While this check can be easily be done in other ways, if we want the equality check to hold regardless, we can use the constructors that use the sheet name everywhere. This PR makes this change and adds the sheet names to the constructors wherever necessary. 

One drawback to this is adding sheet name in cases where we do not really need them in the sake of consistency. Another is having to add two booleans repeatedly just to be able to use the constructors with the sheet name. Also, this might possibly break some implementations if users are depending on some exact check on the references.

Fixes #4588

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.