### PR TITLE
fix: mark CRUD buttons as default to handle them properly

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/BasicUseIT.java
@@ -112,6 +112,21 @@ public class BasicUseIT extends AbstractParallelTest {
     }
 
     @Test
+    public void defaultButtonTexts() {
+        CrudElement crud = $(CrudElement.class).waitForFirst();
+        Assert.assertEquals("New item",
+                crud.getNewItemButton().get().getText().trim());
+
+        crud.openRowForEditing(0);
+        Assert.assertEquals("Save",
+                crud.getEditorSaveButton().getText().trim());
+        Assert.assertEquals("Cancel",
+                crud.getEditorCancelButton().getText().trim());
+        Assert.assertEquals("Delete...",
+                crud.getEditorDeleteButton().getText().trim());
+    }
+
+    @Test
     public void i18n() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         Assert.assertEquals("New item",

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -133,18 +133,26 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
 
         newButton = new Button();
         newButton.getElement().setAttribute("theme", "primary");
+        // Ensure the flag is set before the element is added to the slot
+        newButton.getElement().setProperty("_isDefault", true);
         SlotUtils.addToSlot(this, "new-button", newButton);
 
         saveButton = new SaveButton();
         saveButton.addThemeName("primary");
+        // Ensure the flag is set before the element is added to the slot
+        saveButton.getElement().setProperty("_isDefault", true);
         SlotUtils.addToSlot(this, "save-button", saveButton);
 
         cancelButton = new Button();
         cancelButton.addThemeName("tertiary");
+        // Ensure the flag is set before the element is added to the slot
+        cancelButton.getElement().setProperty("_isDefault", true);
         SlotUtils.addToSlot(this, "cancel-button", cancelButton);
 
         deleteButton = new Button();
         deleteButton.addThemeNames("tertiary", "error");
+        // Ensure the flag is set before the element is added to the slot
+        deleteButton.getElement().setProperty("_isDefault", true);
         SlotUtils.addToSlot(this, "delete-button", deleteButton);
     }
 


### PR DESCRIPTION
## Description

Added a flag that was introduced by https://github.com/vaadin/web-components/pull/5955 
This indicates that the button created by the Flow counterpart is the default one.

## Type of change

- Fix