### PR TITLE
fix(DatePicker): do not attempt to clear bad input when value is present

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/ClearValuePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/ClearValuePage.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.datepicker;
 
+import java.time.LocalDate;
+
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
@@ -7,6 +9,7 @@ import com.vaadin.flow.router.Route;
 @Route("vaadin-date-picker/clear-value")
 public class ClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public ClearValuePage() {
         DatePicker datePicker = new DatePicker();
@@ -15,6 +18,13 @@ public class ClearValuePage extends Div {
         clearButton.setId(CLEAR_BUTTON);
         clearButton.addClickListener(event -> datePicker.clear());
 
-        add(datePicker, clearButton);
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    datePicker.clear();
+                    datePicker.setValue(LocalDate.of(2022, 1, 1));
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
+
+        add(datePicker, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/ClearValueIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/ClearValueIT.java
@@ -10,6 +10,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
 import static com.vaadin.flow.component.datepicker.ClearValuePage.CLEAR_BUTTON;
+import static com.vaadin.flow.component.datepicker.ClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 
 @TestPath("vaadin-date-picker/clear-value")
 public class ClearValueIT extends AbstractComponentIT {
@@ -37,5 +38,12 @@ public class ClearValueIT extends AbstractComponentIT {
 
         $("button").id(CLEAR_BUTTON).click();
         Assert.assertEquals("", datePicker.getInputValue());
+    }
+
+    @Test
+    public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
+        datePicker.sendKeys("INVALID", Keys.ENTER);
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1/1/2022", datePicker.getInputValue());
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -546,11 +546,19 @@ public class DatePicker
 
         super.setValue(value);
 
+        // Clear the input element from possible bad input.
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())
                 && isInputValuePresent()) {
-            // Clear the input element from possible bad input.
-            getElement().executeJs("this.inputElement.value = ''");
+            // The check for value presence guarantees that a non-empty value
+            // won't get cleared when setValue(null) and setValue(...) are
+            // subsequently called within one round-trip.
+            // Flow only sends the final component value to the client
+            // when you update the value multiple times during a round-trip
+            // and the final value is sent in place of the first one, so
+            // `executeJs` can end up invoked after a non-empty value is set.
+            getElement()
+                    .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }


### PR DESCRIPTION
## Description

There is an optimization in Flow to only send the final value for an element property in the case the property is updated multiple times using `setProperty()` within one round-trip. In terms of commands sent to the client, the first value set command will be replaced with the final value set command. However, the optimization doesn't apply to `executeJs()`. It is sent as many times as you call it. 

It is therefore possible that

```java
datePicker.setValue(null);
datePicker.setValue(LocalDate.of(2022, 1, 1));
```

will result in Flow sending the following commands to the browser:

```js
{ command: 'setProperty', name: 'value', value: '2022-01-01' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
```

instead of the following ones, as you might expect:

```js
{ command: 'setProperty', name: 'value', value: '' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
{ command: 'setProperty', name: 'value', value: '2022-01-01' }
```

The PR fixes that by adding a check to prevent the execution of `executeJs()` clearing the input element's value if the component's value is no longer empty.

Related to https://github.com/vaadin/flow-components/issues/4786#issuecomment-1460173710

## Type of change

- [x] Bugfix
