### PR TITLE
fix: make treegrid generate a value for itemHasChildrenPath

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesIT.java
@@ -185,6 +185,19 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
     }
 
     @Test
+    public void keyboard_navigation_row_focus_expand() {
+        getTreeGrid().getCell(0, 0).focus();
+
+        // Enter row focus mode
+        new Actions(getDriver()).sendKeys(Keys.LEFT).perform();
+
+        // Should expand "0 | 0" on right arrow
+        new Actions(getDriver()).sendKeys(Keys.RIGHT).perform();
+        Assert.assertEquals(6, getTreeGrid().getRowCount());
+        assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
+    }
+
+    @Test
     public void keyboard_selection() {
         getTreeGrid().getCell(0, 0).focus();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesIT.java
@@ -185,7 +185,7 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
     }
 
     @Test
-    public void keyboard_navigation_row_focus_expand() {
+    public void keyboard_navigation_row_focus_expand_collapse() {
         getTreeGrid().getCell(0, 0).focus();
 
         // Enter row focus mode
@@ -195,6 +195,11 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
         new Actions(getDriver()).sendKeys(Keys.RIGHT).perform();
         Assert.assertEquals(6, getTreeGrid().getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
+
+        // Should collapse "0 | 0" on left arrow
+        new Actions(getDriver()).sendKeys(Keys.LEFT).perform();
+        Assert.assertEquals(3, getTreeGrid().getRowCount());
+        assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -224,6 +224,20 @@ public class TreeGrid<T> extends Grid<T>
         setUniqueKeyProperty("key");
         getArrayUpdater().getUpdateQueueData()
                 .setHasExpandedItems(getDataCommunicator()::hasExpandedItems);
+
+        addItemHasChildrenPathGenerator();
+    }
+
+    /**
+     * Adds a data generator that produces a value for the <vaadin-grid>'s
+     * itemHasChildrenPath property
+     */
+    private void addItemHasChildrenPathGenerator() {
+        addDataGenerator((T item, JsonObject jsonObject) -> {
+            if (getDataCommunicator().hasChildren(item)) {
+                jsonObject.put("children", true);
+            }
+        });
     }
 
     /**
@@ -243,6 +257,8 @@ public class TreeGrid<T> extends Grid<T>
         setUniqueKeyProperty("key");
         getArrayUpdater().getUpdateQueueData()
                 .setHasExpandedItems(getDataCommunicator()::hasExpandedItems);
+
+        addItemHasChildrenPathGenerator();
     }
 
     @Override


### PR DESCRIPTION
## Description

An item value matching the `<vaadin-grid>`'s [`itemHasChildrenPath`](https://github.com/vaadin/web-components/blob/07792ca769bf9abeb11c1c51eb61223a06cf1c0a/packages/grid/src/vaadin-grid-data-provider-mixin.js#L207) is required for the row focus expand feature to work. The default value for the property is "children".

Before V24, a property with the correct name got accidentally generated by TreeGrid's [addHierarchyColumn](https://github.com/vaadin/flow-components/blob/b7d6d625308285138585e9b4d29c158fead9091a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java#L527-L528) but since [switching](https://github.com/vaadin/flow-components/commit/c680d340811978b2ed4efee054938c53e369fa84#diff-475e451a86c2b6f7ac94ac86ea50ef4eb3b7b9cbdc0c7169c4bce50043cb262cL558-R559) from `TemplateRenderer` to `LitRenderer` in V24, the property name got prefixed (all `LitRenderer` properties are auto-prefixed) and thus no longer worked.

This PR fixes the issue by adding a generator that explicitly produces an item property with the expected name "children".

Fixes https://github.com/vaadin/flow-components/issues/4770

## Type of change

Bugfix