### PR TITLE
refactor: implement hascomponents for details and deprecate old api

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/AccordionPanel.java
@@ -102,14 +102,14 @@ public class AccordionPanel extends Details {
      * @param summary
      *            the summary text to set.
      * @param components
-     *            the content components to set.
+     *            the content components to add.
      *
      * @see #setSummaryText(String)
-     * @see #addContent(Component...)
+     * @see #add(Component...)
      */
     public AccordionPanel(String summary, Component... components) {
         this(summary);
-        addContent(components);
+        add(components);
     }
 
     /**
@@ -119,14 +119,14 @@ public class AccordionPanel extends Details {
      * @param summary
      *            the summary component to set.
      * @param components
-     *            the content components to set.
+     *            the content components to add.
      *
      * @see #setSummary(Component)
-     * @see #addContent(Component...)
+     * @see #add(Component...)
      */
     public AccordionPanel(Component summary, Component... components) {
         this(summary);
-        addContent(components);
+        add(components);
     }
 
     /**

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/main/java/com/vaadin/flow/component/details/tests/Home.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/main/java/com/vaadin/flow/component/details/tests/Home.java
@@ -17,14 +17,14 @@ public class Home extends Div {
 
         Details details = new Details();
         details.setSummary(new Span("Some summary"));
-        details.setContent(new Text("Some content"));
+        details.add("Some content");
 
         Details detailsDisabled = new Details();
         detailsDisabled.setOpened(true);
         detailsDisabled.setEnabled(false);
         detailsDisabled.setSummaryText("Disabled heading");
-        detailsDisabled.addContent(new H3("Disabled content"));
-        detailsDisabled.addContent(new Span("Always visible content"));
+        detailsDisabled.add(new H3("Disabled content"));
+        detailsDisabled.add(new Span("Always visible content"));
 
         Details detailsThemed = new Details("Small Reversed Filled Summary",
                 new Span("Themed Content"));

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.details;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -56,8 +58,8 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/details", version = "24.1.0")
 @JsModule("@vaadin/details/src/vaadin-details.js")
-public class Details extends Component implements HasEnabled, HasSize, HasStyle,
-        HasThemeVariant<DetailsVariant>, HasTooltip {
+public class Details extends Component implements HasComponents, HasEnabled,
+        HasSize, HasStyle, HasThemeVariant<DetailsVariant>, HasTooltip {
 
     private Component summary;
     private Component summaryContainer;
@@ -120,15 +122,15 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      * @param summary
      *            the summary text to set.
      * @param content
-     *            the content component to set.
+     *            the content component to add.
      *
      * @see #setSummaryText(String)
-     * @see #setContent(Component)
+     * @see #add(Component...)
      */
     public Details(String summary, Component content) {
         this();
         setSummaryText(summary);
-        setContent(content);
+        add(content);
     }
 
     /**
@@ -137,15 +139,15 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      * @param summary
      *            the summary component to set.
      * @param content
-     *            the content component to set.
+     *            the content component to add.
      *
      * @see #setSummary(Component)
-     * @see #setContent(Component)
+     * @see #add(Component...)
      */
     public Details(Component summary, Component content) {
         this();
         setSummary(summary);
-        setContent(content);
+        add(content);
     }
 
     /**
@@ -155,14 +157,14 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      * @param summary
      *            the summary text to set.
      * @param components
-     *            the content components to set.
+     *            the content components to add.
      *
      * @see #setSummaryText(String)
-     * @see #addContent(Component...)
+     * @see #add(Component...)
      */
     public Details(String summary, Component... components) {
         this(summary);
-        addContent(components);
+        add(components);
     }
 
     /**
@@ -172,14 +174,14 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      * @param summary
      *            the summary component to set.
      * @param components
-     *            the content components to set.
+     *            the content components to add.
      *
      * @see #setSummary(Component)
-     * @see #addContent(Component...)
+     * @see #add(Component...)
      */
     public Details(Component summary, Component... components) {
         this(summary);
-        addContent(components);
+        add(components);
     }
 
     /**
@@ -245,14 +247,26 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      * @param content
      *            the content of the component to set, or <code>null</code> to
      *            remove any previously set content
+     * @deprecated use {@link #removeAll()} and {@link #add(Component...)}
+     *             instead.
      */
+    @Deprecated
     public void setContent(Component content) {
-        contentContainer.getElement().removeAllChildren();
-        if (content == null) {
-            return;
-        }
+        removeAll();
+        add(content);
+    }
 
-        contentContainer.add(content);
+    /**
+     * Adds components to the content section
+     *
+     * @see #getContent()
+     * @param components
+     *            the components to add
+     * @deprecated use {@link #add(Component...)} instead.
+     */
+    @Deprecated
+    public void addContent(Component... components) {
+        add(components);
     }
 
     /**
@@ -262,13 +276,101 @@ public class Details extends Component implements HasEnabled, HasSize, HasStyle,
      * @param components
      *            the components to add
      */
-    public void addContent(Component... components) {
+    @Override
+    public void add(Component... components) {
+        HasComponents.super.add(components);
+    }
+
+    /**
+     * Adds components to the content section
+     *
+     * @see #getContent()
+     * @param components
+     *            the components to add
+     */
+    @Override
+    public void add(Collection<Component> components) {
         contentContainer.add(components);
     }
 
     /**
+     * Adds the given text to the content section
+     *
+     * @see #getContent()
+     * @param text
+     *            the text to add, not null
+     */
+    @Override
+    public void add(String text) {
+        contentContainer.add(text);
+    }
+
+    /**
+     * Removes specified components from the content section
+     *
+     * @param components
+     *            the components to remove
+     */
+    @Override
+    public void remove(Component... components) {
+        HasComponents.super.remove(components);
+    }
+
+    /**
+     * Removes specified components from the content section
+     *
+     * @param components
+     *            the components to remove
+     */
+    @Override
+    public void remove(Collection<Component> components) {
+        contentContainer.remove(components);
+    }
+
+    /**
+     * Removes all components from the content section
+     */
+    @Override
+    public void removeAll() {
+        contentContainer.removeAll();
+    }
+
+    /**
+     * Adds the given component to the content section at the specific index.
+     * <p>
+     * In case the specified component has already been added to another parent,
+     * it will be removed from there and added to the content section of this
+     * one.
+     *
+     * @param index
+     *            the index, where the component will be added. The index must
+     *            be non-negative and may not exceed the children count
+     * @param component
+     *            the component to add, value should not be null
+     */
+    @Override
+    public void addComponentAtIndex(int index, Component component) {
+        contentContainer.addComponentAtIndex(index, component);
+    }
+
+    /**
+     * Adds the given component as the first child of the content section.
+     * <p>
+     * In case the specified component has already been added to another parent,
+     * it will be removed from there and added to the content section of this
+     * one.
+     *
+     * @param component
+     *            the component to add, value should not be null
+     */
+    @Override
+    public void addComponentAsFirst(Component component) {
+        HasComponents.super.addComponentAsFirst(component);
+    }
+
+    /**
      * Returns the content components which were added via
-     * {@link #setContent(Component)} or via {@link #addContent(Component...)}
+     * {@link #add(Component...)}
      *
      * @return the child components of the content section
      */

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -22,9 +22,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasComponents;
-import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
-import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -58,11 +56,11 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/details", version = "24.1.0")
 @JsModule("@vaadin/details/src/vaadin-details.js")
-public class Details extends Component implements HasComponents, HasEnabled,
-        HasSize, HasStyle, HasThemeVariant<DetailsVariant>, HasTooltip {
+public class Details extends Component implements HasComponents, HasSize,
+        HasThemeVariant<DetailsVariant>, HasTooltip {
 
     private Component summary;
-    private Component summaryContainer;
+    private final Component summaryContainer;
     private final Div contentContainer;
 
     /**
@@ -247,8 +245,8 @@ public class Details extends Component implements HasComponents, HasEnabled,
      * @param content
      *            the content of the component to set, or <code>null</code> to
      *            remove any previously set content
-     * @deprecated use {@link #removeAll()} and {@link #add(Component...)}
-     *             instead.
+     * @deprecated since v24.2, use {@link #removeAll()} and
+     *             {@link #add(Component...)} instead.
      */
     @Deprecated
     public void setContent(Component content) {
@@ -262,7 +260,7 @@ public class Details extends Component implements HasComponents, HasEnabled,
      * @see #getContent()
      * @param components
      *            the components to add
-     * @deprecated use {@link #add(Component...)} instead.
+     * @deprecated since v24.2, use {@link #add(Component...)} instead.
      */
     @Deprecated
     public void addContent(Component... components) {

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -275,18 +275,6 @@ public class Details extends Component implements HasComponents, HasSize,
      *            the components to add
      */
     @Override
-    public void add(Component... components) {
-        HasComponents.super.add(components);
-    }
-
-    /**
-     * Adds components to the content section
-     *
-     * @see #getContent()
-     * @param components
-     *            the components to add
-     */
-    @Override
     public void add(Collection<Component> components) {
         contentContainer.add(components);
     }
@@ -301,17 +289,6 @@ public class Details extends Component implements HasComponents, HasSize,
     @Override
     public void add(String text) {
         contentContainer.add(text);
-    }
-
-    /**
-     * Removes specified components from the content section
-     *
-     * @param components
-     *            the components to remove
-     */
-    @Override
-    public void remove(Component... components) {
-        HasComponents.super.remove(components);
     }
 
     /**
@@ -349,21 +326,6 @@ public class Details extends Component implements HasComponents, HasSize,
     @Override
     public void addComponentAtIndex(int index, Component component) {
         contentContainer.addComponentAtIndex(index, component);
-    }
-
-    /**
-     * Adds the given component as the first child of the content section.
-     * <p>
-     * In case the specified component has already been added to another parent,
-     * it will be removed from there and added to the content section of this
-     * one.
-     *
-     * @param component
-     *            the component to add, value should not be null
-     */
-    @Override
-    public void addComponentAsFirst(Component component) {
-        HasComponents.super.addComponentAsFirst(component);
     }
 
     /**

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
@@ -19,8 +19,7 @@ public class DetailsTest {
 
     @Test
     public void initContent() {
-        details.add(new Span());
-        details.add(new Span());
+        details.add(new Span(), new Span());
         Assert.assertEquals(2, details.getContent().count());
 
         details.removeAll();

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsTest.java
@@ -19,11 +19,12 @@ public class DetailsTest {
 
     @Test
     public void initContent() {
-        details.setContent(new Span());
-        details.addContent(new Span());
+        details.add(new Span());
+        details.add(new Span());
         Assert.assertEquals(2, details.getContent().count());
 
-        details.setContent(new Span());
+        details.removeAll();
+        details.add(new Span());
         Assert.assertEquals(1, details.getContent().count());
     }
 


### PR DESCRIPTION
## Description

This PR 
- deprecates `addContent` and `setContent`
- implements `HasComponents`
- overrides the component handling logic to use the custom component container

Fixes #5085 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.