### PR TITLE
Revert "chore: fix compilation failures for new data provider API (#4982)"

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataViewTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataViewTest.java
@@ -149,11 +149,6 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
             }
 
             @Override
-            public void refreshItems(boolean b) {
-
-            }
-
-            @Override
             public Registration addDataProviderListener(
                     DataProviderListener<String> listener) {
                 return null;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -108,11 +108,6 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
             }
 
             @Override
-            public void refreshItems(boolean b) {
-
-            }
-
-            @Override
             public Registration addDataProviderListener(
                     DataProviderListener<Item> listener) {
                 return null;
@@ -186,11 +181,6 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
 
             @Override
             public void refreshAll() {
-
-            }
-
-            @Override
-            public void refreshItems(boolean b) {
 
             }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridDataViewTest.java
@@ -86,11 +86,6 @@ public class GridDataViewTest extends AbstractComponentDataViewTest {
             }
 
             @Override
-            public void refreshItems(boolean b) {
-
-            }
-
-            @Override
             public Registration addDataProviderListener(
                     DataProviderListener<Item> listener) {
                 return null;
@@ -164,11 +159,6 @@ public class GridDataViewTest extends AbstractComponentDataViewTest {
 
             @Override
             public void refreshAll() {
-
-            }
-
-            @Override
-            public void refreshItems(boolean b) {
 
             }
 

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxDataViewTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxDataViewTest.java
@@ -152,11 +152,6 @@ public class ListBoxDataViewTest extends AbstractComponentDataViewTest {
             }
 
             @Override
-            public void refreshItems(boolean b) {
-
-            }
-
-            @Override
             public Registration addDataProviderListener(
                     DataProviderListener<String> listener) {
                 return null;

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataViewTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataViewTest.java
@@ -158,11 +158,6 @@ public class RadioButtonGroupDataViewTest
             }
 
             @Override
-            public void refreshItems(boolean b) {
-
-            }
-
-            @Override
             public Registration addDataProviderListener(
                     DataProviderListener<String> listener) {
                 return null;

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectDataViewTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectDataViewTest.java
@@ -148,11 +148,6 @@ public class SelectDataViewTest extends AbstractComponentDataViewTest {
             }
 
             @Override
-            public void refreshItems(boolean b) {
-
-            }
-
-            @Override
             public Registration addDataProviderListener(
                     DataProviderListener<String> listener) {
                 return null;


### PR DESCRIPTION
## Description

The new data provider API was reverted by https://github.com/vaadin/flow/pull/16774.

## Type of change

- [x] Revert
