### PR TITLE
refactor: rename side nav item active property to current

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -64,7 +64,7 @@ public class SideNavElement extends TestBenchElement {
     }
 
     public SideNavItemElement getSelectedItem() {
-        return getItemsStream(true).filter(SideNavItemElement::isActive)
+        return getItemsStream(true).filter(SideNavItemElement::isCurrent)
                 .findAny().orElse(null);
     }
 

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -59,8 +59,8 @@ public class SideNavItemElement extends TestBenchElement {
         return hasAttribute("expanded");
     }
 
-    public boolean isActive() {
-        return hasAttribute("active");
+    public boolean isCurrent() {
+        return hasAttribute("current");
     }
 
     @Override


### PR DESCRIPTION
## Description

The `active` property in the Side Nav Item web component was [renamed](https://github.com/vaadin/web-components/pull/6053) to `current`. This PR makes the change for the Flow counterpart.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.