### PR TITLE
feat: expose the tabs in tab sheet directly as a getter

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -282,6 +282,15 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
     }
 
     /**
+     * Returns the {@link Tabs} in this tab sheet.
+     *
+     * @return the tabs
+     */
+    public Tabs getTabs() {
+        return tabs;
+    }
+
+    /**
      * Returns the {@link Component} instance associated with the given tab.
      *
      * @param tab

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -485,4 +485,15 @@ public class TabSheetTest {
 
         tabSheet.getComponent(null);
     }
+
+    @Test
+    public void getTabs_returnsTabs() {
+        tabSheet.add("Tab 0", new Span("Content 0"));
+        tabSheet.add("Tab 1", new Span("Content 1"));
+
+        var tabsInSheet = tabSheet.getTabs();
+        Assert.assertNotNull(tabsInSheet);
+        Assert.assertEquals(2, tabsInSheet.getComponentCount());
+        Assert.assertEquals(tabs, tabsInSheet);
+    }
 }


### PR DESCRIPTION
## Description

Adds a getter in `TabSheet` to expose the `Tabs` directly.

Closes #5232

## Type of change

- [ ] Bugfix
- [x] Feature
