### PR TITLE
fix: only auto add dialog if it is still open

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -760,7 +760,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
         UI ui = getCurrentUI();
         StateTree.ExecutionRegistration addToUiRegistration = ui
                 .beforeClientResponse(ui, context -> {
-                    if (getElement().getNode().getParent() == null && isOpened()) {
+                    if (getElement().getNode().getParent() == null
+                            && isOpened()) {
                         ui.addToModalComponent(this);
                         ui.setChildComponentModal(this, isModal());
                         autoAddedToTheUi = true;

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -760,7 +760,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
         UI ui = getCurrentUI();
         StateTree.ExecutionRegistration addToUiRegistration = ui
                 .beforeClientResponse(ui, context -> {
-                    if (getElement().getNode().getParent() == null) {
+                    if (getElement().getNode().getParent() == null && isOpened()) {
                         ui.addToModalComponent(this);
                         ui.setChildComponentModal(this, isModal());
                         autoAddedToTheUi = true;

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -325,4 +325,29 @@ public class DialogTest {
         Assert.assertEquals(thirdContent,
                 dialogWithComponents.getChildren().toList().get(2));
     }
+
+    @Test
+    public void open_autoAttachedInBeforeClientResponse() {
+        Dialog dialog = new Dialog();
+        dialog.open();
+
+        fakeClientResponse();
+        Assert.assertNotNull(dialog.getElement().getParent());
+    }
+
+    @Test
+    public void open_close_notAutoAttachedInBeforeClientResponse() {
+        Dialog dialog = new Dialog();
+        dialog.open();
+        dialog.close();
+
+        fakeClientResponse();
+        Assert.assertNull(dialog.getElement().getParent());
+    }
+
+    private void fakeClientResponse() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
 }


### PR DESCRIPTION
## Description

In the Dialog#ensureAttached callback, check if the Dialog is still open before adding it to the UI and registering it in the modal stack.

Fixes #5345

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
