### PR TITLE
fix: reject emails with double dot between domain and tld

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.data.validator.EmailValidator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.shared.Registration;
 
@@ -49,10 +50,6 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/email-field/src/vaadin-email-field.js")
 public class EmailField extends TextFieldBase<EmailField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
-    private static final String EMAIL_PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
-            + "@" + "[a-zA-Z0-9-.]+" // domain
-            + "\\." + "[a-zA-Z0-9-]{2,}" // tld
-            + "$";
 
     private boolean isConnectorAttached;
 
@@ -158,7 +155,7 @@ public class EmailField extends TextFieldBase<EmailField, String>
     private TextFieldValidationSupport getValidationSupport() {
         if (validationSupport == null) {
             validationSupport = new TextFieldValidationSupport(this);
-            validationSupport.setPattern(EMAIL_PATTERN);
+            validationSupport.setPattern(EmailValidator.PATTERN);
         }
         return validationSupport;
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
@@ -15,11 +15,58 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class EmailFieldBasicValidationTest
         extends AbstractBasicValidationTest<EmailField, String> {
+    private static String[] VALID_EMAILS = {
+        "email@example.com",
+        "firstname.lastname@example.com",
+        "email@subdomain.example.com",
+        "firstname+lastname@example.com",
+        "email@123.123.123.123",
+        "1234567890@example.com",
+        "email@example-one.com",
+        "_______@example.com",
+        "email@example.name",
+        "email@example.museum",
+        "email@example.co.jp",
+        "firstname-lastname@example.com",
+    };
+
+    private static String[] INVALID_EMAILS = {
+        "plainaddress",
+        "#@%^%#$@#$@#.com",
+        "@example.com",
+        "Joe Smith <email@example.com>",
+        "email.example.com",
+        "email@example@example.com",
+        "あいうえお@example.com",
+        "email@example.com (Joe Smith)",
+        "email@example..com",
+        "email@example",
+    };
+
+    @Test
+    public void setInvalidEmail_fieldIsInvalid() {
+        for (String email : INVALID_EMAILS) {
+            testField.setValue(email);
+            Assert.assertTrue("Should be invalid when setting " + email, testField.isInvalid());
+        }
+    }
+
+    @Test
+    public void setValidEmail_fieldIsValid() {
+        for (String email : VALID_EMAILS) {
+            testField.setValue(email);
+            Assert.assertFalse("Should be valid when setting " + email, testField.isInvalid());
+        }
+    }
+
     protected EmailField createTestField() {
         return new EmailField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
@@ -23,39 +23,25 @@ import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class EmailFieldBasicValidationTest
         extends AbstractBasicValidationTest<EmailField, String> {
-    private static String[] VALID_EMAILS = {
-        "email@example.com",
-        "firstname.lastname@example.com",
-        "email@subdomain.example.com",
-        "firstname+lastname@example.com",
-        "email@123.123.123.123",
-        "1234567890@example.com",
-        "email@example-one.com",
-        "_______@example.com",
-        "email@example.name",
-        "email@example.museum",
-        "email@example.co.jp",
-        "firstname-lastname@example.com",
-    };
+    private static String[] VALID_EMAILS = { "email@example.com",
+            "firstname.lastname@example.com", "email@subdomain.example.com",
+            "firstname+lastname@example.com", "email@123.123.123.123",
+            "1234567890@example.com", "email@example-one.com",
+            "_______@example.com", "email@example.name", "email@example.museum",
+            "email@example.co.jp", "firstname-lastname@example.com", };
 
-    private static String[] INVALID_EMAILS = {
-        "plainaddress",
-        "#@%^%#$@#$@#.com",
-        "@example.com",
-        "Joe Smith <email@example.com>",
-        "email.example.com",
-        "email@example@example.com",
-        "あいうえお@example.com",
-        "email@example.com (Joe Smith)",
-        "email@example..com",
-        "email@example",
-    };
+    private static String[] INVALID_EMAILS = { "plainaddress",
+            "#@%^%#$@#$@#.com", "@example.com", "Joe Smith <email@example.com>",
+            "email.example.com", "email@example@example.com",
+            "あいうえお@example.com", "email@example.com (Joe Smith)",
+            "email@example..com", "email@example", };
 
     @Test
     public void setInvalidEmail_fieldIsInvalid() {
         for (String email : INVALID_EMAILS) {
             testField.setValue(email);
-            Assert.assertTrue("Should be invalid when setting " + email, testField.isInvalid());
+            Assert.assertTrue("Should be invalid when setting " + email,
+                    testField.isInvalid());
         }
     }
 
@@ -63,7 +49,8 @@ public class EmailFieldBasicValidationTest
     public void setValidEmail_fieldIsValid() {
         for (String email : VALID_EMAILS) {
             testField.setValue(email);
-            Assert.assertFalse("Should be valid when setting " + email, testField.isInvalid());
+            Assert.assertFalse("Should be valid when setting " + email,
+                    testField.isInvalid());
         }
     }
 


### PR DESCRIPTION
## Description

As indicated in issue https://github.com/vaadin/flow/issues/17333, this PR changes the validation pattern of an email address by invalidating the dot-dot in the domain name.

In PR https://github.com/vaadin/flow/pull/17353, I made EmailValidator.PATTERN public to use it in EmailField class. So the pattern is not longer duplicates between EmailValidator and EmailField

Fixes vaadin/flow#17333

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.
