### PR TITLE
chore: rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a maven multi-module project including all vaadin flow components.
 
-`master` branch is the latest version of all the components that will be released in the [Vaadin platform](https://github.com/vaadin/platform).
+`main` branch is the latest version of all the components that will be released in the [Vaadin platform](https://github.com/vaadin/platform).
 
 ## Quick start
 

--- a/scripts/cherryPick.js
+++ b/scripts/cherryPick.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * This script is used for cherry-pick commits for vaadin-flow-components repos.
- * To run this script:  
+ * To run this script:
  * 1.collect committed-PRs marked with target/<branch-name>  labels
  * 2.cherry-pick the commit to the target branchs
  * 3.label the original commit PR with cherry-picked-<branch-name>
@@ -43,11 +43,11 @@ async function getAllCommits(){
         'Content-Type': 'application/json',
       }
     };
-    
+
     res = await axios.get(url, options);
     data = res.data;
     data = data.filter(da => da.labels.length > 0 && da.merged_at !== null);
-    
+
     if (data.length === 0) {
       console.log("No commits needs to be picked.");
       process.exit(0);
@@ -69,7 +69,7 @@ async function getCommit(commitURL){
         'Content-Type': 'application/json',
       }
     };
-    
+
     res = await axios.get(commitURL, options);
     data = res.data;
 
@@ -114,19 +114,19 @@ async function filterCommits(commits){
 async function cherryPickCommits(){
   for(let i=arrPR.length-1; i>=0; i--){
     let branchName = `cherry-pick-${arrPR[i]}-to-${arrBranch[i]}-${Date.now()}`;
-    
-    await exec('git checkout master');
+
+    await exec('git checkout main');
     await exec('git pull');
     await exec(`git checkout ${arrBranch[i]}`);
     await exec(`git reset --hard origin/${arrBranch[i]}`);
-    
+
     try{
       await exec(`git checkout -b ${branchName}`);
     } catch (err) {
       console.error(`Cannot Create Branch, error : ${err}`);
       process.exit(1);
     }
-    
+
     try{
       let {stdout, stderr} = await exec(`git cherry-pick ${arrSHA[i]}`);
     } catch (err) {
@@ -134,14 +134,14 @@ async function cherryPickCommits(){
       await labelCommit(arrURL[i], `need to pick manually ${arrBranch[i]}`);
       await postComment(arrURL[i], arrUser[i], arrMergedBy[i], arrBranch[i], err);
       await exec(`git cherry-pick --abort`);
-      await exec(`git checkout master`);
+      await exec(`git checkout main`);
       await exec(`git branch -D ${branchName}`);
       continue;
     }
     await exec(`git push origin HEAD:${branchName}`);
-    
+
     await createPR(arrTitle[i], branchName, arrBranch[i]);
-    await exec(`git checkout master`);
+    await exec(`git checkout main`);
     await exec(`git branch -D ${branchName}`);
     await labelCommit(arrURL[i], `cherry-picked-${arrBranch[i]}`);
   }
@@ -155,7 +155,7 @@ async function labelCommit(url, label){
       'Authorization': `token ${token}`,
     }
   };
-  
+
   await axios.post(issueURL, {"labels":[label]}, options);
 }
 
@@ -173,7 +173,7 @@ async function postComment(url, userName, mergedBy, branch, message){
 
 async function createPR(title, head, base){
   const payload = {title, head, base};
-  
+
   return new Promise(resolve => {
     const content = JSON.stringify({ title, head, base }, null, 1)
     const req = https.request({

--- a/scripts/generateChangeLog.js
+++ b/scripts/generateChangeLog.js
@@ -98,7 +98,7 @@ async function getReleases() {
   try {
     json = await getPlatformVersions(platform);
   } catch (error) {
-    json = await getPlatformVersions('master');
+    json = await getPlatformVersions('main');
   }
   flowVersion = json.core.flow.javaVersion;
 
@@ -328,7 +328,7 @@ function logByComponent(commits) {
     });
   }
   commits.forEach(commit => {
-    // Group the WC update commit to one category 
+    // Group the WC update commit to one category
     if (commit.title.includes("Increase Web-Component version")){
       commit.components=["All Components"];
     }
@@ -339,7 +339,7 @@ function logByComponent(commits) {
   });
 
   Object.keys(byComponent).sort().forEach(k => {
-    k.includes("All Components") ? 
+    k.includes("All Components") ?
     console.log(`\n#### Changes in \`All Components\``) : console.log(`\n#### Changes in \`vaadin-${k}-flow\``);
     logCommitsByType(byComponent[k]);
   });

--- a/scripts/lib/versions.js
+++ b/scripts/lib/versions.js
@@ -31,8 +31,8 @@ async function currentBranch() {
   const parentJs = await xml2js.parseStringPromise(fs.readFileSync('pom.xml', 'utf8'));
   const version = parentJs.project.version[0];
   const branch = version.replace(/^(\d+\.\d+).*$/, '$1');
-  const isMaster = !await checkBranch(branch);
-  return isMaster ? 'master' : branch;
+  const isMain = !await checkBranch(branch);
+  return isMain ? 'main' : branch;
 }
 
 async function getPlatformVersions(branch) {
@@ -58,7 +58,7 @@ async function getVersions() {
     return ['core', 'vaadin'].reduce((prev, k) => {
       return prev.concat(Object.keys(json[k]).filter(pkg => json[k][pkg].npmName || json[k][pkg].javaVersion).map(pkg => {
         const version = json[k][pkg].javaVersion;
-        const branch = version && version.replace('{{version}}', 'master').replace(/^(\d+\.\d+).*$/, '$1');
+        const branch = version && version.replace('{{version}}', 'main').replace(/^(\d+\.\d+).*$/, '$1');
         json[k][pkg].name = pkg;
         json[k][pkg].branch = branch;
         json[k][pkg].module = pkg;

--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -194,7 +194,7 @@ async function createInitListener() {
   copyFileSync(`${templateDir}/index.html`, `${targetFolder}/index.html`);
 }
 
-// Copy components sources from master to the merged integration-tests module
+// Copy components sources from main to the merged integration-tests module
 // At the same time does some source-code changes to adapt them to the new module
 async function copySources() {
   if (!fs.existsSync(itFolder)) {

--- a/scripts/prepareDeploy.sh
+++ b/scripts/prepareDeploy.sh
@@ -50,18 +50,18 @@ pomVersion=`cat pom.xml | grep '<version>' | head -1 | cut -d '>' -f2 | cut -d '
 versionBase=`getBaseVersion $version`
 pomBase=`getBaseVersion $pomVersion`
 
-### Get the master branch version for components
-masterPom=`curl -s "https://raw.githubusercontent.com/vaadin/flow-components/master/pom.xml"`
-masterMajorMinor=`echo "$masterPom" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | grep "^$base" | head -1 | cut -d '-' -f1`
+### Get the main branch version for components
+mainPom=`curl -s "https://raw.githubusercontent.com/vaadin/flow-components/main/pom.xml"`
+mainMajorMinor=`echo "$mainPom" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | grep "^$base" | head -1 | cut -d '-' -f1`
 
 ### Load versions file for this platform release
 branch=$versionBase
-[ $branch = $masterMajorMinor ] && branch=master
+[ $branch = $mainMajorMinor ] && branch=main
 versions=`curl -s "https://raw.githubusercontent.com/vaadin/platform/$branch/versions.json"`
-[ $? != 0 ] && branch=master && versions=`curl -s "https://raw.githubusercontent.com/vaadin/platform/$branch/versions.json"`
+[ $? != 0 ] && branch=main && versions=`curl -s "https://raw.githubusercontent.com/vaadin/platform/$branch/versions.json"`
 
 ### Check that current branch is valid for the version to release
-[ $branch != master -a "$versionBase" != "$pomBase" ] && echo "Incorrect pomVersion=$pomVersion for version=$version" && exit 1
+[ $branch != main -a "$versionBase" != "$pomBase" ] && echo "Incorrect pomVersion=$pomVersion for version=$version" && exit 1
 
 ### Compute flow version
 flow=`getPlatformVersion flow`

--- a/scripts/updatePlatform.js
+++ b/scripts/updatePlatform.js
@@ -123,7 +123,7 @@ async function main() {
   const byName = ['core', 'vaadin', 'bundles'].reduce((prev, k) => {
       Object.keys(json[k]).filter(pkg => (json[k][pkg].npmName || json[k][pkg].javaVersion) && pkg !== 'vaadin-core' ).map(pkg => {
       const version = json[k][pkg].javaVersion;
-      const branch = version && version.replace('{{version}}', 'master').replace(/^(\d+\.\d+).*$/, '$1');
+      const branch = version && version.replace('{{version}}', 'main').replace(/^(\d+\.\d+).*$/, '$1');
       prev[pkg] = prev[pkg] || {};
       prev[pkg]['org'] = json[k][pkg];
       prev[pkg].package = pkg;

--- a/scripts/updateSources.js
+++ b/scripts/updateSources.js
@@ -53,7 +53,7 @@ function computeRoute(wcname, clname, prefix, route, suffix) {
     : `${wcname}/${route ? route : rootRoutes[wcname]}`;
   return `${prefix}${route}${suffix}`;
 }
-// Replace @Route values from master to unique routes in the merged module
+// Replace @Route values from main to unique routes in the merged module
 function replaceRoutes(wcname, clname, content) {
   content = content.replace(/\@Route *\n/, (...args) => {
     return `@Route(value = "${/^Main(View)?$/.test(clname) ? '': clname.replace(/View$/, '').toLowerCase()}")\n`

--- a/vaadin-virtual-list-flow-parent/README.md
+++ b/vaadin-virtual-list-flow-parent/README.md
@@ -1,6 +1,6 @@
 # VirtualList component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-virtual-list>`](https://github.com/vaadin/web-components/tree/master/packages/vaadin-virtual-list) element
+This project is the Component wrapper implementation of [`<vaadin-virtual-list>`](https://github.com/vaadin/web-components/tree/main/packages/virtual-list) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application


### PR DESCRIPTION
## Description

Rename all references to the `master` branch to `main`.

There are several `master` branch references to other Vaadin repos, like the coding convention styles linked from the Flow repo. We'll have to clean those up when their respective main branch is renamed.

Marking as draft as branch needs to be renamed first, and CI scripts adapted.