### PR TITLE
chore: update links to monorepo web-components

### DIFF
--- a/vaadin-accordion-flow-parent/README.md
+++ b/vaadin-accordion-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Accordion component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-accordion>`](https://github.com/vaadin/vaadin-accordion)
+This project is the Component wrapper implementation of [`<vaadin-accordion>`](https://github.com/vaadin/web-components/tree/main/packages/accordion)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-app-layout-flow-parent/README.md
+++ b/vaadin-app-layout-flow-parent/README.md
@@ -1,6 +1,6 @@
 # AppLayout component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-app-layout>`](https://github.com/vaadin/vaadin-app-layout)
+This project is the Component wrapper implementation of [`<vaadin-app-layout>`](https://github.com/vaadin/web-components/tree/main/packages/app-layout)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-avatar-flow-parent/README.md
+++ b/vaadin-avatar-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Avatar component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-avatar>`](https://github.com/vaadin/vaadin-avatar)
+This project is the Component wrapper implementation of [`<vaadin-avatar>`](https://github.com/vaadin/web-components/tree/main/packages/avatar)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-board-flow-parent/README.md
+++ b/vaadin-board-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Board component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-board>`](https://github.com/vaadin/vaadin-board)
+This project is the Component wrapper implementation of [`<vaadin-board>`](https://github.com/vaadin/web-components/tree/main/packages/board)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-button-flow-parent/README.md
+++ b/vaadin-button-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Button component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-button>`](https://github.com/vaadin/vaadin-button) element
+This project is the Component wrapper implementation of [`<vaadin-button>`](https://github.com/vaadin/web-components/tree/main/packages/button) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-charts-flow-parent/README.md
+++ b/vaadin-charts-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Charts component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-charts>`](https://github.com/vaadin/vaadin-charts)
+This project is the Component wrapper implementation of [`<vaadin-charts>`](https://github.com/vaadin/web-components/tree/main/packages/charts)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-checkbox-flow-parent/README.md
+++ b/vaadin-checkbox-flow-parent/README.md
@@ -1,6 +1,6 @@
 # CheckBox component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-checkbox>`](https://github.com/vaadin/vaadin-checkbox) element
+This project is the Component wrapper implementation of [`<vaadin-checkbox>`](https://github.com/vaadin/web-components/tree/main/packages/checkbox) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-combo-box-flow-parent/README.md
+++ b/vaadin-combo-box-flow-parent/README.md
@@ -1,6 +1,6 @@
 # ComboBox component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-combo-box>`](https://github.com/vaadin/vaadin-combo-box) element
+This project is the Component wrapper implementation of [`<vaadin-combo-box>`](https://github.com/vaadin/web-components/tree/main/packages/combo-box) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-confirm-dialog-flow-parent/README.md
+++ b/vaadin-confirm-dialog-flow-parent/README.md
@@ -1,6 +1,6 @@
 # ConfirmDialog component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-confirm-dialog>`](https://github.com/vaadin/vaadin-confirm-dialog)
+This project is the Component wrapper implementation of [`<vaadin-confirm-dialog>`](https://github.com/vaadin/web-components/tree/main/packages/confirm-dialog)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-context-menu-flow-parent/README.md
+++ b/vaadin-context-menu-flow-parent/README.md
@@ -1,6 +1,6 @@
 # ContextMenu component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-context-menu>`](https://github.com/vaadin/vaadin-context-menu) element
+This project is the Component wrapper implementation of [`<vaadin-context-menu>`](https://github.com/vaadin/web-components/tree/main/packages/context-menu) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-cookie-consent-flow-parent/README.md
+++ b/vaadin-cookie-consent-flow-parent/README.md
@@ -1,6 +1,6 @@
 # CookieConsent component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-cookie-consent>`](https://github.com/vaadin/vaadin-cookie-consent)
+This project is the Component wrapper implementation of [`<vaadin-cookie-consent>`](https://github.com/vaadin/web-components/tree/main/packages/cookie-consent)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-crud-flow-parent/README.md
+++ b/vaadin-crud-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Crud component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-crud>`](https://github.com/vaadin/vaadin-crud)
+This project is the Component wrapper implementation of [`<vaadin-crud>`](https://github.com/vaadin/web-components/tree/main/packages/crud)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-custom-field-flow-parent/README.md
+++ b/vaadin-custom-field-flow-parent/README.md
@@ -1,6 +1,6 @@
 # CustomField component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-custom-field>`](https://github.com/vaadin/vaadin-custom-field)
+This project is the Component wrapper implementation of [`<vaadin-custom-field>`](https://github.com/vaadin/web-components/tree/main/packages/custom-field)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-date-picker-flow-parent/README.md
+++ b/vaadin-date-picker-flow-parent/README.md
@@ -1,6 +1,6 @@
 # DatePicker component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-date-picker>`](https://github.com/vaadin/vaadin-date-picker) element
+This project is the Component wrapper implementation of [`<vaadin-date-picker>`](https://github.com/vaadin/web-components/tree/main/packages/date-picker) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-date-time-picker-flow-parent/README.md
+++ b/vaadin-date-time-picker-flow-parent/README.md
@@ -1,6 +1,6 @@
 # DateTimePicker component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-date-time-picker>`](https://github.com/vaadin/vaadin-date-time-picker) element
+This project is the Component wrapper implementation of [`<vaadin-date-time-picker>`](https://github.com/vaadin/web-components/tree/main/packages/date-time-picker) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-details-flow-parent/README.md
+++ b/vaadin-details-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Details component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-details>`](https://github.com/vaadin/vaadin-details)
+This project is the Component wrapper implementation of [`<vaadin-details>`](https://github.com/vaadin/web-components/tree/main/packages/details)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-dialog-flow-parent/README.md
+++ b/vaadin-dialog-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Dialog component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-dialog>`](https://github.com/vaadin/vaadin-dialog) element
+This project is the Component wrapper implementation of [`<vaadin-dialog>`](https://github.com/vaadin/web-components/tree/main/packages/dialog) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-form-layout-flow-parent/README.md
+++ b/vaadin-form-layout-flow-parent/README.md
@@ -1,6 +1,6 @@
 # FormLayout component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-form-layout>`](https://github.com/vaadin/vaadin-form-layout) element
+This project is the Component wrapper implementation of [`<vaadin-form-layout>`](https://github.com/vaadin/web-components/tree/main/packages/form-layout) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-grid-flow-parent/README.md
+++ b/vaadin-grid-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Grid component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-grid>`](https://github.com/vaadin/vaadin-grid) element
+This project is the Component wrapper implementation of [`<vaadin-grid>`](https://github.com/vaadin/web-components/tree/main/packages/grid) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-grid-pro-flow-parent/README.md
+++ b/vaadin-grid-pro-flow-parent/README.md
@@ -1,6 +1,6 @@
 # GridPro component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-grid-pro>`](https://github.com/vaadin/vaadin-grid-pro)
+This project is the Component wrapper implementation of [`<vaadin-grid-pro>`](https://github.com/vaadin/web-components/tree/main/packages/grid-pro)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-icons-flow-parent/README.md
+++ b/vaadin-icons-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Icons component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-icons>`](https://github.com/vaadin/vaadin-icons) element
+This project is the Component wrapper implementation of [`<vaadin-icons>`](https://github.com/vaadin/web-components/tree/main/packages/icons) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-list-box-flow-parent/README.md
+++ b/vaadin-list-box-flow-parent/README.md
@@ -1,6 +1,6 @@
 # ListBox component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-list-box>`](https://github.com/vaadin/vaadin-list-box) element
+This project is the Component wrapper implementation of [`<vaadin-list-box>`](https://github.com/vaadin/web-components/tree/main/packages/list-box) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-login-flow-parent/README.md
+++ b/vaadin-login-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Login component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-login>`](https://github.com/vaadin/vaadin-login)
+This project is the Component wrapper implementation of [`<vaadin-login>`](https://github.com/vaadin/web-components/tree/main/packages/login)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-menu-bar-flow-parent/README.md
+++ b/vaadin-menu-bar-flow-parent/README.md
@@ -1,6 +1,6 @@
 # MenuBar component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-menu-bar>`](https://github.com/vaadin/vaadin-menu-bar) element
+This project is the Component wrapper implementation of [`<vaadin-menu-bar>`](https://github.com/vaadin/web-components/tree/main/packages/menu-bar) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-notification-flow-parent/README.md
+++ b/vaadin-notification-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Notification component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-notification>`](https://github.com/vaadin/vaadin-notification) element
+This project is the Component wrapper implementation of [`<vaadin-notification>`](https://github.com/vaadin/web-components/tree/main/packages/notification) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-ordered-layout-flow-parent/README.md
+++ b/vaadin-ordered-layout-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Layout components for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-ordered-layout>`](https://github.com/vaadin/vaadin-ordered-layout) element
+This project is the Component wrapper implementation of [Vaadin ordered layout web components](https://github.com/vaadin/web-components/) (HorizontalLayout, VerticalLayout etc.)
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-progress-bar-flow-parent/README.md
+++ b/vaadin-progress-bar-flow-parent/README.md
@@ -1,6 +1,6 @@
 # ProgressBar сomponent for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-progress-bar>`](https://github.com/vaadin/vaadin-progress-bar)
+This project is the Component wrapper implementation of [`<vaadin-progress-bar>`](https://github.com/vaadin/web-components/tree/main/packages/progress-bar)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-radio-button-flow-parent/README.md
+++ b/vaadin-radio-button-flow-parent/README.md
@@ -1,6 +1,6 @@
 # RadioButtonGroup component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-radio-button>`](https://github.com/vaadin/vaadin-radio-button) element
+This project is the Component wrapper implementation of [`<vaadin-radio-button>`](https://github.com/vaadin/web-components/tree/main/packages/radio-group) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-rich-text-editor-flow-parent/README.md
+++ b/vaadin-rich-text-editor-flow-parent/README.md
@@ -1,6 +1,6 @@
 # RichTextEditor component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-rich-text-editor>`](https://github.com/vaadin/vaadin-rich-text-editor)
+This project is the Component wrapper implementation of [`<vaadin-rich-text-editor>`](https://github.com/vaadin/web-components/tree/main/packages/rich-text-editor)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-select-flow-parent/README.md
+++ b/vaadin-select-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Select component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-select>`](https://github.com/vaadin/vaadin-select)
+This project is the Component wrapper implementation of [`<vaadin-select>`](https://github.com/vaadin/web-components/tree/main/packages/select)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-split-layout-flow-parent/README.md
+++ b/vaadin-split-layout-flow-parent/README.md
@@ -1,6 +1,6 @@
 # SplitLayout component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-split-layout>`](https://github.com/vaadin/vaadin-split-layout) element
+This project is the Component wrapper implementation of [`<vaadin-split-layout>`](https://github.com/vaadin/web-components/tree/main/packages/split-layout) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-spreadsheet-flow-parent/README.md
+++ b/vaadin-spreadsheet-flow-parent/README.md
@@ -1,7 +1,6 @@
 # Spreadsheet component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-spreadsheet>`](https://github.com/vaadin/vaadin-spreadsheet)
-element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
+This project is the Component implementation of [`<vaadin-spreadsheet>`](https://vaadin.com/docs/latest/components/spreadsheet) for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application
 

--- a/vaadin-tabs-flow-parent/README.md
+++ b/vaadin-tabs-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Tabs сomponent for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-tabs>`](https://github.com/vaadin/vaadin-tabs)
+This project is the Component wrapper implementation of [`<vaadin-tabs>`](https://github.com/vaadin/web-components/tree/main/packages/tabs)
 element for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-text-field-flow-parent/README.md
+++ b/vaadin-text-field-flow-parent/README.md
@@ -1,6 +1,6 @@
 # TextField component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-text-field>`](https://github.com/vaadin/vaadin-text-field) element
+This project is the Component wrapper implementation of [`<vaadin-text-field>`](https://github.com/vaadin/web-components/tree/main/packages/text-field) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-time-picker-flow-parent/README.md
+++ b/vaadin-time-picker-flow-parent/README.md
@@ -1,6 +1,6 @@
 # TimePicker component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-time-picker>`](https://github.com/vaadin/vaadin-time-picker) element
+This project is the Component wrapper implementation of [`<vaadin-time-picker>`](https://github.com/vaadin/web-components/tree/main/packages/time-picker) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application

--- a/vaadin-upload-flow-parent/README.md
+++ b/vaadin-upload-flow-parent/README.md
@@ -1,6 +1,6 @@
 # Upload component for Vaadin Flow
 
-This project is the Component wrapper implementation of [`<vaadin-upload>`](https://github.com/vaadin/vaadin-upload) element
+This project is the Component wrapper implementation of [`<vaadin-upload>`](https://github.com/vaadin/web-components/tree/main/packages/upload) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
 ## Using the component in a Flow application


### PR DESCRIPTION
## Description

It seems that links to web components in README.md files were not updated when web components were switched to a monorepo.

This PR updates links to a monorepo `packages/` directory where applicable.
Notable exceptions from the modification pattern are:

vaadin-ordered-layout-flow-parent/README.md  - just added a generic link to monorepo
vaadin-spreadsheet-flow-parent/README.md - added only link to documentation, cause there is no web-component counterpart
vaadin-radio-button-flow-parent/README.md - used link to `radio-group`

## Type of change

- [x] Chore

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.