### PR TITLE
fix: prevent adding duplicate items to selectedItems on selection

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-multi-mode.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-multi-mode.test.ts
@@ -90,6 +90,12 @@ describe('grid connector - selection – multi mode', () => {
       expect(grid.selectedItems[1].key).to.equal('1');
     });
 
+    it('should not have duplicates in selectedItems after same item selection', () => {
+      grid.$connector.doSelection([{ key: '0' }], false);
+      grid.$connector.doSelection([{ key: '0' }], false);
+      expect(grid.selectedItems).to.have.lengthOf(1);
+    });
+
     it('should deselect items', () => {
       grid.$connector.doSelection([{ key: '0' }, { key: '1' }], false);
       grid.$connector.doDeselection([{ key: '1' }], false);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -153,14 +153,8 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             return;
           }
           if (selectionMode === 'SINGLE') {
-            grid.selectedItems = [];
             selectedKeys = {};
           }
-
-          // For single selection mode, "deselect all" selects a single item `null`,
-          // which should not end up in the selected items
-          const sanitizedItems = items.filter((item) => item !== null);
-          grid.selectedItems = grid.selectedItems.concat(sanitizedItems);
 
           items.forEach((item) => {
             if (item) {
@@ -170,11 +164,16 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
                 grid.$server.select(item.key);
               }
             }
+
+            // FYI: In single selection mode, the server can send items = [null]
+            // which means a "Deselect All" command.
             const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
             if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
               grid.activeItem = item;
             }
           });
+
+          grid.selectedItems = Object.values(selectedKeys);
         });
 
         grid.$connector.doDeselection = tryCatchWrapper(function (items, userOriginated) {


### PR DESCRIPTION
## Description

The PR updates `$connector.doSelection` to prevent adding duplicate items to `selectedItems` which can happen when selecting the same item first through the client and then through the server. Previously, possible duplicate items were removed by `$connector.updateFlatItems` but as of https://github.com/vaadin/flow-components/pull/4902 that method is no longer called on selection. Duplicate items are problematic because `$connector.doDeselection` is currently designed so that it only removes the first occurrence of an item, which can lead to UI inconsistencies as was observed in the issue.

Fixes https://github.com/vaadin/flow-components/issues/4967

## Type of change

- [x] Bugfix
