### PR TITLE
fix: add explicit reference to Chart class

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -34,6 +34,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
 
+import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.dependency.Uses;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.formula.BaseFormulaEvaluator;
@@ -109,6 +111,9 @@ import elemental.json.JsonValue;
  */
 @Tag("vaadin-spreadsheet")
 @JsModule("./vaadin-spreadsheet/vaadin-spreadsheet.js")
+// Need an explicit reference to Chart class, since the DefaultChartCreator
+// class that references it is only accessed through reflection
+@Uses(Chart.class)
 @SuppressWarnings("serial")
 public class Spreadsheet extends Component
         implements HasSize, HasStyle, Action.Container {


### PR DESCRIPTION
## Description

Currently the `Chart` class is not directly referenced from `Spreadsheet`, as the `DefaultChartCreator` class that creates  charts is not directly referenced in the spreadsheet code. This results in the chart JS sources not being included in the production bundle, and at runtime an additional fallback bundle needs to be loaded, increasing the overall amount of JS that is being loaded. Apart from that it breaks 24.1 snapshots, where the fallback bundle is (at least at this point in time) not loaded anymore.

Adding an explicit reference to the `Chart` class fixes that.
