### PR TITLE
fix: check for null item in drag and drop filters

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
@@ -45,6 +45,7 @@ public class DragAndDropGridPage extends Div {
         grid.setItems(items);
         grid.setId("grid");
         grid.setSelectionMode(SelectionMode.MULTI);
+        grid.setDropMode(GridDropMode.BETWEEN);
 
         grid.setRowsDraggable(true);
 
@@ -106,6 +107,11 @@ public class DragAndDropGridPage extends Div {
             button.setId(mode.toString());
             add(button);
         });
+
+        NativeButton noDropMode = new NativeButton("No drop mode",
+                e -> grid.setDropMode(null));
+        noDropMode.setId("no-drop-mode");
+        add(noDropMode);
 
         NativeButton setGeneratorsButton = new NativeButton("set generators",
                 e -> {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +25,12 @@ import org.openqa.selenium.WebElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 @TestPath("vaadin-grid/drag-and-drop")
 public class DragAndDropGridIT extends AbstractComponentIT {
@@ -34,6 +41,12 @@ public class DragAndDropGridIT extends AbstractComponentIT {
     public void init() {
         open();
         grid = $(GridElement.class).first();
+    }
+
+    @Test
+    public void dragAndDropDefined_gridLoaded_noErrors() {
+        List<LogEntry> logs = getLogEntries(Level.SEVERE);
+        Assert.assertTrue(logs.isEmpty());
     }
 
     @Test
@@ -57,6 +70,7 @@ public class DragAndDropGridIT extends AbstractComponentIT {
 
     @Test
     public void noDropMode_dropOnRow_dropEventNotFired() {
+        click("no-drop-mode");
         fireDrop(3, "on-top");
         assertMessages("", "", "");
     }
@@ -197,6 +211,7 @@ public class DragAndDropGridIT extends AbstractComponentIT {
 
     @Test
     public void setDropFilter_undroppable_noDropMode() {
+        click("no-drop-mode");
         click("set-filters");
         fireDrop(2, "on-top");
         assertMessages("", "", "");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1199,9 +1199,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
         grid.dragFilter = tryCatchWrapper((rowData) => rowData.item && !rowData.item.dragDisabled);
 
-        // grid.dropFilter = tryCatchWrapper((rowData) => !rowData.item.dropDisabled);
-        // grid.dragFilter = tryCatchWrapper((rowData) => !rowData.item.dragDisabled);
-
         grid.addEventListener(
           'grid-dragstart',
           tryCatchWrapper((e) => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1195,9 +1195,12 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           return (part.row || '') + ' ' + ((column && part[column._flowId]) || '');
         });
 
-        grid.dropFilter = tryCatchWrapper((rowData) => !rowData.item.dropDisabled);
+        grid.dropFilter = tryCatchWrapper((rowData) => rowData.item && !rowData.item.dropDisabled);
 
-        grid.dragFilter = tryCatchWrapper((rowData) => !rowData.item.dragDisabled);
+        grid.dragFilter = tryCatchWrapper((rowData) => rowData.item && !rowData.item.dragDisabled);
+
+        // grid.dropFilter = tryCatchWrapper((rowData) => !rowData.item.dropDisabled);
+        // grid.dragFilter = tryCatchWrapper((rowData) => !rowData.item.dragDisabled);
 
         grid.addEventListener(
           'grid-dragstart',


### PR DESCRIPTION
## Description

Fix the regression introduced by https://github.com/vaadin/flow-components/pull/5040 by adding a check for the `item` property in `row` in `dragFilter` and `dropFilter` methods. Sometimes the method can be invoked before `item` is defined for the row.

Fixes #5177

## Type of change

- [X] Bugfix
- [ ] Feature
