### PR TITLE
fix: reject emails with double dot between domain and tld (#5327) (CP:23.3)

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.KeyNotifier;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.data.validator.EmailValidator;
 import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.server.VaadinService;
@@ -165,7 +166,7 @@ public class EmailField extends GeneratedVaadinEmailField<EmailField, String>
     private TextFieldValidationSupport getValidationSupport() {
         if (validationSupport == null) {
             validationSupport = new TextFieldValidationSupport(this);
-            validationSupport.setPattern(EMAIL_PATTERN);
+            validationSupport.setPattern(EmailValidator.PATTERN);
         }
         return validationSupport;
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -32,6 +32,18 @@ import static org.junit.Assert.assertTrue;
  * Tests for the {@link EmailField}.
  */
 public class EmailFieldTest {
+    private static final String[] VALID_EMAILS = { "email@example.com",
+            "firstname.lastname@example.com", "email@subdomain.example.com",
+            "firstname+lastname@example.com", "email@123.123.123.123",
+            "1234567890@example.com", "email@example-one.com",
+            "_______@example.com", "email@example.name", "email@example.museum",
+            "email@example.co.jp", "firstname-lastname@example.com", };
+
+    private static final String[] INVALID_EMAILS = { "plainaddress",
+            "#@%^%#$@#$@#.com", "@example.com", "Joe Smith <email@example.com>",
+            "email.example.com", "email@example@example.com",
+            "あいうえお@example.com", "email@example.com (Joe Smith)",
+            "email@example..com", "email@example", };
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -94,5 +106,25 @@ public class EmailFieldTest {
     public void implementsHasTooltip() {
         EmailField field = new EmailField();
         Assert.assertTrue(field instanceof HasTooltip);
+    }
+
+    @Test
+    public void setInvalidEmail_fieldIsInvalid() {
+        EmailField field = new EmailField();
+        for (String email : INVALID_EMAILS) {
+            field.setValue(email);
+            Assert.assertTrue("Should be invalid when setting " + email,
+                    field.isInvalid());
+        }
+    }
+
+    @Test
+    public void setValidEmail_fieldIsValid() {
+        EmailField field = new EmailField();
+        for (String email : VALID_EMAILS) {
+            field.setValue(email);
+            Assert.assertFalse("Should be valid when setting " + email,
+                    field.isInvalid());
+        }
     }
 }


### PR DESCRIPTION
Cherry-pick of #5327 