### PR TITLE
feat: allow setting error message for login fields

### DIFF
--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginI18n.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginI18n.java
@@ -252,6 +252,9 @@ public class LoginI18n implements Serializable {
         private String title;
         private String message;
 
+        private String username;
+        private String password;
+
         /**
          * @return current value for the title property
          */
@@ -280,6 +283,40 @@ public class LoginI18n implements Serializable {
          */
         public void setMessage(String message) {
             this.message = message;
+        }
+
+        /**
+         * @return current value for the username property
+         */
+        public String getUsername() {
+            return username;
+        }
+
+        /**
+         * Sets the error message for the username field
+         *
+         * @param username
+         *            new value for the username property
+         */
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        /**
+         * @return current value for the password property
+         */
+        public String getPassword() {
+            return password;
+        }
+
+        /**
+         * Sets the error message for the password field
+         *
+         * @param password
+         *            new value for the password property
+         */
+        public void setPassword(String password) {
+            this.password = password;
         }
     }
 

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/resources/com/vaadin/flow/component/login/i18n.json
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/resources/com/vaadin/flow/component/login/i18n.json
@@ -8,6 +8,8 @@
   },
   "errorMessage": {
     "title": "Incorrect username or password",
-    "message": "Check that you have entered the correct username and password and try again."
+    "message": "Check that you have entered the correct username and password and try again.",
+    "username": "Username is required",
+    "password": "Password is required"
   }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormI18nTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormI18nTest.java
@@ -22,6 +22,11 @@ public class LoginFormI18nTest {
                 "Check that you have entered the correct username and password and try again.",
                 i18n.getErrorMessage().getMessage());
 
-        Assert.assertEquals(null, i18n.getAdditionalInformation());
+        Assert.assertEquals("Username is required",
+                i18n.getErrorMessage().getUsername());
+        Assert.assertEquals("Password is required",
+                i18n.getErrorMessage().getPassword());
+
+        Assert.assertNull(i18n.getAdditionalInformation());
     }
 }


### PR DESCRIPTION
## Description

Follow up of https://github.com/vaadin/web-components/pull/5836.

Adds the new properties to the `LoginI18n.ErrorMessage` class.

Fixes https://github.com/vaadin/web-components/issues/101

## Type of change

- [ ] Bugfix
- [X] Feature
