### PR TITLE
fix: listen to file-reject instead of file-rejected

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
@@ -47,6 +47,7 @@ public class UploadView extends Div {
 
         MultiFileMemoryBuffer buffer = new MultiFileMemoryBuffer();
         Upload upload = new Upload(buffer);
+        upload.setAcceptedFileTypes(".txt");
 
         upload.addSucceededListener(event -> {
             try {
@@ -59,6 +60,7 @@ public class UploadView extends Div {
             eventsOutput.add("-succeeded");
         });
         upload.addAllFinishedListener(event -> eventsOutput.add("-finished"));
+        upload.addFileRejectedListener(event -> eventsOutput.add("-rejected"));
 
         NativeButton clearFileListBtn = new NativeButton("Clear file list",
                 e -> upload.clearFileList());

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
@@ -9,11 +9,25 @@ import com.vaadin.tests.AbstractComponentIT;
 
 public abstract class AbstractUploadIT extends AbstractComponentIT {
     /**
+     * Creates a temp file with ".txt" extension for testing purposes.
+     *
      * @return The generated temp file handle
      * @throws IOException
      */
     File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        return createTempFile("txt");
+    }
+
+    /**
+     * Creates a temp file with the provided extension for testing purposes.
+     *
+     * @param extension
+     *            the temp file extension without leading dot
+     * @return The generated temp file handle
+     * @throws IOException
+     */
+    File createTempFile(String extension) throws IOException {
+        File tempFile = File.createTempFile("TestFileUpload", "." + extension);
         BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
         writer.write(getTempFileContents());
         writer.close();

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
@@ -8,15 +8,6 @@ import java.io.IOException;
 import com.vaadin.tests.AbstractComponentIT;
 
 public abstract class AbstractUploadIT extends AbstractComponentIT {
-    /**
-     * Creates a temp file with ".txt" extension for testing purposes.
-     *
-     * @return The generated temp file handle
-     * @throws IOException
-     */
-    File createTempFile() throws IOException {
-        return createTempFile("txt");
-    }
 
     /**
      * Creates a temp file with the provided extension for testing purposes.

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferIT.java
@@ -21,7 +21,7 @@ public class FileBufferIT extends AbstractUploadIT {
         final UploadElement upload = $(UploadElement.class).id("single-upload");
         waitUntil(driver -> upload.isDisplayed());
 
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
         upload.upload(tempFile);
 
         WebElement uploadOutput = getDriver()
@@ -42,7 +42,7 @@ public class FileBufferIT extends AbstractUploadIT {
         final UploadElement upload = $(UploadElement.class).id("multi-upload");
         waitUntil(driver -> upload.isDisplayed());
 
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
 
         upload.uploadMultiple(List.of(tempFile, tempFile, tempFile), 10);
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/NonImmediateUploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/NonImmediateUploadIT.java
@@ -28,8 +28,8 @@ public class NonImmediateUploadIT extends AbstractUploadIT {
     private void uploadMultipleFiles_shouldNotThrowException(String buttonType)
             throws Exception {
         open();
-        File file1 = createTempFile();
-        File file2 = createTempFile();
+        File file1 = createTempFile("txt");
+        File file2 = createTempFile("txt");
         UploadElement upload = $(UploadElement.class).waitForFirst();
         upload.upload(file1);
         upload.upload(file2);

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -46,7 +46,7 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testUploadAnyFile() throws Exception {
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
         getUpload().upload(tempFile);
 
         WebElement uploadOutput = getDriver().findElement(By.id("test-output"));
@@ -61,7 +61,7 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testClearFileList() throws Exception {
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
 
         getUpload().upload(tempFile);
         getUpload().upload(tempFile);
@@ -81,7 +81,7 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testUploadMultipleEventOrder() throws Exception {
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
 
         getUpload().uploadMultiple(List.of(tempFile, tempFile, tempFile), 10);
 
@@ -95,7 +95,7 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testUploadEventOrder() throws Exception {
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
 
         getUpload().upload(tempFile);
 
@@ -121,7 +121,7 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void uploadFileAndNoErrorThrown() throws Exception {
-        File tempFile = createTempFile();
+        File tempFile = createTempFile("txt");
         getUpload().upload(tempFile);
 
         List<LogEntry> logList1 = getLogEntries(Level.SEVERE);

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -37,12 +38,14 @@ import static org.junit.Assert.assertThat;
 @TestPath("vaadin-upload")
 public class UploadIT extends AbstractUploadIT {
 
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> getUpload().isDisplayed());
+    }
+
     @Test
     public void testUploadAnyFile() throws Exception {
-        open();
-
-        waitUntil(driver -> getUpload().isDisplayed());
-
         File tempFile = createTempFile();
         getUpload().upload(tempFile);
 
@@ -58,10 +61,6 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testClearFileList() throws Exception {
-        open();
-
-        waitUntil(driver -> getUpload().isDisplayed());
-
         File tempFile = createTempFile();
 
         getUpload().upload(tempFile);
@@ -82,10 +81,6 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testUploadMultipleEventOrder() throws Exception {
-        open();
-
-        waitUntil(driver -> getUpload().isDisplayed());
-
         File tempFile = createTempFile();
 
         getUpload().uploadMultiple(List.of(tempFile, tempFile, tempFile), 10);
@@ -100,10 +95,6 @@ public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testUploadEventOrder() throws Exception {
-        open();
-
-        waitUntil(driver -> getUpload().isDisplayed());
-
         File tempFile = createTempFile();
 
         getUpload().upload(tempFile);
@@ -116,10 +107,20 @@ public class UploadIT extends AbstractUploadIT {
     }
 
     @Test
-    public void uploadFileAndNoErrorThrown() throws Exception {
-        open();
-        waitUntil(driver -> getUpload().isDisplayed());
+    public void uploadInvalidFile_fileIsRejected() throws Exception {
+        File invalidFile = createTempFile("pdf");
 
+        getUpload().upload(invalidFile);
+
+        WebElement eventsOutput = getDriver()
+                .findElement(By.id("test-events-output"));
+
+        Assert.assertEquals("Invalid file was not rejected", "-rejected",
+                eventsOutput.getText());
+    }
+
+    @Test
+    public void uploadFileAndNoErrorThrown() throws Exception {
         File tempFile = createTempFile();
         getUpload().upload(tempFile);
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -108,7 +108,7 @@ public class Upload extends Component implements HasSize, HasStyle {
      */
     public Upload() {
         final String eventDetailError = "event.detail.error";
-        getElement().addEventListener("file-rejected", event -> {
+        getElement().addEventListener("file-reject", event -> {
             String detailError = event.getEventData()
                     .getString(eventDetailError);
             fireEvent(new FileRejectedEvent(this, detailError));


### PR DESCRIPTION
## Description

The name of the event contained a typo, which lead to event not being caught. This PR fixes the typo and adds a file rejection test.

Fixes #4695 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.