### PR TITLE
refactor: do not check for item visibility before ensuring a sub-cache

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -254,6 +254,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           const pendingFetch = ensureSubCacheQueue.shift();
           if (pendingFetch) {
             pendingFetch.cache.doEnsureSubCacheForScaledIndex(pendingFetch.scaledIndex);
+            return true;
           }
           return false;
         });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -251,29 +251,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         });
 
         grid.$connector.flushEnsureSubCache = tryCatchWrapper(function () {
-          let pendingFetch = ensureSubCacheQueue.splice(0, 1)[0];
-          let itemkey = pendingFetch.itemkey;
-
-          const visibleRows = grid._getVisibleRows();
-          let start = visibleRows[0].index;
-          let end = visibleRows[visibleRows.length - 1].index;
-
-          let buffer = end - start;
-          let firstNeededIndex = Math.max(0, start - buffer);
-          let lastNeededIndex = Math.min(end + buffer, grid._effectiveSize);
-
-          // only fetch if given item is still in visible range
-          for (let index = firstNeededIndex; index <= lastNeededIndex; index++) {
-            let item = grid._cache.getItemForIndex(index);
-
-            if (grid.getItemId(item) === itemkey) {
-              if (grid._isExpanded(item)) {
-                pendingFetch.cache.doEnsureSubCacheForScaledIndex(pendingFetch.scaledIndex);
-                return true;
-              } else {
-                break;
-              }
-            }
+          const pendingFetch = ensureSubCacheQueue.shift();
+          if (pendingFetch) {
+            pendingFetch.cache.doEnsureSubCacheForScaledIndex(pendingFetch.scaledIndex);
           }
           return false;
         });


### PR DESCRIPTION
## Description

Now that https://github.com/vaadin/web-components/pull/5647 has been done, there seem to be no cases where `ensureSubCacheQueue` would contain items beyond the viewport:

- The grid web component [requests a sub-cache only for visible rows](https://github.com/vaadin/web-components/blob/7a117e810f8f62977a60e9860248c48db1975a28/packages/grid/src/vaadin-grid-data-provider-mixin.js#L411-L417) while resolving a page request.
- Before resolving a page request, the grid connector [clears](https://github.com/vaadin/flow-components/blob/5949537412cc0dabe1f3b7a57dee5faa409a1f32/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L370) `ensureSubCacheQueue` completely.

which means the grid connector doesn't need anymore to additionally check whether the item is still visible before ensuring a sub-cache for it.

## Type of change

- [x] Refactor
