### PR TITLE
fix: add default for marker text baseline

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureTextPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/FeatureTextPage.java
@@ -50,6 +50,12 @@ public class FeatureTextPage extends Div {
                 });
         setTextStyle.setId("set-text-style");
 
+        NativeButton setDefaultTextStyle = new NativeButton(
+                "Set default custom text style", e -> {
+                    marker1.getStyle().setTextStyle(new TextStyle());
+                });
+        setDefaultTextStyle.setId("set-default-text-style");
+
         NativeButton updateTextStyle = new NativeButton(
                 "Update custom text style", e -> {
                     if (marker1.getStyle().getTextStyle() != null) {
@@ -67,7 +73,7 @@ public class FeatureTextPage extends Div {
 
         add(map);
         add(new Div(updateMarkerText, removeMarkerText, setTextStyle,
-                updateTextStyle, removeTextStyle));
+                setDefaultTextStyle, updateTextStyle, removeTextStyle));
     }
 
     private TextStyle createCustomTextStyle() {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureTextIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/FeatureTextIT.java
@@ -14,6 +14,7 @@ public class FeatureTextIT extends AbstractComponentIT {
     private TestBenchElement updateTextButton;
     private TestBenchElement removeTextButton;
     private TestBenchElement setTextStyleButton;
+    private TestBenchElement setDefaultTextStyle;
     private TestBenchElement updateTextStyleButton;
     private TestBenchElement removeTextStyleButton;
 
@@ -24,6 +25,8 @@ public class FeatureTextIT extends AbstractComponentIT {
         updateTextButton = $(TestBenchElement.class).id("update-marker-text");
         removeTextButton = $(TestBenchElement.class).id("remove-marker-text");
         setTextStyleButton = $(TestBenchElement.class).id("set-text-style");
+        setDefaultTextStyle = $(TestBenchElement.class)
+                .id("set-default-text-style");
         updateTextStyleButton = $(TestBenchElement.class)
                 .id("update-text-style");
         removeTextStyleButton = $(TestBenchElement.class)
@@ -109,6 +112,15 @@ public class FeatureTextIT extends AbstractComponentIT {
         Assert.assertEquals("15px sans-serif", text.getFont());
 
         waitUntil(driver -> getRenderCount() == 2);
+    }
+
+    @Test
+    public void setDefaultTextStyle_noErrors() {
+        setDefaultTextStyle.click();
+
+        waitUntil(driver -> getRenderCount() == 1);
+
+        checkLogsForErrors();
     }
 
     @Test

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/style/TextStyle.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/style/TextStyle.java
@@ -33,9 +33,9 @@ public class TextStyle extends AbstractConfigurationObject {
         rotateWithView = false;
         textAlign = TextAlign.CENTER;
         textBaseline = TextBaseline.MIDDLE;
-        fill = new Fill("#333");
-        stroke = new Stroke("#fff", 3);
         padding = 0;
+        setFill(new Fill("#333"));
+        setStroke(new Stroke("#fff", 3));
     }
 
     @Override

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/style/TextStyle.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/style/TextStyle.java
@@ -32,6 +32,7 @@ public class TextStyle extends AbstractConfigurationObject {
         rotation = 0;
         rotateWithView = false;
         textAlign = TextAlign.CENTER;
+        textBaseline = TextBaseline.MIDDLE;
         fill = new Fill("#333");
         stroke = new Stroke("#fff", 3);
         padding = 0;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/styles.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/styles.js
@@ -83,8 +83,8 @@ export function synchronizeText(target, source, context) {
   target.setScale(source.scale);
   target.setRotation(source.rotation);
   target.setRotateWithView(source.rotateWithView);
-  target.setTextAlign(convertEnumValue(source.textAlign));
-  target.setTextBaseline(convertEnumValue(source.textBaseline));
+  target.setTextAlign(source.textAlign ? convertEnumValue(source.textAlign) : undefined);
+  target.setTextBaseline(source.textBaseline ? convertEnumValue(source.textBaseline) : undefined);
   target.setFill(source.fill ? context.lookup.get(source.fill) : undefined);
   target.setStroke(source.stroke ? context.lookup.get(source.stroke) : undefined);
   target.setBackgroundFill(source.backgroundFill ? context.lookup.get(source.backgroundFill) : undefined);

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObjectTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/AbstractConfigurationObjectTest.java
@@ -253,7 +253,8 @@ public class AbstractConfigurationObjectTest {
     public void addNullableChild_ignoresNull() throws Exception {
         testConfiguration = new TestConfiguration();
         testConfiguration.addNullableChild(null);
-        Assert.assertEquals(0, testConfiguration.getChildren().size());
+        Assert.assertEquals(0,
+                ConfigurationTestUtil.getChildren(testConfiguration).size());
     }
 
     private static class TestConfiguration extends AbstractConfigurationObject {
@@ -289,17 +290,6 @@ public class AbstractConfigurationObjectTest {
         @Override
         protected void deepMarkAsDirty() {
             super.deepMarkAsDirty();
-        }
-
-        // Expose children for testing
-        @SuppressWarnings("unchecked")
-        public Set<AbstractConfigurationObject> getChildren()
-                throws IllegalArgumentException, IllegalAccessException,
-                NoSuchFieldException, SecurityException {
-            Field f = AbstractConfigurationObject.class
-                    .getDeclaredField("children");
-            f.setAccessible(true);
-            return (Set<AbstractConfigurationObject>) f.get(this);
         }
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/ConfigurationTestUtil.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/ConfigurationTestUtil.java
@@ -1,0 +1,17 @@
+package com.vaadin.flow.component.map.configuration;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+public class ConfigurationTestUtil {
+    @SuppressWarnings("unchecked")
+    public static Set<AbstractConfigurationObject> getChildren(
+            AbstractConfigurationObject configurationObject)
+            throws IllegalArgumentException, IllegalAccessException,
+            NoSuchFieldException, SecurityException {
+        Field f = AbstractConfigurationObject.class
+                .getDeclaredField("children");
+        f.setAccessible(true);
+        return (Set<AbstractConfigurationObject>) f.get(configurationObject);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/style/TextStyleTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/style/TextStyleTest.java
@@ -1,8 +1,12 @@
 package com.vaadin.flow.component.map.configuration.style;
 
+import com.vaadin.flow.component.map.configuration.AbstractConfigurationObject;
+import com.vaadin.flow.component.map.configuration.ConfigurationTestUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Set;
 
 public class TextStyleTest {
     private TextStyle textStyle;
@@ -10,6 +14,15 @@ public class TextStyleTest {
     @Before
     public void setup() {
         textStyle = new TextStyle();
+    }
+
+    @Test
+    public void defaults() throws NoSuchFieldException, IllegalAccessException {
+        // Verify initial fill and stroke are added as children
+        Set<AbstractConfigurationObject> children = ConfigurationTestUtil
+                .getChildren(textStyle);
+        Assert.assertTrue(children.contains(textStyle.getFill()));
+        Assert.assertTrue(children.contains(textStyle.getStroke()));
     }
 
     @Test


### PR DESCRIPTION
## Description

Currently `textBaseline` in `TextStyle` has no default value, which causes synchronization into the OL `Text` class to fail if the developer does not provide a custom value. 

This change adds a default, and also adapts the sync logic to handle missing values.

## Type of change

- Bugfix
