### PR TITLE
feat: make DatePicker implement HasAriaLabel

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -30,6 +31,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
@@ -89,8 +91,8 @@ import elemental.json.JsonType;
 @NpmPackage(value = "date-fns", version = "2.29.3")
 public class DatePicker
         extends AbstractSinglePropertyField<DatePicker, LocalDate>
-        implements Focusable<DatePicker>, HasAllowedCharPattern, HasAutoOpen,
-        HasClearButton, HasClientValidation, HasHelper, HasLabel,
+        implements Focusable<DatePicker>, HasAllowedCharPattern, HasAriaLabel,
+        HasAutoOpen, HasClearButton, HasClientValidation, HasHelper, HasLabel,
         HasOverlayClassName, HasPrefix, HasSize, HasStyle, HasTooltip,
         HasThemeVariant<DatePickerVariant>, HasValidationProperties,
         HasValidator<LocalDate> {
@@ -364,6 +366,27 @@ public class DatePicker
         } else {
             return super.getLocale();
         }
+    }
+
+    @Override
+    public void setAriaLabel(String ariaLabel) {
+        getElement().setProperty("accessibleName", ariaLabel);
+    }
+
+    @Override
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    @Override
+    public void setAriaLabelledBy(String labelledBy) {
+        getElement().setProperty("accessibleNameRef", labelledBy);
+    }
+
+    @Override
+    public Optional<String> getAriaLabelledBy() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameRef"));
     }
 
     @Override

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
+import com.vaadin.flow.component.HasAriaLabel;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -280,6 +281,38 @@ public class DatePickerTest {
     public void implementsHasTooltip() {
         DatePicker picker = new DatePicker();
         Assert.assertTrue(picker instanceof HasTooltip);
+    }
+
+    @Test
+    public void implementHasAriaLabel() {
+        Assert.assertTrue(
+                "Date picker should support aria-label and aria-labelledby",
+                HasAriaLabel.class.isAssignableFrom(DatePicker.class));
+    }
+
+    @Test
+    public void setAriaLabel() {
+        DatePicker datePicker = new DatePicker();
+
+        datePicker.setAriaLabel("aria-label");
+        Assert.assertTrue(datePicker.getAriaLabel().isPresent());
+        Assert.assertEquals("aria-label", datePicker.getAriaLabel().get());
+
+        datePicker.setAriaLabel(null);
+        Assert.assertTrue(datePicker.getAriaLabel().isEmpty());
+    }
+
+    @Test
+    public void setAriaLabelledBy() {
+        DatePicker datePicker = new DatePicker();
+
+        datePicker.setAriaLabelledBy("aria-labelledby");
+        Assert.assertTrue(datePicker.getAriaLabelledBy().isPresent());
+        Assert.assertEquals("aria-labelledby",
+                datePicker.getAriaLabelledBy().get());
+
+        datePicker.setAriaLabelledBy(null);
+        Assert.assertTrue(datePicker.getAriaLabelledBy().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Description

Make `DatePicker` implement `HasAriaLabel` interface.


Part of https://github.com/vaadin/platform/issues/3803
Part of https://github.com/vaadin/platform/issues/3814
Part of #2946 
Fixes #4707

## Type of change

- [ ] Bugfix
- [X] Feature
