### PR TITLE
refactor: make TextRenderer extend BasicRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/TextRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/TextRenderer.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.data.renderer;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.function.ValueProvider;
 
 /**
  * A renderer that renders each item as a text using provided
@@ -31,7 +31,7 @@ import com.vaadin.flow.function.SerializableSupplier;
  *            component
  *
  */
-public class TextRenderer<ITEM> extends ComponentRenderer<Component, ITEM> {
+public class TextRenderer<ITEM> extends BasicRenderer<ITEM, ITEM> {
 
     private static class TextRendererComponent extends Component {
 
@@ -58,15 +58,13 @@ public class TextRenderer<ITEM> extends ComponentRenderer<Component, ITEM> {
      *            the item label generator
      */
     public TextRenderer(ItemLabelGenerator<ITEM> itemLabelGenerator) {
-        super((SerializableSupplier<Component>) null);
+        super(ValueProvider.identity());
         this.itemLabelGenerator = itemLabelGenerator;
-
-        withProperty("label", item -> itemLabelGenerator.apply(item));
     }
 
     @Override
     public Component createComponent(ITEM item) {
-        String text = itemLabelGenerator.apply(item);
+        String text = getFormattedValue(item);
         if (text == null) {
             throw new IllegalStateException(String.format(
                     "Got 'null' as a label value for the item '%s'. "
@@ -88,5 +86,15 @@ public class TextRenderer<ITEM> extends ComponentRenderer<Component, ITEM> {
      */
     protected Element createElement(String item) {
         return new Element("span").setText(item);
+    }
+
+    @Override
+    protected String getFormattedValue(ITEM item) {
+        return itemLabelGenerator.apply(item);
+    }
+
+    @Override
+    protected String getTemplateExpression() {
+        return "<span>${item.label}</span>";
     }
 }


### PR DESCRIPTION
## Description

Users might assume that using a built-in renderer such as the `TextRenderer` in the `Grid` columns would work fast. However, `TextRenderer` is currently a `ComponentRenderer` which makes it unnecessarily heavy for its purpose with components that support client-side rendering such as `Grid`.

This PR refactors `TextRenderer` to be a `BasicRenderer` which is a hybrid type renderer that works as a
- `ComponentRenderer` for components that render `Component`s on the server-side (RadioButtonGroup...)
- `LitRenderer` for components that support client-side renderering (Grid...)

## Type of change

Refactor / Performance enhancement