### PR TITLE
feat: add SvgIcon component

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon;
+
+import com.vaadin.flow.dom.ElementConstants;
+
+/**
+ * Component for displaying an icon from a SVG file.
+ */
+public class SvgIcon extends AbstractIcon {
+    private static final String STYLE_FILL = "fill";
+
+    /**
+     * Default constructor. Creates an empty SVG icon.
+     */
+    public SvgIcon() {
+    }
+
+    /**
+     * Creates an SVG icon with the given source
+     *
+     * @param source
+     *            the SVG file path
+     * @see #setSource(String)
+     */
+    public SvgIcon(String source) {
+        setSource(source);
+    }
+
+    /**
+     * Defines the path of the SVG file to be used as the icon. The value can
+     * be:
+     * <ul>
+     *
+     * <li>A path to a standalone SVG file</li>
+     * <li>
+     * <p>
+     * A path in the format `"path/to/file.svg#symbol-id"` to an SVG file, where
+     * "symbol-id" refers to an id of an element (generally a
+     * `<symbol></symbol>` element) to be rendered in the icon component.
+     * </p>
+     * <p>
+     * Note that the sprite file needs to follow the same-origin policy
+     * </p>
+     * </li>
+     * <li>Alternatively, the source can be defined as a string in the format
+     * `"data:image/svg+xml,<svg>...</svg>`</li>
+     * </ul>
+     *
+     * @param source
+     *            the source file of the icon
+     */
+    public void setSource(String source) {
+        getElement().setProperty("src", source);
+    }
+
+    /**
+     * Gets the source defined in the icon
+     *
+     * @return the source defined or {@code null}
+     */
+    public String getSource() {
+        return getElement().getProperty("src");
+    }
+
+    @Override
+    public void setColor(String color) {
+        getStyle().set(STYLE_FILL, color);
+    }
+
+    @Override
+    public String getColor() {
+        return getStyle().get(STYLE_FILL);
+    }
+}

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.icon.tests;
+
+import com.vaadin.flow.component.icon.SvgIcon;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SvgIconTest {
+    @Test
+    public void emptyConstructor_hasNoSource() {
+        var icon = new SvgIcon();
+        Assert.assertNull(icon.getSource());
+        Assert.assertNull(icon.getElement().getProperty("src"));
+    }
+
+    @Test
+    public void sourceConstructor_hasSource() {
+        var path = "path/to/file.svg";
+        var icon = new SvgIcon(path);
+        Assert.assertEquals(path, icon.getSource());
+        Assert.assertEquals(path, icon.getElement().getProperty("src"));
+    }
+
+    @Test
+    public void setSource_hasSource() {
+        var icon = new SvgIcon();
+        var path = "path/to/file.svg";
+        icon.setSource(path);
+        Assert.assertEquals(path, icon.getSource());
+        Assert.assertEquals(path, icon.getElement().getProperty("src"));
+    }
+
+    @Test
+    public void modifySource_hasModifiedSource() {
+        var icon = new SvgIcon("path/to/file.svg");
+        var newPath = "path/to/new/file.svg";
+        icon.setSource(newPath);
+
+        Assert.assertEquals(newPath, icon.getSource());
+        Assert.assertEquals(newPath, icon.getElement().getProperty("src"));
+    }
+
+    @Test
+    public void setColor_hasColor() {
+        var icon = new SvgIcon();
+        icon.setColor("red");
+        Assert.assertEquals("red", icon.getColor());
+        Assert.assertEquals("red", icon.getStyle().get("fill"));
+    }
+
+    @Test
+    public void removeColor_hasNoColor() {
+        var icon = new SvgIcon();
+        icon.setColor("red");
+        icon.setColor(null);
+        Assert.assertNull(icon.getColor());
+        Assert.assertNull(icon.getStyle().get("fill"));
+    }
+}


### PR DESCRIPTION
## Description

Adds `SvgIcon` component that enables adding icons from SVG files. 

Related to https://github.com/vaadin/web-components/issues/6349
Related to https://github.com/vaadin/web-components/issues/6348

## Type of change

- [ ] Bugfix
- [X] Feature
