### PR TITLE
test: refactor and extract dialog close action listener tests

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogCloseActionListenerTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogCloseActionListenerTest.java
@@ -46,7 +46,7 @@ public class DialogCloseActionListenerTest {
     }
 
     @Test
-    public void addDialogCloseActionListenerOnClosedDialog_onCloseNotConfigured() {
+    public void addDialogCloseActionListener_onCloseNotConfigured() {
         Dialog dialog = new Dialog();
 
         dialog.addDialogCloseActionListener(event -> {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogCloseActionListenerTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogCloseActionListenerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dialog;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.Registration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+public class DialogCloseActionListenerTest {
+
+    private UI ui = new UI();
+
+    @Before
+    public void setup() {
+        UI.setCurrent(ui);
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
+    @Test
+    public void addDialogCloseActionListenerOnClosedDialog_onCloseNotConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        assertOnCloseConfigured(false);
+    }
+
+    @Test
+    public void openDialog_onCloseNotConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.open();
+
+        assertOnCloseConfigured(false);
+    }
+
+    @Test
+    public void addDialogCloseActionListener_openDialog_onCloseConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        dialog.open();
+
+        assertOnCloseConfigured(true);
+    }
+
+    @Test
+    public void openDialog_addDialogCloseActionListener_onCloseConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.open();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        assertOnCloseConfigured(true);
+    }
+
+    @Test
+    public void addDialogCloseActionListener_openDialog_removeListener_onCloseNotConfigured() {
+        Dialog dialog = new Dialog();
+
+        Registration registration = dialog
+                .addDialogCloseActionListener(event -> {
+                });
+
+        dialog.open();
+
+        registration.remove();
+
+        assertOnCloseConfigured(false);
+    }
+
+    @Test
+    public void addDialogCloseActionListener_removeListener_openDialog_onCloseNotConfigured() {
+        Dialog dialog = new Dialog();
+
+        Registration registration = dialog
+                .addDialogCloseActionListener(event -> {
+                });
+
+        registration.remove();
+
+        dialog.open();
+
+        assertOnCloseConfigured(false);
+    }
+
+    @Test
+    public void addDialogCloseActionListener_openDialog_closeAndReopen_onCloseConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        dialog.open();
+
+        flushInvocations();
+
+        dialog.close();
+
+        dialog.open();
+
+        assertOnCloseConfigured(true);
+    }
+
+    @Test
+    public void addTwoDialogCloseActionListeners_openDialog_onCloseConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        dialog.open();
+
+        assertOnCloseConfigured(true);
+    }
+
+    @Test
+    public void addTwoDialogCloseActionListeners_openDialog_removeOneListener_onCloseConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        Registration registration = dialog
+                .addDialogCloseActionListener(event -> {
+                });
+
+        dialog.open();
+
+        registration.remove();
+
+        assertOnCloseConfigured(true);
+    }
+
+    @Test
+    public void addTwoDialogCloseActionListeners_openDialog_closeDialog_removeOneListener_reopenDialog_onCloseConfigured() {
+        Dialog dialog = new Dialog();
+
+        dialog.addDialogCloseActionListener(event -> {
+        });
+
+        Registration registration = dialog
+                .addDialogCloseActionListener(event -> {
+                });
+
+        dialog.open();
+
+        flushInvocations();
+
+        dialog.close();
+
+        registration.remove();
+
+        dialog.open();
+
+        assertOnCloseConfigured(true);
+    }
+
+    private List<PendingJavaScriptInvocation> flushInvocations() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        return ui.getInternals().dumpPendingJavaScriptInvocations();
+    }
+
+    private void assertOnCloseConfigured(boolean configured) {
+        List<PendingJavaScriptInvocation> invocations = flushInvocations();
+        long onCloseConfiguredCount = invocations
+                .stream().filter(invocation -> invocation.getInvocation()
+                        .getExpression().startsWith("var f = function(e)"))
+                .count();
+        int expectedCount = configured ? 1 : 0;
+        Assert.assertEquals(expectedCount, onCloseConfiguredCount);
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.shared.Registration;
 
 /**
  * Unit tests for the Dialog.
@@ -102,167 +101,6 @@ public class DialogTest {
         UI.setCurrent(null);
         Dialog dialog = new Dialog();
         dialog.setOpened(true);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogClosed_JavaScriptIsScheduled() {
-        Dialog dialog = new Dialog();
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        Assert.assertTrue(flushInvocations().isEmpty());
-
-        dialog.open();
-
-        assertInvocations(10);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogOpened_JavaScriptIsScheduled() {
-        Dialog dialog = new Dialog();
-
-        dialog.open();
-
-        Assert.assertEquals(9, flushInvocations().size());
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        assertInvocations(1);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_removeListener_dialogIsOpened_noJSAfterReopen() {
-        Dialog dialog = new Dialog();
-
-        Registration registration = dialog
-                .addDialogCloseActionListener(event -> {
-                });
-
-        dialog.open();
-
-        registration.remove();
-
-        dialog.close();
-
-        dialog.open();
-
-        Assert.assertEquals(9, flushInvocations().size());
-    }
-
-    @Test
-    public void addDialogCloseActionListener_removeListener_dialogIsClosed_noJSAfterReopen() {
-        Dialog dialog = new Dialog();
-
-        Registration registration = dialog
-                .addDialogCloseActionListener(event -> {
-                });
-
-        registration.remove();
-
-        dialog.open();
-
-        Assert.assertEquals(9, flushInvocations().size());
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogIsClosing_JavaScriptIsRescheduled() {
-        Dialog dialog = new Dialog();
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        dialog.open();
-
-        flushInvocations();
-
-        dialog.close();
-
-        dialog.open();
-
-        assertInvocations(1);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogClosed_severalListenersAreAdded_onlyOneJavaScriptIsScheduled() {
-        Dialog dialog = new Dialog();
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        dialog.open();
-
-        assertInvocations(10);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogClosed_twoListenersAreAddedAndOneRemoved_onlyOneJavaScriptIsScheduled() {
-        Dialog dialog = new Dialog();
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        Registration registration = dialog
-                .addDialogCloseActionListener(event -> {
-                });
-
-        dialog.open();
-
-        registration.remove();
-
-        assertInvocations(10);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogClosed_twoListenersAreAddedAndOneIsRemoved_oneJavaScriptIsScheduledAfterReopen() {
-        Dialog dialog = new Dialog();
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        Registration registration = dialog
-                .addDialogCloseActionListener(event -> {
-                });
-
-        dialog.open();
-
-        registration.remove();
-
-        flushInvocations();
-
-        dialog.close();
-
-        dialog.open();
-
-        assertInvocations(1);
-    }
-
-    @Test
-    public void addDialogCloseActionListener_dialogClosed_twoListenersAreAddedAndOneIsRemovedAfterClose_oneJavaScriptIsScheduledAfterReopen() {
-        Dialog dialog = new Dialog();
-
-        dialog.addDialogCloseActionListener(event -> {
-        });
-
-        Registration registration = dialog
-                .addDialogCloseActionListener(event -> {
-                });
-
-        dialog.open();
-
-        flushInvocations();
-
-        dialog.close();
-
-        registration.remove();
-
-        dialog.open();
-
-        assertInvocations(1);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -358,17 +196,6 @@ public class DialogTest {
 
         Div div = new Div();
         dialog.addComponentAtIndex(index, div);
-    }
-
-    private List<PendingJavaScriptInvocation> flushInvocations() {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        return ui.getInternals().dumpPendingJavaScriptInvocations();
-    }
-
-    private void assertInvocations(int expectedInvocations) {
-        List<PendingJavaScriptInvocation> invocations = flushInvocations();
-
-        Assert.assertEquals(expectedInvocations, invocations.size());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR refactors tests regarding `addDialogCloseActionListener` and `onCloseConfigured` and extracts them to a new class. The changes include renaming, updating the assertion logic, breaking down tests, and deleting unnecessary blocks. 

See: [related PR 1](https://github.com/vaadin/vaadin-dialog-flow/pull/91)
See: [related PR 2](https://github.com/vaadin/flow-components/pull/4778)

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.