### PR TITLE
Revert "refactor: preload items on grid scroll to index (#4854)"

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -1,6 +1,5 @@
 package com.vaadin.flow.component.grid.it;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -16,8 +15,9 @@ public class GridScrollToPage extends Div {
         Grid<String> grid = new Grid<>();
         grid.setId("data-grid");
 
-        grid.setItems(IntStream.rangeClosed(0, 1000).mapToObj(String::valueOf)
-                .collect(Collectors.toList()));
+        List<String> items = IntStream.rangeClosed(0, 1000)
+                .mapToObj(String::valueOf).collect(Collectors.toList());
+        grid.setItems(items);
 
         grid.addColumn(item -> item).setHeader("Data");
 
@@ -33,23 +33,24 @@ public class GridScrollToPage extends Div {
                 e -> grid.scrollToIndex(500));
         scrollToRow500.setId("scroll-to-row-500");
 
-        Grid<String> grid2 = new Grid<>();
-        grid2.setId("scroll-to-end-grid");
-
-        List<String> items = new ArrayList<>();
-        grid2.setItems(items);
-        grid2.addColumn(item -> item);
-
         NativeButton addRowsAndScrollToEnd = new NativeButton(
                 "Add row and scroll to end", e -> {
                     items.add(String.valueOf(items.size()));
                     items.add(String.valueOf(items.size()));
-                    grid2.getDataProvider().refreshAll();
-                    grid2.scrollToEnd();
+                    grid.getDataProvider().refreshAll();
+                    grid.scrollToEnd();
                 });
         addRowsAndScrollToEnd.setId("add-row-and-scroll-to-end");
 
-        add(grid, scrollToStart, scrollToEnd, scrollToRow500, grid2,
-                addRowsAndScrollToEnd);
+        NativeButton addRowAndScrollToIndex = new NativeButton(
+                "Add row and scroll to index", e -> {
+                    items.add(String.valueOf(items.size()));
+                    grid.getDataProvider().refreshAll();
+                    grid.scrollToIndex(items.size() - 1);
+                });
+        addRowAndScrollToIndex.setId("add-row-and-scroll-to-index");
+
+        add(grid, scrollToStart, scrollToEnd, scrollToRow500,
+                addRowsAndScrollToEnd, addRowAndScrollToIndex);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
@@ -36,8 +36,7 @@ public class GridScrollToIT extends AbstractComponentIT {
     @Before
     public void init() {
         open();
-        waitForElementPresent(By.tagName("vaadin-grid"));
-        grid = $(GridElement.class).first();
+        grid = $(GridElement.class).waitForFirst();
     }
 
     @Test
@@ -74,14 +73,20 @@ public class GridScrollToIT extends AbstractComponentIT {
         WebElement button = $("button").id("add-row-and-scroll-to-end");
         button.click();
 
-        GridElement grid = $(GridElement.class).id("scroll-to-end-grid");
-
-        Assert.assertEquals(0, grid.getFirstVisibleRowIndex());
-        Assert.assertEquals(1, grid.getLastVisibleRowIndex());
+        Assert.assertEquals(1002, grid.getLastVisibleRowIndex());
 
         button.click();
-        Assert.assertEquals(0, grid.getFirstVisibleRowIndex());
-        Assert.assertEquals(3, grid.getLastVisibleRowIndex());
+        Assert.assertEquals(1004, grid.getLastVisibleRowIndex());
+    }
+
+    @Test
+    public void grid_addItem_scrollToIndex() {
+        $("button").id("add-row-and-scroll-to-index").click();
+
+        checkLogsForErrors();
+        Assert.assertEquals(1001, grid.getLastVisibleRowIndex());
+        Assert.assertEquals("1001",
+                grid.getCell(grid.getLastVisibleRowIndex(), 0).getText());
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4509,9 +4509,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
-        // Preload the items for the given index
-        setRequestedRange(rowIndex, getPageSize());
-
         getElement().callJsFunction("scrollToIndex", rowIndex);
     }
 


### PR DESCRIPTION
## Description

Reverts #4854 which introduced a regression when using `scrollToIndex` and adds a respective test.

Fixes https://github.com/vaadin/flow-components/issues/5187
