### PR TITLE
fix: render flow components via a custom Lit directive

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeComponentColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeComponentColumnsIT.java
@@ -83,6 +83,17 @@ public class TreeComponentColumnsIT extends AbstractComponentIT {
         assertCellContains(compThenGrid, 4, 2, "Dad 1/2");
     }
 
+    @Test
+    public void treegridComponentRenderer_expandCollapseExpand_componentsVisible() {
+        compThenGrid.expandWithClick(0);
+        compThenGrid.collapseWithClick(0);
+        compThenGrid.expandWithClick(0);
+
+        assertCellContains(compThenGrid, 4, 0, "vaadin-text-field");
+        assertCellContains(compThenGrid, 4, 1, "vaadin-text-field");
+        assertCellContains(compThenGrid, 4, 2, "Granddad 1");
+    }
+
     private void assertCellContains(GridElement grid, int rowIndex,
             int colIndex, String expected) {
         Assert.assertThat(grid.getCell(rowIndex, colIndex).getInnerHTML(),

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeComponentColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeComponentColumnsIT.java
@@ -94,6 +94,22 @@ public class TreeComponentColumnsIT extends AbstractComponentIT {
         assertCellContains(compThenGrid, 4, 2, "Granddad 1");
     }
 
+    @Test
+    public void treegridComponentRenderer_expandScrollExpand_expectedRowHeights() {
+        var rowHeight = compThenGrid.getRow(1).getSize().getHeight();
+        compThenGrid.expandWithClick(0);
+        compThenGrid.expandWithClick(1);
+        compThenGrid.scrollToRow(104);
+        for (int i = compThenGrid.getFirstVisibleRowIndex()
+                + 1; i < compThenGrid.getLastVisibleRowIndex(); i++) {
+            Assert.assertEquals(
+                    compThenGrid.getRow(i - 1).getRect().y + rowHeight,
+                    compThenGrid.getRow(i).getRect().y, 1);
+            Assert.assertEquals(rowHeight,
+                    compThenGrid.getRow(i).getSize().getHeight());
+        }
+    }
+
     private void assertCellContains(GridElement grid, int rowIndex,
             int colIndex, String expected) {
         Assert.assertThat(grid.getCell(rowIndex, colIndex).getInnerHTML(),

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -148,7 +148,7 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
                 ? UI.getCurrent().getInternals().getAppId()
                 : "";
 
-        return "${Vaadin.FlowComponentHost.flowComponentDirective('" + appId
+        return "${Vaadin.FlowComponentHost.getNode('" + appId
                 + "', item.nodeid)}";
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -148,7 +148,7 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
                 ? UI.getCurrent().getInternals().getAppId()
                 : "";
 
-        return "${Vaadin.FlowComponentHost.getNode('" + appId
+        return "${Vaadin.FlowComponentHost.flowComponentDirective('" + appId
                 + "', item.nodeid)}";
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -1,7 +1,6 @@
 import { noChange } from 'lit';
 import { until } from 'lit/directives/until.js';
 import { directive, Directive, PartType } from 'lit/directive.js';
-import { getNodeInternal } from './flow-component-renderer.js';
 
 class FlowComponentDirective extends Directive {
   constructor(partInfo) {
@@ -14,7 +13,7 @@ class FlowComponentDirective extends Directive {
   update(part, [appid, nodeid]) {
     const { parentNode, startNode } = part;
 
-    const newNode = getNodeInternal(appid, nodeid);
+    const newNode = this.getNewNode(appid, nodeid);
     const oldNode = this.getOldNode(part);
 
     if (oldNode === newNode) {
@@ -28,6 +27,10 @@ class FlowComponentDirective extends Directive {
     }
 
     return noChange;
+  }
+
+  getNewNode(appid, nodeid) {
+    return window.Vaadin.Flow.clients[appid].getByNodeId(nodeid);
   }
 
   getOldNode(part) {
@@ -44,7 +47,7 @@ const flowComponentDirectiveInternal = directive(FlowComponentDirective);
 /**
  * Renders the given flow component node asynchronously.
  *
- * NOTE: The directive is not intended for public use.
+ * WARNING: This directive is not intended for public use.
  *
  * @param {string} appid
  * @param {number} nodeid

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -1,0 +1,32 @@
+import { noChange } from 'lit';
+import { directive, Directive, PartType } from 'lit/directive.js';
+
+class FlowComponentDirective extends Directive {
+  constructor(partInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.CHILD) {
+      throw new Error(`${this.constructor.directiveName}() can only be used in child bindings`);
+    }
+  }
+
+  render() {
+    return noChange;
+  }
+
+  update(part, [newNode]) {
+    const { startNode, parentNode } = part;
+    const oldNode = startNode.nextSibling;
+
+    if (oldNode === newNode) {
+      return noChange;
+    } else if (oldNode && newNode) {
+      parentNode.replaceChild(newNode, oldNode);
+    } else if (oldNode) {
+      parentNode.removeChild(oldNode);
+    } else if (newNode) {
+      parentNode.appendChild(newNode);
+    }
+  }
+}
+
+export const flowComponentDirective = directive(FlowComponentDirective);

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -44,8 +44,11 @@ const flowComponentDirectiveInternal = directive(FlowComponentDirective);
 /**
  * Renders the given flow component node asynchronously.
  *
+ * NOTE: The directive is not intended for public use.
+ *
  * @param {string} appid
  * @param {number} nodeid
+ * @private
  */
 export const flowComponentDirective = (appid, nodeid) => {
   // Theoretically, it could return the directive synchronously.

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -14,8 +14,10 @@ class FlowComponentDirective extends Directive {
   }
 
   update(part, [newNode]) {
-    const { startNode, parentNode } = part;
-    const oldNode = startNode.nextSibling;
+    const { parentNode } = part;
+    const oldNode = [...parentNode.childNodes].find((node) => {
+      return [Node.ELEMENT_NODE, Node.TEXT_NODE].includes(node.nodeType);
+    });
 
     if (oldNode === newNode) {
       return noChange;

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -30,7 +30,11 @@ function getNode(appid, nodeid) {
   // Test in ComponentColumnWithHeightIT::shouldPositionItemsCorrectlyAfterScrollingToEnd
   // makes sure the sizing works correctly. The sizing issue should eventually
   // be fixed in the Virtualizer.
-  return until(new Promise((resolve) => resolve(getNodeInternal(appid, nodeid))));
+  return until(new Promise((resolve) => {
+    const fragment = document.createDocumentFragment();
+    fragment.append(getNodeInternal(appid, nodeid));
+    resolve(fragment);
+  }));
 }
 
 /**

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -3,7 +3,6 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { idlePeriod } from '@polymer/polymer/lib/utils/async.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { until } from 'lit/directives/until.js';
 import { flowComponentDirective } from './flow-component-directive.js';
 
 /**
@@ -12,29 +11,8 @@ import { flowComponentDirective } from './flow-component-directive.js';
  * @param {number} nodeid
  * @returns {Element | null} The element if found, null otherwise.
  */
-function getNodeInternal(appid, nodeid) {
+export function getNodeInternal(appid, nodeid) {
   return window.Vaadin.Flow.clients[appid].getByNodeId(nodeid);
-}
-
-/**
- * Returns the requested node in a form suitable for Lit template interpolation.
- * @param {string} appid
- * @param {number} nodeid
- * @returns {any} The element if found, null otherwise.
- */
-function getNode(appid, nodeid) {
-  // Theoretically, this method could just return the node as-is.
-  // The `until` directive is used for now to work around sizing issues
-  // with ComponentRenderer. The previously used <flow-component-renderer> was
-  // asynchronous by nature and thus worked out of the box.
-  //
-  // Test in ComponentColumnWithHeightIT::shouldPositionItemsCorrectlyAfterScrollingToEnd
-  // makes sure the sizing works correctly. The sizing issue should eventually
-  // be fixed in the Virtualizer.
-  return until(new Promise((resolve) => {
-    const node = getNodeInternal(appid, nodeid);
-    resolve(flowComponentDirective(node));
-  }));
 }
 
 /**
@@ -71,7 +49,7 @@ function patchVirtualContainer(container) {
 }
 
 window.Vaadin ||= {};
-window.Vaadin.FlowComponentHost ||= { patchVirtualContainer, getNode, setChildNodes };
+window.Vaadin.FlowComponentHost ||= { patchVirtualContainer, flowComponentDirective, setChildNodes };
 
 class FlowComponentRenderer extends PolymerElement {
   static get template() {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -16,6 +16,16 @@ export function getNodeInternal(appid, nodeid) {
 }
 
 /**
+ * Returns the requested node in a form suitable for Lit template interpolation.
+ * @param {string} appid
+ * @param {number} nodeid
+ * @returns {any} a Lit directive
+ */
+function getNode(appid, nodeid) {
+  return flowComponentDirective(appid, nodeid);
+}
+
+/**
  * Sets the nodes defined by the given node ids as the child nodes of the
  * given root element.
  * @param {string} appid
@@ -49,7 +59,7 @@ function patchVirtualContainer(container) {
 }
 
 window.Vaadin ||= {};
-window.Vaadin.FlowComponentHost ||= { patchVirtualContainer, flowComponentDirective, setChildNodes };
+window.Vaadin.FlowComponentHost ||= { patchVirtualContainer, getNode, setChildNodes };
 
 class FlowComponentRenderer extends PolymerElement {
   static get template() {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -31,9 +31,11 @@ function getNode(appid, nodeid) {
   // makes sure the sizing works correctly. The sizing issue should eventually
   // be fixed in the Virtualizer.
   return until(new Promise((resolve) => {
-    const fragment = document.createDocumentFragment();
-    fragment.append(getNodeInternal(appid, nodeid));
-    resolve(fragment);
+    queueMicrotask(() => {
+      const fragment = document.createDocumentFragment();
+      fragment.append(getNodeInternal(appid, nodeid));
+      resolve(fragment);
+    });
   }));
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -4,11 +4,12 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { idlePeriod } from '@polymer/polymer/lib/utils/async.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { until } from 'lit/directives/until.js';
+import { flowComponentDirective } from './flow-component-directive.js';
 
 /**
  * Returns the requested node from the Flow client.
- * @param {string} appid 
- * @param {number} nodeid 
+ * @param {string} appid
+ * @param {number} nodeid
  * @returns {Element | null} The element if found, null otherwise.
  */
 function getNodeInternal(appid, nodeid) {
@@ -17,8 +18,8 @@ function getNodeInternal(appid, nodeid) {
 
 /**
  * Returns the requested node in a form suitable for Lit template interpolation.
- * @param {string} appid 
- * @param {number} nodeid 
+ * @param {string} appid
+ * @param {number} nodeid
  * @returns {any} The element if found, null otherwise.
  */
 function getNode(appid, nodeid) {
@@ -31,20 +32,17 @@ function getNode(appid, nodeid) {
   // makes sure the sizing works correctly. The sizing issue should eventually
   // be fixed in the Virtualizer.
   return until(new Promise((resolve) => {
-    queueMicrotask(() => {
-      const fragment = document.createDocumentFragment();
-      fragment.append(getNodeInternal(appid, nodeid));
-      resolve(fragment);
-    });
+    const node = getNodeInternal(appid, nodeid);
+    resolve(flowComponentDirective(node));
   }));
 }
 
 /**
  * Sets the nodes defined by the given node ids as the child nodes of the
  * given root element.
- * @param {string} appid 
+ * @param {string} appid
  * @param {number[]} nodeIds
- * @param {Element} root 
+ * @param {Element} root
  */
 function setChildNodes(appid, nodeIds, root) {
   root.textContent = '';
@@ -56,13 +54,13 @@ function setChildNodes(appid, nodeIds, root) {
  * elements to the container. When the children are manually placed under
  * another element, the call to insertBefore can occasionally fail due to
  * an invalid reference node.
- * 
+ *
  * This is a temporary workaround which patches the container's native API
  * to not fail when called with invalid arguments.
  */
 function patchVirtualContainer(container) {
   const originalInsertBefore = container.insertBefore;
-  
+
   container.insertBefore = function (newNode, referenceNode) {
     if (referenceNode && referenceNode.parentNode === this) {
       return originalInsertBefore.call(this, newNode, referenceNode);

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -11,7 +11,7 @@ import { flowComponentDirective } from './flow-component-directive.js';
  * @param {number} nodeid
  * @returns {Element | null} The element if found, null otherwise.
  */
-export function getNodeInternal(appid, nodeid) {
+function getNodeInternal(appid, nodeid) {
   return window.Vaadin.Flow.clients[appid].getByNodeId(nodeid);
 }
 


### PR DESCRIPTION
## Description

Passing nodes as such to Lit for rendering seems to have issues. I assume it relates to how Lit caches what it renders (since removing the `_$litPart$` property from the cell content element also fixes it): passing the same element instance vs passing a fresh new wrapper instance.

~Wrapping the nodes in document fragments and then passing the fragment instead works more reliably.~ 
UPD: Rendering the nodes via a custom Lit directive that compares them against the real DOM rather than `_$litPart$_` to see if they should be re-rendered fixes the issue, see https://github.com/vaadin/flow-components/pull/4822#issuecomment-1491514853.

Fixes https://github.com/vaadin/flow-components/issues/4821

## Type of change

Bugfix