### PR TITLE
fix: make SideNavItemElement#getLabel() return correct text

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/frontend/side-nav-in-template.js
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/frontend/side-nav-in-template.js
@@ -1,0 +1,26 @@
+import { html, LitElement } from 'lit';
+
+class SideNavInTemplate extends LitElement {
+  render() {
+    return html`
+      <vaadin-side-nav id="sideNav">
+        <vaadin-side-nav-item path="/home">
+          <span slot="prefix">prefix</span>
+            Home
+          <span slot="suffix">suffix</span>
+        </vaadin-side-nav-item>
+        <vaadin-side-nav-item path="/about">
+          About
+          <br>
+          this project
+        </vaadin-side-nav-item>
+      </vaadin-side-nav>
+    `;
+  }
+
+  static get is() {
+    return 'side-nav-in-template';
+  }
+}
+
+customElements.define(SideNavInTemplate.is, SideNavInTemplate);

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -57,6 +57,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-lit-template</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/main/java/com/vaadin/flow/component/sidenav/tests/SideNavInTemplatePage.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/main/java/com/vaadin/flow/component/sidenav/tests/SideNavInTemplatePage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.sidenav.tests;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.sidenav.SideNav;
+import com.vaadin.flow.component.template.Id;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-side-nav/side-nav-in-template")
+@JsModule("side-nav-in-template.js")
+@Tag("side-nav-in-template")
+public class SideNavInTemplatePage extends LitTemplate {
+
+    @Id("sideNav")
+    private SideNav sideNav;
+
+    public SideNavInTemplatePage() {
+    }
+}

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavInTemplateIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavInTemplateIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.sidenav.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.sidenav.testbench.SideNavElement;
+import com.vaadin.flow.component.sidenav.testbench.SideNavItemElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * Integration tests for the {@link SideNavInTemplatePage}.
+ *
+ * @author Vaadin Ltd.
+ */
+@TestPath("vaadin-side-nav/side-nav-in-template")
+public class SideNavInTemplateIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void sideNavItem_getLabel_returnsSingleNodeTextContent() {
+        SideNavElement sideNav = $("side-nav-in-template").first()
+                .$(SideNavElement.class).first();
+        SideNavItemElement item = sideNav.getItems().get(0);
+
+        Assert.assertEquals("Home", item.getLabel());
+    }
+
+    @Test
+    public void sideNavItem_getLabel_returnsMergedNodesTextContent() {
+        SideNavElement sideNav = $("side-nav-in-template").first()
+                .$(SideNavElement.class).first();
+        SideNavItemElement item = sideNav.getItems().get(1);
+
+        Assert.assertEquals("About this project", item.getLabel());
+    }
+}

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -45,7 +45,9 @@ public class SideNavItemElement extends TestBenchElement {
         final WebElement unnamedSlot = getWrappedElement().getShadowRoot()
                 .findElement(By.cssSelector("slot:not([name])"));
         return (String) executeScript(
-                "return arguments[0].assignedNodes().filter(node => node.nodeType === Node.TEXT_NODE)[0].textContent;",
+                "return arguments[0].assignedNodes().map(node => {"
+                        + "  return (node.nodeType === Node.TEXT_NODE) ? node.textContent.trim() : ''"
+                        + "}).filter(Boolean).join(' ')",
                 unnamedSlot);
     }
 


### PR DESCRIPTION
## Description

Fixes #5143

- Updated the script used by `getLabel()` to filter out empty "anonymous" text nodes,
- Added `SideNavInTemplateIT` using `LitTemplate` where this case was reproducible.

## Type of change

- Bugfix