### PR TITLE
fix: make CustomDataFormatter respect UI locale

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CustomDataFormatter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CustomDataFormatter.java
@@ -61,12 +61,14 @@ class CustomDataFormatter extends DataFormatter implements Serializable {
     private final int NEGATIVE_FORMAT_INDEX = 1;
     private final int ZERO_FORMAT_INDEX = 2;
     private final int TEXT_FORMAT_INDEX = 3;
+    private Locale locale;
 
     public CustomDataFormatter() {
     }
 
     public CustomDataFormatter(Locale locale) {
         super(locale);
+        this.locale = locale;
     }
 
     /**
@@ -108,6 +110,12 @@ class CustomDataFormatter extends DataFormatter implements Serializable {
         }
     }
 
+    @Override
+    public void updateLocale(Locale newLocale) {
+        super.updateLocale(newLocale);
+        this.locale = newLocale;
+    }
+
     private CellType getCellType(Cell cell, FormulaEvaluator evaluator) {
 
         CellType cellType = cell.getCellType();
@@ -128,7 +136,7 @@ class CustomDataFormatter extends DataFormatter implements Serializable {
 
         if (isOnlyLiteralFormat(format)) {
             // CellFormat can format literals correctly
-            return CellFormat.getInstance(format).apply(cell).text;
+            return CellFormat.getInstance(locale, format).apply(cell).text;
         } else {
             // possible minus is already taken into account in the format
             final double absValue = Math.abs(value);
@@ -181,6 +189,6 @@ class CustomDataFormatter extends DataFormatter implements Serializable {
             return "";
         }
 
-        return CellFormat.getInstance(formatString).apply(cell).text;
+        return CellFormat.getInstance(locale, formatString).apply(cell).text;
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/BuiltinFormatsTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/BuiltinFormatsTest.java
@@ -21,8 +21,12 @@ public class BuiltinFormatsTest {
 
     @Before
     public void init() {
+        setupWithLocale(Locale.US);
+    }
+
+    private void setupWithLocale(Locale locale) {
         var ui = new UI();
-        ui.setLocale(Locale.US);
+        ui.setLocale(locale);
         UI.setCurrent(ui);
 
         spreadsheet = new Spreadsheet();
@@ -120,6 +124,40 @@ public class BuiltinFormatsTest {
 
         cellStyle.setDataFormat(dataFormat.getFormat("mmm-yy"));
         Assert.assertEquals("Oct-22", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("h:mm AM/PM"));
+        Assert.assertEquals("12:00 PM", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("h:mm:ss AM/PM"));
+        Assert.assertEquals("12:00:00 PM", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("h:mm"));
+        Assert.assertEquals("12:00", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("h:mm:ss"));
+        Assert.assertEquals("12:00:00", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("m/d/yy h:mm"));
+        Assert.assertEquals("10/31/22 12:00", spreadsheet.getCellValue(cell));
+    }
+
+    @Test
+    public void cellWithDateValue_withGermanLocale_testDateFormats() {
+        setupWithLocale(Locale.GERMAN);
+
+        cell.setCellValue(LocalDateTime.of(2022, 10, 31, 12, 0));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("m/d/yy"));
+        Assert.assertEquals("10/31/22", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("d-mmm-yy"));
+        Assert.assertEquals("31-Okt.-22", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("d-mmm"));
+        Assert.assertEquals("31-Okt.", spreadsheet.getCellValue(cell));
+
+        cellStyle.setDataFormat(dataFormat.getFormat("mmm-yy"));
+        Assert.assertEquals("Okt.-22", spreadsheet.getCellValue(cell));
 
         cellStyle.setDataFormat(dataFormat.getFormat("h:mm AM/PM"));
         Assert.assertEquals("12:00 PM", spreadsheet.getCellValue(cell));


### PR DESCRIPTION
## Description

The spreadsheet `BuiltinFormatsTest` currently fails on my system, because I'm using a German system locale. Even though the test sets up `Locale.US` for the current UI, it is ignored, at least for formatting dates. Looking further the issue seems to be that `CustomDataFormatter` reuses the POI `CellFormat` in some cases, but fails to pass the configured locale to it. The issue was obscured because `Locale.US` is probably the default on most dev as well as CI environments.

Changed this to pass the configured locale and added test for formatting dates with a different locale than `Locale.US`.