### PR TITLE
fix: synchronize expanded/collapsed state to server

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/main/java/com/vaadin/flow/component/sidenav/tests/SideNavHierarchyPage.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/main/java/com/vaadin/flow/component/sidenav/tests/SideNavHierarchyPage.java
@@ -107,5 +107,15 @@ public class SideNavHierarchyPage extends Div {
                 event -> navigableParent.setLabel("Changed label"));
         setLabel.setId("change-label");
         add(setLabel);
+
+        Div expandedStatePrintout = new Div();
+        expandedStatePrintout.setId("expanded-state-printout");
+        add(expandedStatePrintout);
+
+        NativeButton printExpandedState = new NativeButton(
+                "Print out expanded state", event -> expandedStatePrintout
+                        .setText(String.valueOf(navigableParent.isExpanded())));
+        printExpandedState.setId("print-expanded-state");
+        add(printExpandedState);
     }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/main/java/com/vaadin/flow/component/sidenav/tests/SideNavPage.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/main/java/com/vaadin/flow/component/sidenav/tests/SideNavPage.java
@@ -108,5 +108,15 @@ public class SideNavPage extends Div {
                 event -> sideNav.setExpanded(!sideNav.isExpanded()));
         toggleExpanded.setId("toggle-expanded");
         add(toggleExpanded);
+
+        Div expandedStatePrintout = new Div();
+        expandedStatePrintout.setId("expanded-state-printout");
+        add(expandedStatePrintout);
+
+        NativeButton printExpandedState = new NativeButton(
+                "Print out expanded state", event -> expandedStatePrintout
+                        .setText(String.valueOf(sideNav.isExpanded())));
+        printExpandedState.setId("print-expanded-state");
+        add(printExpandedState);
     }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavHierarchyIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavHierarchyIT.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.component.sidenav.testbench.SideNavElement;
 import com.vaadin.flow.component.sidenav.testbench.SideNavItemElement;
@@ -175,4 +176,21 @@ public class SideNavHierarchyIT extends AbstractComponentIT {
 
         Assert.assertEquals(navigableParent.getLabel(), "Changed label");
     }
+
+    @Test
+    public void expandItem_expandedStateSynchronized() {
+        assertExpandedStateOnServer("false");
+
+        navigableParent.clickExpandButton();
+
+        assertExpandedStateOnServer("true");
+    }
+
+    private void assertExpandedStateOnServer(String expectedState) {
+        $(NativeButtonElement.class).id("print-expanded-state").click();
+        final String expandedState = $(DivElement.class)
+                .id("expanded-state-printout").getText();
+        Assert.assertEquals(expandedState, expectedState);
+    }
+
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.component.sidenav.testbench.SideNavElement;
 import com.vaadin.flow.component.sidenav.testbench.SideNavItemElement;
@@ -155,5 +156,21 @@ public class SideNavIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("toggle-collapsible").click();
 
         Assert.assertFalse(sideNav.isCollapsible());
+    }
+
+    @Test
+    public void collapseSideNav_expandedStateSynchronized() {
+        assertExpandedStateOnServer("true");
+
+        sideNav.clickExpandButton();
+
+        assertExpandedStateOnServer("false");
+    }
+
+    private void assertExpandedStateOnServer(String expectedState) {
+        $(NativeButtonElement.class).id("print-expanded-state").click();
+        final String expandedState = $(DivElement.class)
+                .id("expanded-state-printout").getText();
+        Assert.assertEquals(expandedState, expectedState);
     }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
@@ -22,6 +22,7 @@ import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -130,6 +131,7 @@ public class SideNav extends SideNavItemContainer implements HasSize, HasStyle {
      *
      * @return true if the side navigation menu is expanded, false if collapsed
      */
+    @Synchronize(property = "collapsed", value = "collapsed-changed")
     public boolean isExpanded() {
         return !getElement().getProperty("collapsed", false);
     }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -249,6 +250,7 @@ public class SideNavItem extends SideNavItemContainer
     /**
      * @return Returns if the item is expanded or not
      */
+    @Synchronize(property = "expanded", value = "expanded-changed")
     public boolean isExpanded() {
         return getElement().getProperty("expanded", false);
     }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -36,10 +36,10 @@ public class SideNavElement extends TestBenchElement {
         // get only the direct vaadin-side-nav-item of this vaadin-side-nav
         return wrapElements(findElements(By.xpath("vaadin-side-nav-item")),
                 getCommandExecutor())
-                        .stream()
-                        .map(testBenchElement -> testBenchElement
-                                .wrap(SideNavItemElement.class))
-                        .collect(Collectors.toList());
+                .stream()
+                .map(testBenchElement -> testBenchElement
+                        .wrap(SideNavItemElement.class))
+                .collect(Collectors.toList());
     }
 
     public String getLabel() {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
@@ -35,10 +36,10 @@ public class SideNavElement extends TestBenchElement {
         // get only the direct vaadin-side-nav-item of this vaadin-side-nav
         return wrapElements(findElements(By.xpath("vaadin-side-nav-item")),
                 getCommandExecutor())
-                .stream()
-                .map(testBenchElement -> testBenchElement
-                        .wrap(SideNavItemElement.class))
-                .collect(Collectors.toList());
+                        .stream()
+                        .map(testBenchElement -> testBenchElement
+                                .wrap(SideNavItemElement.class))
+                        .collect(Collectors.toList());
     }
 
     public String getLabel() {
@@ -48,4 +49,11 @@ public class SideNavElement extends TestBenchElement {
     public boolean isCollapsible() {
         return hasAttribute("collapsible");
     }
+
+    public void clickExpandButton() {
+        final WebElement element = getWrappedElement().getShadowRoot()
+                .findElement(By.cssSelector("summary[part='label']"));
+        executeScript("arguments[0].click();", element);
+    }
+
 }


### PR DESCRIPTION
## Description

The Flow API has setExpanded() method to have the ability to programmatically expand/collapse SideNav and SideNavItems (if they have a hierarchical structure). There is also `isExpanded()` method on both components to check the expanded state. However, this method does not return correct state is user clicks on the expand/collapse button the browser. The state of the client property is not synchronized back to the server.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

