### PR TITLE
fix: make empty grid clear loading state (CP: 24.0)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEmptyPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEmptyPage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.UUID;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/grid-empty")
+public class GridEmptyPage extends Div {
+
+    public GridEmptyPage() {
+        Grid<Person> grid = new Grid<>();
+        grid.setId("empty-grid");
+
+        grid.addColumn(Person::getFirstName)
+                .setKey(UUID.randomUUID().toString()).setHeader("First name")
+                .setSortable(true);
+
+        add(grid);
+
+        final Button clearCache = new Button("Clear cache",
+                event -> grid.getElement().executeJs("this.clearCache()"));
+        clearCache.setId("clear-cache-button");
+        add(clearCache);
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEmptyIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEmptyIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/grid-empty")
+public class GridEmptyIT extends AbstractComponentIT {
+
+    @Test
+    public void clearCacheOnClient_loadingStateNotSet() {
+        open();
+
+        ButtonElement clearCache = $(ButtonElement.class)
+                .id("clear-cache-button");
+        clearCache.click();
+
+        WebElement grid = findElement(By.id("empty-grid"));
+        waitUntil(driver -> "false".equals(grid.getAttribute("loading")));
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEmptyIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEmptyIT.java
@@ -15,9 +15,8 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.grid.testbench.GridElement;
 import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -31,11 +30,9 @@ public class GridEmptyIT extends AbstractComponentIT {
         open();
 
         // Force data provider request by clearing the grid's cache
-        ButtonElement clearCache = $(ButtonElement.class)
-                .id("clear-cache-button");
-        clearCache.click();
+        $(ButtonElement.class).id("clear-cache-button").click();
 
-        WebElement grid = findElement(By.id("empty-grid"));
+        GridElement grid = $(GridElement.class).id("empty-grid");
         waitUntil(driver -> "false".equals(grid.getAttribute("loading")));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEmptyIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEmptyIT.java
@@ -27,9 +27,10 @@ import com.vaadin.tests.AbstractComponentIT;
 public class GridEmptyIT extends AbstractComponentIT {
 
     @Test
-    public void clearCacheOnClient_loadingStateNotSet() {
+    public void emptyGrid_clearCache_loadingStateCleared() {
         open();
 
+        // Force data provider request by clearing the grid's cache
         ButtonElement clearCache = $(ButtonElement.class)
                 .id("clear-cache-button");
         clearCache.click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -61,10 +61,13 @@ public class SortingIT extends AbstractComponentIT {
     public void setInitialSortOrderGridHidden_showGrid_dataPresentAndSorted() {
         findElement(By.id("sort-hidden-by-age")).click();
         findElement(By.id("show-hidden-grid")).click();
-        Assert.assertEquals("B",
-                $(GridElement.class).id("hidden-grid").getCell(0, 0).getText());
-        Assert.assertEquals("A",
-                $(GridElement.class).id("hidden-grid").getCell(1, 0).getText());
+
+        GridElement hiddenGrid = $(GridElement.class).id("hidden-grid");
+
+        waitUntil(driver -> "false".equals(hiddenGrid.getAttribute("loading")));
+
+        Assert.assertEquals("B", hiddenGrid.getCell(0, 0).getText());
+        Assert.assertEquals("A", hiddenGrid.getCell(1, 0).getText());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -133,7 +133,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
         grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
 
         grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
-          return Object.keys(rootPageCallbacks).length > 0 || (rootRequestDebouncer && rootRequestDebouncer.isActive());
+          return Object.keys(rootPageCallbacks).length > 0 || (!!rootRequestDebouncer && rootRequestDebouncer.isActive());
         });
 
         grid.$connector.beforeEnsureSubCacheForScaledIndex = tryCatchWrapper(function (targetCache, scaledIndex) {
@@ -399,6 +399,18 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           } else {
             // workaround: sometimes grid-element gives page index that overflows
             page = Math.min(page, Math.floor(grid.size / grid.pageSize));
+
+            // size is controlled by the server (data communicator), so if the
+            // size is zero, we know that there is no data to fetch.
+            // This also prevents an empty grid getting stuck in a loading state.
+            // The connector does not cache empty pages, so if the grid requests
+            // data again, there would be no cache entry, causing a request to
+            // the server. However, the data communicator will never respond,
+            // as it assumes that the data is already cached.
+            if (grid.size === 0) {
+              callback([], 0);
+              return;
+            }
 
             if (cache[root] && cache[root][page]) {
               callback(cache[root][page]);


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/flow-components/pull/5040

Replaced the connector test with an integration test, as the connector test setup is not available in 24.0. The original issue was applying a server-side sort, calling `clearCache` on the grid element has the same effect to reproduce the issue.
