### PR TITLE
refactor: preload items on grid scroll to index

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4371,6 +4371,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
+        // Preload the items for the given index
+        setRequestedRange(rowIndex, getPageSize());
+
         getElement().callJsFunction("scrollToIndex", rowIndex);
     }
 


### PR DESCRIPTION
## Description

Make Grid's `scrollToIndex` method preload the items for the target index so another server roundtrip wouldn't be needed for fetching the items.

This works as expected with `TreeGrid` also since https://github.com/vaadin/web-components/pull/5428. After https://github.com/vaadin/flow-components/issues/3505#issuecomment-1477442171 is fully implemented, we can optimize this further for `TreeGrid` specifically.

The change has a 19% impact on the `scrolltoindextime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement