### PR TITLE
fix: handle initial null position when calculating splitter position

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -383,10 +383,10 @@ public class SplitLayout extends Component
         }
     }
 
-    private double calcNewSplitterPosition(String primaryWidth,
+    private Double calcNewSplitterPosition(String primaryWidth,
             String secondaryWidth) {
         // set current splitter position value
-        double splitterPositionValue = this.splitterPosition;
+        Double splitterPositionValue = this.splitterPosition;
 
         if (primaryWidth == null || secondaryWidth == null) {
             return splitterPositionValue;

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -104,4 +104,13 @@ public class SplitLayoutUnitTest {
         Assert.assertEquals(45.66, splitLayout.getSplitterPosition(), 0);
     }
 
+    @Test
+    public void testUpdateSplitterPosition_noInitialPosition() {
+        SplitLayout splitLayout = new SplitLayout();
+
+        ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
+                splitLayout, true, "432.68px", "267.32px"));
+
+        Assert.assertEquals(61.81, splitLayout.getSplitterPosition(), 0.01);
+    }
 }


### PR DESCRIPTION
## Description

Fixes a regression from #5158. If the current splitter position is `null`, which is the initial value, then it was not assignable as `double`.

Fixes #5224 

## Type of change

- Bugfix