### PR TITLE
refactor: avoid unnecessary render cycles in the data provider callback

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
@@ -62,6 +62,6 @@ describe('grid connector - tree', () => {
     await nextFrame();
     
     // This number may come down from further optimization
-    expect(spy.callCount).to.equal(5);
+    expect(spy.callCount).to.equal(4);
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
@@ -62,6 +62,6 @@ describe('grid connector - tree', () => {
     await nextFrame();
     
     // This number may come down from further optimization
-    expect(spy.callCount).to.equal(4);
+    expect(spy.callCount).to.equal(3);
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -379,6 +379,10 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
                 // Synchronously make a page load request for the resolvable parent request
                 resolvableParentRequest.cache.doEnsureSubCacheForScaledIndex(resolvableParentRequest.scaledIndex);
+              } else {
+                // No immediately resolvable parent requests found, request a content update to
+                // make sure expanded nodes that require a server roundtrip get loaded
+                grid.requestContentUpdate();
               }
             } else {
               treePageCallbacks[parentUniqueKey][page] = callback;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -44,7 +44,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
 
             return Boolean(
-              this.grid.$connector.confirmingParentItems ||
               this.grid.$connector.hasEnsureSubCacheQueue() ||
                 Object.keys(this.pendingRequests).length ||
                 Object.keys(this.itemCaches).filter((index) => {
@@ -900,7 +899,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         });
 
         grid.$connector.confirm = tryCatchWrapper(function (id) {
-          grid.$connector.confirmingParentItems = true;
           // We're done applying changes from this batch, resolve outstanding
           // callbacks
           let outstandingRequests = Object.getOwnPropertyNames(rootPageCallbacks);
@@ -937,8 +935,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               callback([]);
             }
           }
-
-          grid.$connector.confirmingParentItems = false;
 
           // Let server know we're done
           grid.$server.confirmUpdate(id);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -381,10 +381,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
                 // Synchronously make a page load request for the resolvable parent request
                 resolvableParentRequest.cache.doEnsureSubCacheForScaledIndex(resolvableParentRequest.scaledIndex);
-              } else {
-                // No immediately resolvable parent requests found, request a content update to
-                // make sure expanded nodes that require a server roundtrip get loaded
-                grid.requestContentUpdate();
               }
             } else {
               treePageCallbacks[parentUniqueKey][page] = callback;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -366,6 +366,8 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               // workaround: sometimes grid-element gives page index that overflows
               page = Math.min(page, Math.floor(cache[parentUniqueKey].size / grid.pageSize));
 
+              // Ensure grid isn't in loading state when the callback executes
+              ensureSubCacheQueue = [];
               // Resolve the callback from cache
               callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
 


### PR DESCRIPTION
## Description

This change improves how a data provider callback is processed in `gridConnector`. When the callback resolves synchronously from the cache, the updated data provider checks if there is a pending request for another parent item which could be resolved synchronously as well.

The change has a 73% impact on the `expandedsorttime` and 62% impact on the `expandedrendertime` metrics in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

Depends on https://github.com/vaadin/web-components/pull/5647

## Type of change

Performance enhancement