### PR TITLE
fix: check for presence of inputElement before assigning a value

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -372,13 +372,13 @@ public class BigDecimalField
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())) {
             // Clear the input element from possible bad input.
-            getElement().executeJs("this.inputElement.value = ''");
+            getElement().executeJs("if (this.inputElement) this.inputElement.value = ''");
         } else {
             // Restore the input element's value in case it was cleared
             // in the above branch. That can happen when setValue(null)
             // and setValue(...) are subsequently called within one round-trip
             // and there was bad input.
-            getElement().executeJs("this.inputElement.value = this.value");
+            getElement().executeJs("if (this.inputElement) this.inputElement.value = this.value");
         }
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -372,7 +372,8 @@ public class BigDecimalField
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())) {
             // Clear the input element from possible bad input.
-            getElement().executeJs("this.inputElement.value = ''");
+            getElement().executeJs(
+                    "if (this.inputElement) this.inputElement.value = ''");
         } else {
             // Restore the input element's value in case it was cleared
             // in the above branch. That can happen when setValue(null)

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -372,8 +372,7 @@ public class BigDecimalField
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())) {
             // Clear the input element from possible bad input.
-            getElement().executeJs(
-                    "if (this.inputElement) this.inputElement.value = ''");
+            getElement().executeJs("this.inputElement.value = ''");
         } else {
             // Restore the input element's value in case it was cleared
             // in the above branch. That can happen when setValue(null)

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -372,13 +372,15 @@ public class BigDecimalField
         if (Objects.equals(oldValue, getEmptyValue())
                 && Objects.equals(value, getEmptyValue())) {
             // Clear the input element from possible bad input.
-            getElement().executeJs("if (this.inputElement) this.inputElement.value = ''");
+            getElement().executeJs(
+                    "if (this.inputElement) this.inputElement.value = ''");
         } else {
             // Restore the input element's value in case it was cleared
             // in the above branch. That can happen when setValue(null)
             // and setValue(...) are subsequently called within one round-trip
             // and there was bad input.
-            getElement().executeJs("if (this.inputElement) this.inputElement.value = this.value");
+            getElement().executeJs(
+                    "if (this.inputElement) this.inputElement.value = this.value");
         }
     }
 


### PR DESCRIPTION
## Description

The PR adds a check for the presence of `this.inputElement` before `BigDecimalField` assigns a value to it. As discovered, `this.inputElement` can be `undefined` during initialization when `BigDecimalField` is rendered by the component render. 

Only version 23.3 is affected. The latest versions are using a setter that includes that check already.

Fixes https://github.com/vaadin/flow-components/issues/5169

## Type of change

- [x] Bugfix
