### PR TITLE
fix: remove old node when nodeid is not defined

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
@@ -53,4 +53,18 @@ describe('flow-component-renderer', () => {
 
     expect(container.firstElementChild).to.equal(element);
   });
+
+  it('should remove old node', async () => {
+    const container = fixtureSync<HTMLDivElement>(`<div></div>`);
+    const element = document.createElement('div');
+    elements[0] = element;
+
+    render(html`${window.Vaadin.FlowComponentHost.getNode('ROOT', 0)}`, container);
+    await nextFrame();
+    expect(container.firstElementChild).to.equal(element);
+
+    render(html`${window.Vaadin.FlowComponentHost.getNode('ROOT', undefined)}`, container);
+    await nextFrame();
+    expect(container.firstElementChild).to.equal(null);
+  });
 });

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -18,16 +18,19 @@ class FlowComponentDirective extends Directive {
   updateContent(part, appid, nodeid) {
     const { parentNode, startNode } = part;
 
-    const newNode = this.getNewNode(appid, nodeid);
+    const hasNewNodeId = nodeid !== undefined && nodeid !== null;
+    const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
-    if (!newNode) {
+    if (hasNewNodeId && !newNode) {
       // If the node is not found, try again later.
       setTimeout(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
-    } else if (oldNode) {
+    } else if (oldNode && newNode) {
       parentNode.replaceChild(newNode, oldNode);
+    } else if (oldNode) {
+      parentNode.removeChild(oldNode);
     } else if (newNode) {
       startNode.after(newNode);
     }


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/vaadin/flow-components/pull/4920, where removing the content of a component renderer, for example when closing a grid details cell, would not remove the existing content node.
