### PR TITLE
Revert "refactor: avoid an extra render on grid connector confirm parent (#4894)"

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
@@ -70,7 +70,7 @@ describe('grid connector - tree', () => {
     await nextFrame();
 
     // This number may come down from further optimization
-    expect(spy.callCount).to.equal(2);
+    expect(spy.callCount).to.equal(3);
   });
 
   it('should not compute column auto-width prematurely', async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -889,6 +889,14 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           }
           // Let server know we're done
           grid.$server.confirmParentUpdate(id, parentKey);
+
+          if (!grid.loading) {
+            grid.__confirmParentUpdateDebouncer = Debouncer.debounce(
+              grid.__confirmParentUpdateDebouncer,
+              microTask,
+              () => grid.__updateVisibleRows()
+            );
+          }
         });
 
         grid.$connector.confirm = tryCatchWrapper(function (id) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1,5 +1,5 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
-import { timeOut, animationFrame, microTask } from '@polymer/polymer/lib/utils/async.js';
+import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { ItemCache } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
@@ -893,7 +893,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           if (!grid.loading) {
             grid.__confirmParentUpdateDebouncer = Debouncer.debounce(
               grid.__confirmParentUpdateDebouncer,
-              microTask,
+              animationFrame,
               () => grid.__updateVisibleRows()
             );
           }


### PR DESCRIPTION
## Description

This reverts commit b6ff3ffada160ad5ab90b3b95de8cd37e39fbf75 that causes the regression described in #5045.

I am planning to add a test with the same use case in a separate PR.

Fixes #5045

## Type of change

- [x] Bugfix
- [ ] Feature
