### PR TITLE
fix: Lazy init of disable on click

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -361,8 +361,8 @@ public class Button extends Component
      * if server-side handling takes some time.
      */
     private void initDisableOnClick() {
-        getElement().executeJs(
-                "window.Vaadin.Flow.button.initDisableOnClick($0)");
+        getElement()
+                .executeJs("window.Vaadin.Flow.button.initDisableOnClick($0)");
     }
 
     private void updateIconSlot() {

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -20,7 +20,6 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasEnabled;

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -57,6 +57,7 @@ import java.util.stream.Stream;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/button", version = "24.1.0-alpha5")
 @JsModule("@vaadin/button/src/vaadin-button.js")
+@JsModule("./buttonFunctions.js")
 public class Button extends Component
         implements ClickNotifier<Button>, Focusable<Button>, HasAriaLabel,
         HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix, HasText,
@@ -65,6 +66,7 @@ public class Button extends Component
     private Component iconComponent;
     private boolean iconAfterText;
     private boolean disableOnClick = false;
+    private boolean disableInited = false;
 
     // Register immediately as first listener
     private Registration disableListener = addClickListener(
@@ -340,6 +342,7 @@ public class Button extends Component
         this.disableOnClick = disableOnClick;
         if (disableOnClick) {
             getElement().setAttribute("disableOnClick", "true");
+            initDisableOnClick();
         } else {
             getElement().removeAttribute("disableOnClick");
         }
@@ -359,10 +362,15 @@ public class Button extends Component
      * if server-side handling takes some time.
      */
     private void initDisableOnClick() {
-        getElement().executeJs("var disableEvent = function () {"
-                + "if($0.getAttribute('disableOnClick')){"
-                + " $0.setAttribute('disabled', 'true');" + "}" + "};"
-                + "$0.addEventListener('click', disableEvent)");
+        if(!disableInited) {
+            getElement().executeJs(
+                    "window.Vaadin.Flow.button.initDisableOnClick($0)");
+            disableInited = true;
+        }
+//        var disableEvent = function () {"
+//                + "if($0.getAttribute('disableOnClick')){"
+//                + " $0.setAttribute('disabled', 'true');" + "}" + "};"
+//                + "$0.addEventListener('click', disableEvent)");
     }
 
     private void updateIconSlot() {
@@ -462,7 +470,9 @@ public class Button extends Component
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
-        initDisableOnClick();
+        if (isDisableOnClick()) {
+            initDisableOnClick();
+        }
     }
 
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -66,6 +67,7 @@ public class Button extends Component
     private Component iconComponent;
     private boolean iconAfterText;
     private boolean disableOnClick = false;
+    private PendingJavaScriptResult initDisableOnClick;
 
     // Register immediately as first listener
     private Registration disableListener = addClickListener(
@@ -361,8 +363,13 @@ public class Button extends Component
      * if server-side handling takes some time.
      */
     private void initDisableOnClick() {
-        getElement()
-                .executeJs("window.Vaadin.Flow.button.initDisableOnClick($0)");
+        if (initDisableOnClick == null) {
+            initDisableOnClick = getElement().executeJs(
+                    "window.Vaadin.Flow.button.initDisableOnClick($0)");
+            getElement().getNode()
+                    .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                            executionContext -> this.initDisableOnClick = null));
+        }
     }
 
     private void updateIconSlot() {

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasEnabled;
@@ -66,7 +67,6 @@ public class Button extends Component
     private Component iconComponent;
     private boolean iconAfterText;
     private boolean disableOnClick = false;
-    private boolean disableInited = false;
 
     // Register immediately as first listener
     private Registration disableListener = addClickListener(
@@ -362,11 +362,8 @@ public class Button extends Component
      * if server-side handling takes some time.
      */
     private void initDisableOnClick() {
-        if (!disableInited) {
-            getElement().executeJs(
-                    "window.Vaadin.Flow.button.initDisableOnClick($0)");
-            disableInited = true;
-        }
+        getElement().executeJs(
+                "window.Vaadin.Flow.button.initDisableOnClick($0)");
     }
 
     private void updateIconSlot() {
@@ -470,5 +467,4 @@ public class Button extends Component
             initDisableOnClick();
         }
     }
-
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -362,15 +362,11 @@ public class Button extends Component
      * if server-side handling takes some time.
      */
     private void initDisableOnClick() {
-        if(!disableInited) {
+        if (!disableInited) {
             getElement().executeJs(
                     "window.Vaadin.Flow.button.initDisableOnClick($0)");
             disableInited = true;
         }
-//        var disableEvent = function () {"
-//                + "if($0.getAttribute('disableOnClick')){"
-//                + " $0.setAttribute('disabled', 'true');" + "}" + "};"
-//                + "$0.addEventListener('click', disableEvent)");
     }
 
     private void updateIconSlot() {

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
@@ -1,12 +1,12 @@
+function disableOnClickListener({currentTarget: button}) {
+  button.disabled = button.hasAttribute('disableOnClick');
+}
+
 window.Vaadin.Flow.button = {
   initDisableOnClick: (button) => {
     if (!button.__hasDisableOnClickListener) {
-      button.addEventListener('click', disableOnClickListener(button));
+      button.addEventListener('click', disableOnClickListener);
       button.__hasDisableOnClickListener = true;
     }
   }
-}
-
-function disableOnClickListener({currentTarget: button}) {
-  button.disabled = button.hasAttribute('disableOnClick');
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
@@ -1,10 +1,12 @@
 window.Vaadin.Flow.button = {
-  initDisableOnClick: (target) => {
-    const disableEvent = function (target) {
-      if (target.getAttribute('disableOnClick')) {
-        target.setAttribute('disabled', 'true');
-      }
-    };
-    target.addEventListener('click', disableEvent)
+  initDisableOnClick: (button) => {
+    if (!button.__hasDisableOnClickListener) {
+      button.addEventListener('click', disableOnClickListener(button));
+      button.__hasDisableOnClickListener = true;
+    }
   }
+}
+
+function disableOnClickListener({currentTarget: button}) {
+  button.disabled = button.hasAttribute('disableOnClick');
 }

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
@@ -1,0 +1,10 @@
+window.Vaadin.Flow.button = {
+  initDisableOnClick: (target) => {
+    const disableEvent = function (target) {
+      if (target.getAttribute('disableOnClick')) {
+        target.setAttribute('disabled', 'true');
+      }
+    };
+    target.addEventListener('click', disableEvent)
+  }
+}

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -17,18 +17,21 @@ package com.vaadin.flow.component.button.tests;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.vaadin.flow.component.HasAriaLabel;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
@@ -342,6 +345,28 @@ public class ButtonTest {
 
         Assert.assertTrue(button.getAriaLabel().isPresent());
         Assert.assertEquals("Aria label", button.getAriaLabel().get());
+    }
+
+    @Test
+    public void initDisableOnClick_onlyCalledOnceForSeverRoundtrip() {
+        final Element element = Mockito.mock(Element.class);
+        StateNode node = new StateNode();
+        button = Mockito.spy(Button.class);
+
+        Mockito.when(button.getElement()).thenReturn(element);
+
+        Mockito.when(element.executeJs(Mockito.anyString()))
+                .thenReturn(Mockito.mock(PendingJavaScriptInvocation.class));
+        Mockito.when(element.getComponent()).thenReturn(Optional.of(button));
+        Mockito.when(element.getParent()).thenReturn(null);
+        Mockito.when(element.getNode()).thenReturn(node);
+
+        button.setDisableOnClick(true);
+        button.setDisableOnClick(false);
+        button.setDisableOnClick(true);
+
+        Mockito.verify(element, Mockito.times(1))
+                .executeJs("window.Vaadin.Flow.button.initDisableOnClick($0)");
     }
 
     private void assertButtonHasThemeAttribute(String theme) {


### PR DESCRIPTION
## Description

Only init disable on click
if actually enabled for button.
Move function to buttonFunctions.js
so each button only needs to call the function.

Moving function makes 5000 buttons request
0.5 MB smaller and lazy init to only calll
method for disbleOnClick buttons drops 1MB
from the request.
