### PR TITLE
feat: make CheckBoxGroup implement HasAriaLabel

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasSize;
@@ -89,9 +90,10 @@ import elemental.json.JsonArray;
 @NpmPackage(value = "@vaadin/checkbox-group", version = "24.1.0-alpha9")
 @JsModule("@vaadin/checkbox-group/src/vaadin-checkbox-group.js")
 public class CheckboxGroup<T>
-        extends AbstractSinglePropertyField<CheckboxGroup<T>, Set<T>> implements
-        HasClientValidation, HasDataView<T, Void, CheckboxGroupDataView<T>>,
-        HasHelper, HasItemComponents<T>, HasLabel, HasSize, HasStyle,
+        extends AbstractSinglePropertyField<CheckboxGroup<T>, Set<T>>
+        implements HasAriaLabel, HasClientValidation,
+        HasDataView<T, Void, CheckboxGroupDataView<T>>, HasHelper,
+        HasItemComponents<T>, HasLabel, HasSize, HasStyle,
         HasListDataView<T, CheckboxGroupListDataView<T>>, HasTooltip,
         HasThemeVariant<CheckboxGroupVariant>, HasValidationProperties,
         HasValidator<Set<T>>, MultiSelect<CheckboxGroup<T>, T> {
@@ -495,6 +497,27 @@ public class CheckboxGroup<T>
      */
     public String getLabel() {
         return getElement().getProperty("label");
+    }
+
+    @Override
+    public void setAriaLabel(String ariaLabel) {
+        getElement().setProperty("accessibleName", ariaLabel);
+    }
+
+    @Override
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    @Override
+    public void setAriaLabelledBy(String labelledBy) {
+        getElement().setProperty("accessibleNameRef", labelledBy);
+    }
+
+    @Override
+    public Optional<String> getAriaLabelledBy() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameRef"));
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.data.renderer.TextRenderer;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.Assert;
@@ -613,6 +614,36 @@ public class CheckboxGroupTest {
                 ((Checkbox) components.get(0)).getLabel());
         Assert.assertEquals(secondLabel,
                 ((Checkbox) components.get(1)).getLabel());
+    }
+
+    @Test
+    public void implementHasAriaLabel() {
+        Assert.assertTrue(
+                HasAriaLabel.class.isAssignableFrom(CheckboxGroup.class));
+    }
+
+    @Test
+    public void setAriaLabel() {
+        CheckboxGroup<String> group = new CheckboxGroup<>();
+        group.setAriaLabel("aria-label");
+
+        Assert.assertTrue(group.getAriaLabel().isPresent());
+        Assert.assertEquals("aria-label", group.getAriaLabel().get());
+
+        group.setAriaLabel(null);
+        Assert.assertTrue(group.getAriaLabel().isEmpty());
+    }
+
+    @Test
+    public void setAriaLabelledBy() {
+        CheckboxGroup<String> group = new CheckboxGroup<>();
+        group.setAriaLabelledBy("aria-labelledby");
+
+        Assert.assertTrue(group.getAriaLabelledBy().isPresent());
+        Assert.assertEquals("aria-labelledby", group.getAriaLabelledBy().get());
+
+        group.setAriaLabelledBy(null);
+        Assert.assertTrue(group.getAriaLabelledBy().isEmpty());
     }
 
     /**


### PR DESCRIPTION
## Description

Make `RadioButtonGroup` implement `HasAriaLabel` interface.


Part of https://github.com/vaadin/platform/issues/3803
Part of https://github.com/vaadin/platform/issues/3814
Part of #2946 
Blocked by https://github.com/vaadin/web-components/pull/5818
Fixes #4714 

## Type of change

- [ ] Bugfix
- [X] Feature
