### PR TITLE
fix: return the item position of an item in Select if it exists

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -681,6 +681,11 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         listBox.prependComponents(beforeItem, components);
     }
 
+    @Override
+    public int getItemPosition(T item) {
+        return listBox.getItemPosition(item);
+    }
+
     /**
      * {@inheritDoc}
      * <p>

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -887,6 +887,15 @@ public class SelectTest {
                 select instanceof InputField<AbstractField.ComponentValueChangeEvent<Select<String>, String>, String>);
     }
 
+    @Test
+    public void getItemPosition_ShouldGetTheActualIndexOftheItemIfItExists() {
+        select.setItems("foo", "bar", "buzz");
+        Assert.assertEquals(0, select.getItemPosition("foo"));
+        Assert.assertEquals(1, select.getItemPosition("bar"));
+        Assert.assertEquals(2, select.getItemPosition("buzz"));
+        Assert.assertEquals(-1, select.getItemPosition("does not exist"));
+    }
+
     private void validateItem(int index, String textContent, String label,
             boolean enabled) {
         Element item = getListBoxChild(index);

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -888,7 +888,7 @@ public class SelectTest {
     }
 
     @Test
-    public void getItemPosition_ShouldGetTheActualIndexOftheItemIfItExists() {
+    public void getItemPosition_shouldReturnItemIndexIfItemExists() {
         select.setItems("foo", "bar", "buzz");
         Assert.assertEquals(0, select.getItemPosition("foo"));
         Assert.assertEquals(1, select.getItemPosition("bar"));


### PR DESCRIPTION
## Description

`getItemPosition` in `Select` is delegated to the underlying `InternalListBox` field to return the correct item position.

Fixes #1094

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
