### PR TITLE
fix: reject emails with double dot between domain and tld (#5327) (CP: 24.1)

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.data.validator.EmailValidator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.shared.Registration;
 
@@ -49,10 +50,6 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/email-field/src/vaadin-email-field.js")
 public class EmailField extends TextFieldBase<EmailField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
-    private static final String EMAIL_PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
-            + "@" + "[a-zA-Z0-9-.]+" // domain
-            + "\\." + "[a-zA-Z0-9-]{2,}" // tld
-            + "$";
 
     private boolean isConnectorAttached;
 
@@ -156,7 +153,7 @@ public class EmailField extends TextFieldBase<EmailField, String>
     private TextFieldValidationSupport getValidationSupport() {
         if (validationSupport == null) {
             validationSupport = new TextFieldValidationSupport(this);
-            validationSupport.setPattern(EMAIL_PATTERN);
+            validationSupport.setPattern(EmailValidator.PATTERN);
         }
         return validationSupport;
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
@@ -15,11 +15,45 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class EmailFieldBasicValidationTest
         extends AbstractBasicValidationTest<EmailField> {
+    private static String[] VALID_EMAILS = { "email@example.com",
+            "firstname.lastname@example.com", "email@subdomain.example.com",
+            "firstname+lastname@example.com", "email@123.123.123.123",
+            "1234567890@example.com", "email@example-one.com",
+            "_______@example.com", "email@example.name", "email@example.museum",
+            "email@example.co.jp", "firstname-lastname@example.com", };
+
+    private static String[] INVALID_EMAILS = { "plainaddress",
+            "#@%^%#$@#$@#.com", "@example.com", "Joe Smith <email@example.com>",
+            "email.example.com", "email@example@example.com",
+            "あいうえお@example.com", "email@example.com (Joe Smith)",
+            "email@example..com", "email@example", };
+
+    @Test
+    public void setInvalidEmail_fieldIsInvalid() {
+        for (String email : INVALID_EMAILS) {
+            testField.setValue(email);
+            Assert.assertTrue("Should be invalid when setting " + email,
+                    testField.isInvalid());
+        }
+    }
+
+    @Test
+    public void setValidEmail_fieldIsValid() {
+        for (String email : VALID_EMAILS) {
+            testField.setValue(email);
+            Assert.assertFalse("Should be valid when setting " + email,
+                    testField.isInvalid());
+        }
+    }
+
     protected EmailField createTestField() {
         return new EmailField();
     }


### PR DESCRIPTION
Cherry-pick of #5327