### PR TITLE
feat: make Button implement HasAriaLabel

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -57,9 +57,10 @@ import java.util.stream.Stream;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/button", version = "24.0.0-rc1")
 @JsModule("@vaadin/button/src/vaadin-button.js")
-public class Button extends Component implements ClickNotifier<Button>,
-        Focusable<Button>, HasAriaLabel, HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix,
-        HasText, HasThemeVariant<ButtonVariant>, HasTooltip {
+public class Button extends Component
+        implements ClickNotifier<Button>, Focusable<Button>, HasAriaLabel,
+        HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix, HasText,
+        HasThemeVariant<ButtonVariant>, HasTooltip {
 
     private Component iconComponent;
     private boolean iconAfterText;

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -57,7 +58,7 @@ import java.util.stream.Stream;
 @NpmPackage(value = "@vaadin/button", version = "24.0.0-rc1")
 @JsModule("@vaadin/button/src/vaadin-button.js")
 public class Button extends Component implements ClickNotifier<Button>,
-        Focusable<Button>, HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix,
+        Focusable<Button>, HasAriaLabel, HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix,
         HasText, HasThemeVariant<ButtonVariant>, HasTooltip {
 
     private Component iconComponent;

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.vaadin.flow.component.HasAriaLabel;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -326,6 +327,21 @@ public class ButtonTest {
     public void implementsHasTooltip() {
         button = new Button();
         Assert.assertTrue(button instanceof HasTooltip);
+    }
+
+    @Test
+    public void implementHasAriaLabel() {
+        button = new Button();
+        Assert.assertTrue(button instanceof HasAriaLabel);
+    }
+
+    @Test
+    public void setAriaLabel() {
+        button = new Button();
+        button.setAriaLabel("Aria label");
+
+        Assert.assertTrue(button.getAriaLabel().isPresent());
+        Assert.assertEquals("Aria label", button.getAriaLabel().get());
     }
 
     private void assertButtonHasThemeAttribute(String theme) {


### PR DESCRIPTION
## Description

Make `Button` implement `HasAriaLabel` interface.


Part of https://github.com/vaadin/platform/issues/3803
Part of https://github.com/vaadin/platform/issues/3814
Part of #2946 
Fixes #4716 

## Type of change

- [ ] Bugfix
- [X] Feature
