### PR TITLE
refactor: avoid unnecessary re-renders in grid connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -44,6 +44,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
 
             return Boolean(
+              this.grid.$connector.flushingEnsureSubCache ||
               this.grid.$connector.hasEnsureSubCacheQueue() ||
                 Object.keys(this.pendingRequests).length ||
                 Object.keys(this.itemCaches).filter((index) => {
@@ -135,9 +136,11 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           });
 
           ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
+            grid.$connector.flushingEnsureSubCache = true;
             while (ensureSubCacheQueue.length) {
               grid.$connector.flushEnsureSubCache();
             }
+            grid.$connector.flushingEnsureSubCache = false;
           });
         });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -375,6 +375,8 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               ensureSubCacheQueue = [];
               // Request a content update manually
               grid.requestContentUpdate();
+              // Check if column auto-widths should be recalculated
+              grid.__itemsReceived();
             } else {
               treePageCallbacks[parentUniqueKey][page] = callback;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -141,6 +141,8 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               grid.$connector.flushEnsureSubCache();
             }
             grid.$connector.flushingEnsureSubCache = false;
+            // Check if column auto-widths should be recalculated
+            grid.__itemsReceived();
           });
         });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -44,7 +44,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
 
             return Boolean(
-              this.grid.$connector.flushingEnsureSubCache ||
               this.grid.$connector.hasEnsureSubCacheQueue() ||
                 Object.keys(this.pendingRequests).length ||
                 Object.keys(this.itemCaches).filter((index) => {
@@ -136,13 +135,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           });
 
           ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
-            grid.$connector.flushingEnsureSubCache = true;
             while (ensureSubCacheQueue.length) {
               grid.$connector.flushEnsureSubCache();
             }
-            grid.$connector.flushingEnsureSubCache = false;
-            // Check if column auto-widths should be recalculated
-            grid.__itemsReceived();
           });
         });
 
@@ -371,8 +366,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               // workaround: sometimes grid-element gives page index that overflows
               page = Math.min(page, Math.floor(cache[parentUniqueKey].size / grid.pageSize));
 
-              // Ensure grid isn't in loading state when the callback executes
-              ensureSubCacheQueue = [];
               callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
 
               // Update effective size


### PR DESCRIPTION
## Description

Remove the unnecessary `ensureSubCacheQueue = [];` from gridConnector's dataProvider. This will enable `isLoading` to return `true` when the state is [checked](https://github.com/vaadin/web-components/blob/6eb1e181763c67abb71bd406f2ded33495d63c02/packages/grid/src/vaadin-grid-data-provider-mixin.js#L433) in the vaadin-grid-data-provider-mixin, which will prevent a synchronous re-render.

The change has a 20% impact on the `expandedsorttime` and 14% impact on the `expandedrendertime` metrics in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement