### PR TITLE
feat: Expose data provider setter and getters in components

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -321,15 +321,14 @@ public class CheckboxGroup<T>
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Use instead one of the {@code setItems} methods which provide access to
-     * either {@link CheckboxGroupListDataView} or
-     * {@link CheckboxGroupDataView}.
-     *
+     * Sets a generic data provider for the CheckboxGroup to use.
+     * <p>
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
+     *
+     * @param dataProvider
+     *            DataProvider instance to use, not <code>null</code>
      */
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -320,7 +320,18 @@ public class CheckboxGroup<T>
         }
     }
 
-    private void setDataProvider(DataProvider<T, ?> dataProvider) {
+    /**
+     * {@inheritDoc}
+     *
+     * Use instead one of the {@code setItems} methods which provide access to
+     * either {@link CheckboxGroupListDataView} or
+     * {@link CheckboxGroupDataView}.
+     *
+     * Use this method when none of the {@code setItems} methods are applicable,
+     * e.g. when having a data provider with filter that cannot be transformed
+     * to {@code DataProvider<T, Void>}.
+     */
+    public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
         DataViewUtils.removeComponentFilterAndSortComparator(this);
         reset();
@@ -388,11 +399,16 @@ public class CheckboxGroup<T>
     }
 
     /**
-     * Gets the data provider.
+     * Gets the data provider used by this CheckboxGroup.
      *
-     * @return the data provider, not {@code null}
+     * <p>
+     * To get information and control over the items in the CheckboxGroup, use
+     * either {@link #getListDataView()} or {@link #getGenericDataView()}
+     * instead.
+     *
+     * @return the data provider used by this CheckboxGroup
      */
-    private DataProvider<T, ?> getDataProvider() {
+    public DataProvider<T, ?> getDataProvider() {
         // dataProvider reference won't have been initialized before
         // calling from CheckboxGroup constructor
         return Optional.ofNullable(dataProvider).map(AtomicReference::get)

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -979,6 +979,55 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     // ****************************************************
 
     /**
+     * Sets a generic data provider for the ComboBox to use.
+     * <p>
+     * ComboBox triggers filtering queries based on the strings users type into
+     * the field. For this reason you need to provide the second parameter, a
+     * function which converts the filter-string typed by the user into
+     * filter-type used by your data provider. If your data provider already
+     * supports String as the filter-type, it can be used without a converter
+     * function via {@link #setItems(DataProvider)}.
+     * <p>
+     * Using this method provides the same result as using a data provider
+     * wrapped with
+     * {@link DataProvider#withConvertedFilter(SerializableFunction)}.
+     * <p>
+     * Changing the combo box's data provider resets its current value to
+     * {@code null}.
+     * <p>
+     * Use this method when none of the {@code setItems} methods are applicable,
+     * e.g. when having a data provider with filter that cannot be transformed
+     * to {@code DataProvider<T, Void>}.
+     */
+    public <C> void setDataProvider(DataProvider<TItem, C> dataProvider,
+            SerializableFunction<String, C> filterConverter) {
+        dataController.setDataProvider(dataProvider, filterConverter);
+    }
+
+    /**
+     * Sets a CallbackDataProvider using the given fetch items callback and a
+     * size callback.
+     * <p>
+     * This method is a shorthand for making a {@link CallbackDataProvider} that
+     * handles a partial {@link com.vaadin.flow.data.provider.Query Query}
+     * object.
+     * <p>
+     * Changing the combo box's data provider resets its current value to
+     * {@code null}.
+     *
+     * @param fetchItems
+     *            a callback for fetching items, not <code>null</code>
+     * @param sizeCallback
+     *            a callback for getting the count of items, not
+     *            <code>null</code>
+     * @see CallbackDataProvider
+     */
+    public void setDataProvider(ComboBox.FetchItemsCallback<TItem> fetchItems,
+            SerializableFunction<String, Integer> sizeCallback) {
+        dataController.setDataProvider(fetchItems, sizeCallback);
+    }
+
+    /**
      * Gets the data provider used by this ComboBox.
      * <p>
      * To get information and control over the items in the ComboBox, use either

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -980,6 +980,9 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
 
     /**
      * Gets the data provider used by this ComboBox.
+     * <p>
+     * To get information and control over the items in the ComboBox, use either
+     * {@link #getListDataView()} or {@link #getLazyDataView()} instead.
      *
      * @return the data provider used by this ComboBox
      */

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2501,14 +2501,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Use instead one of the {@code setItems} methods which provide access to
-     * either {@link GridListDataView} or {@link GridLazyDataView}.
-     *
+     * Sets a generic data provider for the Grid to use.
+     * <p>
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
+     *
+     * @param dataProvider
+     *            DataProvider instance to use, not <code>null</code>
      */
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         Objects.requireNonNull(dataProvider, "data provider cannot be null");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2503,8 +2503,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     /**
      * {@inheritDoc}
      *
-     * Use this method only when having a data provider with filter that cannot
-     * be transformed to {@code DataProvider<T, Void>}.
+     * Use instead one of the {@code setItems} methods which provide access to
+     * either {@link GridListDataView} or {@link GridLazyDataView}.
+     *
+     * Use this method when none of the {@code setItems} methods are applicable,
+     * e.g. when having a data provider with filter that cannot be transformed
+     * to {@code DataProvider<T, Void>}.
      */
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         Objects.requireNonNull(dataProvider, "data provider cannot be null");

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -99,14 +99,14 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Use instead one of the {@code setItems} methods which provide access to
-     * either {@link ListBoxDataView} or {@link ListBoxListDataView}.
-     *
+     * Sets a generic data provider for the ListBox to use.
+     * <p>
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
+     *
+     * @param dataProvider
+     *            DataProvider instance to use, not <code>null</code>
      */
     public void setDataProvider(DataProvider<ITEM, ?> dataProvider) {
         this.dataProvider.set(Objects.requireNonNull(dataProvider));

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -98,7 +98,17 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
                 presentationToModel, modelToPresentation);
     }
 
-    private void setDataProvider(DataProvider<ITEM, ?> dataProvider) {
+    /**
+     * {@inheritDoc}
+     *
+     * Use instead one of the {@code setItems} methods which provide access to
+     * either {@link ListBoxDataView} or {@link ListBoxListDataView}.
+     *
+     * Use this method when none of the {@code setItems} methods are applicable,
+     * e.g. when having a data provider with filter that cannot be transformed
+     * to {@code DataProvider<T, Void>}.
+     */
+    public void setDataProvider(DataProvider<ITEM, ?> dataProvider) {
         this.dataProvider.set(Objects.requireNonNull(dataProvider));
         DataViewUtils.removeComponentFilterAndSortComparator(this);
         clear();
@@ -139,11 +149,15 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     }
 
     /**
-     * Gets the data provider.
+     * Gets the data provider used by this ListBox.
      *
-     * @return the data provider, not {@code null}
+     * <p>
+     * To get information and control over the items in the ListBox, use either
+     * {@link #getListDataView()} or {@link #getGenericDataView()} instead.
+     *
+     * @return the data provider used by this ListBox
      */
-    private DataProvider<ITEM, ?> getDataProvider() {
+    public DataProvider<ITEM, ?> getDataProvider() {
         return dataProvider.get();
     }
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -307,15 +307,14 @@ public class RadioButtonGroup<T>
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Use instead one of the {@code setItems} methods which provide access to
-     * either {@link RadioButtonGroupDataView} or
-     * {@link RadioButtonGroupListDataView}.
-     *
+     * Sets a generic data provider for the RadioButtonGroup to use.
+     * <p>
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
+     *
+     * @param dataProvider
+     *            DataProvider instance to use, not <code>null</code>
      */
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -306,7 +306,18 @@ public class RadioButtonGroup<T>
         return itemEnabledProvider.test(keyMapper.get(selectedKey));
     }
 
-    private void setDataProvider(DataProvider<T, ?> dataProvider) {
+    /**
+     * {@inheritDoc}
+     *
+     * Use instead one of the {@code setItems} methods which provide access to
+     * either {@link RadioButtonGroupDataView} or
+     * {@link RadioButtonGroupListDataView}.
+     *
+     * Use this method when none of the {@code setItems} methods are applicable,
+     * e.g. when having a data provider with filter that cannot be transformed
+     * to {@code DataProvider<T, Void>}.
+     */
+    public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
         DataViewUtils.removeComponentFilterAndSortComparator(this);
         reset();
@@ -386,11 +397,16 @@ public class RadioButtonGroup<T>
     }
 
     /**
-     * Gets the data provider.
+     * Gets the data provider used by this RadioButtonGroup.
      *
-     * @return the data provider, not {@code null}
+     * <p>
+     * To get information and control over the items in the RadioButtonGroup,
+     * use either {@link #getListDataView()} or {@link #getGenericDataView()}
+     * instead.
+     *
+     * @return the data provider used by this RadioButtonGroup
      */
-    private DataProvider<T, ?> getDataProvider() {
+    public DataProvider<T, ?> getDataProvider() {
         return Optional.ofNullable(dataProvider).map(AtomicReference::get)
                 .orElse(null);
     }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -523,7 +523,17 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         return getElement().getProperty("autofocus", false);
     }
 
-    private void setDataProvider(DataProvider<T, ?> dataProvider) {
+    /**
+     * {@inheritDoc}
+     *
+     * Use instead one of the {@code setItems} methods which provide access to
+     * either {@link SelectDataView} or {@link SelectListDataView}.
+     *
+     * Use this method when none of the {@code setItems} methods are applicable,
+     * e.g. when having a data provider with filter that cannot be transformed
+     * to {@code DataProvider<T, Void>}.
+     */
+    public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
         DataViewUtils.removeComponentFilterAndSortComparator(this);
         reset();
@@ -536,9 +546,13 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     }
 
     /**
-     * Gets the data provider.
+     * Gets the data provider used by this Select.
      *
-     * @return the data provider, not {@code null}
+     * <p>
+     * To get information and control over the items in the Select, use either
+     * {@link #getListDataView()} or {@link #getGenericDataView()} instead.
+     *
+     * @return the data provider used by this Select
      */
     public DataProvider<T, ?> getDataProvider() {
         return dataProvider.get();

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -524,14 +524,14 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Use instead one of the {@code setItems} methods which provide access to
-     * either {@link SelectDataView} or {@link SelectListDataView}.
-     *
+     * Sets a generic data provider for the Select to use.
+     * <p>
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
+     *
+     * @param dataProvider
+     *            DataProvider instance to use, not <code>null</code>
      */
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);


### PR DESCRIPTION
## Description

Some components, like Grid and ComboBox, have publicly exposed `setDataProvider` and `getDataProvider` methods - others do not, and they were modified recently to have these methods private. These two methods are made public in this patch, mainly for API consistency and for letting developers use filterable data providers (non Void filter generic parameter), which is not possible with `setItems` methods in most of the components.

Motivated by a comment from user https://github.com/vaadin/flow/issues/15665#issuecomment-1527067023 and internal discussion about having public `getDataProvider` method in all components.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
