### PR TITLE
feat: make TimePicker implement HasAriaLabel

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AbstractSinglePropertyField;
@@ -27,6 +28,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
@@ -74,9 +76,9 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("./vaadin-time-picker/timepickerConnector.js")
 public class TimePicker
         extends AbstractSinglePropertyField<TimePicker, LocalTime>
-        implements Focusable<TimePicker>, HasAllowedCharPattern, HasAutoOpen,
-        HasClearButton, HasClientValidation, HasHelper, HasLabel, HasPrefix,
-        HasOverlayClassName, HasSize, HasStyle, HasTooltip,
+        implements Focusable<TimePicker>, HasAllowedCharPattern, HasAriaLabel,
+        HasAutoOpen, HasClearButton, HasClientValidation, HasHelper, HasLabel,
+        HasPrefix, HasOverlayClassName, HasSize, HasStyle, HasTooltip,
         HasThemeVariant<TimePickerVariant>, HasValidationProperties,
         HasValidator<LocalTime> {
 
@@ -270,6 +272,27 @@ public class TimePicker
      */
     public String getLabel() {
         return getElement().getProperty("label");
+    }
+
+    @Override
+    public void setAriaLabel(String ariaLabel) {
+        getElement().setProperty("accessibleName", ariaLabel);
+    }
+
+    @Override
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    @Override
+    public void setAriaLabelledBy(String labelledBy) {
+        getElement().setProperty("accessibleNameRef", labelledBy);
+    }
+
+    @Override
+    public Optional<String> getAriaLabelledBy() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameRef"));
     }
 
     @Override

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 
+import com.vaadin.flow.component.HasAriaLabel;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -278,6 +279,38 @@ public class TimePickerTest {
     public void setTextAsPrefix_throws() {
         TimePicker picker = new TimePicker();
         picker.setPrefixComponent(new Text("Prefix"));
+    }
+
+    @Test
+    public void implementHasAriaLabel() {
+        Assert.assertTrue(
+                "Time picker should support aria-label and aria-labelledby",
+                HasAriaLabel.class.isAssignableFrom(TimePicker.class));
+    }
+
+    @Test
+    public void setAriaLabel() {
+        TimePicker timePicker = new TimePicker();
+
+        timePicker.setAriaLabel("aria-label");
+        Assert.assertTrue(timePicker.getAriaLabel().isPresent());
+        Assert.assertEquals("aria-label", timePicker.getAriaLabel().get());
+
+        timePicker.setAriaLabel(null);
+        Assert.assertTrue(timePicker.getAriaLabel().isEmpty());
+    }
+
+    @Test
+    public void setAriaLabelledBy() {
+        TimePicker timePicker = new TimePicker();
+
+        timePicker.setAriaLabelledBy("aria-labelledby");
+        Assert.assertTrue(timePicker.getAriaLabelledBy().isPresent());
+        Assert.assertEquals("aria-labelledby",
+                timePicker.getAriaLabelledBy().get());
+
+        timePicker.setAriaLabelledBy(null);
+        Assert.assertTrue(timePicker.getAriaLabelledBy().isEmpty());
     }
 
     @Tag("div")


### PR DESCRIPTION
## Description

Make `TimePicker` implement `HasAriaLabel` interface.


Part of https://github.com/vaadin/platform/issues/3803
Part of https://github.com/vaadin/platform/issues/3814
Part of #2946 
Fixes #4710

## Type of change

- [ ] Bugfix
- [X] Feature
