### PR TITLE
fix: remove static spreadsheet reference

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetState.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetState.java
@@ -20,12 +20,9 @@ import org.apache.poi.ss.usermodel.Sheet;
  * last selected cell is considered depends on which one happens later.
  */
 class SheetState implements Serializable {
-    private static Spreadsheet spreadSheet;
-    private static WeakHashMap<Sheet, String> selectedCells = new WeakHashMap<Sheet, String>();
+    private final WeakHashMap<Sheet, String> selectedCells = new WeakHashMap<Sheet, String>();
 
     SheetState(final Spreadsheet spreadSheet) {
-        this.spreadSheet = spreadSheet;
-
         spreadSheet.addSelectionChangeListener(
                 new Spreadsheet.SelectionChangeListener() {
                     @Override


### PR DESCRIPTION
## Description

Currently the `SheetState` class uses a `static ` reference to its spreadsheet, which means:
- the last constructed spreadsheet will be kept in memory indefinitely, causing a minor memory leak
- previously constructed spreadsheets will use the last constructed spreadsheet for storing selected cells

This change removes the static references (intention might have been to use `final` instead).

Related to this comment: https://github.com/vaadin/flow-components/issues/5130#issuecomment-1596800160

## Type of change

- Bugfix
