### PR TITLE
fix: move listener from AsHtml constructor to RTE constructor

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/tests/MainView.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/tests/MainView.java
@@ -78,6 +78,8 @@ public class MainView extends VerticalLayout {
         createRichTextEditorInATemplate();
 
         createRichTextEditorWithHtmlBinder();
+
+        createEagerRichTextEditor();
     }
 
     private RichTextEditor.RichTextEditorI18n createCustomI18n() {
@@ -256,6 +258,20 @@ public class MainView extends VerticalLayout {
         reset.setId("html-binder-reset");
 
         add(actions, infoPanel, valuePanel);
+    }
+
+    private void createEagerRichTextEditor() {
+        Div eagerRteValuePanel = new Div();
+        eagerRteValuePanel.setId("eager-rte-value-panel");
+
+        RichTextEditor eagerRte = new RichTextEditor();
+        eagerRte.setValueChangeMode(ValueChangeMode.EAGER);
+        eagerRte.setId("eager-rte");
+        eagerRte.addValueChangeListener(event -> {
+            eagerRteValuePanel.setText(eagerRte.asHtml().getValue());
+        });
+
+        add(eagerRte, eagerRteValuePanel);
     }
 
     /**

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/tests/BasicUseIT.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/tests/BasicUseIT.java
@@ -176,6 +176,19 @@ public class BasicUseIT extends AbstractParallelTest {
         });
     }
 
+    @Test
+    public void eagerRichTextEditor_triggerValueChangeTwice_producesCorrectHtml() {
+        RichTextEditorElement eagerRte = $(RichTextEditorElement.class)
+                .id("eager-rte");
+        TestBenchElement valuePanel = $("div").id("eager-rte-value-panel");
+
+        eagerRte.getEditor().sendKeys("a");
+        waitUntil(driver -> "<p>a</p>".equals(valuePanel.getText()));
+
+        eagerRte.getEditor().sendKeys("b");
+        waitUntil(driver -> "<p>ab</p>".equals(valuePanel.getText()));
+    }
+
     private ButtonElement getTestButton(String id) {
         return $(ButtonElement.class).onPage().id(id);
     }

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -114,6 +114,11 @@ public class RichTextEditor
     public RichTextEditor() {
         super("", "", false, true);
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
+        addValueChangeListener(e -> {
+            if (this.asHtml != null) {
+                this.asHtml.value.clear();
+            }
+        });
     }
 
     /**
@@ -841,7 +846,6 @@ public class RichTextEditor
 
         AsHtml() {
             this.value = new HtmlValue();
-            RichTextEditor.this.addValueChangeListener(e -> this.value.clear());
         }
 
         /**


### PR DESCRIPTION
## Description

When used in a value change listener, `RichTextEditor.asHtml().getValue()` produces incorrect results in the second value change. When `asHtml()` is called the first time, it is initialized with the current value. The constructor also adds a value change listener to the editor which clears the value in `AsHtml`. In each editor value change, the `AsHtml` value should be cleared and calculated again. If a value change listener is added and used before calling `asHtml()`, that listener takes precedence and the `AsHtml` value cannot be cleared before the value change. Therefore, the `AsHtml` value is not updated. This PR moves the listener to the `RichTextEditor` constructor. This way, the value is properly cleared before  `getValue` is executed.

Fixes #4767

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.