### PR TITLE
refactor: improve testbench api

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -51,23 +51,25 @@ public class SideNavIT extends AbstractComponentIT {
 
     @Test
     public void pageOpened_itemHierarchyRendered() {
-        Assert.assertEquals(2, sideNav.getItems().size());
-        Assert.assertEquals(3, sideNav.getItems().get(0).getItems().size());
-        Assert.assertEquals(2, sideNav.getItems().get(1).getItems().size());
+        Assert.assertEquals(2, sideNav.getItems(false).size());
+        Assert.assertEquals(3,
+                sideNav.getItems(false).get(0).getItems(false).size());
+        Assert.assertEquals(2,
+                sideNav.getItems(false).get(1).getItems(false).size());
     }
 
     @Test
     public void clickNonNavigableParent_childNodesDisplayed() {
         Assert.assertFalse(nonNavigableParent.isExpanded());
 
-        nonNavigableParent.navigate();
+        nonNavigableParent.click();
 
         Assert.assertTrue(nonNavigableParent.isExpanded());
     }
 
     @Test
     public void clickNavigableParent_urlChanged() {
-        navigableParent.navigate();
+        navigableParent.click();
 
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));
@@ -76,7 +78,7 @@ public class SideNavIT extends AbstractComponentIT {
     @Test
     public void clickChildOfNavigableParent_urlChanged() {
         navigableParent.clickExpandButton();
-        navigableParent.getItems().get(0).navigate();
+        navigableParent.getItems(false).get(0).click();
 
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -51,11 +51,9 @@ public class SideNavIT extends AbstractComponentIT {
 
     @Test
     public void pageOpened_itemHierarchyRendered() {
-        Assert.assertEquals(2, sideNav.getItems(false).size());
-        Assert.assertEquals(3,
-                sideNav.getItems(false).get(0).getItems(false).size());
-        Assert.assertEquals(2,
-                sideNav.getItems(false).get(1).getItems(false).size());
+        Assert.assertEquals(2, sideNav.getItems().size());
+        Assert.assertEquals(3, sideNav.getItems().get(0).getItems().size());
+        Assert.assertEquals(2, sideNav.getItems().get(1).getItems().size());
     }
 
     @Test
@@ -78,7 +76,7 @@ public class SideNavIT extends AbstractComponentIT {
     @Test
     public void clickChildOfNavigableParent_urlChanged() {
         navigableParent.clickExpandButton();
-        navigableParent.getItems(false).get(0).click();
+        navigableParent.getItems().get(0).click();
 
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -75,7 +75,7 @@ public class SideNavIT extends AbstractComponentIT {
 
     @Test
     public void clickChildOfNavigableParent_urlChanged() {
-        navigableParent.clickExpandButton();
+        navigableParent.toggle();
         navigableParent.getItems().get(0).click();
 
         Assert.assertTrue(getDriver().getCurrentUrl()
@@ -84,15 +84,15 @@ public class SideNavIT extends AbstractComponentIT {
 
     @Test
     public void clickExpandItem_itemExpanded() {
-        navigableParent.clickExpandButton();
+        navigableParent.toggle();
 
         Assert.assertTrue(navigableParent.isExpanded());
     }
 
     @Test
     public void clickExpandAndCollapse_itemCollapsed() {
-        navigableParent.clickExpandButton();
-        navigableParent.clickExpandButton();
+        navigableParent.toggle();
+        navigableParent.toggle();
 
         Assert.assertFalse(navigableParent.isExpanded());
     }
@@ -101,7 +101,7 @@ public class SideNavIT extends AbstractComponentIT {
     public void expandItem_expandedStateSynchronized() {
         assertExpandedStateOnServer("print-item-expanded-state", "false");
 
-        navigableParent.clickExpandButton();
+        navigableParent.toggle();
 
         assertExpandedStateOnServer("print-item-expanded-state", "true");
     }
@@ -110,7 +110,7 @@ public class SideNavIT extends AbstractComponentIT {
     public void collapseSideNav_expandedStateSynchronized() {
         assertExpandedStateOnServer("print-side-nav-expanded-state", "true");
 
-        sideNav.clickExpandButton();
+        sideNav.toggle();
 
         assertExpandedStateOnServer("print-side-nav-expanded-state", "false");
     }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -41,7 +41,7 @@ public class SideNavElement extends TestBenchElement {
         return hasAttribute("collapsible");
     }
 
-    public void clickExpandButton() {
+    public void toggle() {
         final WebElement element = getWrappedElement().getShadowRoot()
                 .findElement(By.cssSelector("summary[part='label']"));
         executeScript("arguments[0].click();", element);

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -51,6 +51,7 @@ public class SideNavElement extends TestBenchElement {
             throw new NoSuchElementException(
                     "Nav does not contain a toggle button", e);
         }
+        // click() on elements in shadow DOM does not work with Chrome driver
         executeScript("arguments[0].click();", element);
     }
 

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.sidenav.testbench;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -32,16 +33,6 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("vaadin-side-nav")
 public class SideNavElement extends TestBenchElement {
 
-    public List<SideNavItemElement> getItems() {
-        // get only the direct vaadin-side-nav-item of this vaadin-side-nav
-        return wrapElements(findElements(By.xpath("vaadin-side-nav-item")),
-                getCommandExecutor())
-                .stream()
-                .map(testBenchElement -> testBenchElement
-                        .wrap(SideNavItemElement.class))
-                .collect(Collectors.toList());
-    }
-
     public String getLabel() {
         return $("span").attributeContains("slot", "label").first().getText();
     }
@@ -56,4 +47,32 @@ public class SideNavElement extends TestBenchElement {
         executeScript("arguments[0].click();", element);
     }
 
+    public List<SideNavItemElement> getItems(boolean includeChildren) {
+        return getItemsStream(includeChildren).collect(Collectors.toList());
+    }
+
+    public SideNavItemElement getSelectedItem() {
+        return getItemsStream(true).filter(SideNavItemElement::isActive)
+                .findAny().orElse(null);
+    }
+
+    public SideNavItemElement getItemByLabel(String label) {
+        return getItemsStream(true)
+                .filter(item -> label.equals(item.getLabel())).findAny()
+                .orElse(null);
+    }
+
+    public SideNavItemElement getItemByPath(String path) {
+        return getItemsStream(true).filter(item -> path.equals(item.getPath()))
+                .findAny().orElse(null);
+    }
+
+    private Stream<SideNavItemElement> getItemsStream(boolean includeChildren) {
+        String xpathExp = includeChildren ? ".//vaadin-side-nav-item"
+                : "vaadin-side-nav-item";
+        return wrapElements(findElements(By.xpath(xpathExp)),
+                getCommandExecutor()).stream()
+                .map(testBenchElement -> testBenchElement
+                        .wrap(SideNavItemElement.class));
+    }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.TestBenchElement;
@@ -42,8 +43,14 @@ public class SideNavElement extends TestBenchElement {
     }
 
     public void toggle() {
-        final WebElement element = getWrappedElement().getShadowRoot()
-                .findElement(By.cssSelector("summary[part='label']"));
+        final WebElement element;
+        try {
+            element = getWrappedElement().getShadowRoot()
+                    .findElement(By.cssSelector("summary[part='label']"));
+        } catch (NoSuchElementException e) {
+            throw new NoSuchElementException(
+                    "Nav does not contain a toggle button", e);
+        }
         executeScript("arguments[0].click();", element);
     }
 

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -47,8 +47,12 @@ public class SideNavElement extends TestBenchElement {
         executeScript("arguments[0].click();", element);
     }
 
-    public List<SideNavItemElement> getItems(boolean includeChildren) {
-        return getItemsStream(includeChildren).collect(Collectors.toList());
+    public List<SideNavItemElement> getItems() {
+        return getItems(false);
+    }
+
+    public List<SideNavItemElement> getItems(boolean includeNestedItems) {
+        return getItemsStream(includeNestedItems).collect(Collectors.toList());
     }
 
     public SideNavItemElement getSelectedItem() {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -32,8 +32,12 @@ import org.openqa.selenium.WebElement;
 @Element("vaadin-side-nav-item")
 public class SideNavItemElement extends TestBenchElement {
 
-    public List<SideNavItemElement> getItems(boolean includeChildren) {
-        return getItemsStream(includeChildren).collect(Collectors.toList());
+    public List<SideNavItemElement> getItems() {
+        return getItems(false);
+    }
+
+    public List<SideNavItemElement> getItems(boolean includeNestedItems) {
+        return getItemsStream(includeNestedItems).collect(Collectors.toList());
     }
 
     public String getLabel() {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -65,12 +65,12 @@ public class SideNavItemElement extends TestBenchElement {
         click(1, 1);
     }
 
-    public void clickAnchor() {
+    public void navigate() {
         executeScript("arguments[0].click();", getWrappedElement()
                 .getShadowRoot().findElement((By.cssSelector("a"))));
     }
 
-    public void clickExpandButton() {
+    public void toggle() {
         executeScript("arguments[0].click();",
                 getWrappedElement().getShadowRoot().findElement(
                         By.cssSelector("button[part='toggle-button']")));

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.By;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -66,14 +67,28 @@ public class SideNavItemElement extends TestBenchElement {
     }
 
     public void navigate() {
-        executeScript("arguments[0].click();", getWrappedElement()
-                .getShadowRoot().findElement((By.cssSelector("a"))));
+        WebElement anchorElement;
+        try {
+            anchorElement = getWrappedElement().getShadowRoot()
+                    .findElement((By.cssSelector("a")));
+        } catch (NoSuchElementException e) {
+            throw new NoSuchElementException("Item does not contain an anchor",
+                    e);
+        }
+        executeScript("arguments[0].click();", anchorElement);
     }
 
     public void toggle() {
-        executeScript("arguments[0].click();",
-                getWrappedElement().getShadowRoot().findElement(
-                        By.cssSelector("button[part='toggle-button']")));
+        WebElement toggleButtonElement;
+        try {
+            toggleButtonElement = getWrappedElement().getShadowRoot()
+                    .findElement(
+                            By.cssSelector("button[part='toggle-button']"));
+        } catch (NoSuchElementException e) {
+            throw new NoSuchElementException(
+                    "Item does not contain a toggle button", e);
+        }
+        executeScript("arguments[0].click();", toggleButtonElement);
     }
 
     private Stream<SideNavItemElement> getItemsStream(boolean includeChildren) {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -75,6 +75,7 @@ public class SideNavItemElement extends TestBenchElement {
             throw new NoSuchElementException("Item does not contain an anchor",
                     e);
         }
+        // click() on elements in shadow DOM does not work with Chrome driver
         executeScript("arguments[0].click();", anchorElement);
     }
 
@@ -88,6 +89,7 @@ public class SideNavItemElement extends TestBenchElement {
             throw new NoSuchElementException(
                     "Item does not contain a toggle button", e);
         }
+        // click() on elements in shadow DOM does not work with Chrome driver
         executeScript("arguments[0].click();", toggleButtonElement);
     }
 


### PR DESCRIPTION
## Description

This PR addresses some shortcomings and issues discovered during the Start integration of `SideNav`. 

Improvements regarding item access through the component:
- `includeChildren` option for `SideNavElement.getItems`
- querying items with the new `SideNavElement.getItemByPath` and `SideNavElement.getItemByLabel`
- getting the active item with the new `SideNavElement.getSelectedItem`

Improvements regarding the individual items:
- `includeChildren` option for `SideNavItemElement.getItems`
- a separate way of clicking the anchor via `SideNavItemElement.clickAnchor`
- `SideNavItemElement.navigate` was renamed to `SideNavItemElement.click` (overrides the regular `click`)
- getting the path via `SideNavItemElement.getPath`
- bug fix in `SideNavItemElement.getLabel`


Note: Should be back-ported to v24.1.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.