### PR TITLE
fix: apply route parameters to side nav item correctly

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -379,7 +379,7 @@ public class SideNavItem extends SideNavItemContainer
                 getRouteParametersForAlias(alias, routeParameters));
     }
 
-    private static RouteParameters getRouteParametersForAlias(String alias,
+    private RouteParameters getRouteParametersForAlias(String alias,
             RouteParameters routeParameters) {
         Map<String, String> parametersMapForAlias = routeParameters
                 .getParameterNames().stream()

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -39,8 +39,10 @@ import elemental.json.JsonArray;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -368,9 +370,23 @@ public class SideNavItem extends SideNavItemContainer
 
     private String updateAliasWithRouteParameters(String alias,
             RouteParameters routeParameters) {
+        if (!alias.contains(":")) {
+            return alias;
+        }
         ConfigureRoutes configuredAliases = new ConfigureRoutes();
         configuredAliases.setRoute(alias, getClass());
-        return configuredAliases.getTargetUrl(getClass(), routeParameters);
+        return configuredAliases.getTargetUrl(getClass(),
+                getRouteParametersForAlias(alias, routeParameters));
+    }
+
+    private static RouteParameters getRouteParametersForAlias(String alias,
+            RouteParameters routeParameters) {
+        Map<String, String> parametersMapForAlias = routeParameters
+                .getParameterNames().stream()
+                .filter(paramName -> alias.contains(":" + paramName))
+                .collect(Collectors.toMap(Function.identity(),
+                        paramName -> routeParameters.get(paramName).get()));
+        return new RouteParameters(parametersMapForAlias);
     }
 
     private String updateQueryParameters(String path) {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -542,22 +542,47 @@ public class SideNavItemTest {
     }
 
     @Test
-    public void createFromComponentWithRouteParameters_aliasContainsParameters() {
+    public void setPathAndRouteParametersAsComponent_aliasesWithMatchingParamsUpdated() {
         runWithMockRouter(() -> {
-            sideNavItem = new SideNavItem("test", TestRouteWithAliases.class,
-                    new RouteParameters(Map.of("key", "value")));
+            sideNavItem.setPath(TestRouteWithAliases.class, new RouteParameters(
+                    Map.of("key1", "value1", "key2", "value2")));
 
-            assertPathAliases(Set.of("foo/value/bar"));
+            assertPathAliases(Set.of("foo/baz", "foo/qux", "foo/value1/bar",
+                    "foo/value1/value1/bar", "foo/value1/value2/bar"));
         }, TestRouteWithAliases.class);
     }
 
     @Test
-    public void setPathAndRouteParametersAsComponent_aliasContainsParameters() {
+    public void createFromComponentWithRouteParameters_aliasesWithMatchingParamsUpdated() {
+        runWithMockRouter(() -> {
+            sideNavItem = new SideNavItem("test", TestRouteWithAliases.class,
+                    new RouteParameters(
+                            Map.of("key1", "value1", "key2", "value2")));
+
+            assertPathAliases(Set.of("foo/baz", "foo/qux", "foo/value1/bar",
+                    "foo/value1/value1/bar", "foo/value1/value2/bar"));
+        }, TestRouteWithAliases.class);
+    }
+
+    @Test
+    public void setPathAndRouteParametersAsComponent_aliasWithMissingParamNotAdded() {
         runWithMockRouter(() -> {
             sideNavItem.setPath(TestRouteWithAliases.class,
-                    new RouteParameters(Map.of("key", "value")));
+                    new RouteParameters(Map.of("key1", "value1")));
 
-            assertPathAliases(Set.of("foo/value/bar"));
+            assertPathAliases(Set.of("foo/baz", "foo/qux", "foo/value1/bar",
+                    "foo/value1/value1/bar"));
+        }, TestRouteWithAliases.class);
+    }
+
+    @Test
+    public void createFromComponentWithRouteParameters_aliasWithMissingParamNotAdded() {
+        runWithMockRouter(() -> {
+            sideNavItem = new SideNavItem("test", TestRouteWithAliases.class,
+                    new RouteParameters(Map.of("key1", "value1")));
+
+            assertPathAliases(Set.of("foo/baz", "foo/qux", "foo/value1/bar",
+                    "foo/value1/value1/bar"));
         }, TestRouteWithAliases.class);
     }
 
@@ -687,7 +712,9 @@ public class SideNavItemTest {
     @Route("foo/bar")
     @RouteAlias("foo/baz")
     @RouteAlias("foo/qux")
-    @RouteAlias("foo/:key/bar")
+    @RouteAlias("foo/:key1/bar")
+    @RouteAlias("foo/:key1/:key1/bar")
+    @RouteAlias("foo/:key1/:key2/bar")
     private static class TestRouteWithAliases extends Component {
 
     }


### PR DESCRIPTION
## Description

This PR
- fixes the case where an alias does not require some of the provided route parameters, and therefore does not get added
- adds tests for not adding aliases that have parameters that are not provided
- expands the Side Nav Item route parameter tests with more aliases

No related issue.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.