### PR TITLE
fix: run component renderer in sync

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ColumnAutoWidthPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ColumnAutoWidthPage.java
@@ -23,20 +23,15 @@ import com.vaadin.flow.router.Route;
 
 @Route("vaadin-grid/column-auto-width")
 public class ColumnAutoWidthPage extends Div {
-
-    public static final String GRID_ID = "auto-width-grid";
-
     public ColumnAutoWidthPage() {
         Grid<Person> grid = new Grid<>();
-        grid.setId(GRID_ID);
         grid.getStyle().set("--lumo-font-family",
                 "Arial, Helvetica, sans-serif");
         grid.setItems(new Person("Jorma", 2018));
 
-        grid.addComponentColumn(person -> {
-            NativeButton button = new NativeButton("F");
-            return button;
-        }).setAutoWidth(true).setHeader("A").setFlexGrow(0);
+        grid.addComponentColumn(
+                person -> new NativeButton(person.getFirstName()))
+                .setAutoWidth(true).setHeader("A").setFlexGrow(0);
         grid.addColumn(Person::getId).setHeader("B");
         grid.addColumn(
                 person -> "This is some length of text to check auto column width.")
@@ -45,6 +40,13 @@ public class ColumnAutoWidthPage extends Div {
                 .setHeader("Some long text for column header").setFlexGrow(0);
 
         add(grid);
+
+        NativeButton updateItems = new NativeButton("Update items", event -> {
+            grid.setItems(new Person("A longer firstname", 2018));
+            grid.recalculateColumnWidths();
+        });
+        updateItems.setId("update-items");
+        add(updateItems);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ColumnAutoWidthIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ColumnAutoWidthIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.tests.AbstractComponentIT;
@@ -34,11 +33,35 @@ public class ColumnAutoWidthIT extends AbstractComponentIT {
     @Before
     public void init() {
         open();
-        waitForElementPresent(By.id(ColumnAutoWidthPage.GRID_ID));
-        grid = $(GridElement.class).id(ColumnAutoWidthPage.GRID_ID);
+        grid = $(GridElement.class).waitForFirst();
         waitUntil(driver -> (Boolean) executeScript(
                 "return arguments[0]._getColumns()[0].width !== '100px'",
                 grid));
+    }
+
+    @Test
+    public void columnWidthsAreSetCorrectly() {
+        List<String> colWidths = getColumnWidths();
+
+        assertCssPixelValueCloseTo(86, colWidths.get(0));
+        assertCssPixelValueCloseTo(421, colWidths.get(2));
+        assertCssPixelValueCloseTo(243, colWidths.get(3));
+    }
+
+    @Test
+    public void updateItems_updatesComponentRendererColumnWidth() {
+        $("button").id("update-items").click();
+
+        List<String> colWidths = getColumnWidths();
+
+        assertCssPixelValueCloseTo(156, colWidths.get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getColumnWidths() {
+        return (List<String>) executeScript(
+                "return arguments[0]._getColumns().map(col => col.width)",
+                grid);
     }
 
     /**
@@ -55,17 +78,15 @@ public class ColumnAutoWidthIT extends AbstractComponentIT {
 
     /**
      * Assert that the given CSS pixel value is close to the expected value
-     * (with a margin of ±<code>delta</code>)
+     * (with a margin of ±5 pixels)
      *
      * @param expected
      *            expected value
      * @param cssValue
      *            CSS pixel value
-     * @param delta
-     *            allowed margin of deviation from the expected value
      */
-    private void assertCssPixelValueCloseTo(int expected, String cssValue,
-            int delta) {
+    private void assertCssPixelValueCloseTo(int expected, String cssValue) {
+        final int delta = 5;
         int value = cssPixelValueToInteger(cssValue);
         int min = expected - delta;
         int max = expected + delta;
@@ -74,17 +95,5 @@ public class ColumnAutoWidthIT extends AbstractComponentIT {
                 "CSS value '" + cssValue + "' does not match the expected "
                         + expected + " (±" + delta + ") pixels.",
                 valueInAllowedRange);
-    }
-
-    @Test
-    public void columnWidthsAreSetCorrectly() {
-        @SuppressWarnings("unchecked")
-        List<String> colWidths = (List<String>) executeScript(
-                "return arguments[0]._getColumns().map(col => col.width)",
-                grid);
-
-        assertCssPixelValueCloseTo(55, colWidths.get(0), 5);
-        assertCssPixelValueCloseTo(420, colWidths.get(2), 5);
-        assertCssPixelValueCloseTo(243, colWidths.get(3), 5);
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -1,5 +1,4 @@
 import { noChange } from 'lit';
-import { until } from 'lit/directives/until.js';
 import { directive, Directive, PartType } from 'lit/directive.js';
 
 class FlowComponentDirective extends Directive {
@@ -49,8 +48,6 @@ class FlowComponentDirective extends Directive {
   }
 }
 
-const flowComponentDirectiveInternal = directive(FlowComponentDirective);
-
 /**
  * Renders the given flow component node.
  *
@@ -60,6 +57,4 @@ const flowComponentDirectiveInternal = directive(FlowComponentDirective);
  * @param {number} nodeid
  * @private
  */
-export const flowComponentDirective = (appid, nodeid) => {
-  return flowComponentDirectiveInternal(appid, nodeid);
-};
+export const flowComponentDirective = directive(FlowComponentDirective);

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -52,7 +52,7 @@ class FlowComponentDirective extends Directive {
 const flowComponentDirectiveInternal = directive(FlowComponentDirective);
 
 /**
- * Renders the given flow component node asynchronously.
+ * Renders the given flow component node.
  *
  * WARNING: This directive is not intended for public use.
  *

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -61,17 +61,5 @@ const flowComponentDirectiveInternal = directive(FlowComponentDirective);
  * @private
  */
 export const flowComponentDirective = (appid, nodeid) => {
-  // Theoretically, it could return the directive synchronously.
-  // The `until` directive is used for now to work around sizing issues
-  // with ComponentRenderer. The previously used <flow-component-renderer> was
-  // asynchronous by nature and thus worked out of the box.
-  //
-  // Test in ComponentColumnWithHeightIT::shouldPositionItemsCorrectlyAfterScrollingToEnd
-  // makes sure the sizing works correctly. The sizing issue should eventually
-  // be fixed in the Virtualizer.
-  return until(
-    new Promise((resolve) => {
-      resolve(flowComponentDirectiveInternal(appid, nodeid));
-    })
-  );
+  return flowComponentDirectiveInternal(appid, nodeid);
 };


### PR DESCRIPTION
## Description

Currently the `flowComponentDirective` is wrapped into an `until` directive, which breaks the auto-width feature when refreshing items. It seems like the `until` is not needed anymore now that the logic has been refactored into its own directive, and the IT mentioned in the comment passes without it.

Fixes #4944
