### PR TITLE
chore: fix WTR test setup

### DIFF
--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -34,6 +34,18 @@ function runTests() {
     if (fs.existsSync(`${itFolder}/${wtrTestsFolderName}`)) {
       console.log(`Installing dependencies in ${itFolder}`);
 
+      // Set up an empty node_modules and package.json before running Flow build
+      // Those will get cleaned up by `flow:build-frontend` unless they existed
+      // before, but we need them for running web-test-runner
+      const nodeModules = `${itFolder}/node_modules`;
+      const packageJson = `${itFolder}/package.json`;
+      if (!fs.existsSync(nodeModules)) {
+        fs.mkdirSync(nodeModules);
+      }
+      if (!fs.existsSync(packageJson)) {
+        fs.writeFileSync(packageJson, '{}');
+      }
+
       // Install the IT module dependencies
       execSync(`mvn -DskipTests flow:prepare-frontend flow:build-frontend`, {
         cwd: itFolder,


### PR DESCRIPTION
## Description

web-test-runner tests currently fail in snapshot validation, a recent change in Flow seems to now clean up frontend resources (package.json, node_modules) after a build, which means WTR can't load dependencies during the tests.

Ensuring that an empty node_modules / package.json exist before the Flow build fixes that because the build does not remove folders/files that existed before.