### PR TITLE
Revert "refactor: reduce grid eager fetch viewport size estimate"

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPreloadIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPreloadIT.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("vaadin-grid/treegrid-preload")
 public class TreeGridPreloadIT extends AbstractTreeGridIT {
 
-    private static final int EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE = 20;
+    private static final int EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE = 40;
     private TextFieldElement requestCount;
     private TextFieldElement dataProviderFetchCount;
     private ButtonElement requestCountReset;
@@ -95,7 +95,7 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
     @Test
     public void firstExpanded_shouldOptimizeDataProviderFetches() {
         open(Arrays.asList(0), null, null, null, null);
-        Assert.assertEquals("49", dataProviderFetchCount.getValue());
+        Assert.assertEquals("55", dataProviderFetchCount.getValue());
     }
 
     @Test
@@ -114,8 +114,8 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
     public void firstExpanded_scrollByViewportEstimate_shouldHaveItemRecursivelyExpanded() {
         open(Arrays.asList(0), null, null, null, null);
         getTreeGrid().scrollToRow(EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE);
-        verifyRow(EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE + 5,
-                "/0/0/1/0/2/1/3/2/4/0");
+        verifyRow(EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE + 4,
+                "/0/0/1/1/2/0/3/0/4/0");
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
         requestCountReset.click();
 
         getTreeGrid().scrollToRow(EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE);
-        Assert.assertEquals("2", requestCount.getValue());
+        Assert.assertEquals("1", requestCount.getValue());
     }
 
     @Test
@@ -152,7 +152,6 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
         requestCountReset.click();
 
         getTreeGrid().collapseWithClick(2);
-        requestCountReset.click();
         getTreeGrid().expandWithClick(2);
         Assert.assertEquals("0", requestCount.getValue());
     }
@@ -200,16 +199,16 @@ public class TreeGridPreloadIT extends AbstractTreeGridIT {
 
     @Test
     public void expandedOnSecondPage_scrollToIndex_shouldHaveItemExpanded() {
-        open(Arrays.asList(60), null, 100, 1, null);
-        verifyRow(61, "/0/60/1/0");
+        open(Arrays.asList(70), null, 100, 1, null);
+        verifyRow(71, "/0/70/1/0");
     }
 
     @Test
     public void expandedOnSecondPage_scrollToIndex_shouldPreLoadDataForExpandedChildren() {
-        open(Arrays.asList(60), null, 100, 1, null);
+        open(Arrays.asList(70), null, 100, 1, null);
         requestCountReset.click();
 
-        getTreeGrid().scrollToRow(60);
+        getTreeGrid().scrollToRow(70);
         Assert.assertEquals("1", requestCount.getValue());
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -134,7 +134,7 @@ public class TreeGrid<T> extends Grid<T>
 
     private class TreeGridArrayUpdaterImpl implements TreeGridArrayUpdater {
         // Approximated size of the viewport. Used for eager fetching.
-        private static final int EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE = 20;
+        private static final int EAGER_FETCH_VIEWPORT_SIZE_ESTIMATE = 40;
 
         private UpdateQueueData data;
         private SerializableBiFunction<UpdateQueueData, Integer, UpdateQueue> updateQueueFactory;


### PR DESCRIPTION
## Description

This PR reverts https://github.com/vaadin/flow-components/pull/4748

Even though the first contentful paint is a bit faster with a lower viewport estimate, the Grid immediately needs to start fetching more items for the rows that are in the DOM but still outside the viewport. This has an overall negative impact on how performant the component feels especially on a slower network connection.

## Type of change

Refactor