### PR TITLE
test: fix flaky sorting test

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreMultiSortedIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreMultiSortedIT.java
@@ -34,6 +34,8 @@ public class PreMultiSortedIT extends AbstractComponentIT {
     @Test
     public void rowsRendered() {
         GridElement grid = $(GridElement.class).first();
+        // Wait for page with "First 13" to be loaded
+        waitUntil(driver -> grid.getText().contains("First 13"));
         Assert.assertEquals("First 13", grid.getCell(5, 0).getText());
     }
 }


### PR DESCRIPTION
## Description

This test fails quite often in 14.10 and 14.9 snapshots validation. The test uses a page size of 5, and then does an assertion on row 6. Though I can't reproduce the test failure locally it's visible that it first loads the first page and then later on the remaining pages, so my guess is that at the time of the assertion row 6 might not have loaded yet. Adding a wait for the row's text to appear in the DOM should make this more reliable.