### PR TITLE
fix: only fire opened change events on state change

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPage.java
@@ -108,6 +108,9 @@ public class ModalityDialogsPage extends Div {
         nonModalDialog.setCloseOnOutsideClick(false);
         nonModalDialog.setModal(false);
 
+        nonModalDialog.addOpenedChangeListener(
+                openedChangeEvent -> log.log("opened-change"));
+
         return nonModalDialog;
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
@@ -35,7 +35,9 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
     public void init() {
         open();
         Assert.assertEquals("No log messages should exist on open", 0,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("Clicked")).count());
     }
 
     @Test
@@ -51,7 +53,9 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
         Assert.assertTrue("Dialog should not have closed",
                 $(DialogElement.class).exists());
         Assert.assertEquals("Click should have resulted in a log message", 1,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("Clicked")).count());
 
         $(DialogElement.class).first().$(NativeButtonElement.class).first()
                 .click();
@@ -77,7 +81,10 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
         Assert.assertTrue("Dialog should not have closed",
                 $(DialogElement.class).exists());
         Assert.assertEquals("Click on button should not generate a log message",
-                0, $(DivElement.class).id(LOG_ID).$("div").all().size());
+                0,
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("Clicked")).count());
 
         $(DialogElement.class).first().$(NativeButtonElement.class).id("close")
                 .click();
@@ -88,7 +95,9 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("log").click();
 
         Assert.assertEquals("Click should have resulted in a log message", 1,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("Clicked")).count());
     }
 
     @Test
@@ -106,7 +115,9 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
         // Now that dialog is closed, verify that click events work
         $(NativeButtonElement.class).id("log").click();
         Assert.assertEquals("Click should have resulted in a log message", 1,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("Clicked")).count());
     }
 
     @Test
@@ -123,7 +134,9 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
         subDialog.$(NativeButtonElement.class).id("log-sub").click();
 
         Assert.assertEquals("Click should have resulted in a log message", 1,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("sub-click")).count());
 
         subDialog.$(NativeButtonElement.class).id("close-sub").click();
 
@@ -145,7 +158,9 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("log").click();
 
         Assert.assertEquals("Click should have resulted in a log message", 1,
-                $(DivElement.class).id(LOG_ID).$("div").all().size());
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("Clicked")).count());
 
         $(NativeButtonElement.class).id("show").click();
 
@@ -154,5 +169,29 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
         Assert.assertFalse("Dialog should have closed",
                 $(DialogElement.class).exists());
+    }
+
+    @Test
+    public void openModalDialog_openNonModalOnTop_oneOpenedChangeEventIsFired() {
+        $(NativeButtonElement.class).id("open-modal-dialog").click();
+
+        Assert.assertEquals(
+                "There should have been no opened-change event logs", 0,
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("opened-change"))
+                        .count());
+
+        final DialogElement first = $(DialogElement.class).first();
+        first.$(NativeButtonElement.class).id("open-sub").click();
+
+        waitUntil(driver -> $(DialogElement.class).all().size() == 2);
+
+        Assert.assertEquals(
+                "There should have been a single opened-change event log", 1,
+                $(DivElement.class).id(LOG_ID).$("div").all().stream()
+                        .map(TestBenchElement::getText)
+                        .filter(text -> text.contains("opened-change"))
+                        .count());
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -96,6 +96,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     private String maxHeight;
     private DialogHeader dialogHeader;
     private DialogFooter dialogFooter;
+    private boolean previousOpenedState;
 
     private Registration afterProgrammaticNavigationListenerRegistration;
 
@@ -111,9 +112,16 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
         // Workaround for: https://github.com/vaadin/flow/issues/3496
         setOpened(false);
+        previousOpenedState = false;
 
-        getElement().addPropertyChangeListener("opened", event -> fireEvent(
-                new OpenedChangeEvent(this, event.isUserOriginated())));
+        getElement().addPropertyChangeListener("opened", event -> {
+            boolean newOpenedState = isOpened();
+            if (newOpenedState != previousOpenedState) {
+                fireEvent(
+                        new OpenedChangeEvent(this, event.isUserOriginated()));
+            }
+            previousOpenedState = newOpenedState;
+        });
 
         addOpenedChangeListener(event -> {
             if (!isOpened()) {


### PR DESCRIPTION
## Description

As stated in a [comment](https://github.com/vaadin/flow-components/issues/5103#issuecomment-1570462149) in the issue, a subdialog momentarily disconnects and reconnects when opened. This results in 2 extra opened-change events. The changes in those events are not actually reflected in the server-side opened state of the component. This PR prevents the event to be fired when there is no actual change in the state.

Fixes #5103 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.