### PR TITLE
feat: add constants for warning colors in Lumo Utility Classes

### DIFF
--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/LumoUtility.java
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/LumoUtility.java
@@ -206,8 +206,10 @@ public final class LumoUtility {
         public static final String ERROR_10 = notConstant("border-error-10");
 
         public static final String WARNING = notConstant("border-warning");
-        public static final String WARNING_10 = notConstant("border-warning-10");
-        public static final String WARNING_STRONG = notConstant("border-warning-strong");
+        public static final String WARNING_10 = notConstant(
+                "border-warning-10");
+        public static final String WARNING_STRONG = notConstant(
+                "border-warning-strong");
 
         public static final String SUCCESS = notConstant("border-success");
         public static final String SUCCESS_50 = notConstant(

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/LumoUtility.java
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/src/main/java/com/vaadin/flow/theme/lumo/LumoUtility.java
@@ -138,6 +138,9 @@ public final class LumoUtility {
         public static final String ERROR_50 = notConstant("bg-error-50");
         public static final String ERROR_10 = notConstant("bg-error-10");
 
+        public static final String WARNING = notConstant("bg-warning");
+        public static final String WARNING_10 = notConstant("bg-warning-10");
+
         public static final String SUCCESS = notConstant("bg-success");
         public static final String SUCCESS_50 = notConstant("bg-success-50");
         public static final String SUCCESS_10 = notConstant("bg-success-10");
@@ -201,6 +204,10 @@ public final class LumoUtility {
         public static final String ERROR = notConstant("border-error");
         public static final String ERROR_50 = notConstant("border-error-50");
         public static final String ERROR_10 = notConstant("border-error-10");
+
+        public static final String WARNING = notConstant("border-warning");
+        public static final String WARNING_10 = notConstant("border-warning-10");
+        public static final String WARNING_STRONG = notConstant("border-warning-strong");
 
         public static final String SUCCESS = notConstant("border-success");
         public static final String SUCCESS_50 = notConstant(
@@ -1472,6 +1479,10 @@ public final class LumoUtility {
         public static final String ERROR = notConstant("text-error");
         public static final String ERROR_CONTRAST = notConstant(
                 "text-error-contrast");
+
+        public static final String WARNING = notConstant("text-warning");
+        public static final String WARNING_CONTRAST = notConstant(
+                "text-warning-contrast");
 
         public static final String SUCCESS = notConstant("text-success");
         public static final String SUCCESS_CONTRAST = notConstant(


### PR DESCRIPTION
## Description
Adds constants for new warning colors to Lumo Utility Class constants in Flow

Fixes https://github.com/vaadin/web-components/issues/1655

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
