### PR TITLE
fix: reject emails with double dot between domain and tld

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.data.validator.EmailValidator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.shared.Registration;
 
@@ -49,10 +50,6 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/email-field/src/vaadin-email-field.js")
 public class EmailField extends TextFieldBase<EmailField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
-    private static final String EMAIL_PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
-            + "@" + "[a-zA-Z0-9-.]+" // domain
-            + "\\." + "[a-zA-Z0-9-]{2,}" // tld
-            + "$";
 
     private boolean isConnectorAttached;
 
@@ -158,7 +155,7 @@ public class EmailField extends TextFieldBase<EmailField, String>
     private TextFieldValidationSupport getValidationSupport() {
         if (validationSupport == null) {
             validationSupport = new TextFieldValidationSupport(this);
-            validationSupport.setPattern(EMAIL_PATTERN);
+            validationSupport.setPattern(EmailValidator.PATTERN);
         }
         return validationSupport;
     }


### PR DESCRIPTION
## Description

As indicated in issue https://github.com/vaadin/flow/issues/17333, this PR changes the validation pattern of an email address by invalidating the dot-dot in the domain name.

In PR https://github.com/vaadin/flow/pull/17353, I made EmailValidator.PATTERN public to use it in EmailField class. So the pattern is not longer duplicates between EmailValidator and EmailField

Fixes vaadin/flow#17333

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.
