### PR TITLE
fix: do not serialize file output stream

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/FileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/FileBuffer.java
@@ -37,7 +37,7 @@ import com.vaadin.flow.component.upload.Receiver;
  */
 public class FileBuffer extends AbstractFileBuffer implements Receiver {
 
-    private FileData file;
+    private transient FileData file;
 
     /**
      * Creates a file buffer with a default file factory.

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
@@ -41,7 +41,7 @@ import com.vaadin.flow.component.upload.MultiFileReceiver;
 public class MultiFileBuffer extends AbstractFileBuffer
         implements MultiFileReceiver {
 
-    private Map<String, FileData> files = new HashMap<>();
+    private transient Map<String, FileData> files = new HashMap<>();
 
     /**
      * Creates a file buffer with a default file factory.

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSerializableTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSerializableTest.java
@@ -3,7 +3,10 @@ package com.vaadin.flow.component.upload.tests;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.upload.receivers.FileBuffer;
+import com.vaadin.flow.component.upload.receivers.MultiFileBuffer;
 import com.vaadin.flow.testutil.ClassesSerializableTest;
+import org.junit.Test;
 
 public class UploadSerializableTest extends ClassesSerializableTest {
     private static final UI FAKE_UI = new UI();
@@ -29,4 +32,19 @@ public class UploadSerializableTest extends ClassesSerializableTest {
         UI.setCurrent(FAKE_UI);
     }
 
+    @Test
+    public void serializeFileBuffer() throws Throwable {
+        FileBuffer fileBuffer = new FileBuffer();
+        fileBuffer.receiveUpload("foo.txt", "text/plain");
+
+        serializeAndDeserialize(fileBuffer);
+    }
+
+    @Test
+    public void serializeMultiFileBuffer() throws Throwable {
+        MultiFileBuffer multiFileBuffer = new MultiFileBuffer();
+        multiFileBuffer.receiveUpload("foo.txt", "text/plain");
+
+        serializeAndDeserialize(multiFileBuffer);
+    }
 }


### PR DESCRIPTION
## Description

Currently the file buffer implementations in `Upload` serialize the output streams of uploaded files, which can not be deserialized:
```
java.io.InvalidClassException: com.vaadin.flow.component.upload.receivers.UploadOutputStream; no valid constructor
```

This change removes the file data, and with that the output streams, from serialization. As before, uploaded files can not be retrieved after serialization + deserialization. 

Fixes https://github.com/vaadin/flow-components/issues/5039

## Type of change

- Bugfix