### PR TITLE
feat: make RadioButtonGroup implement HasAriaLabel

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
@@ -79,7 +80,7 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/radio-group/src/vaadin-radio-group.js")
 public class RadioButtonGroup<T>
         extends AbstractSinglePropertyField<RadioButtonGroup<T>, T>
-        implements HasClientValidation,
+        implements HasAriaLabel, HasClientValidation,
         HasDataView<T, Void, RadioButtonGroupDataView<T>>, HasHelper, HasLabel,
         HasListDataView<T, RadioButtonGroupListDataView<T>>, HasSize, HasStyle,
         HasThemeVariant<RadioGroupVariant>, HasTooltip, HasValidationProperties,
@@ -507,6 +508,27 @@ public class RadioButtonGroup<T>
      */
     public String getLabel() {
         return getElement().getProperty("label");
+    }
+
+    @Override
+    public void setAriaLabel(String ariaLabel) {
+        getElement().setProperty("accessibleName", ariaLabel);
+    }
+
+    @Override
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    @Override
+    public void setAriaLabelledBy(String labelledBy) {
+        getElement().setProperty("accessibleNameRef", labelledBy);
+    }
+
+    @Override
+    public Optional<String> getAriaLabelledBy() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameRef"));
     }
 
     @SuppressWarnings("unchecked")

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.HasAriaLabel;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -454,5 +455,35 @@ public class RadioButtonGroupTest {
     public void implementsHasTooltip() {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
         Assert.assertTrue(group instanceof HasTooltip);
+    }
+
+    @Test
+    public void implementHasAriaLabel() {
+        Assert.assertTrue(
+                HasAriaLabel.class.isAssignableFrom(RadioButtonGroup.class));
+    }
+
+    @Test
+    public void setAriaLabel() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setAriaLabel("aria-label");
+
+        Assert.assertTrue(group.getAriaLabel().isPresent());
+        Assert.assertEquals("aria-label", group.getAriaLabel().get());
+
+        group.setAriaLabel(null);
+        Assert.assertTrue(group.getAriaLabel().isEmpty());
+    }
+
+    @Test
+    public void setAriaLabelledBy() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setAriaLabelledBy("aria-labelledby");
+
+        Assert.assertTrue(group.getAriaLabelledBy().isPresent());
+        Assert.assertEquals("aria-labelledby", group.getAriaLabelledBy().get());
+
+        group.setAriaLabelledBy(null);
+        Assert.assertTrue(group.getAriaLabelledBy().isEmpty());
     }
 }


### PR DESCRIPTION
## Description

Make `RadioButtonGroup` implement `HasAriaLabel` interface.


Part of https://github.com/vaadin/platform/issues/3803
Part of https://github.com/vaadin/platform/issues/3814
Part of #2946 
Blocked by https://github.com/vaadin/web-components/pull/5818
Fixes #4715

## Type of change

- [ ] Bugfix
- [X] Feature
