### PR TITLE
refactor: do not remove the sub-cache on item collapse

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -527,15 +527,15 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
         // Patch grid.expandItem and grid.collapseItem to have
         // itemExpandedChanged run when either happens.
-        grid.expandItem = tryCatchWrapper(function (item) {
-          itemExpandedChanged(item, true);
-          Grid.prototype.expandItem.call(grid, item);
-        });
+        // grid.expandItem = tryCatchWrapper(function (item) {
+        //   itemExpandedChanged(item, true);
+        //   Grid.prototype.expandItem.call(grid, item);
+        // });
 
-        grid.collapseItem = tryCatchWrapper(function (item) {
-          itemExpandedChanged(item, false);
-          Grid.prototype.collapseItem.call(grid, item);
-        });
+        // grid.collapseItem = tryCatchWrapper(function (item) {
+        //   itemExpandedChanged(item, false);
+        //   Grid.prototype.collapseItem.call(grid, item);
+        // });
 
         const itemsUpdated = function (items) {
           if (!items || !Array.isArray(items)) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -509,33 +509,19 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           }
           let parentKey = grid.getItemId(item);
           grid.$server.updateExpandedState(parentKey, expanded);
-
-          if (!expanded) {
-            delete cache[parentKey];
-            let parentCache = grid.$connector.getCacheByKey(parentKey);
-            if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
-              delete parentCache.itemkeyCaches[parentKey];
-            }
-            if (parentCache && parentCache.itemkeyCaches) {
-              Object.keys(parentCache.itemCaches)
-                .filter((idx) => parentCache.items[idx].key === parentKey)
-                .forEach((idx) => delete parentCache.itemCaches[idx]);
-            }
-            delete lastRequestedRanges[parentKey];
-          }
         });
 
         // Patch grid.expandItem and grid.collapseItem to have
         // itemExpandedChanged run when either happens.
-        // grid.expandItem = tryCatchWrapper(function (item) {
-        //   itemExpandedChanged(item, true);
-        //   Grid.prototype.expandItem.call(grid, item);
-        // });
+        grid.expandItem = tryCatchWrapper(function (item) {
+          itemExpandedChanged(item, true);
+          Grid.prototype.expandItem.call(grid, item);
+        });
 
-        // grid.collapseItem = tryCatchWrapper(function (item) {
-        //   itemExpandedChanged(item, false);
-        //   Grid.prototype.collapseItem.call(grid, item);
-        // });
+        grid.collapseItem = tryCatchWrapper(function (item) {
+          itemExpandedChanged(item, false);
+          Grid.prototype.collapseItem.call(grid, item);
+        });
 
         const itemsUpdated = function (items) {
           if (!items || !Array.isArray(items)) {


### PR DESCRIPTION
## Description

The PR drops grid connector logic that removes the sub-cache when its associated item collapses. This logic only worked when the toggle action would originate from the web component but not from the server. For example, it didn't work in the most common use case, when you are toggling a row with <kbd>Space</kbd> or a click.

## Type of change

- [x] Refactor
