### PR TITLE
fix: return the item position of an item in Select if it exists (#5369) (CP: 24.0)

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -644,6 +644,11 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         listBox.prependComponents(beforeItem, components);
     }
 
+    @Override
+    public int getItemPosition(T item) {
+        return listBox.getItemPosition(item);
+    }
+
     /**
      * {@inheritDoc}
      * <p>

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -846,6 +846,15 @@ public class SelectTest {
         Assert.assertEquals(1, listenerInvokedCount.get());
     }
 
+    @Test
+    public void getItemPosition_shouldReturnItemIndexIfItemExists() {
+        select.setItems("foo", "bar", "buzz");
+        Assert.assertEquals(0, select.getItemPosition("foo"));
+        Assert.assertEquals(1, select.getItemPosition("bar"));
+        Assert.assertEquals(2, select.getItemPosition("buzz"));
+        Assert.assertEquals(-1, select.getItemPosition("does not exist"));
+    }
+
     private void validateItem(int index, String textContent, String label,
             boolean enabled) {
         Element item = getListBoxChild(index);


### PR DESCRIPTION
Cherry-pick of #5369 