### PR TITLE
fix: do not modify reference date in connector

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -40,7 +40,7 @@ public class DatePickerLocalePage extends Div {
         NativeButton applyCustomReferenceDate = new NativeButton(
                 "Apply custom reference date", e -> {
                     DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
-                    i18n.setReferenceDate(LocalDate.of(1980, 2, 2));
+                    i18n.setReferenceDate(LocalDate.of(2000, 1, 1));
                     datePicker.setI18n(i18n);
                 });
         applyCustomReferenceDate.setId("apply-custom-reference-date");

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -3,7 +3,6 @@ package com.vaadin.flow.component.datepicker;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.util.List;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -2,6 +2,9 @@ package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -187,32 +190,70 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     }
 
     @Test
-    public void datePickerWithLocale_setInputValue_blur_defaultReferenceDateIsUsed() {
-        LocalDate now = LocalDate.now();
-        int currentYear = now.getYear();
+    public void noReferenceDate_usesCurrentDateAsReferenceDate() {
+        // Due to an issue with date-fns the reference date always refers to the
+        // start of the year, so use that for testing bounds
+        LocalDate startOfThisYear = LocalDate.now()
+                .with(TemporalAdjusters.firstDayOfYear());
+        LocalDate endOfThisYear = LocalDate.now()
+                .with(TemporalAdjusters.lastDayOfYear());
 
-        int testYear1 = (currentYear + 51) % 100;
-        int adjustedYear1 = getAdjustedYear(currentYear, testYear1);
-        testParseReformatCycle(Integer.toString(testYear1),
-                Integer.toString(adjustedYear1));
+        // Test lower boundary
+        LocalDate testDate = startOfThisYear.minusYears(50);
+        enterShortYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
 
-        int testYear2 = (currentYear + 49) % 100;
-        int adjustedYear2 = getAdjustedYear(currentYear, testYear2);
-        testParseReformatCycle(Integer.toString(testYear2),
-                Integer.toString(adjustedYear2));
+        // Test upper boundary
+        testDate = endOfThisYear.plusYears(49);
+        enterShortYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
 
-        testParseReformatCycle("2031", "2031");
-        testParseReformatCycle("0030", "0030");
+        // Test full years
+        testDate = LocalDate.of(2031, 1, 1);
+        enterFullYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
+
+        testDate = LocalDate.of(30, 1, 1);
+        enterFullYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
     }
 
     @Test
-    public void datePickerWithLocale_setCustomReferenceDate_setInputValue_blur_customReferenceDateIsUsed() {
+    public void setCustomReferenceDate_usesCustomReferenceDate() {
         $("button").id("apply-custom-reference-date").click();
 
-        testParseReformatCycle("31", "1931");
-        testParseReformatCycle("29", "2029");
-        testParseReformatCycle("2031", "2031");
-        testParseReformatCycle("0030", "0030");
+        // Test lower boundary
+        LocalDate testDate = LocalDate.of(1950, 1, 1);
+        enterShortYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
+
+        // Test upper boundary
+        testDate = LocalDate.of(2049, 12, 31);
+        enterShortYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
+
+        // Test full years
+        testDate = LocalDate.of(2031, 1, 1);
+        enterFullYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
+
+        testDate = LocalDate.of(30, 1, 1);
+        enterFullYearDate(testDate);
+        Assert.assertEquals(testDate, picker.getDate());
+    }
+
+    private void enterShortYearDate(LocalDate date) {
+        String formattedDate = date
+                .format(DateTimeFormatter.ofPattern("MM/dd/yy"));
+        picker.setInputValue(formattedDate);
+        picker.sendKeys(Keys.TAB);
+    }
+
+    private void enterFullYearDate(LocalDate date) {
+        String formattedDate = date
+                .format(DateTimeFormatter.ofPattern("MM/dd/yyyy"));
+        picker.setInputValue(formattedDate);
+        picker.sendKeys(Keys.TAB);
     }
 
     private void applyLocale(Locale locale) {
@@ -240,28 +281,5 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                     "Received a warning in browser log console, message: %s",
                     logEntry));
         }
-    }
-
-    private int getAdjustedYear(int currentYear, int testYear) {
-        int adjustedYear = testYear + (currentYear / 100) * 100;
-        if (currentYear < adjustedYear - 50) {
-            return adjustedYear - 100;
-        }
-        if (currentYear > adjustedYear + 50) {
-            return adjustedYear + 100;
-        }
-        return adjustedYear;
-    }
-
-    private void testParseReformatCycle(String testYear, String expectedYear) {
-        int dayOfTheMonth = 27;
-        int month = 11;
-        String dateStringWithoutYear = month + "/" + dayOfTheMonth + "/";
-        picker.setInputValue(dateStringWithoutYear + testYear);
-        picker.sendKeys(Keys.TAB);
-        Assert.assertEquals(dateStringWithoutYear + expectedYear,
-                picker.getInputValue());
-        Assert.assertEquals(LocalDate.of(Integer.valueOf(expectedYear), month,
-                dayOfTheMonth), picker.getDate());
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -139,7 +139,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
 
         function _getReferenceDate() {
           const { referenceDate } = datepicker.i18n;
-          return referenceDate ? new Date(referenceDate.year, referenceDate.month - 1, referenceDate.day) : new Date();
+          return referenceDate ? new Date(referenceDate.year, referenceDate.month, referenceDate.day) : new Date();
         }
 
         datepicker.$connector.updateI18n = tryCatchWrapper(function (locale, i18n) {


### PR DESCRIPTION
## Description

Currently the date picker connector subtracts a month from the reference date, causing a reference date of `2000-01-01` to be interpreted as `1999-12-01`. Due to a separate issue in date-fns, that leads to an effective reference date of `1999-01-01` (see this comment: https://github.com/vaadin/flow-components/issues/4629#issuecomment-1431578099).

This fixes the connector to not subtract the month. The fact that date-fns ignores the day and month of the reference date is not addressed in this PR.

Fixes #4629

## Type of change

- Bugfix