### PR TITLE
fix: allow unregistering event handlers through event (#4909) (CP: 23.3)

### DIFF
--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -26,8 +26,6 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -80,6 +78,9 @@ public class Details extends Component
         if (getElement().getPropertyRaw("opened") == null) {
             setOpened(false);
         }
+
+        getElement().addPropertyChangeListener("opened", event -> fireEvent(
+                new OpenedChangeEvent(this, event.isUserOriginated())));
     }
 
     /**
@@ -333,8 +334,6 @@ public class Details extends Component
      */
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
-        return getElement().addPropertyChangeListener("opened",
-                event -> listener.onComponentEvent(
-                        new OpenedChangeEvent(this, event.isUserOriginated())));
+        return addListener(OpenedChangeEvent.class, listener);
     }
 }

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
@@ -6,6 +6,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class DetailsTest {
 
     private Details details;
@@ -39,5 +41,19 @@ public class DetailsTest {
     @Test
     public void implementsHasTooltip() {
         Assert.assertTrue(details instanceof HasTooltip);
+    }
+
+    @Test
+    public void unregisterOpenedChangeListenerOnEvent() {
+        var listenerInvokedCount = new AtomicInteger(0);
+        details.addOpenedChangeListener(e -> {
+            listenerInvokedCount.incrementAndGet();
+            e.unregisterListener();
+        });
+
+        details.setOpened(true);
+        details.setOpened(false);
+
+        Assert.assertEquals(1, listenerInvokedCount.get());
     }
 }


### PR DESCRIPTION
Cherry-pick of #4909 

Only contains the changes needed to fix the regression in `Details`.