### PR TITLE
refactor: remove fluency from SideNav API to align with rest of Vaadin

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
@@ -62,14 +62,11 @@ public class SideNav extends Component implements HasSize, HasStyle {
      *
      * @param sideNavItems
      *            the menu item(s) to add
-     * @return the menu for chaining
      */
-    public SideNav addItem(SideNavItem... sideNavItems) {
+    public void addItem(SideNavItem... sideNavItems) {
         for (SideNavItem sideNavItem : sideNavItems) {
             getElement().appendChild(sideNavItem.getElement());
         }
-
-        return this;
     }
 
     /**
@@ -79,29 +76,23 @@ public class SideNav extends Component implements HasSize, HasStyle {
      *
      * @param sideNavItem
      *            the menu item to remove
-     * @return the menu for chaining
      */
-    public SideNav removeItem(SideNavItem sideNavItem) {
+    public void removeItem(SideNavItem sideNavItem) {
         Optional<Component> parent = sideNavItem.getParent();
         if (parent.isPresent() && parent.get() == this) {
             getElement().removeChild(sideNavItem.getElement());
         }
-
-        return this;
     }
 
     /**
      * Removes all menu items from this item.
-     *
-     * @return this item for chaining
      */
-    public SideNav removeAllItems() {
+    public void removeAllItems() {
         final List<Element> allNavItems = getElement()
                 .getChildren().filter(element -> !Objects
                         .equals(element.getAttribute("slot"), "label"))
                 .toList();
         getElement().removeChild(allNavItems);
-        return this;
     }
 
     /**
@@ -121,11 +112,9 @@ public class SideNav extends Component implements HasSize, HasStyle {
      *
      * @param label
      *            the label to set
-     * @return this instance for chaining
      */
-    public SideNav setLabel(String label) {
+    public void setLabel(String label) {
         getLabelElement().setText(label);
-        return this;
     }
 
     private Optional<Element> getExistingLabelElement() {
@@ -163,15 +152,13 @@ public class SideNav extends Component implements HasSize, HasStyle {
      * @param collapsible
      *            true to make the whole navigation component collapsible, false
      *            otherwise
-     * @return this instance for chaining
      */
-    public SideNav setCollapsible(boolean collapsible) {
+    public void setCollapsible(boolean collapsible) {
         if (collapsible) {
             getElement().setAttribute("collapsible", "");
         } else {
             getElement().removeAttribute("collapsible");
         }
-        return this;
     }
 
     @Override

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -120,15 +120,12 @@ public class SideNavItem extends Component {
      *
      * @param sideNavItems
      *            the menu item(s) to add
-     * @return this item for chaining
      */
-    public SideNavItem addItem(SideNavItem... sideNavItems) {
+    public void addItem(SideNavItem... sideNavItems) {
         for (SideNavItem sideNavItem : sideNavItems) {
             sideNavItem.getElement().setAttribute("slot", "children");
             getElement().appendChild(sideNavItem.getElement());
         }
-
-        return this;
     }
 
     /**
@@ -138,29 +135,23 @@ public class SideNavItem extends Component {
      *
      * @param sideNavItem
      *            the menu item to remove
-     * @return this item for chaining
      */
-    public SideNavItem removeItem(SideNavItem sideNavItem) {
+    public void removeItem(SideNavItem sideNavItem) {
         Optional<Component> parent = sideNavItem.getParent();
         if (parent.isPresent() && parent.get() == this) {
             getElement().removeChild(sideNavItem.getElement());
         }
-
-        return this;
     }
 
     /**
      * Removes all menu items from this item.
-     *
-     * @return this item for chaining
      */
-    public SideNavItem removeAllItems() {
+    public void removeAllItems() {
         final List<Element> allNavItems = getElement()
                 .getChildren().filter(element -> Objects
                         .equals(element.getAttribute("slot"), "children"))
                 .toList();
         getElement().removeChild(allNavItems);
-        return this;
     }
 
     /**
@@ -179,11 +170,9 @@ public class SideNavItem extends Component {
      *
      * @param label
      *            the label to set
-     * @return this instance for chaining
      */
-    public SideNavItem setLabel(String label) {
+    public void setLabel(String label) {
         getLabelElement().setText(label);
-        return this;
     }
 
     private Optional<Element> getExistingLabelElement() {
@@ -204,11 +193,9 @@ public class SideNavItem extends Component {
      *
      * @param path
      *            the path to link to
-     * @return this instance for chaining
      */
-    public SideNavItem setPath(String path) {
+    public void setPath(String path) {
         getElement().setAttribute("path", path);
-        return this;
     }
 
     /**
@@ -216,13 +203,11 @@ public class SideNavItem extends Component {
      *
      * @param view
      *            the view to link to
-     * @return this instance for chaining
      */
-    public SideNavItem setPath(Class<? extends Component> view) {
+    public void setPath(Class<? extends Component> view) {
         String url = RouteConfiguration.forRegistry(getRouter().getRegistry())
                 .getUrl(view);
         setPath(url);
-        return this;
     }
 
     private Router getRouter() {
@@ -264,9 +249,8 @@ public class SideNavItem extends Component {
      *
      * @param icon
      *            the icon to show
-     * @return this instance for chaining
      */
-    public SideNavItem setIcon(Component icon) {
+    public void setIcon(Component icon) {
         icon.getElement().setAttribute("slot", "prefix");
         int iconElementIndex = getIconElementIndex();
         if (iconElementIndex != -1) {
@@ -274,7 +258,6 @@ public class SideNavItem extends Component {
         } else {
             getElement().appendChild(icon.getElement());
         }
-        return this;
     }
 
     /**
@@ -283,13 +266,12 @@ public class SideNavItem extends Component {
      * @param value
      *            true to expand the item, false to collapse it
      */
-    public SideNavItem setExpanded(boolean value) {
+    public void setExpanded(boolean value) {
         if (value) {
             getElement().setAttribute("expanded", "");
         } else {
             getElement().removeAttribute("expanded");
         }
-        return this;
     }
 
     @Override


### PR DESCRIPTION
## Description

Removes fluency from the SideNav API, to better align with the rest of the components.

Fixes vaadin/vcf-nav#20

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.