### PR TITLE
fix: set listenOn to make shortcuts work in ConfirmDialog

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/ShortcutsPage.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/ShortcutsPage.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.component.confirmdialog.tests;
+
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-confirm-dialog/shortcuts")
+public class ShortcutsPage extends Div {
+    public ShortcutsPage() {
+        ConfirmDialog dialog = new ConfirmDialog();
+
+        Button shortcutButton = new Button("Confirm");
+        shortcutButton.setId("shortcut-button");
+        shortcutButton.addClickShortcut(Key.KEY_X);
+        shortcutButton.addClickListener(e -> dialog.close());
+        dialog.add(shortcutButton);
+
+        Button openDialog = new Button("Open");
+        openDialog.setId("open-dialog-button");
+        openDialog.addClickListener(e -> dialog.open());
+        add(openDialog);
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/ShortcutsIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/ShortcutsIT.java
@@ -1,0 +1,47 @@
+package com.vaadin.flow.component.confirmdialog.tests;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+
+@TestPath("vaadin-confirm-dialog/shortcuts")
+public class ShortcutsIT extends AbstractComponentIT {
+
+    private ButtonElement openDialog;
+    private ButtonElement shortcutButton;
+
+    @Before
+    public void init() {
+        open();
+        openDialog = $(ButtonElement.class).id("open-dialog-button");
+    }
+
+    @Test
+    public void clickShortcut_dialogClosed() {
+        openDialog.click();
+
+        waitForElementPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+
+        ConfirmDialogElement confirmDialog = getConfirmDialog();
+
+        shortcutButton = confirmDialog.$(ButtonElement.class)
+                .id("shortcut-button");
+        shortcutButton.focus();
+        shortcutButton.sendKeys("x");
+
+        waitForElementNotPresent(By.tagName("vaadin-confirm-dialog-overlay"));
+    }
+
+    private ConfirmDialogElement getConfirmDialog() {
+        return $(ConfirmDialogElement.class).waitForFirst();
+    }
+}

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.confirmdialog;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -23,6 +24,7 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Shortcuts;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -681,6 +683,14 @@ public class ConfirmDialog extends Component
      */
     public void setCloseOnEsc(boolean closeOnEsc) {
         getElement().setProperty("noCloseOnEsc", !closeOnEsc);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+
+        // Same as https://github.com/vaadin/flow-components/pull/725
+        Shortcuts.setShortcutListenOnElement("this._overlayElement", this);
     }
 
     private void setModality(boolean modal) {


### PR DESCRIPTION
## Description

Fixes #5389

Added `Shortcuts.setShortcutListenOnElement()` call similarly to how it was done for `Dialog` in #725

## Type of change

- Bugfix