### PR TITLE
refactor: reintroduce side nav item constructor

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -133,6 +133,24 @@ public class SideNavItem extends SideNavItemContainer
      *            the label for the item
      * @param view
      *            the view to link to
+     * @param prefixComponent
+     *            the prefixComponent for the item (usually an icon)
+     */
+    public SideNavItem(String label, Class<? extends Component> view,
+            Component prefixComponent) {
+        setPath(view);
+        setLabel(label);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Creates a new menu item using the given label and prefix component (like
+     * an icon) that links to the given view.
+     *
+     * @param label
+     *            the label for the item
+     * @param view
+     *            the view to link to
      * @param routeParameters
      *            the route parameters
      * @param prefixComponent


### PR DESCRIPTION
## Description

Reintroduce removed constructor.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.