### PR TITLE
refactor: debounce update in grid connector confirm parent

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1,5 +1,5 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
-import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
+import { timeOut, animationFrame, microTask } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
@@ -906,7 +906,11 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           grid.$server.confirmParentUpdate(id, parentKey);
 
           if (!grid.loading) {
-            grid.__updateVisibleRows();
+            grid.__confirmParentUpdateDebouncer = Debouncer.debounce(
+              grid.__confirmParentUpdateDebouncer,
+              microTask,
+              () => grid.__updateVisibleRows()
+            );
           }
         });
 


### PR DESCRIPTION
## Description

When multiple hierarchy updates in `TreeGrid` take place at once, the `confirmParent` function in `gridConnector` gets called multiple times. Currently, the `confirmParent` function requests `<vaadin-grid>` to update its rows synchronously after each invocation.

This PR debounces the update request which reduces the overhead on hierarchy updates.

The change has a 40% impact on the `expandtime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement