### PR TITLE
refactor: make BigDecimalField reference TextField

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
@@ -53,6 +54,7 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.1.0-alpha8")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./vaadin-big-decimal-field.js")
+@Uses(TextField.class)
 public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         implements HasThemeVariant<TextFieldVariant> {
 


### PR DESCRIPTION
## Description

`BigDecimalField` uses `vaadin-text-field` as a base for its custom web component: 
https://github.com/vaadin/flow-components/blob/876adfa0eb2097558f5f35de0eeb1aac08d959f8/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js#L19-L20

With a recent change in Flow, all pages / routes have their own bundle / chunk in production mode. As `BigDecimalField` doesn't explicitly reference `TextField`, and doesn't have annotations to include it, the `vaadin-text-field` web component might not be loaded if a page only uses big decimal fields, but no text fields. That is the case in our integration test pages which started failing due to this change.

Adding an explicit reference to `TextField` should ensure that the `vaadin-text-field` web component is loaded, even if the page doesn't contain a text field otherwise.
