### PR TITLE
feat: add dirty state to field components

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxDirtyStatePage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-checkbox/dirty-state")
+public class CheckboxDirtyStatePage extends AbstractDirtyStatePage<Checkbox> {
+    @Override
+    protected Checkbox createTestField() {
+        return new Checkbox();
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDirtyStatePage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-checkbox-group/dirty-state")
-public class CheckboxGroupDirtyStatePage extends AbstractDirtyStatePage<CheckboxGroup<String>> {
+public class CheckboxGroupDirtyStatePage
+        extends AbstractDirtyStatePage<CheckboxGroup<String>> {
     @Override
     protected CheckboxGroup<String> createTestField() {
         return new CheckboxGroup<>();

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDirtyStatePage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-checkbox-group/dirty-state")
+public class CheckboxGroupDirtyStatePage extends AbstractDirtyStatePage<CheckboxGroup<String>> {
+    @Override
+    protected CheckboxGroup<String> createTestField() {
+        return new CheckboxGroup<>();
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxDirtyStateIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-checkbox/dirty-state")
+public class CheckboxDirtyStateIT
+        extends AbstractDirtyStateIT<CheckboxElement> {
+    @Override
+    protected CheckboxElement getTestField() {
+        return $(CheckboxElement.class).first();
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDirtyStateIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.testbench.CheckboxGroupElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-checkbox-group/dirty-state")
+public class CheckboxGroupDirtyStateIT
+        extends AbstractDirtyStateIT<CheckboxGroupElement> {
+    @Override
+    protected CheckboxGroupElement getTestField() {
+        return $(CheckboxGroupElement.class).first();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxDirtyStatePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-combo-box/dirty-state")
+public class ComboBoxDirtyStatePage extends AbstractDirtyStatePage<ComboBox<String>> {
+    @Override
+    protected ComboBox<String> createTestField() {
+        return new ComboBox<>();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxDirtyStatePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-combo-box/dirty-state")
-public class ComboBoxDirtyStatePage extends AbstractDirtyStatePage<ComboBox<String>> {
+public class ComboBoxDirtyStatePage
+        extends AbstractDirtyStatePage<ComboBox<String>> {
     @Override
     protected ComboBox<String> createTestField() {
         return new ComboBox<>();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDirtyStatePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-multi-select-combo-box/dirty-state")
-public class MultiSelectComboBoxDirtyStatePage extends AbstractDirtyStatePage<MultiSelectComboBox<String>> {
+public class MultiSelectComboBoxDirtyStatePage
+        extends AbstractDirtyStatePage<MultiSelectComboBox<String>> {
     @Override
     protected MultiSelectComboBox<String> createTestField() {
         return new MultiSelectComboBox<>();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDirtyStatePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-multi-select-combo-box/dirty-state")
+public class MultiSelectComboBoxDirtyStatePage extends AbstractDirtyStatePage<MultiSelectComboBox<String>> {
+    @Override
+    protected MultiSelectComboBox<String> createTestField() {
+        return new MultiSelectComboBox<>();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxDirtyStateIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-combo-box/dirty-state")
+public class ComboBoxDirtyStateIT
+        extends AbstractDirtyStateIT<ComboBoxElement> {
+    @Override
+    protected ComboBoxElement getTestField() {
+        return $(ComboBoxElement.class).first();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDirtyStateIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-multi-select-combo-box/dirty-state")
+public class MultiSelectComboBoxDirtyStateIT
+        extends AbstractDirtyStateIT<MultiSelectComboBoxElement> {
+    @Override
+    protected MultiSelectComboBoxElement getTestField() {
+        return $(MultiSelectComboBoxElement.class).first();
+    }
+}

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -66,7 +66,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-flow-components-test-util</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.component.customfield.tests;
+
+import com.vaadin.flow.component.customfield.CustomField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-custom-field/dirty-state")
+public class DirtyStatePage extends AbstractDirtyStatePage<CustomField<String>> {
+    private class NameField extends CustomField<String> {
+        @Override
+        protected String generateModelValue() {
+            return "";
+        }
+
+        @Override
+        protected void setPresentationValue(String newPresentationValue) {}
+    };
+
+    @Override
+    protected CustomField<String> createTestField() {
+        return new NameField();
+    }
+}

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
@@ -1,25 +1,36 @@
 package com.vaadin.flow.component.customfield.tests;
 
 import com.vaadin.flow.component.customfield.CustomField;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-custom-field/dirty-state")
 public class DirtyStatePage
         extends AbstractDirtyStatePage<CustomField<String>> {
-    private class NameField extends CustomField<String> {
+    private class TestCustomField extends CustomField<String> {
+        private TextField field1 = new TextField();
+        private TextField field2 = new TextField();
+
+        TestCustomField() {
+            add(field1, field2);
+        }
+
         @Override
         protected String generateModelValue() {
-            return "";
+            return field1.getValue() + "," + field2.getValue();
         }
 
         @Override
         protected void setPresentationValue(String newPresentationValue) {
+            String[] parts = newPresentationValue.split(",");
+            field1.setValue(parts[1]);
+            field2.setValue(parts[2]);
         }
     };
 
     @Override
     protected CustomField<String> createTestField() {
-        return new NameField();
+        return new TestCustomField();
     }
 }

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-custom-field/dirty-state")
-public class DirtyStatePage extends AbstractDirtyStatePage<CustomField<String>> {
+public class DirtyStatePage
+        extends AbstractDirtyStatePage<CustomField<String>> {
     private class NameField extends CustomField<String> {
         @Override
         protected String generateModelValue() {
@@ -13,7 +14,8 @@ public class DirtyStatePage extends AbstractDirtyStatePage<CustomField<String>> 
         }
 
         @Override
-        protected void setPresentationValue(String newPresentationValue) {}
+        protected void setPresentationValue(String newPresentationValue) {
+        }
     };
 
     @Override

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/customfield/tests/DirtyStatePage.java
@@ -8,7 +8,7 @@ import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 @Route("vaadin-custom-field/dirty-state")
 public class DirtyStatePage
         extends AbstractDirtyStatePage<CustomField<String>> {
-    private class TestCustomField extends CustomField<String> {
+    private static class TestCustomField extends CustomField<String> {
         private TextField field1 = new TextField();
         private TextField field2 = new TextField();
 

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/DirtyStateIT.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/DirtyStateIT.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.customfield.tests;
+
+import com.vaadin.flow.component.customfield.testbench.CustomFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-custom-field/dirty-state")
+public class DirtyStateIT extends AbstractDirtyStateIT<CustomFieldElement> {
+    @Override
+    protected CustomFieldElement getTestField() {
+        return $(CustomFieldElement.class).first();
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DirtyStatePage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DirtyStatePage.java
@@ -1,0 +1,12 @@
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-date-picker/dirty-state")
+public class DirtyStatePage extends AbstractDirtyStatePage<DatePicker> {
+    @Override
+    protected DatePicker createTestField() {
+        return new DatePicker();
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DirtyStateIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-date-picker/dirty-state")
+public class DirtyStateIT
+        extends AbstractDirtyStateIT<DatePickerElement> {
+    @Override
+    protected DatePickerElement getTestField() {
+        return $(DatePickerElement.class).first();
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DirtyStateIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DirtyStateIT.java
@@ -5,8 +5,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
 
 @TestPath("vaadin-date-picker/dirty-state")
-public class DirtyStateIT
-        extends AbstractDirtyStateIT<DatePickerElement> {
+public class DirtyStateIT extends AbstractDirtyStateIT<DatePickerElement> {
     @Override
     protected DatePickerElement getTestField() {
         return $(DatePickerElement.class).first();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DirtyStatePage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DirtyStatePage.java
@@ -1,0 +1,12 @@
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-date-time-picker/dirty-state")
+public class DirtyStatePage extends AbstractDirtyStatePage<DateTimePicker> {
+    @Override
+    protected DateTimePicker createTestField() {
+        return new DateTimePicker();
+    }
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DirtyStateIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DirtyStateIT.java
@@ -5,8 +5,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
 
 @TestPath("vaadin-date-time-picker/dirty-state")
-public class DirtyStateIT
-        extends AbstractDirtyStateIT<DateTimePickerElement> {
+public class DirtyStateIT extends AbstractDirtyStateIT<DateTimePickerElement> {
     @Override
     protected DateTimePickerElement getTestField() {
         return $(DateTimePickerElement.class).first();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DirtyStateIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.datetimepicker;
+
+import com.vaadin.flow.component.datetimepicker.testbench.DateTimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-date-time-picker/dirty-state")
+public class DirtyStateIT
+        extends AbstractDirtyStateIT<DateTimePickerElement> {
+    @Override
+    protected DateTimePickerElement getTestField() {
+        return $(DateTimePickerElement.class).first();
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasDirtyState.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasDirtyState.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Synchronize;
+
+/**
+ * Mixin interface for field components that support the dirty state.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasDirtyState extends HasElement {
+    /**
+     * Sets the dirty state for the component.
+     *
+     * @param dirty
+     *              whether the field is dirty.
+     */
+    default void setDirty(boolean dirty) {
+        getElement().setProperty("dirty", dirty);
+    }
+
+    /**
+     * Gets the dirty state of the component.
+     * <p>
+     * The component is automatically marked as dirty once the user triggers an
+     * `input` or `change` event. Additionally, the component can be manually
+     * marked as dirty with {@link #setDirty(boolean)}.
+     *
+     * @return whether the field is dirty.
+     */
+    @Synchronize("dirty-changed")
+    default boolean isDirty() {
+        return getElement().getProperty("dirty", false);
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasDirtyState.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasDirtyState.java
@@ -28,7 +28,7 @@ public interface HasDirtyState extends HasElement {
      * Sets the dirty state for the component.
      *
      * @param dirty
-     *              whether the field is dirty.
+     *            whether the field is dirty.
      */
     default void setDirty(boolean dirty) {
         getElement().setProperty("dirty", dirty);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InputField.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InputField.java
@@ -44,7 +44,8 @@ import com.vaadin.flow.component.HasValue;
  * @author Vaadin Ltd
  * @since 24.1
  */
-public interface InputField<E extends HasValue.ValueChangeEvent<V>, V> extends
-        HasEnabled, HasLabel, HasSize, HasStyle, HasTooltip, HasValue<E, V>, HasDirtyState {
+public interface InputField<E extends HasValue.ValueChangeEvent<V>, V>
+        extends HasEnabled, HasLabel, HasSize, HasStyle, HasTooltip,
+        HasValue<E, V>, HasDirtyState {
 
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InputField.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/InputField.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.HasValue;
  * <li>{@link HasTooltip}</li>
  * <li>{@link HasSize}</li>
  * <li>{@link HasValue}</li>
+ * <li>{@link HasDirtyState}</li>
  * </ul>
  *
  * @param <E>
@@ -44,6 +45,6 @@ import com.vaadin.flow.component.HasValue;
  * @since 24.1
  */
 public interface InputField<E extends HasValue.ValueChangeEvent<V>, V> extends
-        HasEnabled, HasLabel, HasSize, HasStyle, HasTooltip, HasValue<E, V> {
+        HasEnabled, HasLabel, HasSize, HasStyle, HasTooltip, HasValue<E, V>, HasDirtyState {
 
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasDirtyStateTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasDirtyStateTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+public class HasDirtyStateTest {
+    @Tag("test-component")
+    private static class TestComponent extends Component implements HasDirtyState {}
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @Test
+    public void notDirtyByDefault() {
+        Assert.assertFalse(component.isDirty());
+        Assert.assertFalse(component.getElement().getProperty("dirty", false));
+    }
+
+    @Test
+    public void setDirty_isDirty() {
+        component.setDirty(true);
+        Assert.assertTrue(component.isDirty());
+        Assert.assertTrue(component.getElement().getProperty("dirty", false));
+
+        component.setDirty(false);
+        Assert.assertFalse(component.isDirty());
+        Assert.assertFalse(component.getElement().getProperty("dirty", false));
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasDirtyStateTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasDirtyStateTest.java
@@ -24,7 +24,9 @@ import com.vaadin.flow.component.Tag;
 
 public class HasDirtyStateTest {
     @Tag("test-component")
-    private static class TestComponent extends Component implements HasDirtyState {}
+    private static class TestComponent extends Component
+            implements HasDirtyState {
+    }
 
     private TestComponent component;
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dirtystate/AbstractDirtyStateIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dirtystate/AbstractDirtyStateIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dirtystate;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.vaadin.tests.dirtystate.AbstractDirtyStatePage.DIRTY_STATE;
+import static com.vaadin.tests.dirtystate.AbstractDirtyStatePage.DIRTY_STATE_BUTTON;
+
+public abstract class AbstractDirtyStateIT<T extends TestBenchElement>
+        extends AbstractComponentIT {
+    protected T testField;
+
+    @Before
+    public void init() {
+        open();
+        testField = getTestField();
+    }
+
+    @Test
+    public void notDirtyByDefault() {
+        Assert.assertFalse(isDirty());
+    }
+
+    @Test
+    public void clientSideDirtyStateIsPropagatedToServer() {
+        testField.setProperty("dirty", true);
+        Assert.assertTrue(isDirty());
+
+        testField.setProperty("dirty", false);
+        Assert.assertFalse(isDirty());
+    }
+
+    private boolean isDirty() {
+        $("button").id(DIRTY_STATE_BUTTON).click();
+        String actual = $("div").id(DIRTY_STATE).getText();
+        return actual.equals("true");
+    }
+
+    protected abstract T getTestField();
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dirtystate/AbstractDirtyStatePage.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dirtystate/AbstractDirtyStatePage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dirtystate;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.shared.HasDirtyState;
+
+public abstract class AbstractDirtyStatePage<T extends Component & HasDirtyState>
+        extends Div {
+    public static final String DIRTY_STATE = "dirty-state";
+    public static final String DIRTY_STATE_BUTTON = "dirty-state-button";
+
+    protected T testField;
+
+    protected AbstractDirtyStatePage() {
+        testField = createTestField();
+
+        Div dirtyState = new Div();
+        dirtyState.setId(DIRTY_STATE);
+
+        NativeButton dirtyStateButton = new NativeButton("Retrieve dirty state",
+                event -> {
+                    boolean isDirty = testField.isDirty();
+                    dirtyState.setText(String.valueOf(isDirty));
+                });
+        dirtyStateButton.setId(DIRTY_STATE_BUTTON);
+
+        add(testField, dirtyState, dirtyStateButton);
+    }
+
+    /**
+     * A field to test.
+     */
+    protected abstract T createTestField();
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDirtyStatePage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.radiobutton.tests;
+
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-radio-button-group/dirty-state")
+public class RadioButtonGroupDirtyStatePage extends AbstractDirtyStatePage<RadioButtonGroup<String>> {
+    @Override
+    protected RadioButtonGroup<String> createTestField() {
+        return new RadioButtonGroup<>();
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDirtyStatePage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-radio-button-group/dirty-state")
-public class RadioButtonGroupDirtyStatePage extends AbstractDirtyStatePage<RadioButtonGroup<String>> {
+public class RadioButtonGroupDirtyStatePage
+        extends AbstractDirtyStatePage<RadioButtonGroup<String>> {
     @Override
     protected RadioButtonGroup<String> createTestField() {
         return new RadioButtonGroup<>();

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDirtyStateIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.radiobutton.tests;
+
+import com.vaadin.flow.component.radiobutton.testbench.RadioButtonGroupElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-radio-button-group/dirty-state")
+public class RadioButtonGroupDirtyStateIT
+        extends AbstractDirtyStateIT<RadioButtonGroupElement> {
+    @Override
+    protected RadioButtonGroupElement getTestField() {
+        return $(RadioButtonGroupElement.class).first();
+    }
+}

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/DirtyStatePage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/DirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.select.tests;
+
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-select/dirty-state")
+public class DirtyStatePage extends AbstractDirtyStatePage<Select<String>> {
+    @Override
+    protected Select<String> createTestField() {
+        return new Select<>();
+    }
+}

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/DirtyStateIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/DirtyStateIT.java
@@ -5,8 +5,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
 
 @TestPath("vaadin-select/dirty-state")
-public class DirtyStateIT
-        extends AbstractDirtyStateIT<SelectElement> {
+public class DirtyStateIT extends AbstractDirtyStateIT<SelectElement> {
     @Override
     protected SelectElement getTestField() {
         return $(SelectElement.class).first();

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/DirtyStateIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/DirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.select.tests;
+
+import com.vaadin.flow.component.select.testbench.SelectElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-select/dirty-state")
+public class DirtyStateIT
+        extends AbstractDirtyStateIT<SelectElement> {
+    @Override
+    protected SelectElement getTestField() {
+        return $(SelectElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/BigDecimalFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/BigDecimalFieldDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-big-decimal-field/dirty-state")
-public class BigDecimalFieldDirtyStatePage extends AbstractDirtyStatePage<BigDecimalField> {
+public class BigDecimalFieldDirtyStatePage
+        extends AbstractDirtyStatePage<BigDecimalField> {
     @Override
     protected BigDecimalField createTestField() {
         return new BigDecimalField();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/BigDecimalFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/BigDecimalFieldDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-big-decimal-field/dirty-state")
+public class BigDecimalFieldDirtyStatePage extends AbstractDirtyStatePage<BigDecimalField> {
+    @Override
+    protected BigDecimalField createTestField() {
+        return new BigDecimalField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/EmailFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/EmailFieldDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.EmailField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-email-field/dirty-state")
+public class EmailFieldDirtyStatePage extends AbstractDirtyStatePage<EmailField> {
+    @Override
+    protected EmailField createTestField() {
+        return new EmailField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/EmailFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/EmailFieldDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-email-field/dirty-state")
-public class EmailFieldDirtyStatePage extends AbstractDirtyStatePage<EmailField> {
+public class EmailFieldDirtyStatePage
+        extends AbstractDirtyStatePage<EmailField> {
     @Override
     protected EmailField createTestField() {
         return new EmailField();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/IntegerFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/IntegerFieldDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-integer-field/dirty-state")
+public class IntegerFieldDirtyStatePage extends AbstractDirtyStatePage<IntegerField> {
+    @Override
+    protected IntegerField createTestField() {
+        return new IntegerField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/IntegerFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/IntegerFieldDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-integer-field/dirty-state")
-public class IntegerFieldDirtyStatePage extends AbstractDirtyStatePage<IntegerField> {
+public class IntegerFieldDirtyStatePage
+        extends AbstractDirtyStatePage<IntegerField> {
     @Override
     protected IntegerField createTestField() {
         return new IntegerField();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/NumberFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/NumberFieldDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-number-field/dirty-state")
-public class NumberFieldDirtyStatePage extends AbstractDirtyStatePage<NumberField> {
+public class NumberFieldDirtyStatePage
+        extends AbstractDirtyStatePage<NumberField> {
     @Override
     protected NumberField createTestField() {
         return new NumberField();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/NumberFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/NumberFieldDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-number-field/dirty-state")
+public class NumberFieldDirtyStatePage extends AbstractDirtyStatePage<NumberField> {
+    @Override
+    protected NumberField createTestField() {
+        return new NumberField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/PasswordFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/PasswordFieldDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.PasswordField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-password-field/dirty-state")
+public class PasswordFieldDirtyStatePage extends AbstractDirtyStatePage<PasswordField> {
+    @Override
+    protected PasswordField createTestField() {
+        return new PasswordField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/PasswordFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/PasswordFieldDirtyStatePage.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
 
 @Route("vaadin-password-field/dirty-state")
-public class PasswordFieldDirtyStatePage extends AbstractDirtyStatePage<PasswordField> {
+public class PasswordFieldDirtyStatePage
+        extends AbstractDirtyStatePage<PasswordField> {
     @Override
     protected PasswordField createTestField() {
         return new PasswordField();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextAreaDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextAreaDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-text-area/dirty-state")
+public class TextAreaDirtyStatePage extends AbstractDirtyStatePage<TextArea> {
+    @Override
+    protected TextArea createTestField() {
+        return new TextArea();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextFieldDirtyStatePage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextFieldDirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-text-field/dirty-state")
+public class TextFieldDirtyStatePage extends AbstractDirtyStatePage<TextField> {
+    @Override
+    protected TextField createTestField() {
+        return new TextField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/BigDecimalFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/BigDecimalFieldDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.BigDecimalFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-big-decimal-field/dirty-state")
+public class BigDecimalFieldDirtyStateIT
+        extends AbstractDirtyStateIT<BigDecimalFieldElement> {
+    @Override
+    protected BigDecimalFieldElement getTestField() {
+        return $(BigDecimalFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/EmailFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/EmailFieldDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.EmailFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-email-field/dirty-state")
+public class EmailFieldDirtyStateIT
+        extends AbstractDirtyStateIT<EmailFieldElement> {
+    @Override
+    protected EmailFieldElement getTestField() {
+        return $(EmailFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/IntegerFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/IntegerFieldDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-integer-field/dirty-state")
+public class IntegerFieldDirtyStateIT
+        extends AbstractDirtyStateIT<IntegerFieldElement> {
+    @Override
+    protected IntegerFieldElement getTestField() {
+        return $(IntegerFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/NumberFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/NumberFieldDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.NumberFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-number-field/dirty-state")
+public class NumberFieldDirtyStateIT
+        extends AbstractDirtyStateIT<NumberFieldElement> {
+    @Override
+    protected NumberFieldElement getTestField() {
+        return $(NumberFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/PasswordFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/PasswordFieldDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-password-field/dirty-state")
+public class PasswordFieldDirtyStateIT
+        extends AbstractDirtyStateIT<PasswordFieldElement> {
+    @Override
+    protected PasswordFieldElement getTestField() {
+        return $(PasswordFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextAreaDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextAreaDirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-text-area/dirty-state")
+public class TextAreaDirtyStateIT
+        extends AbstractDirtyStateIT<TextAreaElement> {
+    @Override
+    protected TextAreaElement getTestField() {
+        return $(TextAreaElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextFieldDirtyStateIT.java
@@ -5,7 +5,8 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
 
 @TestPath("vaadin-text-field/dirty-state")
-public class TextFieldDirtyStateIT extends AbstractDirtyStateIT<TextFieldElement> {
+public class TextFieldDirtyStateIT
+        extends AbstractDirtyStateIT<TextFieldElement> {
     @Override
     protected TextFieldElement getTestField() {
         return $(TextFieldElement.class).first();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextFieldDirtyStateIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/dirtystate/TextFieldDirtyStateIT.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.textfield.tests.dirtystate;
+
+import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-text-field/dirty-state")
+public class TextFieldDirtyStateIT extends AbstractDirtyStateIT<TextFieldElement> {
+    @Override
+    protected TextFieldElement getTestField() {
+        return $(TextFieldElement.class).first();
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/DirtyStatePage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/DirtyStatePage.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.dirtystate.AbstractDirtyStatePage;
+
+@Route("vaadin-time-picker/dirty-state")
+public class DirtyStatePage extends AbstractDirtyStatePage<TimePicker> {
+    @Override
+    protected TimePicker createTestField() {
+        return new TimePicker();
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/DirtyStateIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/DirtyStateIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
+
+@TestPath("vaadin-time-picker/dirty-state")
+public class DirtyStateIT
+        extends AbstractDirtyStateIT<TimePickerElement> {
+    @Override
+    protected TimePickerElement getTestField() {
+        return $(TimePickerElement.class).first();
+    }
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/DirtyStateIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/DirtyStateIT.java
@@ -5,8 +5,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.dirtystate.AbstractDirtyStateIT;
 
 @TestPath("vaadin-time-picker/dirty-state")
-public class DirtyStateIT
-        extends AbstractDirtyStateIT<TimePickerElement> {
+public class DirtyStateIT extends AbstractDirtyStateIT<TimePickerElement> {
     @Override
     protected TimePickerElement getTestField() {
         return $(TimePickerElement.class).first();


### PR DESCRIPTION
## Description

Introduces a dirty state to the field components. The component automatically becomes dirty once the user triggers an input or change event. Additionally, the component can be manually marked as dirty with `setDirty(true)`.

Precedes
- https://github.com/vaadin/web-components/pull/6238

Depends on
- https://github.com/vaadin/web-components/pull/6160

Part of https://github.com/vaadin/web-components/issues/6146

## Type of change

- [x] Feature
