### PR TITLE
refactor: remove static element to tooltip map

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -35,6 +35,8 @@ import com.vaadin.flow.function.SerializableRunnable;
 @JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 public class Tooltip implements Serializable {
 
+    private static final String TOOLTIP_DATA_KEY = "tooltip";
+
     /**
      * The {@code <vaadin-tooltip>} element controlled by this tooltip instance.
      */
@@ -127,7 +129,7 @@ public class Tooltip implements Serializable {
      */
     static Tooltip getForElement(Element element) {
         var component = ComponentUtil.getInnermostComponent(element);
-        return (Tooltip) ComponentUtil.getData(component, "tooltip");
+        return (Tooltip) ComponentUtil.getData(component, TOOLTIP_DATA_KEY);
     }
 
     /**
@@ -142,7 +144,7 @@ public class Tooltip implements Serializable {
         var tooltip = new Tooltip();
         SlotUtils.setSlot(hasTooltip, "tooltip", tooltip.tooltipElement);
         var component = ComponentUtil.getInnermostComponent(hasTooltip.getElement());
-        ComponentUtil.setData(component, "tooltip", tooltip);
+        ComponentUtil.setData(component, TOOLTIP_DATA_KEY, tooltip);
         return tooltip;
     }
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -17,9 +17,9 @@ package com.vaadin.flow.component.shared;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.WeakHashMap;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -119,13 +119,6 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * Keeps track of elements that have a tooltip. Currently only used for the {@link HasTooltip} APIs.
-     * The other APIs, such as {@link #forElement(Element)} and {@link #forComponent(Component)}, do not use this
-     * because they always return a new {@code Tooltip} instance (support adding multiple tooltips for one target).
-     */
-    private static final WeakHashMap<Element, Tooltip> elementTooltips = new WeakHashMap<>();
-
-    /**
      * Gets the tooltip handle for the given element.
      *
      * @param element
@@ -133,7 +126,8 @@ public class Tooltip implements Serializable {
      * @return the tooltip handle
      */
     static Tooltip getForElement(Element element) {
-        return elementTooltips.get(element);
+        var component = ComponentUtil.getInnermostComponent(element);
+        return (Tooltip) ComponentUtil.getData(component, "tooltip");
     }
 
     /**
@@ -147,7 +141,8 @@ public class Tooltip implements Serializable {
     static Tooltip forHasTooltip(HasTooltip hasTooltip) {
         var tooltip = new Tooltip();
         SlotUtils.setSlot(hasTooltip, "tooltip", tooltip.tooltipElement);
-        elementTooltips.put(hasTooltip.getElement(), tooltip);
+        var component = ComponentUtil.getInnermostComponent(hasTooltip.getElement());
+        ComponentUtil.setData(component, "tooltip", tooltip);
         return tooltip;
     }
 


### PR DESCRIPTION
## Description

Remove the static `WeakHashMap<Element, Tooltip>` that is used for tracking the `Tooltip` instances associated with `HasTooltip` instances in favor of `ComponentUtil.setData`

Fixes https://github.com/vaadin/flow-components/issues/4637

## Type of change

Refactor