### PR TITLE
test: force the legacy Chrome headless mode

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -11,7 +11,7 @@ public abstract class AbstractComponentIT
 
     @Override
     protected void updateHeadlessChromeOptions(ChromeOptions options) {
-        // Force legacy Chrome headless mode for the time being,
+        // Force the legacy Chrome headless mode for the time being,
         // as `--headless=new` has an issue that doesn't allow
         // tests to adjust the browser window size with
         // `getDriver().manage().window().setSize(...)`.

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -1,6 +1,10 @@
 package com.vaadin.tests;
 
+import java.util.List;
+import java.util.Map;
+
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 public abstract class AbstractComponentIT
         extends com.vaadin.flow.testutil.AbstractComponentIT {
@@ -10,13 +14,22 @@ public abstract class AbstractComponentIT
     }
 
     @Override
-    protected void updateHeadlessChromeOptions(ChromeOptions options) {
-        // Force the legacy Chrome headless mode for the time being,
-        // as `--headless=new` has an issue that doesn't allow
-        // tests to adjust the browser window size with
-        // `getDriver().manage().window().setSize(...)`.
-        // See more https://github.com/SeleniumHQ/selenium/issues/11706
-        options.addArguments("--headless");
+    protected List<DesiredCapabilities> customizeCapabilities(
+            List<DesiredCapabilities> capabilities) {
+        // This method is overridden to force the legacy Chrome headless mode
+        // for the time being. The new `--headless=new` mode has an issue
+        // that doesn't allow tests to adjust the browser window size with
+        // `getDriver().manage().window().setSize(...)`, see more:
+        // https://github.com/SeleniumHQ/selenium/issues/11706
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--headless", "--disable-gpu");
+
+        capabilities.stream()
+                .filter(cap -> "chrome".equalsIgnoreCase(cap.getBrowserName()))
+                .forEach(cap -> cap.setCapability(ChromeOptions.CAPABILITY,
+                        chromeOptions));
+
+        return capabilities;
     }
 
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -1,10 +1,22 @@
 package com.vaadin.tests;
 
+import org.openqa.selenium.chrome.ChromeOptions;
+
 public abstract class AbstractComponentIT
         extends com.vaadin.flow.testutil.AbstractComponentIT {
 
     protected int getDeploymentPort() {
         return 8080;
+    }
+
+    @Override
+    protected void updateHeadlessChromeOptions(ChromeOptions options) {
+        // Force legacy Chrome headless mode for the time being,
+        // as `--headless=new` has an issue that doesn't allow
+        // tests to adjust the browser window size with
+        // `getDriver().manage().window().setSize(...)`.
+        // See more https://github.com/SeleniumHQ/selenium/issues/11706
+        options.addArguments("--headless");
     }
 
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -1,7 +1,6 @@
 package com.vaadin.tests;
 
 import java.util.List;
-import java.util.Map;
 
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;


### PR DESCRIPTION
## Description

The PR forces the legacy Chrome headless mode until https://github.com/SeleniumHQ/selenium/issues/11706 is resolved. That issue doesn't let tests adjust the browser window size with `getDriver().manage().window().setSize(...)` which results in their failure.

Related to https://github.com/vaadin/flow/pull/15865

## Type of change

- [x] Internal
