### PR TITLE
fix: restore input value when setting a non-empty value (#4834) (CP: 23.3)

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValuePage.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.textfield.tests;
 
+import java.math.BigDecimal;
+
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
@@ -8,6 +10,7 @@ import com.vaadin.flow.component.textfield.BigDecimalField;
 @Route("vaadin-big-decimal-field/clear-value")
 public class BigDecimalFieldClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public BigDecimalFieldClearValuePage() {
         BigDecimalField bigDecimalField = new BigDecimalField();
@@ -16,6 +19,13 @@ public class BigDecimalFieldClearValuePage extends Div {
         clearButton.setId(CLEAR_BUTTON);
         clearButton.addClickListener(event -> bigDecimalField.clear());
 
-        add(bigDecimalField, clearButton);
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    bigDecimalField.clear();
+                    bigDecimalField.setValue(BigDecimal.valueOf(12.34));
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
+
+        add(bigDecimalField, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
@@ -11,6 +11,7 @@ import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 import static com.vaadin.flow.component.textfield.tests.BigDecimalFieldClearValuePage.CLEAR_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.BigDecimalFieldClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 
 @TestPath("vaadin-big-decimal-field/clear-value")
 public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
@@ -41,5 +42,12 @@ public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
 
         $("button").id(CLEAR_BUTTON).click();
         Assert.assertEquals("", input.getPropertyString("value"));
+    }
+
+    @Test
+    public void badInput_setInputValue_clearAndSetValue_inputValueIsPresent() {
+        bigDecimalField.sendKeys("--2", Keys.ENTER);
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("12.34", input.getPropertyString("value"));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -373,6 +373,12 @@ public class BigDecimalField
                 && Objects.equals(value, getEmptyValue())) {
             // Clear the input element from possible bad input.
             getElement().executeJs("this.inputElement.value = ''");
+        } else {
+            // Restore the input element's value in case it was cleared
+            // in the above branch. That can happen when setValue(null)
+            // and setValue(...) are subsequently called within one round-trip
+            // and there was bad input.
+            getElement().executeJs("this.inputElement.value = this.value");
         }
     }
 


### PR DESCRIPTION
## Description

A manual cherry-pick of the following fix to `23.3`:

- #4834

## Type of change

- [x] Bugfix
