### PR TITLE
fix: do not attempt to clear bad input when value is present

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
@@ -8,13 +8,22 @@ import com.vaadin.flow.component.textfield.IntegerField;
 @Route("vaadin-integer-field/clear-value")
 public class IntegerFieldClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public IntegerFieldClearValuePage() {
         IntegerField integerField = new IntegerField();
 
-        NativeButton clearButton = new NativeButton("Clear value");
+        NativeButton clearButton = new NativeButton("Clear value", event -> {
+            integerField.clear();
+        });
         clearButton.setId(CLEAR_BUTTON);
-        clearButton.addClickListener(event -> integerField.clear());
+
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    integerField.clear();
+                    integerField.setValue(1234);
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
 
         add(integerField, clearButton);
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValuePage.java
@@ -25,6 +25,6 @@ public class IntegerFieldClearValuePage extends Div {
                 });
         clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
 
-        add(integerField, clearButton);
+        add(integerField, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValuePage.java
@@ -8,14 +8,23 @@ import com.vaadin.flow.component.textfield.NumberField;
 @Route("vaadin-number-field/clear-value")
 public class NumberFieldClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public NumberFieldClearValuePage() {
         NumberField numberField = new NumberField();
 
-        NativeButton clearButton = new NativeButton("Clear value");
+        NativeButton clearButton = new NativeButton("Clear value", event -> {
+            numberField.clear();
+        });
         clearButton.setId(CLEAR_BUTTON);
-        clearButton.addClickListener(event -> numberField.clear());
 
-        add(numberField, clearButton);
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    numberField.clear();
+                    numberField.setValue(Double.valueOf(1234));
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
+
+        add(numberField, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
@@ -11,6 +11,7 @@ import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 import static com.vaadin.flow.component.textfield.tests.IntegerFieldClearValuePage.CLEAR_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.IntegerFieldClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 
 @TestPath("vaadin-integer-field/clear-value")
 public class IntegerFieldClearValueIT extends AbstractComponentIT {
@@ -49,5 +50,12 @@ public class IntegerFieldClearValueIT extends AbstractComponentIT {
         Assert.assertEquals("", input.getPropertyString("value"));
         Assert.assertFalse((Boolean) executeScript(
                 "return arguments[0].validity.badInput", input));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
+        integerField.sendKeys("--2", Keys.ENTER);
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1234", input.getPropertyString("value"));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
@@ -11,6 +11,7 @@ import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 import static com.vaadin.flow.component.textfield.tests.NumberFieldClearValuePage.CLEAR_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.NumberFieldClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 
 @TestPath("vaadin-number-field/clear-value")
 public class NumberFieldClearValueIT extends AbstractComponentIT {
@@ -49,5 +50,12 @@ public class NumberFieldClearValueIT extends AbstractComponentIT {
         Assert.assertEquals("", input.getPropertyString("value"));
         Assert.assertFalse((Boolean) executeScript(
                 "return arguments[0].validity.badInput", input));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
+        numberField.sendKeys("--2", Keys.ENTER);
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1234", input.getPropertyString("value"));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -138,11 +138,19 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
         super.setValue(value);
 
+        // Clear the input element from possible bad input.
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())
                 && isInputValuePresent()) {
-            // Clear the input element from possible bad input.
-            getElement().executeJs("this.inputElement.value = ''");
+            // The check for value presence before clearing the input element's
+            // value is necessary to ensure the last non-empty value won't get
+            // cleared when clear() and setValue(...) are subsequently called
+            // within one round-trip.
+            // Note, Flow is optimized to only send the last component's value
+            // when changing it several times during a round-trip.
+            // The last set value is sent in place of the first set one.
+            getElement()
+                    .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -145,10 +145,10 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             // The check for value presence guarantees that a non-empty value
             // won't get cleared when setValue(null) and setValue(...) are
             // subsequently called within one round-trip.
-            // That may happen otherwise due to the Flow optimization:
             // Flow only sends the final component value to the client
             // when you update the value multiple times during a round-trip
-            // and the final value is sent in place of the first one.
+            // and the final value is sent in place of the first one, so
+            // `executeJs` can end up invoked after a non-empty value is set.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -146,9 +146,9 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             // won't get cleared when setValue(null) and setValue(...) are
             // subsequently called within one round-trip.
             // That may happen otherwise due to the Flow optimization:
-            // Flow only sends the final component's value to the client
-            // when you update it multiple times during a round-trip and
-            // the final value is sent in place of the first one.
+            // Flow only sends the final component value to the client
+            // when you update the value multiple times during a round-trip
+            // and the final value is sent in place of the first one.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -142,13 +142,13 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())
                 && isInputValuePresent()) {
-            // The check for value presence before clearing the input element's
-            // value is necessary to ensure the last non-empty value won't get
-            // cleared when clear() and setValue(...) are subsequently called
-            // within one round-trip.
-            // Note, Flow is optimized to only send the last component's value
-            // when changing it several times during a round-trip.
-            // The last set value is sent in place of the first set one.
+            // The check for value presence guarantees that a non-empty value
+            // won't get cleared when setValue(null) and setValue(...) are
+            // subsequently called within one round-trip.
+            // That may happen otherwise due to the Flow optimization:
+            // Flow only sends the latest component's value to the client
+            // when you update it multiple times during a round-trip and
+            // the latest value is sent in place of the first one.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -146,9 +146,9 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             // won't get cleared when setValue(null) and setValue(...) are
             // subsequently called within one round-trip.
             // That may happen otherwise due to the Flow optimization:
-            // Flow only sends the latest component's value to the client
+            // Flow only sends the final component's value to the client
             // when you update it multiple times during a round-trip and
-            // the latest value is sent in place of the first one.
+            // the final value is sent in place of the first one.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.component.timepicker.tests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
 import com.vaadin.flow.testutil.TestPath;

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -3,7 +3,6 @@ package com.vaadin.flow.component.timepicker.tests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
 import com.vaadin.flow.testutil.TestPath;


### PR DESCRIPTION
## Description

There is an optimization in Flow to only send the final value for an element property in the case the property is updated multiple times using `setProperty()` within one round-trip. In terms of a set of commands that Flow sends to the client, the first value set command will be replaced with the final value set command. However, the optimization doesn't apply to `executeJs()`. It is sent as many times as you call it. 

It is therefore possible that

```java
integerField.setValue(null);
integerField.setValue(1234);
```

will result in Flow sending the following commands to the browser:

```js
{ command: 'setProperty', name: 'value', value: '1234' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
```

instead of the following ones, as you might expect:

```js
{ command: 'setProperty', name: 'value', value: '' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
{ command: 'setProperty', name: 'value', value: '1234' }
```

The PR fixes that by adding a check to prevent the execution of `executeJs()` clearing the input element's value if the component's value is no longer empty.

> **Note**
> I'll do the same fix for DatePicker, TimePicker, BigDecimalField separately.

Fixes https://github.com/vaadin/flow-components/issues/4787

## Type of change

- [x] Bugfix
