### PR TITLE
fix: Use global style imports

### DIFF
--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/Lumo.java
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/Lumo.java
@@ -33,13 +33,12 @@ import com.vaadin.flow.theme.AbstractTheme;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.1.0-alpha3")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/vaadin-lumo-styles", version = "24.1.0-alpha3")
-@JsModule("@vaadin/vaadin-lumo-styles/color.js")
-@JsModule("@vaadin/vaadin-lumo-styles/typography.js")
+@JsModule("@vaadin/vaadin-lumo-styles/color-global.js")
+@JsModule("@vaadin/vaadin-lumo-styles/typography-global.js")
 @JsModule("@vaadin/vaadin-lumo-styles/sizing.js")
 @JsModule("@vaadin/vaadin-lumo-styles/spacing.js")
 @JsModule("@vaadin/vaadin-lumo-styles/style.js")
 @JsModule("@vaadin/vaadin-lumo-styles/vaadin-iconset.js")
-@JsModule("./lumo-includes.ts")
 public class Lumo implements AbstractTheme {
 
     public static final String LIGHT = "light";

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/resources/META-INF/resources/frontend/lumo-includes.ts
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/resources/META-INF/resources/frontend/lumo-includes.ts
@@ -1,9 +1,0 @@
-import { color } from '@vaadin/vaadin-lumo-styles/color.js';
-import { typography } from '@vaadin/vaadin-lumo-styles/typography.js';
-
-const tpl = document.createElement('template');
-tpl.innerHTML = `<style>
-  ${color.cssText}
-  ${typography.cssText}
-</style>`;
-document.head.appendChild(tpl.content);


### PR DESCRIPTION
## Description

Adapts the Lumo class to the changes done in https://github.com/vaadin/web-components/pull/5666

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
