### PR TITLE
refactor: reuse GridSelectionColumnBaseMixin in Flow Grid selection column

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
@@ -51,6 +51,9 @@ public class GridMultiSelectionColumnPage extends Div {
      * Constructor.
      */
     public GridMultiSelectionColumnPage() {
+        // Add a padding, so we can actually scroll past the grids
+        getStyle().set("padding", "20px");
+
         message = new Div();
         message.setId("selected-item-count");
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -79,11 +79,13 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 selectAllCheckbox.getAttribute("indeterminate"));
 
         // Select single
+        // Note that in indeterminate state, the select all checkbox is also
+        // checked
         selectCheckbox.click();
         Assert.assertEquals("Selected item count: 1", message.getText());
-        Assert.assertNull(
-                "Select all checkbox is checked even though not all items selected",
-                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not checked even though an item is selected",
+                "true", selectAllCheckbox.getAttribute("checked"));
         Assert.assertEquals(
                 "Select all checkbox is not in indeterminate state even though an item is selected",
                 "true", selectAllCheckbox.getAttribute("indeterminate"));
@@ -102,14 +104,16 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 selectAllCheckbox.getAttribute("indeterminate"));
 
         // Deselect single
+        // Note that in indeterminate state, the select all checkbox is also
+        // checked
         selectCheckbox.click();
         Assert.assertEquals(
                 "Selected item count: "
                         + (GridMultiSelectionColumnPage.ITEM_COUNT - 1),
                 message.getText());
-        Assert.assertNull(
-                "Select all checkbox is checked even though not all items selected",
-                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not checked even though an item is selected",
+                "true", selectAllCheckbox.getAttribute("checked"));
         Assert.assertEquals(
                 "Select all checkbox is not in indeterminate state even though not all items selected",
                 "true", selectAllCheckbox.getAttribute("indeterminate"));
@@ -291,9 +295,16 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 .id("deSelectRow0");
         deSelectRow.click();
 
+        // Note that in indeterminate state, the select all checkbox is also
+        // checked
         WebElement selectAllCheckbox = grid
                 .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
-        Assert.assertEquals(null, selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not checked even though an item is selected",
+                "true", selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals(
+                "Select all checkbox is not in indeterminate state even though not all items selected",
+                "true", selectAllCheckbox.getAttribute("indeterminate"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
@@ -72,18 +72,23 @@ public class GridViewSelectionIT extends AbstractComponentIT {
         Assert.assertFalse(isRowSelected(grid, 6));
 
         // test the select all button
-        grid.findElement(By.id("selectAllCheckbox")).click();
+        TestBenchElement selectAllCheckbox = grid
+                .findElement(By.id("selectAllCheckbox"));
+        selectAllCheckbox.click();
+
         // deselect 1
         getCellContent(grid.getCell(0, 0)).click();
-        Assert.assertEquals("Select all should have been deselected", false,
-                grid.findElement(By.id("selectAllCheckbox"))
-                        .getPropertyBoolean("checked"));
+        Assert.assertEquals("Select all should be checked", "true",
+                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals("Select all should be indeterminate", "true",
+                selectAllCheckbox.getAttribute("indeterminate"));
 
+        // reselect 1
         getCellContent(grid.getCell(0, 0)).click();
-        Assert.assertEquals("Select all should have been reselected", true,
-                grid.findElement(By.id("selectAllCheckbox"))
-                        .getPropertyBoolean("checked"));
-
+        Assert.assertEquals("Select all should be checked", "true",
+                selectAllCheckbox.getAttribute("checked"));
+        Assert.assertNull("Select all should not be indeterminate",
+                selectAllCheckbox.getAttribute("indeterminate"));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -71,7 +71,7 @@ public class GridSelectionColumn extends Component {
      *            the new indeterminate state of the select all checkbox
      */
     public void setSelectAllCheckboxIndeterminateState(boolean indeterminate) {
-        getElement().setProperty("indeterminate", indeterminate);
+        getElement().setProperty("_indeterminate", indeterminate);
     }
 
     /**
@@ -81,7 +81,7 @@ public class GridSelectionColumn extends Component {
      *            whether to display the select all checkbox or hide it
      */
     public void setSelectAllCheckBoxVisibility(boolean visible) {
-        getElement().setProperty("selectAllHidden", !visible);
+        getElement().setProperty("_selectAllHidden", !visible);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -1,156 +1,97 @@
 import '@vaadin/grid/vaadin-grid-column.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
-{
-  class GridFlowSelectionColumnElement extends GridColumn {
+import { GridSelectionColumnBaseMixin } from '@vaadin/grid/src/vaadin-grid-selection-column-base-mixin.js';
 
-    static get is() {
-      return 'vaadin-grid-flow-selection-column';
-    }
+class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
 
-    static get properties() {
-      return {
+  static get is() {
+    return 'vaadin-grid-flow-selection-column';
+  }
 
-        /**
-         * Automatically sets the width of the column based on the column contents when this is set to `true`.
-         */
-        autoWidth: {
-          type: Boolean,
-          value: true
-        },
+  static get properties() {
+    return {
+      /**
+       * Automatically sets the width of the column based on the column contents when this is set to `true`.
+       */
+      autoWidth: {
+        type: Boolean,
+        value: true
+      },
 
-        /**
-         * Width of the cells for this column.
-         */
-        width: {
-          type: String,
-          value: '56px'
-        },
-
-        /**
-         * Flex grow ratio for the cell widths. When set to 0, cell width is fixed.
-         */
-        flexGrow: {
-          type: Number,
-          value: 0
-        },
-
-        /**
-         * When true, all the items are selected.
-         */
-        selectAll: {
-          type: Boolean,
-          value: false,
-          notify: true
-        },
-
-        /**
-         * Whether to display the select all checkbox in indeterminate state,
-         * which means some, but not all, items are selected
-         */
-        indeterminate: {
-          type: Boolean,
-          value: false,
-          notify: true
-        },
-
-        selectAllHidden: Boolean
-      };
-    }
-
-    constructor() {
-      super();
-      this._boundOnSelectEvent = this._onSelectEvent.bind(this);
-      this._boundOnDeselectEvent = this._onDeselectEvent.bind(this);
-    }
-
-    static get observers() {
-      return [
-        '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, indeterminate, selectAllHidden)'
-      ];
-    }
-
-    /** @private */
-    connectedCallback() {
-      super.connectedCallback();
-      if (this._grid) {
-        this._grid.addEventListener('select', this._boundOnSelectEvent);
-        this._grid.addEventListener('deselect', this._boundOnDeselectEvent);
+      /**
+       * Width of the cells for this column.
+       */
+      width: {
+        type: String,
+        value: '56px'
       }
-    }
+    };
+  }
 
-    /** @private */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-      if (this._grid) {
-        this._grid.removeEventListener('select', this._boundOnSelectEvent);
-        this._grid.removeEventListener('deselect', this._boundOnDeselectEvent);
-      }
-    }
-
-    /**
-     * Renders the Select All checkbox to the header cell.
-     *
-     * @override
-     */
-    _defaultHeaderRenderer(root, _column) {
-      let checkbox = root.firstElementChild;
-      if (!checkbox) {
-        checkbox = document.createElement('vaadin-checkbox');
-        checkbox.id = 'selectAllCheckbox';
-        checkbox.setAttribute('aria-label', 'Select All');
-        checkbox.classList.add('vaadin-grid-select-all-checkbox');
-        checkbox.addEventListener('click', this._onSelectAllClick.bind(this));
-        root.appendChild(checkbox);
-      }
-
-      const checked = this.selectAll;
-      checkbox.hidden = this.selectAllHidden;
-      checkbox.checked = checked;
-      checkbox.indeterminate = this.indeterminate;
-    }
-
-    /**
-     * Renders the Select Row checkbox to the body cell.
-     *
-     * @override
-     */
-    _defaultRenderer(root, _column, { item, selected }) {
-      let checkbox = root.firstElementChild;
-      if (!checkbox) {
-        checkbox = document.createElement('vaadin-checkbox');
-        checkbox.setAttribute('aria-label', 'Select Row');
-        checkbox.addEventListener('click', this._onSelectClick.bind(this));
-        root.appendChild(checkbox);
-      }
-
-      checkbox.__item = item;
-      checkbox.checked = selected;
-    }
-
-    _onSelectClick(e) {
-      e.currentTarget.checked ? this._grid.$connector.doDeselection([e.currentTarget.__item], true) : this._grid.$connector.doSelection([e.currentTarget.__item], true);
-    }
-
-    _onSelectAllClick(e) {
-      e.preventDefault();
-      if (this._grid.hasAttribute('disabled')) {
-        e.currentTarget.checked = !e.currentTarget.checked;
-        return;
-      }
-      this.selectAll ? this.$server.deselectAll() : this.$server.selectAll();
-    }
-
-    _onSelectEvent(e) {
-    }
-
-    _onDeselectEvent(e) {
-      if (e.detail.userOriginated) {
-        this.selectAll = false;
-      }
+  /**
+   * Renders the Select All checkbox to the header cell.
+   *
+   * @override
+   */
+  _defaultHeaderRenderer(root, _column) {
+    super._defaultHeaderRenderer(root, _column);
+    const checkbox = root.firstElementChild;
+    if (checkbox) {
+      // TODO: Remove id and use CSS class selector in TestBench
+      checkbox.id = 'selectAllCheckbox';
     }
   }
 
-  customElements.define(GridFlowSelectionColumnElement.is, GridFlowSelectionColumnElement);
 
-  Vaadin.GridFlowSelectionColumnElement = GridFlowSelectionColumnElement;
+  /**
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * selecting all items.
+   *
+   * @protected
+   * @override
+   */
+  _selectAll() {
+    this.selectAll = true;
+    this.$server.selectAll();
+  }
+
+  /**
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * deselecting all items.
+   *
+   * @protected
+   * @override
+   */
+  _deselectAll() {
+    this.selectAll = false;
+    this.$server.deselectAll();
+  }
+
+  /**
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * selecting an item.
+   *
+   * @param {Object} item the item to select
+   * @protected
+   * @override
+   */
+  _selectItem(item) {
+    this._grid.$connector.doSelection([item], true);
+  }
+
+  /**
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * deselecting an item.
+   *
+   * @param {Object} item the item to deselect
+   * @protected
+   * @override
+   */
+  _deselectItem(item) {
+    this._grid.$connector.doDeselection([item], true);
+    // Optimistically update select all state
+    this.selectAll = false;
+  }
 }
+
+customElements.define(GridFlowSelectionColumn.is, GridFlowSelectionColumn);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -11,7 +11,7 @@ class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
   static get properties() {
     return {
       /**
-       * Automatically sets the width of the column based on the column contents when this is set to `true`.
+       * Override property to enable auto-width
        */
       autoWidth: {
         type: Boolean,
@@ -19,7 +19,7 @@ class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
       },
 
       /**
-       * Width of the cells for this column.
+       * Override property to set custom width
        */
       width: {
         type: String,
@@ -29,7 +29,8 @@ class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
   }
 
   /**
-   * Renders the Select All checkbox to the header cell.
+   * Override method from `GridSelectionColumnBaseMixin` to add ID to select all
+   * checkbox
    *
    * @override
    */
@@ -37,7 +38,6 @@ class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
     super._defaultHeaderRenderer(root, _column);
     const checkbox = root.firstElementChild;
     if (checkbox) {
-      // TODO: Remove id and use CSS class selector in TestBench
       checkbox.id = 'selectAllCheckbox';
     }
   }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -234,13 +234,13 @@ public class AbstractGridMultiSelectionModelTest {
         grid.getSelectionModel().select("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // select second, which equals all selected
         grid.getSelectionModel().select("bar");
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -253,13 +253,13 @@ public class AbstractGridMultiSelectionModelTest {
         grid.getSelectionModel().selectFromClient("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // select second, which equals all selected
         grid.getSelectionModel().selectFromClient("bar");
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -273,19 +273,19 @@ public class AbstractGridMultiSelectionModelTest {
                 .selectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect first
         grid.getSelectionModel().deselect("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect second, which equals none selected
         grid.getSelectionModel().deselect("bar");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -299,19 +299,19 @@ public class AbstractGridMultiSelectionModelTest {
                 .selectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect first
         grid.getSelectionModel().deselectFromClient("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect second, which equals none selected
         grid.getSelectionModel().deselectFromClient("bar");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -324,7 +324,7 @@ public class AbstractGridMultiSelectionModelTest {
                 .selectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -337,7 +337,7 @@ public class AbstractGridMultiSelectionModelTest {
                 .clientSelectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -351,12 +351,12 @@ public class AbstractGridMultiSelectionModelTest {
                 .selectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         grid.getSelectionModel().deselectAll();
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -370,13 +370,13 @@ public class AbstractGridMultiSelectionModelTest {
                 .selectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         ((AbstractGridMultiSelectionModel<String>) grid.getSelectionModel())
                 .clientDeselectAll();
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -389,19 +389,19 @@ public class AbstractGridMultiSelectionModelTest {
         grid.asMultiSelect().updateSelection(Set.of("foo", "bar"), Set.of());
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // Deselect single
         grid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // Deselect all
         grid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -37,7 +37,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         treeGrid.getSelectionModel().select("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // select second, which equals all selected
         // with hierarchical data provider we can not detect whether all are
@@ -45,7 +45,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         treeGrid.getSelectionModel().select("bar");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -56,7 +56,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         treeGrid.getSelectionModel().selectFromClient("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // select second, which equals all selected
         // with hierarchical data provider we can not detect whether all are
@@ -64,7 +64,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         treeGrid.getSelectionModel().selectFromClient("bar");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -76,19 +76,19 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 .clientSelectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect first
         treeGrid.getSelectionModel().deselect("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect second, which equals none selected
         treeGrid.getSelectionModel().deselect("bar");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -100,19 +100,19 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 .clientSelectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect first
         treeGrid.getSelectionModel().deselectFromClient("foo");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect second, which equals none selected
         treeGrid.getSelectionModel().deselectFromClient("bar");
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 .clientSelectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -135,12 +135,12 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 .clientSelectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         treeGrid.getSelectionModel().deselectAll();
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -152,13 +152,13 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 .clientSelectAll();
         Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
                 .clientDeselectAll();
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     @Test
@@ -172,19 +172,19 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 Set.of());
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // Deselect single
         treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertTrue(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // Deselect all
         treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
-                (boolean) columnElement.getPropertyRaw("indeterminate"));
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
     }
 
     private <T> GridSelectionColumn getGridSelectionColumn(Grid<T> grid) {


### PR DESCRIPTION
## Description

Reuse the `GridSelectionColumnBaseMixin` introduced with https://github.com/vaadin/web-components/pull/6143 in the `<vaadin-grid-flow-selection-column>` element.

Closes https://github.com/vaadin/web-components/issues/6103

## Type of change

- Refactoring