### PR TITLE
fix: Use non themed imports

### DIFF
--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.1.0-alpha2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/board", version = "24.1.0-alpha2")
-@JsModule("@vaadin/board/vaadin-board.js")
+@JsModule("@vaadin/board/src/vaadin-board.js")
 public class Board extends Component
         implements HasSize, HasStyle, HasOrderedComponents {
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.1.0-alpha2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/board", version = "24.1.0-alpha2")
-@JsModule("@vaadin/board/vaadin-board-row.js")
+@JsModule("@vaadin/board/src/vaadin-board-row.js")
 public class Row extends Component
         implements HasStyle, HasSize, HasOrderedComponents {
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
@@ -1,4 +1,4 @@
-import { Tooltip } from '@vaadin/tooltip';
+import { Tooltip } from '@vaadin/tooltip/src/tooltip.js';
 
 const _window = window as any;
 _window.Vaadin = _window.Vaadin || {};

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/tooltip.ts
@@ -1,4 +1,4 @@
-import { Tooltip } from '@vaadin/tooltip/src/tooltip.js';
+import { Tooltip } from '@vaadin/tooltip/src/vaadin-tooltip.js';
 
 const _window = window as any;
 _window.Vaadin = _window.Vaadin || {};

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.dom.ElementConstants;
 @NpmPackage(value = "@vaadin/icons", version = "24.1.0-alpha2")
 @JsModule("@vaadin/icons/vaadin-iconset.js")
 @NpmPackage(value = "@vaadin/icon", version = "24.1.0-alpha2")
-@JsModule("@vaadin/icon/vaadin-icon.js")
+@JsModule("@vaadin/icon/src/vaadin-icon.js")
 public class Icon extends Component
         implements HasStyle, ClickNotifier<Icon>, HasTooltip {
 

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/Scroller.java
@@ -38,7 +38,7 @@ import java.util.Locale;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.1.0-alpha2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/scroller", version = "24.1.0-alpha2")
-@JsModule("@vaadin/scroller/vaadin-scroller.js")
+@JsModule("@vaadin/scroller/src/vaadin-scroller.js")
 public class Scroller extends Component
         implements HasSize, HasStyle, HasThemeVariant<ScrollerVariant> {
 

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -69,7 +69,7 @@ import elemental.json.JsonValue;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.1.0-alpha2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/virtual-list", version = "24.1.0-alpha2")
-@JsModule("@vaadin/virtual-list/vaadin-virtual-list.js")
+@JsModule("@vaadin/virtual-list/src/vaadin-virtual-list.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./virtualListConnector.js")
 public class VirtualList<T> extends Component implements HasDataProvider<T>,


### PR DESCRIPTION
## Description

All imports should be for the non-themed version so the components can be used without Lumo

Fixes https://github.com/vaadin/flow/issues/16249

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.
