### PR TITLE
fix: keep dialog open when inert

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -79,7 +79,7 @@ public class DialogTestPage extends Div {
         dialog.addOpenedChangeListener(event -> {
             message.setText(
                     "The open state of the dialog is " + dialog.isOpened());
-            eventCounterMessage.setText("Number of event is " + eventCounter++);
+            eventCounterMessage.setText("Number of event is " + ++eventCounter);
             eventSourceMessage.setText("The event came from "
                     + (event.isFromClient() ? "client" : "server"));
         });

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -79,7 +79,7 @@ public class DialogTestPage extends Div {
         dialog.addOpenedChangeListener(event -> {
             message.setText(
                     "The open state of the dialog is " + dialog.isOpened());
-            eventCounterMessage.setText("Number of event is " + ++eventCounter);
+            eventCounterMessage.setText("Number of events is " + ++eventCounter);
             eventSourceMessage.setText("The event came from "
                     + (event.isFromClient() ? "client" : "server"));
         });

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -79,7 +79,8 @@ public class DialogTestPage extends Div {
         dialog.addOpenedChangeListener(event -> {
             message.setText(
                     "The open state of the dialog is " + dialog.isOpened());
-            eventCounterMessage.setText("Number of events is " + ++eventCounter);
+            eventCounterMessage
+                    .setText("Number of events is " + ++eventCounter);
             eventSourceMessage.setText("The event came from "
                     + (event.isFromClient() ? "client" : "server"));
         });

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/InertDialogPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/InertDialogPage.java
@@ -1,0 +1,26 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.ElementUtil;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-dialog/inert-dialog")
+public class InertDialogPage extends Div {
+    public InertDialogPage() {
+        Dialog dialog = new Dialog();
+        dialog.setModal(true);
+        dialog.setCloseOnOutsideClick(true);
+        dialog.setCloseOnEsc(true);
+        add(dialog);
+
+        NativeButton setInert = new NativeButton("Set inert", event -> {
+            ElementUtil.setInert(dialog.getElement(), true);
+        });
+        setInert.setId("set-inert");
+        dialog.add(setInert);
+
+        dialog.open();
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -63,9 +63,8 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertEquals("The open state of the dialog is true",
                 message.getText());
-        Assert.assertEquals(
-                "There should not be initial events before opening the dialog",
-                "Number of event is 0", eventCounterMessage.getText());
+        Assert.assertEquals("There should one event from opening the dialog",
+                "Number of event is 1", eventCounterMessage.getText());
         Assert.assertEquals("The event came from server",
                 eventSourceMessage.getText());
 
@@ -76,7 +75,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         checkDialogIsClosed();
         Assert.assertEquals("The open state of the dialog is false",
                 message.getText());
-        Assert.assertEquals("Number of event is 1",
+        Assert.assertEquals("Number of event is 2",
                 eventCounterMessage.getText());
         Assert.assertEquals("The event came from server",
                 eventSourceMessage.getText());

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -64,7 +64,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         Assert.assertEquals("The open state of the dialog is true",
                 message.getText());
         Assert.assertEquals("There should one event from opening the dialog",
-                "Number of event is 1", eventCounterMessage.getText());
+                "Number of events is 1", eventCounterMessage.getText());
         Assert.assertEquals("The event came from server",
                 eventSourceMessage.getText());
 
@@ -75,7 +75,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         checkDialogIsClosed();
         Assert.assertEquals("The open state of the dialog is false",
                 message.getText());
-        Assert.assertEquals("Number of event is 2",
+        Assert.assertEquals("Number of events is 2",
                 eventCounterMessage.getText());
         Assert.assertEquals("The event came from server",
                 eventSourceMessage.getText());

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/InertDialogIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/InertDialogIT.java
@@ -1,0 +1,50 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.dialog.testbench.DialogElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+@TestPath("vaadin-dialog/inert-dialog")
+public class InertDialogIT extends AbstractComponentIT {
+    private DialogElement dialog;
+    private TestBenchElement setInert;
+
+    @Before
+    public void init() {
+        open();
+        dialog = $(DialogElement.class).waitForFirst();
+        setInert = dialog.$(TestBenchElement.class).id("set-inert");
+    }
+
+    @Test
+    public void notInert_closesOnOutsideClick() {
+        $("body").first().click();
+        Assert.assertFalse("Dialog should have closed", dialog.isOpen());
+    }
+
+    @Test
+    public void notInert_closesOnEscape() {
+        new Actions(getDriver()).sendKeys(Keys.ESCAPE).build().perform();
+        Assert.assertFalse("Dialog should have closed", dialog.isOpen());
+    }
+
+    @Test
+    public void inert_doesNotCloseOnOutsideClick() {
+        setInert.click();
+        $("body").first().click();
+        Assert.assertTrue("Dialog should stay open", dialog.isOpen());
+    }
+
+    @Test
+    public void inert_doesNotCloseOnEscape() {
+        setInert.click();
+        new Actions(getDriver()).sendKeys(Keys.ESCAPE).build().perform();
+        Assert.assertTrue("Dialog should stay open", dialog.isOpen());
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -87,7 +88,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     private static final String OVERLAY_LOCATOR_JS = "this.$.overlay";
 
     private boolean autoAddedToTheUi;
-    private int onCloseConfigured;
+    private int configuredCloseActionListeners;
     private String width;
     private String minWidth;
     private String maxWidth;
@@ -112,16 +113,11 @@ public class Dialog extends Component implements HasComponents, HasSize,
         // Workaround for: https://github.com/vaadin/flow/issues/3496
         setOpened(false);
 
-        getElement().addPropertyChangeListener("opened", event -> fireEvent(
-                new OpenedChangeEvent(this, event.isUserOriginated())));
-
-        addOpenedChangeListener(event -> {
-            if (!isOpened()) {
-                setModality(false);
-            }
-            if (autoAddedToTheUi && !isOpened()) {
-                getElement().removeFromParent();
-                autoAddedToTheUi = false;
+        getElement().addPropertyChangeListener("opened", event -> {
+            // Only handle client-side changes, server-side changes are already
+            // handled by setOpened
+            if (event.isUserOriginated()) {
+                doSetOpened(this.isOpened(), event.isUserOriginated());
             }
         });
 
@@ -284,14 +280,14 @@ public class Dialog extends Component implements HasComponents, HasSize,
     public Registration addDialogCloseActionListener(
             ComponentEventListener<DialogCloseActionEvent> listener) {
         if (isOpened()) {
-            ensureOnCloseConfigured();
+            configuredCloseActionListeners++;
         }
 
         Registration openedRegistration = addOpenedChangeListener(event -> {
             if (event.isOpened()) {
-                ensureOnCloseConfigured();
+                configuredCloseActionListeners++;
             } else {
-                onCloseConfigured = 0;
+                configuredCloseActionListeners = 0;
             }
         });
 
@@ -301,7 +297,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
             if (isOpened()) {
                 // the count is decremented if the dialog is closed. So we
                 // should decrement is explicitly if listener is deregistered
-                onCloseConfigured--;
+                configuredCloseActionListeners--;
             }
             openedRegistration.remove();
             registration.remove();
@@ -785,30 +781,43 @@ public class Dialog extends Component implements HasComponents, HasSize,
         }
     }
 
-    private void ensureOnCloseConfigured() {
-        if (onCloseConfigured == 0) {
-            getElement().getNode()
-                    .runWhenAttached(ui -> ui.beforeClientResponse(this,
-                            context -> doEnsureOnCloseConfigured(ui)));
-        }
-        onCloseConfigured++;
+    /**
+     * Registers event listeners on the dialog's overlay that prevent it from
+     * closing itself on outside click and escape press. Instead, the event
+     * listeners delegate to the server-side {@link #handleClientClose()}
+     * method. This serves two purposes:
+     * <ul>
+     * <li>Prevent the client overlay from closing if a custom close action
+     * listener is registered</li>
+     * <li>Prevent the client overlay from closing if the server-side dialog has
+     * become inert in the meantime, in which case the @ClientCallable call to
+     * {@link #handleClientClose()} will never be processed</li>
+     * </ul>
+     */
+    private void registerClientCloseHandler() {
+        //@formatter:off
+        getElement().executeJs("const listener = (e) => {"
+                + "  if (e.type == 'vaadin-overlay-escape-press' && !$0.noCloseOnEsc ||"
+                + "      e.type == 'vaadin-overlay-outside-click' && !$0.noCloseOnOutsideClick) {"
+                + "    e.preventDefault();"
+                + "    this.$server.handleClientClose();"
+                + "  }"
+                + "};"
+                + "this.$.overlay.addEventListener('vaadin-overlay-outside-click', listener);"
+                + "this.$.overlay.addEventListener('vaadin-overlay-escape-press', listener);");
+        //@formatter:on
     }
 
-    private void doEnsureOnCloseConfigured(UI ui) {
-        if (onCloseConfigured > 0) {
-            ui.getPage().executeJs("var f = function(e) {"
-                    + "  if (e.type == 'vaadin-overlay-escape-press' && !$0.noCloseOnEsc ||"
-                    + "      e.type == 'vaadin-overlay-outside-click' && !$0.noCloseOnOutsideClick) {"
-                    + "    e.preventDefault();"
-                    + "    $0.dispatchEvent(new CustomEvent('vaadin-dialog-close-action'));"
-                    + "  }" + "};"
-                    + "$0.$.overlay.addEventListener('vaadin-overlay-outside-click', f);"
-                    + "$0.$.overlay.addEventListener('vaadin-overlay-escape-press', f);"
-                    + "$0.addEventListener('opened-changed', function(){"
-                    + " if (!$0.opened) {"
-                    + " $0.$.overlay.removeEventListener('vaadin-overlay-outside-click',f);"
-                    + "$0.$.overlay.removeEventListener('vaadin-overlay-escape-press', f);"
-                    + "} });", getElement());
+    @ClientCallable
+    void handleClientClose() {
+        if (!isOpened()) {
+            return;
+        }
+
+        if (configuredCloseActionListeners > 0) {
+            fireEvent(new DialogCloseActionEvent(this, true));
+        } else {
+            doSetOpened(false, true);
         }
     }
 
@@ -824,11 +833,21 @@ public class Dialog extends Component implements HasComponents, HasSize,
      *            {@code true} to open the dialog, {@code false} to close it
      */
     public void setOpened(boolean opened) {
+        if (opened != isOpened()) {
+            doSetOpened(opened, false);
+        }
+    }
+
+    private void doSetOpened(boolean opened, boolean fromClient) {
         if (opened) {
             ensureAttached();
+        } else if (autoAddedToTheUi) {
+            getElement().removeFromParent();
+            autoAddedToTheUi = false;
         }
         setModality(opened && isModal());
         getElement().setProperty("opened", opened);
+        fireEvent(new OpenedChangeEvent(this, fromClient));
     }
 
     /**
@@ -936,6 +955,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
         Shortcuts.setShortcutListenOnElement(OVERLAY_LOCATOR_JS, this);
         initHeaderFooterRenderer();
         updateVirtualChildNodeIds();
+        registerClientCloseHandler();
     }
 
     /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -797,8 +797,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
     private void registerClientCloseHandler() {
         //@formatter:off
         getElement().executeJs("const listener = (e) => {"
-                + "  if (e.type == 'vaadin-overlay-escape-press' && !$0.noCloseOnEsc ||"
-                + "      e.type == 'vaadin-overlay-outside-click' && !$0.noCloseOnOutsideClick) {"
+                + "  if (e.type == 'vaadin-overlay-escape-press' && !this.noCloseOnEsc ||"
+                + "      e.type == 'vaadin-overlay-outside-click' && !this.noCloseOnOutsideClick) {"
                 + "    e.preventDefault();"
                 + "    this.$server.handleClientClose();"
                 + "  }"

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -111,7 +111,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
         getElement().getNode().addAttachListener(this::attachComponentRenderer);
 
         // Workaround for: https://github.com/vaadin/flow/issues/3496
-        setOpened(false);
+        getElement().setProperty("opened", false);
 
         getElement().addPropertyChangeListener("opened", event -> {
             // Only handle client-side changes, server-side changes are already

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogOpenedChangeListenerTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogOpenedChangeListenerTest.java
@@ -1,0 +1,97 @@
+package com.vaadin.flow.component.dialog;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinSession;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DialogOpenedChangeListenerTest {
+    private final UI ui = new UI();
+    private Dialog dialog;
+    private AtomicReference<Dialog.OpenedChangeEvent> event;
+    private ComponentEventListener<Dialog.OpenedChangeEvent> mockListener;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+        UI.setCurrent(ui);
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+
+        dialog = new Dialog();
+        event = new AtomicReference<>();
+        dialog.addOpenedChangeListener(event::set);
+
+        mockListener = Mockito.mock(ComponentEventListener.class);
+        dialog.addOpenedChangeListener(mockListener);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
+    @Test
+    public void open() {
+        dialog.open();
+
+        Assert.assertFalse(event.get().isFromClient());
+        Assert.assertTrue(event.get().isOpened());
+        assertListenerCalls(1);
+
+        clearCapturedData();
+        dialog.open();
+        Assert.assertNull(event.get());
+        assertListenerCalls(0);
+    }
+
+    @Test
+    public void close() {
+        dialog.open();
+        clearCapturedData();
+
+        dialog.close();
+        Assert.assertFalse(event.get().isFromClient());
+        Assert.assertFalse(event.get().isOpened());
+        assertListenerCalls(1);
+
+        clearCapturedData();
+        dialog.close();
+        Assert.assertNull(event.get());
+        assertListenerCalls(0);
+    }
+
+    @Test
+    public void closeFromClient() {
+        dialog.open();
+        clearCapturedData();
+
+        dialog.handleClientClose();
+        Assert.assertTrue(event.get().isFromClient());
+        Assert.assertFalse(event.get().isOpened());
+        assertListenerCalls(1);
+
+        clearCapturedData();
+        dialog.handleClientClose();
+        Assert.assertNull(event.get());
+        assertListenerCalls(0);
+    }
+
+    private void assertListenerCalls(int expectedCount) {
+        Mockito.verify(mockListener, Mockito.times(expectedCount))
+                .onComponentEvent(Mockito.any());
+    }
+
+    private void clearCapturedData() {
+        event.set(null);
+        Mockito.reset(mockListener);
+    }
+}


### PR DESCRIPTION
## Description

Currently a dialog's opened state can desync between the client and the server, for example:
- on mouse down, a focus out is triggered, which opens a second modal dialog, which sets the first dialog to be inert
- on the subsequent click event, the dialog closes on the client, but the server will never process the opened-changed event from the client because the dialog is inert, so the server-side dialog stays open

This fix involves:
- prevent the client dialog overlay from closing itself on outside click and escape presses (should be the only ways to close a dialog on the client)
- instead, make a call to the server component to close itself - if the dialog has become inert in the meantime this call will never be processed and the dialog will stay open on both the client and the server
- close the dialog from the server, while still firing the opened changed event as coming from the client

Fixes https://github.com/vaadin/flow-components/issues/4997

## Type of change

- Bugfix