### PR TITLE
fix: back-port update effectiveSize at the end of clear

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridRefreshAllPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridRefreshAllPage.java
@@ -15,16 +15,28 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.bean.HierarchicalTestBean;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.router.Route;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Route("vaadin-grid/treegrid-refresh-all")
 public class TreeGridRefreshAllPage extends Div {
 
     public TreeGridRefreshAllPage() {
+        addRefreshAllGrid();
+        addGridWithPageSize();
+    }
+
+    private void addRefreshAllGrid() {
         TreeGrid<HierarchicalTestBean> grid = new TreeGrid<>();
         grid.addHierarchyColumn(HierarchicalTestBean::toString);
         LazyHierarchicalDataProvider dataProvider = new LazyHierarchicalDataProvider(
@@ -42,5 +54,29 @@ public class TreeGridRefreshAllPage extends Div {
         clear.setId("clear");
 
         add(grid, refreshAll, clear);
+    }
+
+    private void addGridWithPageSize() {
+        TreeGrid<String> treeGrid = new TreeGrid<>();
+        treeGrid.setId("grid-with-page-size");
+        treeGrid.addHierarchyColumn(item -> item);
+
+        TreeData<String> treeData = new TreeData<>();
+        List<String> rootItems = IntStream.iterate(1, i -> i + 1).limit(11)
+                .mapToObj(String::valueOf).collect(Collectors.toList());
+        treeData.addRootItems(rootItems);
+        rootItems.forEach(
+                rootItem -> treeData.addItem(rootItem, "item: " + rootItem));
+
+        TreeDataProvider<String> provider = new TreeDataProvider<>(treeData);
+        treeGrid.setDataProvider(provider);
+
+        treeGrid.setPageSize(10);
+        treeGrid.expand(treeData.getRootItems());
+
+        Button button = new Button("Refresh All", e -> provider.refreshAll());
+        button.setId("refresh-all-grid-with-page-size");
+
+        add(treeGrid, button);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridRefreshAllIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridRefreshAllIT.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,4 +91,18 @@ public class TreeGridRefreshAllIT extends AbstractTreeGridIT {
                 getTreeGrid().getRowCount());
     }
 
+    @Test
+    public void scrollToEnd_selectRootItem_refreshAll_lastRootItemRendered() {
+        TreeGridElement grid = $(TreeGridElement.class)
+                .id("grid-with-page-size");
+
+        grid.scrollToRow(20);
+
+        grid.select(14);
+
+        $(ButtonElement.class).id("refresh-all-grid-with-page-size").click();
+
+        Assert.assertEquals("Invalid row at index 20", "11",
+                grid.getCell(20, 0).getText());
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -809,6 +809,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           }
           grid._cache.updateSize();
+          grid._effectiveSize = grid._cache.effectiveSize;
         });
 
         grid.$connector.reset = tryCatchWrapper(function () {


### PR DESCRIPTION
## Description

The effective size was not correctly updated after `grid.$connector.clear`. This led to miscalculation of indexes, requests, and page numbers. This PR adds the update to the end of `clear`.

Back-port of the changes in v24 [PR](https://github.com/vaadin/flow-components/pull/4657) to v23.3.

Fixes #4611 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.