### PR TITLE
chore: expose MenuBar setTooltipText

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -33,7 +33,7 @@ public class MenuBarTooltipPage extends Div {
 
         MenuBar menuBar = new MenuBar();
         // Use each add API with tooltip parameter to add menu items
-        menuBar.addItem("Edit", "Edit tooltip");
+        var editMenuItem = menuBar.addItem("Edit", "Edit tooltip");
         menuBar.addItem(new Span("Share"), "Share tooltip");
         menuBar.addItem("Move", "Move tooltip", (e) -> {
         });
@@ -50,6 +50,14 @@ public class MenuBarTooltipPage extends Div {
                 });
         toggleAttachedButton.setId("toggle-attached-button");
 
-        add(toggleAttachedButton, menuBar);
+        // Add a button for updating an item's tooltip
+        var updateItemTooltipButton = new NativeButton("Update item tooltip",
+                event -> {
+                    menuBar.setTooltipText(editMenuItem,
+                            "Updated Edit tooltip");
+                });
+        updateItemTooltipButton.setId("update-item-tooltip-button");
+
+        add(toggleAttachedButton, updateItemTooltipButton, menuBar);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -21,9 +21,9 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
-import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-menu-bar/tooltip")
 public class MenuBarTooltipIT extends AbstractComponentIT {
@@ -60,6 +60,17 @@ public class MenuBarTooltipIT extends AbstractComponentIT {
         var menuBar = $(MenuBarElement.class).first();
         showTooltip(menuBar.getButtons().get(0));
         Assert.assertEquals("Edit tooltip", getActiveTooltipText());
+    }
+
+    @Test
+    public void updateTooltipText_showUpdatedTooltip() {
+        var menuBar = $(MenuBarElement.class).first();
+
+        // Udpate tooltip text
+        clickElementWithJs("update-item-tooltip-button");
+
+        showTooltip(menuBar.getButtons().get(0));
+        Assert.assertEquals("Updated Edit tooltip", getActiveTooltipText());
     }
 
     private void showTooltip(TestBenchElement button) {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.menubar;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AttachEvent;
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.contextmenu.HasMenuItems;
@@ -210,7 +208,7 @@ public class MenuBar extends Component
      */
     public MenuItem addItem(String text, String tooltipText) {
         var item = addItem(text);
-        setTooltip(item, tooltipText);
+        setTooltipText(item, tooltipText);
         return item;
     }
 
@@ -235,7 +233,7 @@ public class MenuBar extends Component
      */
     public MenuItem addItem(Component component, String tooltipText) {
         var item = addItem(component);
-        setTooltip(item, tooltipText);
+        setTooltipText(item, tooltipText);
         return item;
     }
 
@@ -264,7 +262,7 @@ public class MenuBar extends Component
     public MenuItem addItem(String text, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         var item = addItem(text, clickListener);
-        setTooltip(item, tooltipText);
+        setTooltipText(item, tooltipText);
         return item;
     }
 
@@ -293,7 +291,7 @@ public class MenuBar extends Component
     public MenuItem addItem(Component component, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         var item = addItem(component, clickListener);
-        setTooltip(item, tooltipText);
+        setTooltipText(item, tooltipText);
         return item;
     }
 
@@ -492,11 +490,14 @@ public class MenuBar extends Component
     }
 
     /**
-     * Sets the tooltip property for the given menu item. A vaadin-tooltip
-     * element with a custom generator is created and added inside the menu bar
-     * in case it doesn't exist.
+     * Sets the tooltip text for the given {@link MenuItem}.
+     *
+     * @param item
+     *            the menu item to set the tooltip for
+     * @param tooltipText
+     *            the tooltip text to set for the item
      */
-    private void setTooltip(MenuItem item, String tooltipText) {
+    public void setTooltipText(MenuItem item, String tooltipText) {
         if (!getElement().getChildren().anyMatch(
                 child -> "tooltip".equals(child.getAttribute("slot")))) {
             // No <vaadin-tooltip> yet added, add one


### PR DESCRIPTION
## Description

Makes the previously private `setTooltipText` in `MenuBar` public, which enables changing a tooltip's text dynamically.

Closes https://github.com/vaadin/flow-components/issues/5226