### PR TITLE
feat: add event listeners for Grid DataProvider change

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDataProviderChange.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDataProviderChange.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.router.Route;
+
+/**
+ * @author Vaadin Ltd.
+ */
+@Route("vaadin-grid/grid-data-provider-change")
+public class GridDataProviderChange extends Div {
+
+    public GridDataProviderChange() {
+        final Grid<String> grid = new Grid<>(
+                DataProvider.ofItems("Item 1", "Item 2", "Item 3"));
+        grid.addColumn(it -> it).setHeader("First column");
+
+        final NativeButton setItemsButton = new NativeButton("Set items");
+        setItemsButton.addClickListener(
+                e -> grid.setItems("Item 4", "Item 5", "Item 6"));
+        setItemsButton.setId("set-items");
+
+        Div dataProviderChange = new Div();
+        dataProviderChange.setId("dataProviderChange");
+        grid.addDataProviderChangeListener(e -> dataProviderChange
+                .setText("dataProvider event from client " + e.isFromClient()));
+
+        add(grid, setItemsButton, dataProviderChange);
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDataProviderChangeIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDataProviderChangeIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/grid-data-provider-change")
+public class GridDataProviderChangeIT extends AbstractComponentIT {
+
+    @Test
+    public void dataProviderChange() {
+        open();
+
+        WebElement button = $("button").id("set-items");
+
+        WebElement div = $("div").id("dataProviderChange");
+        Assert.assertEquals(
+                "DataProviderChangeEvent should be triggered from client",
+                "dataProvider event from client true", div.getText());
+
+        button.click();
+
+        Assert.assertEquals(
+                "DataProviderChangeEvent should be triggered from server",
+                "dataProvider event from client false", div.getText());
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/DataProviderChangeEvent.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/DataProviderChangeEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+
+/**
+ * Event fired when Grid data provider changed.
+ *
+ * @param <T>
+ *            the grid bean type
+ *
+ * @author Vaadin Ltd
+ *
+ * @see Grid#addDataProviderChangeListener(com.vaadin.flow.component.ComponentEventListener)
+ *
+ */
+@DomEvent("data-provider-changed")
+public class DataProviderChangeEvent<T> extends ComponentEvent<Grid<T>> {
+
+    /**
+     * Creates a new data provider change event.
+     *
+     * @param source
+     *            the component that fired the event
+     * @param fromClient
+     *            whether the value change originated from the client
+     */
+    public DataProviderChangeEvent(Grid<T> source, boolean fromClient) {
+        super(source, fromClient);
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2556,6 +2556,22 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             model.setSelectAllCheckboxVisibility(
                     model.getSelectAllCheckboxVisibility());
         }
+
+        fireEvent(new DataProviderChangeEvent<>(this, false));
+    }
+
+    /**
+     * Adds a data provider change listener to this component.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Registration addDataProviderChangeListener(
+            ComponentEventListener<DataProviderChangeEvent<T>> listener) {
+        return addListener(DataProviderChangeEvent.class,
+                (ComponentEventListener) listener);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDataProviderChangeTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDataProviderChangeTest.java
@@ -1,0 +1,43 @@
+package com.vaadin.flow.component.grid;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for Grid DataProvider change event
+ *
+ * @author Vaadin Ltd.
+ */
+public class GridDataProviderChangeTest {
+
+    transient List<String> dummyData = Arrays.asList("item1", "item2", "item3");
+
+    @Test
+    public void setItemsInConstructor_noChangeEvent() {
+        Grid<String> grid = new Grid<>(dummyData);
+
+        grid.addDataProviderChangeListener(event -> {
+            Assert.fail(
+                    "DataProvider change should not be triggered from server");
+        });
+    }
+
+    @Test
+    public void setItems_triggerChangeEvent() {
+        Grid<String> grid = new Grid<>();
+
+        AtomicInteger listenerCalled = new AtomicInteger();
+        grid.addDataProviderChangeListener(
+                event -> listenerCalled.incrementAndGet());
+
+        grid.setItems(dummyData);
+        Assert.assertEquals(1, listenerCalled.get());
+
+        grid.setItems(dummyData);
+        Assert.assertEquals(2, listenerCalled.get());
+    }
+}


### PR DESCRIPTION
## Description

Fire a `DataProviderChangeEvent` event to notify listeners when Grid DataProvider changes.

Closes #5324

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
