### PR TITLE
fix: grid scroll to index after setting size

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -47,7 +48,23 @@ public class GridScrollToPage extends Div {
                 });
         addRowsAndScrollToEnd.setId("add-row-and-scroll-to-end");
 
+        NativeButton addAlreadyScrolledGridButton = new NativeButton(
+                "Add already scrolled grid", e -> {
+                    Grid<String> alreadyScrolledGrid = new Grid<>();
+                    alreadyScrolledGrid.setId("already-scrolled-grid");
+                    alreadyScrolledGrid.addColumn(item -> item);
+
+                    alreadyScrolledGrid.setItems(IntStream.rangeClosed(0, 1000)
+                            .mapToObj(String::valueOf)
+                            .collect(Collectors.toList()));
+                    alreadyScrolledGrid.scrollToIndex(300);
+                    add(alreadyScrolledGrid);
+
+                    e.getSource().setVisible(false);
+                });
+        addAlreadyScrolledGridButton.setId("add-already-scrolled-grid-button");
+
         add(grid, scrollToStart, scrollToEnd, scrollToRow500, grid2,
-                addRowsAndScrollToEnd);
+                addRowsAndScrollToEnd, addAlreadyScrolledGridButton);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
@@ -41,6 +41,17 @@ public class GridScrollToIT extends AbstractComponentIT {
     }
 
     @Test
+    public void scrollToIndexBeforeAttach_scrolledCorrectly() {
+        $("button").id("add-already-scrolled-grid-button").click();
+
+        GridElement grid = $(GridElement.class).id("already-scrolled-grid");
+
+        Assert.assertEquals(
+                "First visible index did not equal scrollToIndex parameter.",
+                300L, grid.getFirstVisibleRowIndex());
+    }
+
+    @Test
     public void grid_scrollToEnd() {
         $("button").id("scroll-to-end").click();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4486,7 +4486,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
-        getElement().callJsFunction("scrollToIndex", rowIndex);
+        getElement().executeJs(
+                "queueMicrotask(() => this.scrollToIndex(" + rowIndex + "))");
     }
 
     /**
@@ -4500,9 +4501,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * Scrolls to the last data row of the grid.
      */
     public void scrollToEnd() {
-        getUI().ifPresent(
-                ui -> ui.beforeClientResponse(this, ctx -> getElement()
-                        .executeJs("this.scrollToIndex(this._effectiveSize)")));
+        getUI().ifPresent(ui -> ui.beforeClientResponse(this,
+                ctx -> getElement().executeJs(
+                        "queueMicrotask(() => this.scrollToIndex(this._effectiveSize))")));
     }
 
     private void onDragStart(GridDragStartEvent<T> event) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1193,10 +1193,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           })
         );
-
-        grid.scrollToIndex = tryCatchWrapper(function (index) {
-          queueMicrotask(() => Grid.prototype.scrollToIndex.call(grid, index));
-        });
       })(grid)
   };
 })();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1193,6 +1193,10 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           })
         );
+
+        grid.scrollToIndex = tryCatchWrapper(function (index) {
+          queueMicrotask(() => Grid.prototype.scrollToIndex.call(grid, index));
+        });
       })(grid)
   };
 })();


### PR DESCRIPTION
## Description

With the empty grid stuck in loading state [fix](https://github.com/vaadin/flow-components/pull/5043), it became possible that the size is set after `scrollToIndex` is called. This issue is only present in v23.3.

This PR uses `queueMicrotask` in order to delay the `scrollToIndex` call just enough to make sure that the size is initialized.

Fixes #5375 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.