### PR TITLE
fix: use correct generic type in ClickNotifier

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/AbstractIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/AbstractIcon.java
@@ -35,7 +35,7 @@ import com.vaadin.flow.dom.ElementConstants;
 @NpmPackage(value = "@vaadin/icon", version = "24.2.0-alpha11")
 @JsModule("@vaadin/icon/src/vaadin-icon.js")
 public abstract class AbstractIcon extends Component
-        implements ClickNotifier<Icon>, HasTooltip {
+        implements ClickNotifier<AbstractIcon>, HasTooltip {
 
     /**
      * Sets the width and the height of the icon.

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/AbstractIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/AbstractIcon.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.icon;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -34,8 +33,8 @@ import com.vaadin.flow.dom.ElementConstants;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/icon", version = "24.2.0-alpha11")
 @JsModule("@vaadin/icon/src/vaadin-icon.js")
-public abstract class AbstractIcon extends Component
-        implements ClickNotifier<AbstractIcon>, HasTooltip {
+public abstract class AbstractIcon<T extends AbstractIcon<T>> extends Component
+        implements ClickNotifier<T>, HasTooltip {
 
     /**
      * Sets the width and the height of the icon.

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  */
 @NpmPackage(value = "@vaadin/icons", version = "24.2.0-alpha11")
 @JsModule("@vaadin/icons/vaadin-iconset.js")
-public class Icon extends AbstractIcon {
+public class Icon extends AbstractIcon<Icon> {
 
     private static final String ICON_ATTRIBUTE_NAME = "icon";
     private static final String ICON_COLLECTION_NAME = "vaadin";


### PR DESCRIPTION
## Description

Use the correct type in the `ClickNotifier` generic param.

Fixes #5395 

## Type of change

- [X] Bugfix
- [ ] Feature
