### PR TITLE
feat: access updated splitter position from drag end event

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitterPositionView.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitterPositionView.java
@@ -56,18 +56,9 @@ public class SplitterPositionView extends Div {
 
         Span showSplitterPosition = new Span();
         showSplitterPosition.setId("showSplitterPositionJavaApi");
-        Span showPrimaryComponentWidth = new Span();
-        showPrimaryComponentWidth.setId("showPrimaryComponentWidthJavaApi");
-        Span showSecondaryComponentWidth = new Span();
-        showSecondaryComponentWidth.setId("showSecondaryComponentWidthJavaApi");
-        layout.addSplitterDragendListener(e -> {
-            showSplitterPosition
-                    .setText(String.valueOf(e.getNewSplitterPosition()));
-            showPrimaryComponentWidth.setText(e.getPrimaryComponentWidth());
-            showSecondaryComponentWidth.setText(e.getSecondaryComponentWidth());
-        });
-        add(setSplitterPosition, layout, showSplitterPosition,
-                showPrimaryComponentWidth, showSecondaryComponentWidth);
+        layout.addSplitterDragendListener(e -> showSplitterPosition
+                .setText(String.valueOf(e.getSource().getSplitterPosition())));
+        add(setSplitterPosition, layout, showSplitterPosition);
     }
 
     private void createLayoutElementApi() {
@@ -88,18 +79,8 @@ public class SplitterPositionView extends Div {
 
         Span showSplitterPosition = new Span();
         showSplitterPosition.setId("showSplitterPositionElementApi");
-        Span showPrimaryComponentWidth = new Span();
-        showPrimaryComponentWidth.setId("showPrimaryComponentWidthElementApi");
-        Span showSecondaryComponentWidth = new Span();
-        showSecondaryComponentWidth
-                .setId("showSecondaryComponentWidthElementApi");
-        layout.addSplitterDragendListener(e -> {
-            showSplitterPosition
-                    .setText(String.valueOf(e.getNewSplitterPosition()));
-            showPrimaryComponentWidth.setText(e.getPrimaryComponentWidth());
-            showSecondaryComponentWidth.setText(e.getSecondaryComponentWidth());
-        });
-        add(setSplitterPosition, layout, showSplitterPosition,
-                showPrimaryComponentWidth, showSecondaryComponentWidth);
+        layout.addSplitterDragendListener(e -> showSplitterPosition
+                .setText(String.valueOf(e.getSource().getSplitterPosition())));
+        add(setSplitterPosition, layout, showSplitterPosition);
     }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitterPositionView.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitterPositionView.java
@@ -53,7 +53,21 @@ public class SplitterPositionView extends Div {
                 "set splitter position",
                 event -> layout.setSplitterPosition(FINAL_POSITION));
         setSplitterPosition.setId("setSplitPositionJavaApi");
-        add(setSplitterPosition, layout);
+
+        Span showSplitterPosition = new Span();
+        showSplitterPosition.setId("showSplitterPositionJavaApi");
+        Span showPrimaryComponentWidth = new Span();
+        showPrimaryComponentWidth.setId("showPrimaryComponentWidthJavaApi");
+        Span showSecondaryComponentWidth = new Span();
+        showSecondaryComponentWidth.setId("showSecondaryComponentWidthJavaApi");
+        layout.addSplitterDragendListener(e -> {
+            showSplitterPosition
+                    .setText(String.valueOf(e.getNewSplitterPosition()));
+            showPrimaryComponentWidth.setText(e.getPrimaryComponentWidth());
+            showSecondaryComponentWidth.setText(e.getSecondaryComponentWidth());
+        });
+        add(setSplitterPosition, layout, showSplitterPosition,
+                showPrimaryComponentWidth, showSecondaryComponentWidth);
     }
 
     private void createLayoutElementApi() {
@@ -71,6 +85,21 @@ public class SplitterPositionView extends Div {
                 "set splitter position",
                 event -> layout.setSplitterPosition(FINAL_POSITION));
         setSplitterPosition.setId("setSplitPositionElementApi");
-        add(setSplitterPosition, layout);
+
+        Span showSplitterPosition = new Span();
+        showSplitterPosition.setId("showSplitterPositionElementApi");
+        Span showPrimaryComponentWidth = new Span();
+        showPrimaryComponentWidth.setId("showPrimaryComponentWidthElementApi");
+        Span showSecondaryComponentWidth = new Span();
+        showSecondaryComponentWidth
+                .setId("showSecondaryComponentWidthElementApi");
+        layout.addSplitterDragendListener(e -> {
+            showSplitterPosition
+                    .setText(String.valueOf(e.getNewSplitterPosition()));
+            showPrimaryComponentWidth.setText(e.getPrimaryComponentWidth());
+            showSecondaryComponentWidth.setText(e.getSecondaryComponentWidth());
+        });
+        add(setSplitterPosition, layout, showSplitterPosition,
+                showPrimaryComponentWidth, showSecondaryComponentWidth);
     }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -15,22 +15,21 @@
  */
 package com.vaadin.flow.component.splitlayout.tests;
 
-import com.vaadin.flow.component.html.testbench.DivElement;
-import com.vaadin.flow.component.splitlayout.test.SplitLayoutView;
+import java.util.function.Consumer;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.component.html.testbench.SpanElement;
-import com.vaadin.flow.component.splitlayout.test.SplitterPositionView;
-import com.vaadin.flow.component.splitlayout.testbench.SplitLayoutElement;
-import com.vaadin.tests.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 import org.openqa.selenium.interactions.Actions;
 
-import java.util.function.Consumer;
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.component.splitlayout.test.SplitLayoutView;
+import com.vaadin.flow.component.splitlayout.testbench.SplitLayoutElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
 
 /**
  * Integration tests for {@link SplitLayoutView}.
@@ -89,15 +88,7 @@ public class SplitterPositionIT extends AbstractComponentIT {
         testSplitterPosition(testId, layout -> {
             new Actions(getDriver()).dragAndDropBy(layout.getSplitter(), 20, 0)
                     .perform();
-            Assert.assertNotEquals("", getPrimaryElement(layout, testId)
-                    .getPropertyString("style", "flex"));
-            Assert.assertNotEquals("", getSecondaryElement(layout, testId)
-                    .getPropertyString("style", "flex"));
             Assert.assertNotEquals("", getShowSplitterPositionElement(testId).getText());
-            Assert.assertNotEquals("",
-                    getShowPrimaryComponentWidthElement(testId).getText());
-            Assert.assertNotEquals("",
-                    getShowSecondaryComponentWidthElement(testId).getText());
         });
     }
 
@@ -106,47 +97,14 @@ public class SplitterPositionIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("createLayout" + testId).click();
         SplitLayoutElement layout = $(SplitLayoutElement.class)
                 .id("splitLayout" + testId);
-        TestBenchElement primaryElement = getPrimaryElement(layout, testId);
-        TestBenchElement secondaryElement = getSecondaryElement(layout, testId);
-        SplitLayoutAssertions.assertChildWidthInPercentage(layout,
-                primaryElement, SplitterPositionView.INITIAL_POSITION);
-        SplitLayoutAssertions.assertChildWidthInPercentage(layout,
-                secondaryElement, SplitterPositionView.FINAL_POSITION);
 
         Assert.assertEquals("", getShowSplitterPositionElement(testId).getText());
-        Assert.assertEquals("",
-                getShowPrimaryComponentWidthElement(testId).getText());
-        Assert.assertEquals("",
-                getShowSecondaryComponentWidthElement(testId).getText());
 
         modifyState.accept(layout);
         $(NativeButtonElement.class).id("setSplitPosition" + testId).click();
-
-        SplitLayoutAssertions.assertChildWidthInPercentage(layout,
-                primaryElement, SplitterPositionView.FINAL_POSITION);
-        SplitLayoutAssertions.assertChildWidthInPercentage(layout,
-                secondaryElement, SplitterPositionView.INITIAL_POSITION);
-    }
-
-    private TestBenchElement getPrimaryElement(SplitLayoutElement layout,
-            String testId) {
-        return layout.$(SpanElement.class).id("primary" + testId);
-    }
-
-    private TestBenchElement getSecondaryElement(SplitLayoutElement layout,
-            String testId) {
-        return layout.$(SpanElement.class).id("secondary" + testId);
     }
 
     private SpanElement getShowSplitterPositionElement(String testId) {
         return $(SpanElement.class).id("showSplitterPosition" + testId);
-    }
-
-    private SpanElement getShowPrimaryComponentWidthElement(String testId) {
-        return $(SpanElement.class).id("showPrimaryComponentWidth" + testId);
-    }
-
-    private SpanElement getShowSecondaryComponentWidthElement(String testId) {
-        return $(SpanElement.class).id("showSecondaryComponentWidth" + testId);
     }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -93,6 +93,11 @@ public class SplitterPositionIT extends AbstractComponentIT {
                     .getPropertyString("style", "flex"));
             Assert.assertNotEquals("", getSecondaryElement(layout, testId)
                     .getPropertyString("style", "flex"));
+            Assert.assertNotEquals("", getShowSplitterPositionElement(testId).getText());
+            Assert.assertNotEquals("",
+                    getShowPrimaryComponentWidthElement(testId).getText());
+            Assert.assertNotEquals("",
+                    getShowSecondaryComponentWidthElement(testId).getText());
         });
     }
 
@@ -107,6 +112,12 @@ public class SplitterPositionIT extends AbstractComponentIT {
                 primaryElement, SplitterPositionView.INITIAL_POSITION);
         SplitLayoutAssertions.assertChildWidthInPercentage(layout,
                 secondaryElement, SplitterPositionView.FINAL_POSITION);
+
+        Assert.assertEquals("", getShowSplitterPositionElement(testId).getText());
+        Assert.assertEquals("",
+                getShowPrimaryComponentWidthElement(testId).getText());
+        Assert.assertEquals("",
+                getShowSecondaryComponentWidthElement(testId).getText());
 
         modifyState.accept(layout);
         $(NativeButtonElement.class).id("setSplitPosition" + testId).click();
@@ -125,5 +136,17 @@ public class SplitterPositionIT extends AbstractComponentIT {
     private TestBenchElement getSecondaryElement(SplitLayoutElement layout,
             String testId) {
         return layout.$(SpanElement.class).id("secondary" + testId);
+    }
+
+    private SpanElement getShowSplitterPositionElement(String testId) {
+        return $(SpanElement.class).id("showSplitterPosition" + testId);
+    }
+
+    private SpanElement getShowPrimaryComponentWidthElement(String testId) {
+        return $(SpanElement.class).id("showPrimaryComponentWidth" + testId);
+    }
+
+    private SpanElement getShowSecondaryComponentWidthElement(String testId) {
+        return $(SpanElement.class).id("showSecondaryComponentWidth" + testId);
     }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -88,7 +88,8 @@ public class SplitterPositionIT extends AbstractComponentIT {
         testSplitterPosition(testId, layout -> {
             new Actions(getDriver()).dragAndDropBy(layout.getSplitter(), 20, 0)
                     .perform();
-            Assert.assertNotEquals("", getShowSplitterPositionElement(testId).getText());
+            Assert.assertNotEquals("",
+                    getShowSplitterPositionElement(testId).getText());
         });
     }
 
@@ -98,7 +99,8 @@ public class SplitterPositionIT extends AbstractComponentIT {
         SplitLayoutElement layout = $(SplitLayoutElement.class)
                 .id("splitLayout" + testId);
 
-        Assert.assertEquals("", getShowSplitterPositionElement(testId).getText());
+        Assert.assertEquals("",
+                getShowSplitterPositionElement(testId).getText());
 
         modifyState.accept(layout);
         $(NativeButtonElement.class).id("setSplitPosition" + testId).click();

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -217,8 +217,12 @@ public class SplitLayout extends Component
     }
 
     /**
-     * Gets splitter position
-     * 
+     * Gets the relative position of the splitter as a percentage value between
+     * 0 and 100. The value will be null unless the splitter position has been
+     * explicitly set on the server-side, or the splitter has been moved on the
+     * client side. The splitter position is automatically updated when as part
+     * of the {@link SplitterDragendEvent}.
+     *
      * @return the splitter position, may be null
      */
     public Double getSplitterPosition() {

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -4,8 +4,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout.SplitterDragendEvent;
 
 public class SplitLayoutUnitTest {
 
@@ -42,4 +44,66 @@ public class SplitLayoutUnitTest {
         Assert.assertEquals("Wrong number of children", 2,
                 secondaryComponent.getChildren().count());
     }
+
+    @Test
+    public void testGtetSplitterPosition() {
+        SplitLayout splitLayout = new SplitLayout();
+        double splitterPosition = 45.66;
+
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        Assert.assertEquals(splitterPosition, splitLayout.getSplitterPosition(),
+                0.01);
+    }
+
+    @Test
+    public void testUpdateSplitterPosition_dragEndEvent_widthInPixels() {
+        SplitLayout splitLayout = new SplitLayout();
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
+                splitLayout, true, "432.68px", "267.32px"));
+
+        Assert.assertEquals(61.81, splitLayout.getSplitterPosition(),
+                0.01);
+    }
+
+    @Test
+    public void testUpdateSplitterPosition_dragEndEvent_widthInPercentage() {
+        SplitLayout splitLayout = new SplitLayout();
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
+                splitLayout, true, "58.23%", "41.77%"));
+
+        Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
+    }
+
+    @Test
+    public void testUpdateSplitterPosition_dragEndEvent_primaryWidthNull() {
+        SplitLayout splitLayout = new SplitLayout();
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout,
+                new SplitterDragendEvent(splitLayout, true, null, "41.77%"));
+
+        Assert.assertEquals(45.66, splitLayout.getSplitterPosition(), 0);
+    }
+
+    @Test
+    public void testUpdateSplitterPosition_dragEndEvent_secondaryWidthNull() {
+        SplitLayout splitLayout = new SplitLayout();
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout,
+                new SplitterDragendEvent(splitLayout, true, "41.77%", null));
+
+        Assert.assertEquals(45.66, splitLayout.getSplitterPosition(), 0);
+    }
+
+
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -46,7 +46,7 @@ public class SplitLayoutUnitTest {
     }
 
     @Test
-    public void testGtetSplitterPosition() {
+    public void testGetSplitterPosition() {
         SplitLayout splitLayout = new SplitLayout();
         double splitterPosition = 45.66;
 

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -65,8 +65,7 @@ public class SplitLayoutUnitTest {
         ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
                 splitLayout, true, "432.68px", "267.32px"));
 
-        Assert.assertEquals(61.81, splitLayout.getSplitterPosition(),
-                0.01);
+        Assert.assertEquals(61.81, splitLayout.getSplitterPosition(), 0.01);
     }
 
     @Test
@@ -104,6 +103,5 @@ public class SplitLayoutUnitTest {
 
         Assert.assertEquals(45.66, splitLayout.getSplitterPosition(), 0);
     }
-
 
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description
As requested in the issue, it's now possible to get the new splitter position in drag end event after moving the splitter manually. Also added the new primary and secondary components width to the same event.
Implementation based on this recipe https://github.com/vaadin/cookbook/pull/264

Fixes #1517

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
