### PR TITLE
fix: close open details for cleared items in grid connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsPage.java
@@ -40,8 +40,6 @@ public class GridViewItemDetailsPage extends LegacyTestView {
         grid.addColumn(Person::getFirstName).setHeader("Name");
         grid.addColumn(Person::getAge).setHeader("Age");
 
-        grid.setSelectionMode(SelectionMode.NONE);
-
         // You can use any renderer for the item details. By default, the
         // details are opened and closed by clicking the rows.
         grid.setItemDetailsRenderer(LitRenderer.<Person> of(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsPage.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.grid.it;
 import java.util.List;
 
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.data.renderer.NativeButtonRenderer;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
@@ -92,6 +92,26 @@ public class GridViewItemDetailsIT extends AbstractComponentIT {
                         .contains("Hi! My name is Person 2!"));
     }
 
+    @Test
+    public void openDetails_scrollToEnd_scrollToStart_detailsOpenedItems() {
+        GridElement grid = $(GridElement.class).id("grid-with-details-row");
+
+        // Open details
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+
+        // Check the detailsOpenedItems property (expected to be a list with one item)
+        Assert.assertEquals(1, ((List<?>) grid.getProperty("detailsOpenedItems")).size());
+        
+        // Scroll to end
+        grid.scrollToRow(grid.getRowCount() - 1);
+        
+        // Scroll to start
+        grid.scrollToRow(0);
+
+        // Check the detailsOpenedItems property (expected to be a list with one item)
+        Assert.assertEquals(1, ((List<?>) grid.getProperty("detailsOpenedItems")).size());
+    }
+
     private void assertAmountOfOpenDetails(WebElement grid,
             int expectedAmount) {
         waitUntil(driver -> grid.findElements(By.className("custom-details"))

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
@@ -99,17 +99,21 @@ public class GridViewItemDetailsIT extends AbstractComponentIT {
         // Open details
         clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
 
-        // Check the detailsOpenedItems property (expected to be a list with one item)
-        Assert.assertEquals(1, ((List<?>) grid.getProperty("detailsOpenedItems")).size());
-        
+        // Check the detailsOpenedItems property (expected to be a list with one
+        // item)
+        Assert.assertEquals(1,
+                ((List<?>) grid.getProperty("detailsOpenedItems")).size());
+
         // Scroll to end
         grid.scrollToRow(grid.getRowCount() - 1);
-        
+
         // Scroll to start
         grid.scrollToRow(0);
 
-        // Check the detailsOpenedItems property (expected to be a list with one item)
-        Assert.assertEquals(1, ((List<?>) grid.getProperty("detailsOpenedItems")).size());
+        // Check the detailsOpenedItems property (expected to be a list with one
+        // item)
+        Assert.assertEquals(1,
+                ((List<?>) grid.getProperty("detailsOpenedItems")).size());
     }
 
     private void assertAmountOfOpenDetails(WebElement grid,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
@@ -93,7 +93,7 @@ public class GridViewItemDetailsIT extends AbstractComponentIT {
     }
 
     @Test
-    public void openDetails_scrollToEnd_scrollToStart_detailsOpenedItems() {
+    public void openDetails_scrollToEnd_scrollToStart_detailsOpenedItemsCountDoesNotIncrease() {
         GridElement grid = $(GridElement.class).id("grid-with-details-row");
 
         // Open details
@@ -110,8 +110,7 @@ public class GridViewItemDetailsIT extends AbstractComponentIT {
         // Scroll to start
         grid.scrollToRow(0);
 
-        // Check the detailsOpenedItems property (expected to be a list with one
-        // item)
+        // Check that the detailsOpenedItems array does not increase / does not contain duplicates
         Assert.assertEquals(1,
                 ((List<?>) grid.getProperty("detailsOpenedItems")).size());
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
@@ -110,7 +110,8 @@ public class GridViewItemDetailsIT extends AbstractComponentIT {
         // Scroll to start
         grid.scrollToRow(0);
 
-        // Check that the detailsOpenedItems array does not increase / does not contain duplicates
+        // Check that the detailsOpenedItems array does not increase / does not
+        // contain duplicates
         Assert.assertEquals(1,
                 ((List<?>) grid.getProperty("detailsOpenedItems")).size());
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -783,6 +783,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             let page = firstPage + i;
             let items = cache[pkey][page];
             grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
+            items.forEach((item) => grid.closeItemDetails(item));
             delete cache[pkey][page];
             const updatedItems = updateGridCache(page, parentKey);
             if (updatedItems) {


### PR DESCRIPTION
## Description

The grid connector should remove cleared items from the `grid.detailsOpenedItems` array on `grid.$connector.clear`

Fixes https://github.com/vaadin/flow-components/issues/4516

## Type of change

Bugfix