### PR TITLE
feat: introduce manual validation mode for manual invalid state control

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -796,12 +796,8 @@ public class CheckboxGroup<T>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             boolean isRequired = isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil
                     .checkRequired(isRequired, getValue(), getEmptyValue())

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -121,6 +121,8 @@ public class CheckboxGroup<T>
 
     private SerializableConsumer<UI> sizeRequest;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Creates an empty checkbox group
      */
@@ -790,13 +792,24 @@ public class CheckboxGroup<T>
         keyMapper.setIdentifierGetter(identifierProvider);
     }
 
-    protected void validate() {
-        boolean isRequired = isRequiredIndicatorVisible();
-        boolean isInvalid = ValidationUtil
-                .checkRequired(isRequired, getValue(), getEmptyValue())
-                .isError();
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
 
-        setInvalid(isInvalid);
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
+    protected void validate() {
+        if (!isManualValidationEnabled()) {
+            boolean isRequired = isRequiredIndicatorVisible();
+            boolean isInvalid = ValidationUtil
+                    .checkRequired(isRequired, getValue(), getEmptyValue())
+                    .isError();
+
+            setInvalid(isInvalid);
+        }
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBasicValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBasicValidationTest.java
@@ -20,8 +20,8 @@ import java.util.Set;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
-public class CheckboxGroupBasicValidationTest
-        extends AbstractBasicValidationTest<CheckboxGroup<String>, Set<String>> {
+public class CheckboxGroupBasicValidationTest extends
+        AbstractBasicValidationTest<CheckboxGroup<String>, Set<String>> {
     protected CheckboxGroup<String> createTestField() {
         return new CheckboxGroup<String>();
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBasicValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBasicValidationTest.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.checkbox.tests.validation;
 
+import java.util.Set;
+
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class CheckboxGroupBasicValidationTest
-        extends AbstractBasicValidationTest<CheckboxGroup<String>> {
+        extends AbstractBasicValidationTest<CheckboxGroup<String>, Set<String>> {
     protected CheckboxGroup<String> createTestField() {
         return new CheckboxGroup<String>();
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -1162,12 +1162,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             boolean isRequired = isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil
                     .checkRequired(isRequired, getValue(), getEmptyValue())

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -126,6 +126,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     private final ComboBoxDataController<TItem> dataController;
     private int customValueListenersCount;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Constructs a new ComboBoxBase instance
      *
@@ -1157,13 +1159,24 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
                 "window.Vaadin.Flow.comboBoxConnector.initLazy(this)");
     }
 
-    protected void validate() {
-        boolean isRequired = isRequiredIndicatorVisible();
-        boolean isInvalid = ValidationUtil
-                .checkRequired(isRequired, getValue(), getEmptyValue())
-                .isError();
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
 
-        setInvalid(isInvalid);
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
+    protected void validate() {
+        if (!isManualValidationEnabled()) {
+            boolean isRequired = isRequiredIndicatorVisible();
+            boolean isInvalid = ValidationUtil
+                    .checkRequired(isRequired, getValue(), getEmptyValue())
+                    .isError();
+
+            setInvalid(isInvalid);
+        }
     }
 
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/ComboBoxBasicValidationTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/ComboBoxBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class ComboBoxBasicValidationTest
-        extends AbstractBasicValidationTest<ComboBox<String>> {
+        extends AbstractBasicValidationTest<ComboBox<String>, String> {
     protected ComboBox<String> createTestField() {
         return new ComboBox<String>();
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
@@ -18,8 +18,8 @@ package com.vaadin.flow.component.combobox.validation;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
-public class MultiSelectComboBoxBasicValidationTest
-        extends AbstractBasicValidationTest<MultiSelectComboBox<String>, String> {
+public class MultiSelectComboBoxBasicValidationTest extends
+        AbstractBasicValidationTest<MultiSelectComboBox<String>, String> {
     protected MultiSelectComboBox<String> createTestField() {
         return new MultiSelectComboBox<String>();
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.combobox.validation;
 
+import java.util.Set;
+
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class MultiSelectComboBoxBasicValidationTest extends
-        AbstractBasicValidationTest<MultiSelectComboBox<String>, String> {
+        AbstractBasicValidationTest<MultiSelectComboBox<String>, Set<String>> {
     protected MultiSelectComboBox<String> createTestField() {
         return new MultiSelectComboBox<String>();
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class MultiSelectComboBoxBasicValidationTest
-        extends AbstractBasicValidationTest<MultiSelectComboBox<String>> {
+        extends AbstractBasicValidationTest<MultiSelectComboBox<String>, String> {
     protected MultiSelectComboBox<String> createTestField() {
         return new MultiSelectComboBox<String>();
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -115,6 +115,8 @@ public class DatePicker
 
     private StateTree.ExecutionRegistration pendingI18nUpdate;
 
+    private boolean internalValidationDisabled = false;
+
     /**
      * Default constructor.
      */
@@ -780,7 +782,9 @@ public class DatePicker
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(isInvalid(getValue()));
+        if (!isInternalValidationDisabled()) {
+            setInvalid(isInvalid(getValue()));
+        }
     }
 
     /**
@@ -840,6 +844,16 @@ public class DatePicker
     public Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent> listener) {
         return addListener(InvalidChangeEvent.class, listener);
+    }
+
+    @Override
+    public void setInternalValidationDisabled(boolean disabled) {
+        this.internalValidationDisabled = disabled;
+    }
+
+    @Override
+    public boolean isInternalValidationDisabled() {
+        return this.internalValidationDisabled;
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -115,7 +115,7 @@ public class DatePicker
 
     private StateTree.ExecutionRegistration pendingI18nUpdate;
 
-    private boolean internalValidationDisabled = false;
+    private boolean manualValidationEnabled = false;
 
     /**
      * Default constructor.
@@ -776,13 +776,22 @@ public class DatePicker
         return getElement().getProperty("name");
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isInternalValidationDisabled()) {
+        if (!isManualValidationEnabled()) {
             setInvalid(isInvalid(getValue()));
         }
     }
@@ -844,16 +853,6 @@ public class DatePicker
     public Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent> listener) {
         return addListener(InvalidChangeEvent.class, listener);
-    }
-
-    @Override
-    public void setInternalValidationDisabled(boolean disabled) {
-        this.internalValidationDisabled = disabled;
-    }
-
-    @Override
-    public boolean isInternalValidationDisabled() {
-        return this.internalValidationDisabled;
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -779,17 +779,13 @@ public class DatePicker
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(isInvalid(getValue()));
         }
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationTest.java
@@ -17,38 +17,12 @@ package com.vaadin.flow.component.datepicker.validation;
 
 import java.time.LocalDate;
 
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.datepicker.DatePicker;
-import com.vaadin.flow.component.shared.HasClientValidation.ClientValidatedEvent;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
-        extends AbstractBasicValidationTest<DatePicker> {
+        extends AbstractBasicValidationTest<DatePicker, LocalDate> {
     protected DatePicker createTestField() {
         return new DatePicker();
-    }
-
-    @Test
-    public void setInternalValidationDisabled_changeValue_noValidation() {
-        testField.setRequired(true);
-        testField.setInternalValidationDisabled(true);
-
-        testField.setValue(LocalDate.now());
-        Assert.assertFalse(testField.isInvalid());
-
-        testField.setValue(null);
-        Assert.assertFalse(testField.isInvalid());
-    }
-
-    @Test
-    public void setInternalValidationDisabled_fireClientValidatedEvent_noValidation() {
-        testField.setRequired(true);
-        testField.setInternalValidationDisabled(true);
-
-        ComponentUtil.fireEvent(testField, new ClientValidatedEvent(testField, false));
-        Assert.assertFalse(testField.isInvalid());
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationTest.java
@@ -15,12 +15,40 @@
  */
 package com.vaadin.flow.component.datepicker.validation;
 
+import java.time.LocalDate;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.shared.HasClientValidation.ClientValidatedEvent;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
         extends AbstractBasicValidationTest<DatePicker> {
     protected DatePicker createTestField() {
         return new DatePicker();
+    }
+
+    @Test
+    public void setInternalValidationDisabled_changeValue_noValidation() {
+        testField.setRequired(true);
+        testField.setInternalValidationDisabled(true);
+
+        testField.setValue(LocalDate.now());
+        Assert.assertFalse(testField.isInvalid());
+
+        testField.setValue(null);
+        Assert.assertFalse(testField.isInvalid());
+    }
+
+    @Test
+    public void setInternalValidationDisabled_fireClientValidatedEvent_noValidation() {
+        testField.setRequired(true);
+        testField.setInternalValidationDisabled(true);
+
+        ComponentUtil.fireEvent(testField, new ClientValidatedEvent(testField, false));
+        Assert.assertFalse(testField.isInvalid());
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -145,6 +145,8 @@ public class DateTimePicker
     private LocalDateTime min;
     private boolean required;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Default constructor.
      */
@@ -799,13 +801,24 @@ public class DateTimePicker
         return requiredValidation.isError() || checkValidity(value).isError();
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(isInvalid(getValue()));
+        if (!isManualValidationEnabled()) {
+            setInvalid(isInvalid(getValue()));
+        }
     }
 
     /**

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -804,17 +804,13 @@ public class DateTimePicker extends
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(isInvalid(getValue()));
         }
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.datetimepicker.validation;
 
+import java.time.LocalDateTime;
+
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
-        extends AbstractBasicValidationTest<DateTimePicker> {
+        extends AbstractBasicValidationTest<DateTimePicker, LocalDateTime> {
     protected DateTimePicker createTestField() {
         return new DateTimePicker();
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -51,6 +51,7 @@ public interface HasValidationProperties extends HasElement, HasValidation {
     /**
      * Sets the invalid state of the component.
      *
+     * <p>
      * NOTE: If you need to manually control the invalid state, consider
      * enabling manual validation mode with
      * {@link #setManualValidation(boolean)} to avoid potential conflicts

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -51,6 +51,11 @@ public interface HasValidationProperties extends HasElement, HasValidation {
     /**
      * Sets the invalid state of the component.
      *
+     * NOTE: If you need to manually control the invalid state, consider
+     * enabling manual validation mode with
+     * {@link #setManualValidation(boolean)} to avoid potential conflicts
+     * between your custom validation and the component's built-in validation.
+     *
      * @param invalid
      *            {@code true} for invalid, {@code false} for valid
      */

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -50,7 +50,6 @@ public interface HasValidationProperties extends HasElement, HasValidation {
 
     /**
      * Sets the invalid state of the component.
-     *
      * <p>
      * NOTE: If you need to manually control the invalid state, consider
      * enabling manual validation mode with

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -19,14 +19,17 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasValidation;
+import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
+import com.vaadin.flow.component.shared.HasClientValidation.ClientValidatedEvent;
 
 /**
  * An abstract class that provides tests verifying that a component correctly
  * implements the {@link HasValidation} interface.
  */
-public abstract class AbstractBasicValidationTest<T extends Component & HasValidation> {
+public abstract class AbstractBasicValidationTest<T extends AbstractField<T, V> & HasValidation, V> {
     protected T testField;
 
     @Before
@@ -41,6 +44,24 @@ public abstract class AbstractBasicValidationTest<T extends Component & HasValid
         testField.setInternalValidationDisabled(true);
 
         Assert.assertTrue(testField.isInternalValidationDisabled());
+    }
+
+    @Test
+    public void setRequired_setInternalValidationDisabled_fireValueChangeEvent_noValidation() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setInternalValidationDisabled(true);
+
+        ComponentUtil.fireEvent(testField, new ComponentValueChangeEvent<>(testField, testField, testField.getEmptyValue(), false));
+        Assert.assertFalse(testField.isInvalid());
+    }
+
+    @Test
+    public void setRequired_setInternalValidationDisabled_fireClientValidatedEvent_noValidation() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setInternalValidationDisabled(true);
+
+        ComponentUtil.fireEvent(testField, new ClientValidatedEvent(testField, false));
+        Assert.assertFalse(testField.isInvalid());
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -29,8 +29,8 @@ import com.vaadin.flow.component.shared.HasClientValidation.ClientValidatedEvent
  * An abstract class that provides tests verifying that a component correctly
  * implements the {@link HasValidation} interface.
  */
-public abstract class AbstractBasicValidationTest<T extends AbstractField<T, V> & HasValidation, V> {
-    protected T testField;
+public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> & HasValidation, V> {
+    protected C testField;
 
     @Before
     public void setup() {
@@ -88,5 +88,5 @@ public abstract class AbstractBasicValidationTest<T extends AbstractField<T, V> 
         Assert.assertTrue(testField.getElement().getProperty("invalid", false));
     }
 
-    protected abstract T createTestField();
+    protected abstract C createTestField();
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -35,6 +35,15 @@ public abstract class AbstractBasicValidationTest<T extends Component & HasValid
     }
 
     @Test
+    public void setInternalValidationDisabled_isInternalValidationDisabled() {
+        Assert.assertFalse(testField.isInternalValidationDisabled());
+
+        testField.setInternalValidationDisabled(true);
+
+        Assert.assertTrue(testField.isInternalValidationDisabled());
+    }
+
+    @Test
     public void setErrorMessage_getErrorMessage() {
         Assert.assertNull(testField.getErrorMessage());
         Assert.assertNull(testField.getElement().getProperty("errorMessage"));

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -38,18 +38,9 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
     }
 
     @Test
-    public void setInternalValidationDisabled_isInternalValidationDisabled() {
-        Assert.assertFalse(testField.isInternalValidationDisabled());
-
-        testField.setInternalValidationDisabled(true);
-
-        Assert.assertTrue(testField.isInternalValidationDisabled());
-    }
-
-    @Test
-    public void setRequired_setInternalValidationDisabled_fireValueChangeEvent_noValidation() {
+    public void setRequired_setManualValidation_fireValueChangeEvent_noValidation() {
         testField.setRequiredIndicatorVisible(true);
-        testField.setInternalValidationDisabled(true);
+        testField.setManualValidation(true);
 
         ComponentUtil.fireEvent(testField, new ComponentValueChangeEvent<>(
                 testField, testField, testField.getEmptyValue(), false));
@@ -57,9 +48,9 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
     }
 
     @Test
-    public void setRequired_setInternalValidationDisabled_fireClientValidatedEvent_noValidation() {
+    public void setRequired_setManualValidation_fireClientValidatedEvent_noValidation() {
         testField.setRequiredIndicatorVisible(true);
-        testField.setInternalValidationDisabled(true);
+        testField.setManualValidation(true);
 
         ComponentUtil.fireEvent(testField,
                 new ClientValidatedEvent(testField, false));

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -51,7 +51,8 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
         testField.setRequiredIndicatorVisible(true);
         testField.setInternalValidationDisabled(true);
 
-        ComponentUtil.fireEvent(testField, new ComponentValueChangeEvent<>(testField, testField, testField.getEmptyValue(), false));
+        ComponentUtil.fireEvent(testField, new ComponentValueChangeEvent<>(
+                testField, testField, testField.getEmptyValue(), false));
         Assert.assertFalse(testField.isInvalid());
     }
 
@@ -60,7 +61,8 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
         testField.setRequiredIndicatorVisible(true);
         testField.setInternalValidationDisabled(true);
 
-        ComponentUtil.fireEvent(testField, new ClientValidatedEvent(testField, false));
+        ComponentUtil.fireEvent(testField,
+                new ClientValidatedEvent(testField, false));
         Assert.assertFalse(testField.isInvalid());
     }
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -724,12 +724,8 @@ public class RadioButtonGroup<T>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             boolean isRequired = isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil
                     .checkRequired(isRequired, getValue(), getEmptyValue())

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -106,6 +106,8 @@ public class RadioButtonGroup<T>
 
     private SerializableConsumer<UI> sizeRequest;
 
+    private boolean manualValidationEnabled = false;
+
     private static <T> T presentationToModel(
             RadioButtonGroup<T> radioButtonGroup, String presentation) {
         if (radioButtonGroup.keyMapper == null) {
@@ -718,13 +720,24 @@ public class RadioButtonGroup<T>
         keyMapper.setIdentifierGetter(identifierProvider);
     }
 
-    protected void validate() {
-        boolean isRequired = isRequiredIndicatorVisible();
-        boolean isInvalid = ValidationUtil
-                .checkRequired(isRequired, getValue(), getEmptyValue())
-                .isError();
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
 
-        setInvalid(isInvalid);
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
+    protected void validate() {
+        if (!isManualValidationEnabled()) {
+            boolean isRequired = isRequiredIndicatorVisible();
+            boolean isInvalid = ValidationUtil
+                    .checkRequired(isRequired, getValue(), getEmptyValue())
+                    .isError();
+
+            setInvalid(isInvalid);
+        }
     }
 
     @Override

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/validation/BasicValidationTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/validation/BasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
-        extends AbstractBasicValidationTest<RadioButtonGroup<String>> {
+        extends AbstractBasicValidationTest<RadioButtonGroup<String>, String> {
     protected RadioButtonGroup<String> createTestField() {
         return new RadioButtonGroup<String>();
     }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -1034,12 +1034,8 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             boolean isRequired = this.isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil
                     .checkRequired(isRequired, getValue(), getEmptyValue())

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -130,6 +130,8 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
 
     private SerializableConsumer<UI> sizeRequest;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Constructs a select.
      */
@@ -1028,13 +1030,24 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         keyMapper.setIdentifierGetter(identifierProvider);
     }
 
-    protected void validate() {
-        boolean isRequired = this.isRequiredIndicatorVisible();
-        boolean isInvalid = ValidationUtil
-                .checkRequired(isRequired, getValue(), getEmptyValue())
-                .isError();
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
 
-        setInvalid(isInvalid);
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
+    protected void validate() {
+        if (!isManualValidationEnabled()) {
+            boolean isRequired = this.isRequiredIndicatorVisible();
+            boolean isInvalid = ValidationUtil
+                    .checkRequired(isRequired, getValue(), getEmptyValue())
+                    .isError();
+
+            setInvalid(isInvalid);
+        }
     }
 
     @Override

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/validation/BasicValidationTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/validation/BasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.select.Select;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
-        extends AbstractBasicValidationTest<Select<String>> {
+        extends AbstractBasicValidationTest<Select<String>, String> {
     protected Select<String> createTestField() {
         return new Select<String>();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -296,11 +296,11 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         if (!isManualValidationEnabled()) {
             T value = getValue();
 
-            final var requiredValidation = ValidationUtil.checkRequired(required,
-                    value, getEmptyValue());
+            final var requiredValidation = ValidationUtil
+                    .checkRequired(required, value, getEmptyValue());
 
-            setInvalid(
-                    requiredValidation.isError() || checkValidity(value).isError());
+            setInvalid(requiredValidation.isError()
+                    || checkValidity(value).isError());
         }
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -55,6 +55,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
     private boolean stepSetByUser;
     private boolean minSetByUser;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Sets up the common logic for number fields.
      *
@@ -276,19 +278,30 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         return ValidationResult.ok();
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        T value = getValue();
+        if (!isManualValidationEnabled()) {
+            T value = getValue();
 
-        final var requiredValidation = ValidationUtil.checkRequired(required,
-                value, getEmptyValue());
+            final var requiredValidation = ValidationUtil.checkRequired(required,
+                    value, getEmptyValue());
 
-        setInvalid(
-                requiredValidation.isError() || checkValidity(value).isError());
+            setInvalid(
+                    requiredValidation.isError() || checkValidity(value).isError());
+        }
     }
 
     private boolean isValidByStep(T value) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -283,17 +283,13 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             T value = getValue();
 
             final var requiredValidation = ValidationUtil

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -80,6 +80,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
                     : valueFromModel.toPlainString().replace('.',
                             field.getDecimalSeparator());
 
+                            private boolean manualValidationEnabled = false;
+
     /**
      * Constructs an empty {@code BigDecimalField}.
      */
@@ -249,20 +251,31 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         return super.getValue();
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        BigDecimal value = getValue();
+        if (!isManualValidationEnabled()) {
+            BigDecimal value = getValue();
 
-        boolean isRequired = isRequiredIndicatorVisible();
-        ValidationResult requiredValidation = ValidationUtil
-                .checkRequired(isRequired, value, getEmptyValue());
+            boolean isRequired = isRequiredIndicatorVisible();
+            ValidationResult requiredValidation = ValidationUtil
+                    .checkRequired(isRequired, value, getEmptyValue());
 
-        setInvalid(
-                requiredValidation.isError() || checkValidity(value).isError());
+            setInvalid(
+                    requiredValidation.isError() || checkValidity(value).isError());
+        }
     }
 
     private ValidationResult checkValidity(BigDecimal value) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -80,7 +80,7 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
                     : valueFromModel.toPlainString().replace('.',
                             field.getDecimalSeparator());
 
-                            private boolean manualValidationEnabled = false;
+    private boolean manualValidationEnabled = false;
 
     /**
      * Constructs an empty {@code BigDecimalField}.
@@ -273,8 +273,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
             ValidationResult requiredValidation = ValidationUtil
                     .checkRequired(isRequired, value, getEmptyValue());
 
-            setInvalid(
-                    requiredValidation.isError() || checkValidity(value).isError());
+            setInvalid(requiredValidation.isError()
+                    || checkValidity(value).isError());
         }
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -256,17 +256,13 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             BigDecimal value = getValue();
 
             boolean isRequired = isRequiredIndicatorVisible();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -58,6 +58,8 @@ public class EmailField extends TextFieldBase<EmailField, String>
 
     private TextFieldValidationSupport validationSupport;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Constructs an empty {@code EmailField}.
      */
@@ -303,13 +305,24 @@ public class EmailField extends TextFieldBase<EmailField, String>
                                 !isInvalid())));
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (!isManualValidationEnabled()) {
+            setInvalid(getValidationSupport().isInvalid(getValue()));
+        }
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -310,17 +310,13 @@ public class EmailField extends TextFieldBase<EmailField, String>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(getValidationSupport().isInvalid(getValue()));
         }
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -49,6 +49,8 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
 
     private TextFieldValidationSupport validationSupport;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Constructs an empty {@code PasswordField}.
      */
@@ -323,13 +325,24 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
                                 !isInvalid())));
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (!isManualValidationEnabled()) {
+            setInvalid(getValidationSupport().isInvalid(getValue()));
+        }
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -330,17 +330,13 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(getValidationSupport().isInvalid(getValue()));
         }
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -48,6 +48,8 @@ public class TextArea extends TextFieldBase<TextArea, String>
 
     private TextFieldValidationSupport validationSupport;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Constructs an empty {@code TextArea}.
      */
@@ -327,13 +329,24 @@ public class TextArea extends TextFieldBase<TextArea, String>
                         new ValidationStatusChangeEvent<>(this, !isInvalid())));
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (!isManualValidationEnabled()) {
+            setInvalid(getValidationSupport().isInvalid(getValue()));
+        }
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -334,17 +334,13 @@ public class TextArea extends TextFieldBase<TextArea, String>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(getValidationSupport().isInvalid(getValue()));
         }
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -334,10 +334,6 @@ public class TextField extends TextFieldBase<TextField, String>
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value and the validation
      * constraints of the field, such as {@link #setPattern(String)}. This is
@@ -345,7 +341,7 @@ public class TextField extends TextFieldBase<TextField, String>
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(getValidationSupport().isInvalid(getValue()));
         }
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -47,6 +47,8 @@ public class TextField extends TextFieldBase<TextField, String>
 
     private TextFieldValidationSupport validationSupport;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Constructs an empty {@code TextField}.
      */
@@ -327,6 +329,15 @@ public class TextField extends TextFieldBase<TextField, String>
                                 !isInvalid())));
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value and the validation
      * constraints of the field, such as {@link #setPattern(String)}. This is
@@ -334,7 +345,9 @@ public class TextField extends TextFieldBase<TextField, String>
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (!isManualValidationEnabled()) {
+            setInvalid(getValidationSupport().isInvalid(getValue()));
+        }
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import java.math.BigDecimal;
+
 import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BigDecimalFieldBasicValidationTest
-        extends AbstractBasicValidationTest<BigDecimalField> {
+        extends AbstractBasicValidationTest<BigDecimalField, BigDecimal> {
     protected BigDecimalField createTestField() {
         return new BigDecimalField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class EmailFieldBasicValidationTest
-        extends AbstractBasicValidationTest<EmailField> {
+        extends AbstractBasicValidationTest<EmailField, String> {
     protected EmailField createTestField() {
         return new EmailField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/IntegerFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/IntegerFieldBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class IntegerFieldBasicValidationTest
-        extends AbstractBasicValidationTest<IntegerField> {
+        extends AbstractBasicValidationTest<IntegerField, Integer> {
     protected IntegerField createTestField() {
         return new IntegerField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/NumberFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/NumberFieldBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class NumberFieldBasicValidationTest
-        extends AbstractBasicValidationTest<NumberField> {
+        extends AbstractBasicValidationTest<NumberField, Double> {
     protected NumberField createTestField() {
         return new NumberField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/PasswordFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/PasswordFieldBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class PasswordFieldBasicValidationTest
-        extends AbstractBasicValidationTest<PasswordField> {
+        extends AbstractBasicValidationTest<PasswordField, String> {
     protected PasswordField createTestField() {
         return new PasswordField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextAreaBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextAreaBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class TextAreaBasicValidationTest
-        extends AbstractBasicValidationTest<TextArea> {
+        extends AbstractBasicValidationTest<TextArea, String> {
     protected TextArea createTestField() {
         return new TextArea();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextFieldBasicValidationTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class TextFieldBasicValidationTest
-        extends AbstractBasicValidationTest<TextField> {
+        extends AbstractBasicValidationTest<TextField, String> {
     protected TextField createTestField() {
         return new TextField();
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -98,6 +98,8 @@ public class TimePicker
     private boolean required;
     private StateTree.ExecutionRegistration pendingLocaleUpdate;
 
+    private boolean manualValidationEnabled = false;
+
     /**
      * Default constructor.
      */
@@ -495,13 +497,24 @@ public class TimePicker
         return addListener(InvalidChangeEvent.class, listener);
     }
 
+    @Override
+    public void setManualValidation(boolean enabled) {
+        this.manualValidationEnabled = enabled;
+    }
+
+    private boolean isManualValidationEnabled() {
+        return this.manualValidationEnabled;
+    }
+
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        setInvalid(isInvalid(getValue()));
+        if (!isManualValidationEnabled()) {
+            setInvalid(isInvalid(getValue()));
+        }
     }
 
     @Override

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -500,17 +500,13 @@ public class TimePicker
         this.manualValidationEnabled = enabled;
     }
 
-    private boolean isManualValidationEnabled() {
-        return this.manualValidationEnabled;
-    }
-
     /**
      * Performs server-side validation of the current value. This is needed
      * because it is possible to circumvent the client-side validation
      * constraints using browser development tools.
      */
     protected void validate() {
-        if (!isManualValidationEnabled()) {
+        if (!this.manualValidationEnabled) {
             setInvalid(isInvalid(getValue()));
         }
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.timepicker.tests.validation;
 
+import java.time.LocalTime;
+
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
-        extends AbstractBasicValidationTest<TimePicker> {
+        extends AbstractBasicValidationTest<TimePicker, LocalTime> {
     protected TimePicker createTestField() {
         return new TimePicker();
     }


### PR DESCRIPTION
## Description

The PR introduces a manual validation mode that disables the component's built-in validation to allow developers to have manual control over the component's invalid state without conflicts.

Depends on 
- https://github.com/vaadin/flow/pull/17029

Fixes https://github.com/vaadin/flow-components/issues/5074, https://github.com/vaadin/flow-components/issues/4804

## Affected components

- [x] DatePicker
- [x] TimePicker
- [x] DateTimePicker
- [x] ComboBox
- [x] CheckboxGroup
- [x] RadioGroup
- [x] Select
- [x] TextField
- [x] PasswordField
- [x] EmailField
- [x] TextArea
- [x] IntegerField
- [x] NumberField

## Type of change

- [x] Feature
