### PR TITLE
refactor: ensure sub-cache for cached parents synchronously

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -32,7 +32,12 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               return;
             }
 
-            if (!this.itemCaches[scaledIndex]) {
+            const isCached = this.grid.$connector.hasCacheForParentKey(this.grid.getItemId(this.items[scaledIndex]));
+            if (isCached) {
+              // The sub-cache items are already in the connector's cache. Skip the debouncing process.
+              this.doEnsureSubCacheForScaledIndex(scaledIndex);
+            } else if (!this.itemCaches[scaledIndex]) {
+              // The items need to be fetched from the server.
               this.grid.$connector.beforeEnsureSubCacheForScaledIndex(this, scaledIndex);
             }
           });
@@ -117,6 +122,8 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         grid.itemIdPath = 'key';
 
         grid.$connector = {};
+
+        grid.$connector.hasCacheForParentKey = tryCatchWrapper((parentKey) => cache[parentKey] !== undefined);
 
         grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(() => ensureSubCacheQueue.length > 0);
 
@@ -351,18 +358,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               ensureSubCacheQueue = [];
               // Resolve the callback from cache
               callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
-
-              // Check if there are any pending requests for expanded parents that could be resolved
-              // synchronously from cache
-              const resolvableParentRequest = ensureSubCacheQueue.find(({ itemkey }) => cache[itemkey]);
-              if (resolvableParentRequest) {
-                // Found a resolvable parent request, remove all pending requests as fresh ones will be
-                // created once the callback executes
-                ensureSubCacheQueue = [];
-
-                // Synchronously make a page load request for the resolvable parent request
-                resolvableParentRequest.cache.doEnsureSubCacheForScaledIndex(resolvableParentRequest.scaledIndex);
-              }
             } else {
               treePageCallbacks[parentUniqueKey][page] = callback;
 


### PR DESCRIPTION
## Description

Skip the debouncing on ensureSubCache if the parentItem is already in the connector's cache.

The change has a 4% impact on the `expandedrendertime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement