### PR TITLE
test: use fixed grid height in count estimate tests

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/AbstractItemCountGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/AbstractItemCountGridPage.java
@@ -125,7 +125,8 @@ public abstract class AbstractItemCountGridPage extends VerticalLayout
     private void initGrid() {
         grid = new Grid<>();
         grid.setItems(this::fakeFetch);
-        grid.setSizeFull();
+        grid.setWidthFull();
+        grid.setHeight("1000px");
 
         grid.addColumn(ValueProvider.identity()).setHeader("Name");
     }


### PR DESCRIPTION
## Description

`ItemCountEstimateGridIT.itemCountEstimateGrid_estimateLessThanCurrentRange_estimateNotChanged` fails consistently on my system, apparently because size of the grid is tied to the size of the browser window. Let's use a fixed grid size to get a consistent setup regardless of the size of the browser window.