### PR TITLE
refactor: avoid an extra render on grid connector confirm parent

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
@@ -62,7 +62,7 @@ describe('grid connector - tree', () => {
     await nextFrame();
 
     // This number may come down from further optimization
-    expect(spy.callCount).to.equal(3);
+    expect(spy.callCount).to.equal(2);
   });
 
   it('should not compute column auto-width prematurely', async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -865,14 +865,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           }
           // Let server know we're done
           grid.$server.confirmParentUpdate(id, parentKey);
-
-          if (!grid.loading) {
-            grid.__confirmParentUpdateDebouncer = Debouncer.debounce(
-              grid.__confirmParentUpdateDebouncer,
-              microTask,
-              () => grid.__updateVisibleRows()
-            );
-          }
         });
 
         grid.$connector.confirm = tryCatchWrapper(function (id) {


### PR DESCRIPTION
## Description

Remove an unnecessary manual `grid.__updateVisibleRows()` call in grid connector's `confirmParent` as suggested [here](https://github.com/vaadin/flow-components/pull/4739#discussion_r1116999850).

The change has a 4% impact on the `expandedrendertime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement