### PR TITLE
fix: use property change listener for opened change event

### DIFF
--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/main/java/com/vaadin/flow/component/details/tests/DetailsEventsPage.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/main/java/com/vaadin/flow/component/details/tests/DetailsEventsPage.java
@@ -1,0 +1,29 @@
+package com.vaadin.flow.component.details.tests;
+
+import com.vaadin.flow.component.details.Details;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-details/events")
+public class DetailsEventsPage extends Div {
+    public DetailsEventsPage() {
+        Details details = new Details();
+
+        Div output = new Div();
+        output.setId("output");
+        output.getStyle().set("white-space", "pre");
+        details.addOpenedChangeListener(e -> {
+            output.setText(output.getText() + String.format(
+                    "Opened changed: opened=%s, isFromClient=%s\n",
+                    e.isOpened(), e.isFromClient()));
+        });
+
+        NativeButton toggle = new NativeButton("Toggle", e -> {
+            details.setOpened(!details.isOpened());
+        });
+        toggle.setId("toggle");
+
+        add(details, new Div(toggle), output);
+    }
+}

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/main/java/com/vaadin/flow/component/details/tests/Home.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/main/java/com/vaadin/flow/component/details/tests/Home.java
@@ -30,14 +30,6 @@ public class Home extends Div {
                 new Span("Themed Content"));
         detailsThemed.addThemeVariants(DetailsVariant.values());
 
-        Details detailsListener = new Details(
-                "Details with opened change listener", new Span("Content"));
-        detailsListener.addOpenedChangeListener(event -> {
-            if (event.isOpened()) {
-                info.setText("opened-change");
-            }
-        });
-
-        add(details, detailsDisabled, detailsThemed, detailsListener, info);
+        add(details, detailsDisabled, detailsThemed, info);
     }
 }

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/BasicIT.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/BasicIT.java
@@ -24,7 +24,7 @@ public class BasicIT extends AbstractParallelTest {
         getDriver().get(url);
         detailsElements = $(DetailsElement.class).all();
 
-        Assert.assertEquals(4, detailsElements.size());
+        Assert.assertEquals(3, detailsElements.size());
     }
 
     @Test
@@ -40,13 +40,6 @@ public class BasicIT extends AbstractParallelTest {
                 .collect(Collectors.toList())));
         Assert.assertEquals("Small Reversed Filled Summary",
                 detailsThemed.getSummaryText());
-    }
-
-    @Test
-    public void testOpenedChange() {
-        DetailsElement detail = detailsElements.get(3);
-        detail.toggle();
-        Assert.assertEquals("opened-change", $("div").id("info").getText());
     }
 
     @Test

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/DetailsEventsIT.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/DetailsEventsIT.java
@@ -1,0 +1,43 @@
+package com.vaadin.flow.component.details.tests;
+
+import com.vaadin.flow.component.details.testbench.DetailsElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@TestPath("vaadin-details/events")
+public class DetailsEventsIT extends AbstractComponentIT {
+    private DetailsElement details;
+    private TestBenchElement toggle;
+    private TestBenchElement output;
+
+    @Before
+    public void init() {
+        open();
+        details = $(DetailsElement.class).waitForFirst();
+        toggle = $(TestBenchElement.class).id("toggle");
+        output = $(TestBenchElement.class).id("output");
+    }
+
+    @Test
+    public void noInitialOpenedChangeEvent() {
+        Assert.assertEquals("", output.getText());
+    }
+
+    @Test
+    public void toggleOnClient_openedChangeEventIsFromClient() {
+        details.toggle();
+        Assert.assertEquals("Opened changed: opened=true, isFromClient=true",
+                output.getText());
+    }
+
+    @Test
+    public void toggleOnServer_openedChangeEventIsNotFromClient() {
+        toggle.click();
+        Assert.assertEquals("Opened changed: opened=true, isFromClient=false",
+                output.getText());
+    }
+}

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -84,6 +84,10 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
         getElement().appendChild(contentContainer.getElement());
         summaryContainer = createSummaryContainer();
         SlotUtils.addToSlot(this, "summary", summaryContainer);
+
+        if (getElement().getPropertyRaw("opened") == null) {
+            setOpened(false);
+        }
     }
 
     /**
@@ -294,7 +298,6 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
         getElement().setProperty("opened", opened);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent extends ComponentEvent<Details> {
         private final boolean opened;
 
@@ -309,8 +312,8 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
     }
 
     /**
-     * Adds a listener for {@code opened-changed} events fired by the
-     * webcomponent.
+     * Adds a listener to get notified when the opened state of the component
+     * changes.
      *
      * @param listener
      *            the listener
@@ -318,7 +321,8 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      */
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
-        return ComponentUtil.addListener(this, OpenedChangeEvent.class,
-                listener);
+        return getElement().addPropertyChangeListener("opened",
+                event -> listener.onComponentEvent(
+                        new OpenedChangeEvent(this, event.isUserOriginated())));
     }
 }


### PR DESCRIPTION
## Description

Currently the opened change listener for `Details` listens for the `opened-changed` event from the client, which means that even when changing the opened state on the server, the event will always be from the client.

This change fixes that by using a property change listener instead, so that the event will correctly report whether the state was changed on the client or on the server. This also properly initializes the opened state on the server, so that the initial opened change event from initializing the Polymer property is discarded.

Fixes #4659
Fixes #4654

## Type of change

- Bugfix