### PR TITLE
fix: allow unregistering event handlers through event (#4909) (CP: 14.10)

### DIFF
--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -26,8 +26,6 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasTheme;
@@ -60,6 +58,9 @@ public class Details extends Component
         if (getElement().getPropertyRaw("opened") == null) {
             setOpened(false);
         }
+
+        getElement().addPropertyChangeListener("opened", event -> fireEvent(
+                new OpenedChangeEvent(this, event.isUserOriginated())));
     }
 
     /**
@@ -255,8 +256,6 @@ public class Details extends Component
      */
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
-        return getElement().addPropertyChangeListener("opened",
-                event -> listener.onComponentEvent(
-                        new OpenedChangeEvent(this, event.isUserOriginated())));
+        return addListener(OpenedChangeEvent.class, listener);
     }
 }

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class DetailsTest {
 
     private Details details;
@@ -33,5 +35,19 @@ public class DetailsTest {
     public void summaryDefined_getSummaryText_returnsStringDefined() {
         details.setSummaryText("summary");
         Assert.assertEquals("summary", details.getSummaryText());
+    }
+
+    @Test
+    public void unregisterOpenedChangeListenerOnEvent() {
+        AtomicInteger listenerInvokedCount = new AtomicInteger(0);
+        details.addOpenedChangeListener(e -> {
+            listenerInvokedCount.incrementAndGet();
+            e.unregisterListener();
+        });
+
+        details.setOpened(true);
+        details.setOpened(false);
+
+        Assert.assertEquals(1, listenerInvokedCount.get());
     }
 }


### PR DESCRIPTION
## Description

Cherry-pick of #4909 