### PR TITLE
fix: Improve robustness of GridElement getLastVisibleRowIndex/getFirstVisibleRowIndex

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -77,11 +77,16 @@ public class GridElement extends TestBenchElement {
     /**
      * Gets the index of the first row which is at least partially visible.
      *
-     * @return the index of the first visible row
+     * @return the index of the first visible row, -1 if Grid is empty
      */
     public int getFirstVisibleRowIndex() {
-        return ((Long) executeScript("return arguments[0]._firstVisibleIndex",
-                this)).intValue();
+        Object index = executeScript("return arguments[0]._firstVisibleIndex",
+                this);
+        if (index != null) {
+            return ((Long) index).intValue();
+        } else {
+            return -1;
+        }
     }
 
     /**
@@ -165,12 +170,16 @@ public class GridElement extends TestBenchElement {
     /**
      * Gets the index of the last row which is at least partially visible.
      *
-     * @return the index of the last visible row
+     * @return the index of the last visible row, -1 if Grid is empty
      */
     public int getLastVisibleRowIndex() {
-        // Private for now because this seems to be slightly incorrect
-        return ((Long) executeScript("return arguments[0]._lastVisibleIndex",
-                this)).intValue();
+        Object index = executeScript("return arguments[0]._lastVisibleIndex",
+                this);
+        if (index != null) {
+            return ((Long) index).intValue();
+        } else {
+            return -1;
+        }
     }
 
     /**
@@ -181,8 +190,7 @@ public class GridElement extends TestBenchElement {
      * @return <code>true</code> if the row is at least partially in view,
      *         <code>false</code> otherwise
      */
-    private boolean isRowInView(int rowIndex) {
-        // Private for now because this seems to be slightly incorrect
+    public boolean isRowInView(int rowIndex) {
         return (getFirstVisibleRowIndex() <= rowIndex
                 && rowIndex <= getLastVisibleRowIndex());
     }


### PR DESCRIPTION
It is better to return -1 than throw NPE here

- Remove also outdated comment
- Make isRowInView public

