### PR TITLE
fix(BigDecimalField): restore input value when setting a non-empty value

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
@@ -22,7 +22,7 @@ public class BigDecimalFieldClearValuePage extends Div {
         NativeButton clearAndSetValueButton = new NativeButton(
                 "Clear and set value", event -> {
                     bigDecimalField.clear();
-                    bigDecimalField.setValue(BigDecimal.valueOf(1234));
+                    bigDecimalField.setValue(BigDecimal.valueOf(12.34));
                 });
         clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
+import java.math.BigDecimal;
+
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
@@ -8,6 +10,7 @@ import com.vaadin.flow.component.textfield.BigDecimalField;
 @Route("vaadin-big-decimal-field/clear-value")
 public class BigDecimalFieldClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public BigDecimalFieldClearValuePage() {
         BigDecimalField bigDecimalField = new BigDecimalField();
@@ -16,6 +19,13 @@ public class BigDecimalFieldClearValuePage extends Div {
         clearButton.setId(CLEAR_BUTTON);
         clearButton.addClickListener(event -> bigDecimalField.clear());
 
-        add(bigDecimalField, clearButton);
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    bigDecimalField.clear();
+                    bigDecimalField.setValue(BigDecimal.valueOf(1234));
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
+
+        add(bigDecimalField, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
@@ -11,6 +11,7 @@ import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 import static com.vaadin.flow.component.textfield.tests.BigDecimalFieldClearValuePage.CLEAR_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.BigDecimalFieldClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 
 @TestPath("vaadin-big-decimal-field/clear-value")
 public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
@@ -41,5 +42,12 @@ public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
 
         $("button").id(CLEAR_BUTTON).click();
         Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
+        bigDecimalField.sendKeys("--2", Keys.ENTER);
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1234", input.getPropertyString("value"));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
@@ -48,6 +48,6 @@ public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
     public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
         bigDecimalField.sendKeys("--2", Keys.ENTER);
         $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
-        Assert.assertEquals("1234", input.getPropertyString("value"));
+        Assert.assertEquals("12.34", input.getPropertyString("value"));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -228,9 +228,10 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
             getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         } else {
-            // Restore the input element's value to prevent a non-empty value
-            // from getting cleared when setValue(null) and setValue(...) are
-            // subsequently called within one round-trip.
+            // Restore the input element's value in case it was cleared
+            // in the previous branch which can happen when setValue(null)
+            // and setValue(...) are subsequently called within one round-trip
+            // and there was bad input.
             getElement().executeJs("this._inputElementValue = $0",
                     FORMATTER.apply(this, value));
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -229,11 +229,10 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
             fireEvent(new ClientValidatedEvent(this, false));
         } else {
             // Restore the input element's value in case it was cleared
-            // in the previous branch which can happen when setValue(null)
+            // in the above branch. That can happen when setValue(null)
             // and setValue(...) are subsequently called within one round-trip
             // and there was bad input.
-            getElement().executeJs("this._inputElementValue = $0",
-                    FORMATTER.apply(this, value));
+            getElement().executeJs("this._inputElementValue = this.value");
         }
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -220,11 +220,19 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
         super.setValue(value);
 
+        // Clear the input element from possible bad input.
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())
                 && isInputValuePresent()) {
-            // Clear the input element from possible bad input.
-            getElement().executeJs("this.inputElement.value = ''");
+            // The check for value presence guarantees that a non-empty value
+            // won't get cleared when setValue(null) and setValue(...) are
+            // subsequently called within one round-trip.
+            // Flow only sends the final component value to the client
+            // when you update the value multiple times during a round-trip
+            // and the final value is sent in place of the first one, so
+            // `executeJs` can end up invoked after a non-empty value is set.
+            getElement()
+                    .executeJs("if (!this.value) this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -220,21 +220,19 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
         super.setValue(value);
 
-        // Clear the input element from possible bad input.
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())
                 && isInputValuePresent()) {
-            // The check for value presence guarantees that a non-empty value
-            // won't get cleared when setValue(null) and setValue(...) are
-            // subsequently called within one round-trip.
-            // Flow only sends the final component value to the client
-            // when you update the value multiple times during a round-trip
-            // and the final value is sent in place of the first one, so
-            // `executeJs` can end up invoked after a non-empty value is set.
-            getElement()
-                    .executeJs("if (!this.value) this._inputElementValue = ''");
+            // Clear the input element from possible bad input.
+            getElement().executeJs("this._inputElementValue = ''");
             getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
+        } else {
+            // Restore the input element's value to prevent a non-empty value
+            // from getting cleared when setValue(null) and setValue(...) are
+            // subsequently called within one round-trip.
+            getElement().executeJs("this._inputElementValue = $0",
+                    FORMATTER.apply(this, value));
         }
     }
 


### PR DESCRIPTION
## Description

There is an optimization in Flow to only send the final value for an element property in the case the property is updated multiple times using `setProperty()` within one round-trip. In terms of commands sent to the client, the first value set command will be replaced with the final value set command. However, the optimization doesn't apply to `executeJs()`. It is sent as many times as you call it. 

It is therefore possible that

```java
bigDecimalField.setValue(null);
bigDecimalField.setValue(BigDecimal.valueOf(1234));
```

will result in Flow sending the following commands to the browser:

```js
{ command: 'setProperty', name: 'value', value: '1234' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
```

instead of the following ones, as you might expect:

```js
{ command: 'setProperty', name: 'value', value: '' }
{ command: 'executeJs', value: 'this._inputElementValue = ""' }
{ command: 'setProperty', name: 'value', value: '1234' }
```

The PR fixes that by restoring the input element's value when setting a non-empty component value, in case it was cleared due to bad input in the above case.

Fixes https://github.com/vaadin/flow-components/issues/4786
## Type of change

- [x] Bugfix
