### PR TITLE
feat: add Dialog constructors with title parameter

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -338,6 +338,30 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
+     * Creates a dialog with given title.
+     *
+     * @param title
+     *            the title of the component
+     */
+    public Dialog(String title) {
+        this();
+        setHeaderTitle(title);
+    }
+
+    /**
+     * Creates a dialog with given title and components inside.
+     *
+     * @param title
+     *            the title of the component
+     * @param components
+     *            the components inside the dialog
+     */
+    public Dialog(String title, Component... components) {
+        this(components);
+        setHeaderTitle(title);
+    }
+
+    /**
      * Adds the given components into this dialog.
      * <p>
      * The elements in the DOM will not be children of the

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -303,4 +303,26 @@ public class DialogTest {
 
         Assert.assertEquals(1, listenerInvokedCount.get());
     }
+
+    @Test
+    public void createDialogWithTitle() {
+        String title = "Title";
+
+        var dialog = new Dialog(title);
+        Assert.assertEquals(title, dialog.getHeaderTitle());
+
+        Span content = new Span("content");
+        Span secondContent = new Span("second_content");
+        Span thirdContent = new Span("third_content");
+
+        var dialogWithComponents = new Dialog(title, content, secondContent,
+                thirdContent);
+        Assert.assertEquals(title, dialogWithComponents.getHeaderTitle());
+        Assert.assertEquals(content,
+                dialogWithComponents.getChildren().toList().get(0));
+        Assert.assertEquals(secondContent,
+                dialogWithComponents.getChildren().toList().get(1));
+        Assert.assertEquals(thirdContent,
+                dialogWithComponents.getChildren().toList().get(2));
+    }
 }


### PR DESCRIPTION
## Description

Added two constructors to Dialog Component. It is very frequent that a dialog includes a title so these constructors would help this use case. Also this way Flow Dialog would have the same signatures than V8 Window constructors helping upgrading V8 apps.

```java 
public Dialog(String title);
public Dialog(String title, Component... components);
```

Fixes #4987

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
