### PR TITLE
feat: add FontIcon component

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/main/java/com/vaadin/flow/component/icon/demo/FontIconPage.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/main/java/com/vaadin/flow/component/icon/demo/FontIconPage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon.demo;
+
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.FontIcon;
+import com.vaadin.flow.router.Route;
+
+/**
+ * @author Vaadin Ltd
+ */
+@Route("vaadin-icons/font-icons")
+@NpmPackage(value = "@fortawesome/fontawesome-free", version = "6.4.2")
+@CssImport("@fortawesome/fontawesome-free/css/all.min.css")
+public class FontIconPage extends Div {
+
+    public FontIconPage() {
+        add(FontAwesomeIcons.USER.create());
+    }
+
+    enum FontAwesomeIcons {
+        CAMERA("fa-camera"), USER("fa-user");
+
+        private String iconClassName;
+
+        FontAwesomeIcons(String iconClassName) {
+            this.iconClassName = iconClassName;
+        }
+
+        public FontIcon create() {
+            return new FontIcon("fa-solid", iconClassName);
+        }
+    }
+
+}

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/FontIconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/FontIconIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-icons/font-icons")
+public class FontIconIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void fontAwesomeIcon() {
+        var icon = findElement(By.tagName("vaadin-icon"));
+        // Get the pseudo element's width and height separated by a space
+        var beforeBounds = executeScript(
+                """
+                        const { width, height } = window.getComputedStyle(arguments[0], '::before');
+                        return `${width} ${height}`;
+                        """,
+                icon);
+
+        Assert.assertEquals("21px 24px", beforeBounds);
+    }
+}

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/FontIconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/FontIconIT.java
@@ -32,9 +32,9 @@ public class FontIconIT extends AbstractComponentIT {
     }
 
     @Test
-    public void fontAwesomeIcon() {
-        var icon = findElement(By.tagName("vaadin-icon"));
-        // Get the pseudo element's width and height separated by a space
+    public void fontIconUsingFont() {
+        var icon = findElement(By.className("fa-user"));
+        // Get the ::before element's width and height separated by a space
         var beforeBounds = executeScript(
                 """
                         const { width, height } = window.getComputedStyle(arguments[0], '::before');
@@ -42,6 +42,7 @@ public class FontIconIT extends AbstractComponentIT {
                         """,
                 icon);
 
+        // Expect the icon size to match FontAwesome "user" icon's size
         Assert.assertEquals("21px 24px", beforeBounds);
     }
 }

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon;
+
+import java.util.Optional;
+
+import com.vaadin.flow.dom.ElementConstants;
+
+/**
+ * Component for displaying an icon from a font icon collection.
+ *
+ * @author Vaadin Ltd
+ */
+public class FontIcon extends AbstractIcon {
+
+    /**
+     * Default constructor. Creates an empty font icon.
+     */
+    public FontIcon() {
+    }
+
+    /**
+     * Creates a font icon component with the given font class names.
+     *
+     * @param font
+     *            The font class names, not null
+     * @see #setFont(String...)
+     */
+    public FontIcon(String... font) {
+        setFont(font);
+    }
+
+    /**
+     * Sets the font class names defining an icon font and/or a specific glyph
+     * inside an icon font.
+     *
+     * @param font
+     *            The font class names, not null
+     */
+    public void setFont(String... font) {
+        getElement().setProperty("font",
+                font.length == 0 ? null : String.join(" ", font));
+    }
+
+    /**
+     * Gets the font class names defining an icon font and/or a specific glyph
+     * inside an icon font.
+     *
+     * @return The font class names
+     */
+    public String[] getFont() {
+        return Optional.ofNullable(getElement().getProperty("font"))
+                .map(f -> f.split(" ")).orElse(new String[0]);
+    }
+
+    /**
+     * Sets the font family to use for the font icon.
+     *
+     * @param fontFamily
+     *            the font family to use
+     */
+    public void setFontFamily(String fontFamily) {
+        getElement().setProperty("fontFamily", fontFamily);
+    }
+
+    /**
+     * Gets the font family to use for the font icon.
+     *
+     * @return the font family to use
+     */
+    public String getFontFamily() {
+        return getElement().getProperty("fontFamily");
+    }
+
+    /**
+     * Sets the specific glyph from a font to use as an icon. Can be a code
+     * point or a ligature name.
+     *
+     * @param charCode
+     *            the character code to use
+     */
+    public void setCharCode(String charCode) {
+        getElement().setProperty("char", charCode);
+    }
+
+    /**
+     * Gets the specific glyph from a font to use as an icon. Can be a code
+     * point or a ligature name.
+     *
+     * @return the character code to use
+     */
+    public String getCharCode() {
+        return getElement().getProperty("char");
+    }
+
+    @Override
+    public void setColor(String color) {
+        getStyle().set(ElementConstants.STYLE_COLOR, color);
+    }
+
+    @Override
+    public String getColor() {
+        return getStyle().get(ElementConstants.STYLE_COLOR);
+    }
+
+}

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/FontIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/FontIconTest.java
@@ -108,4 +108,13 @@ public class FontIconTest {
         Assert.assertEquals("red", icon.getColor());
         Assert.assertEquals("red", icon.getElement().getStyle().get("color"));
     }
+
+    @Test
+    public void clearColor_hasNoColor() {
+        var icon = new FontIcon();
+        icon.setColor("red");
+        icon.setColor(null);
+        Assert.assertNull(icon.getColor());
+        Assert.assertNull(icon.getStyle().get("fill"));
+    }
 }

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/FontIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/FontIconTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon.tests;
+
+import com.vaadin.flow.component.icon.FontIcon;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FontIconTest {
+
+    @Test
+    public void constructor_hasFont() {
+        var icon = new FontIcon("fa-solid", "fa-user");
+        Assert.assertEquals("fa-solid fa-user",
+                String.join(" ", icon.getFont()));
+        Assert.assertEquals("fa-solid fa-user",
+                icon.getElement().getProperty("font"));
+    }
+
+    @Test
+    public void emptyConstructorArgs_hasNoFont() {
+        var icon = new FontIcon();
+        Assert.assertArrayEquals(new String[0], icon.getFont());
+        Assert.assertNull(icon.getElement().getProperty("font"));
+    }
+
+    @Test
+    public void setFont_hasFont() {
+        var icon = new FontIcon();
+        icon.setFont("fa-solid", "fa-user");
+        Assert.assertEquals("fa-solid fa-user",
+                String.join(" ", icon.getFont()));
+        Assert.assertEquals("fa-solid fa-user",
+                icon.getElement().getProperty("font"));
+    }
+
+    @Test
+    public void modifyFont_hasModifiedFont() {
+        var icon = new FontIcon();
+        icon.setFont("fa-solid", "fa-user");
+        icon.setFont("fa-solid");
+        Assert.assertEquals("fa-solid", String.join(" ", icon.getFont()));
+        Assert.assertEquals("fa-solid", icon.getElement().getProperty("font"));
+    }
+
+    @Test
+    public void clearFont_hasNoFont() {
+        var icon = new FontIcon();
+        icon.setFont("fa-solid", "fa-user");
+        icon.setFont();
+        Assert.assertArrayEquals(new String[0], icon.getFont());
+        Assert.assertNull(icon.getElement().getProperty("font"));
+    }
+
+    @Test
+    public void setFontFamily_hasFontFamily() {
+        var icon = new FontIcon();
+        icon.setFontFamily("lumo-icons");
+        Assert.assertEquals("lumo-icons", icon.getFontFamily());
+        Assert.assertEquals("lumo-icons",
+                icon.getElement().getProperty("fontFamily"));
+    }
+
+    @Test
+    public void clearFontFamily_hasNoFontFamily() {
+        var icon = new FontIcon();
+        icon.setFontFamily("lumo-icons");
+        icon.setFontFamily(null);
+        Assert.assertNull(icon.getFontFamily());
+        Assert.assertNull(icon.getElement().getProperty("fontFamily"));
+    }
+
+    @Test
+    public void setCharCode_hasCharCode() {
+        var icon = new FontIcon();
+        icon.setCharCode("\uea0e");
+        Assert.assertEquals("\uea0e", icon.getCharCode());
+        Assert.assertEquals("\uea0e", icon.getElement().getProperty("char"));
+    }
+
+    @Test
+    public void clearCharCode_hasNoCharCode() {
+        var icon = new FontIcon();
+        icon.setCharCode("\uea0e");
+        icon.setCharCode(null);
+        Assert.assertNull(icon.getCharCode());
+        Assert.assertNull(icon.getElement().getProperty("char"));
+    }
+
+    @Test
+    public void setColor_hasColor() {
+        var icon = new FontIcon();
+        icon.setColor("red");
+        Assert.assertEquals("red", icon.getColor());
+        Assert.assertEquals("red", icon.getElement().getStyle().get("color"));
+    }
+}


### PR DESCRIPTION
## Description

Adds `FontIcon` component, which can be used to render glyphs from an icon font collection.

Related to https://github.com/vaadin/web-components/issues/6212

## Type of change

- [ ] Bugfix
- [x] Feature