### PR TITLE
fix(TimePicker): do not attempt to clear bad input when value is present 

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/ClearValuePage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/ClearValuePage.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.timepicker.tests;
 
+import java.time.LocalTime;
+
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.timepicker.TimePicker;
@@ -8,6 +10,7 @@ import com.vaadin.flow.router.Route;
 @Route("vaadin-time-picker/clear-value")
 public class ClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public ClearValuePage() {
         TimePicker timePicker = new TimePicker();
@@ -16,6 +19,13 @@ public class ClearValuePage extends Div {
         clearButton.setId(CLEAR_BUTTON);
         clearButton.addClickListener(event -> timePicker.clear());
 
-        add(timePicker, clearButton);
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    timePicker.clear();
+                    timePicker.setValue(LocalTime.of(10, 0));
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
+
+        add(timePicker, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/ClearValuePage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/ClearValuePage.java
@@ -22,7 +22,7 @@ public class ClearValuePage extends Div {
         NativeButton clearAndSetValueButton = new NativeButton(
                 "Clear and set value", event -> {
                     timePicker.clear();
-                    timePicker.setValue(LocalTime.of(10, 0));
+                    timePicker.setValue(LocalTime.of(12, 0));
                 });
         clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -44,6 +44,6 @@ public class ClearValueIT extends AbstractComponentIT {
     public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
         timePicker.selectByText("INVALID");
         $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
-        Assert.assertEquals("12:00", timePicker.getTimePickerInputValue());
+        Assert.assertEquals("12:00 PM", timePicker.getTimePickerInputValue());
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -10,6 +10,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
 import static com.vaadin.flow.component.timepicker.tests.ClearValuePage.CLEAR_BUTTON;
+import static com.vaadin.flow.component.timepicker.tests.ClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 
 @TestPath("vaadin-time-picker/clear-value")
 public class ClearValueIT extends AbstractComponentIT {
@@ -37,5 +38,12 @@ public class ClearValueIT extends AbstractComponentIT {
 
         $("button").id(CLEAR_BUTTON).click();
         Assert.assertEquals("", timePicker.getTimePickerInputValue());
+    }
+
+    @Test
+    public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
+        timePicker.sendKeys("INVALID", Keys.ENTER);
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1234", timePicker.getTimePickerInputValue());
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -44,6 +44,6 @@ public class ClearValueIT extends AbstractComponentIT {
     public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
         timePicker.sendKeys("INVALID", Keys.ENTER);
         $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
-        Assert.assertEquals("1234", timePicker.getTimePickerInputValue());
+        Assert.assertEquals("12:00", timePicker.getTimePickerInputValue());
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -42,7 +42,7 @@ public class ClearValueIT extends AbstractComponentIT {
 
     @Test
     public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
-        timePicker.sendKeys("INVALID", Keys.ENTER);
+        timePicker.selectByText("INVALID");
         $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
         Assert.assertEquals("12:00", timePicker.getTimePickerInputValue());
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -253,11 +253,19 @@ public class TimePicker
 
         super.setValue(value);
 
+        // Clear the input element from possible bad input.
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())
                 && isInputValuePresent()) {
-            // Clear the input element from possible bad input.
-            getElement().executeJs("this.inputElement.value = ''");
+            // The check for value presence guarantees that a non-empty value
+            // won't get cleared when setValue(null) and setValue(...) are
+            // subsequently called within one round-trip.
+            // Flow only sends the final component value to the client
+            // when you update the value multiple times during a round-trip
+            // and the final value is sent in place of the first one, so
+            // `executeJs` can end up invoked after a non-empty value is set.
+            getElement()
+                    .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }


### PR DESCRIPTION
## Description

There is an optimization in Flow to only send the final value for an element property in the case the property is updated multiple times using `setProperty()` within one round-trip. In terms of commands sent to the client, the final value set command will replace the first value set command. However, the optimization doesn't apply to `executeJs()`. It is sent as many times as you call it. 

It is therefore possible that

```java
timePicker.setValue(null);
timePicker.setValue(LocalTime.of(12, 0));
```

will result in Flow sending the following commands to the browser:

```js
{ command: 'setProperty', name: 'value', value: '12:00' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
```

instead of the following ones, as you might expect:

```js
{ command: 'setProperty', name: 'value', value: '' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
{ command: 'setProperty', name: 'value', value: '12:00' }
```

The PR fixes that by adding a check to prevent the execution of `executeJs()` clearing the input element's value if the component's value is no longer empty.

Depends on
- https://github.com/vaadin/web-components/issues/5695.



Related to https://github.com/vaadin/flow-components/issues/4786#issuecomment-1460173710

## Type of change

- [x] Bugfix
