### PR TITLE
fix: wait until content visible in notification element

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NotificationView.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/main/java/com/vaadin/flow/component/notification/tests/NotificationView.java
@@ -64,8 +64,9 @@ public class NotificationView extends Div {
     private void createNotificationWithPosition() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
         Notification notification = new Notification(
-                "This notification is located on Top-Left", 3000,
-                Position.TOP_START);
+                new Span("This notification is located on Top-Left"));
+        notification.setDuration(3000);
+        notification.setPosition(Position.TOP_START);
         button.addClickListener(event -> notification.open());
         button.setId("position-notification-button");
         notification.setId("position-notification");

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.component.notification.testbench.NotificationElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
@@ -54,6 +55,10 @@ public class NotificationIT extends AbstractComponentIT {
     public void notificationWithPosition() {
         findElement(By.id("position-notification-button")).click();
         checkNotificationIsOpen();
+        var notification = $(NotificationElement.class)
+                .id("position-notification");
+        Assert.assertEquals("This notification is located on Top-Left",
+                notification.getText());
         assertNotificationContent("Top-Left");
         Assert.assertEquals(1,
                 findElements(By.id("position-notification")).size());

--- a/vaadin-notification-flow-parent/vaadin-notification-testbench/src/main/java/com/vaadin/flow/component/notification/testbench/NotificationElement.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-testbench/src/main/java/com/vaadin/flow/component/notification/testbench/NotificationElement.java
@@ -67,10 +67,10 @@ public class NotificationElement extends TestBenchElement {
         try {
             // Wait until the content becomes visible
             waitUntil(driver -> {
-                var hasVisbleText = !card.getText().isEmpty();
+                var hasVisibleText = !card.getText().isEmpty();
                 var hasVisibleChildren = card.findElements(By.cssSelector("*"))
                         .stream().anyMatch(element -> element.isDisplayed());
-                return hasVisbleText || hasVisibleChildren;
+                return hasVisibleText || hasVisibleChildren;
             }, 1);
         } catch (TimeoutException e) {
             // Ignore, the card may be empty on purpose

--- a/vaadin-notification-flow-parent/vaadin-notification-testbench/src/main/java/com/vaadin/flow/component/notification/testbench/NotificationElement.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-testbench/src/main/java/com/vaadin/flow/component/notification/testbench/NotificationElement.java
@@ -71,7 +71,7 @@ public class NotificationElement extends TestBenchElement {
                 var hasVisibleChildren = card.findElements(By.cssSelector("*"))
                         .stream().anyMatch(element -> element.isDisplayed());
                 return hasVisbleText || hasVisibleChildren;
-            }, 100);
+            }, 1);
         } catch (TimeoutException e) {
             // Ignore, the card may be empty on purpose
         }

--- a/vaadin-notification-flow-parent/vaadin-notification-testbench/src/main/java/com/vaadin/flow/component/notification/testbench/NotificationElement.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-testbench/src/main/java/com/vaadin/flow/component/notification/testbench/NotificationElement.java
@@ -15,8 +15,10 @@
  */
 package com.vaadin.flow.component.notification.testbench;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.TimeoutException;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
@@ -60,6 +62,19 @@ public class NotificationElement extends TestBenchElement {
      * @return the card for the notification
      */
     private TestBenchElement getCard() {
-        return getPropertyElement("_card");
+        var card = getPropertyElement("_card");
+
+        try {
+            // Wait until the content becomes visible
+            waitUntil(driver -> {
+                var hasVisbleText = !card.getText().isEmpty();
+                var hasVisibleChildren = card.findElements(By.cssSelector("*"))
+                        .stream().anyMatch(element -> element.isDisplayed());
+                return hasVisbleText || hasVisibleChildren;
+            }, 100);
+        } catch (TimeoutException e) {
+            // Ignore, the card may be empty on purpose
+        }
+        return card;
     }
 }


### PR DESCRIPTION
## Description

If a `Notification` is being animated open and it contains text, `WebElement.getText()` may still return empty if the notification card hasn't become fully visible yet. This manifests especially with Notifications that are positioned at the top of the screen so that they slide down until visible.

This PR works around the issue by making `getCard()` wait until the notification content is considered visible.

Fixes https://github.com/vaadin/flow-components/issues/4921

## Type of change

- Bugfix