### PR TITLE
refactor: remove duplicate checks from isLoading

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -48,13 +48,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               return this.isLoadingOriginal();
             }
 
-            return Boolean(
-              this.grid.$connector.hasEnsureSubCacheQueue() ||
-                Object.keys(this.pendingRequests).length ||
-                Object.keys(this.itemCaches).filter((index) => {
-                  return this.itemCaches[index].isLoading();
-                })[0]
-            );
+            return this.grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
           });
 
           ItemCache.prototype.doEnsureSubCacheForScaledIndex = tryCatchWrapper(function (scaledIndex) {


### PR DESCRIPTION
## Description

Refactors the `isLoading` method to get rid of duplicate checks by reusing the [original `isLoading` method](https://github.com/vaadin/web-components/blob/21e3826c882c863909aa4b48b57369b799ef2b59/packages/grid/src/vaadin-grid-data-provider-mixin.js#L41C16-L48) provided by the web component.

## Type of change

- [x] Refactor
