### PR TITLE
feat: split char into ligature and char

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
@@ -88,7 +88,7 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     /**
      * Sets the hexadecimal code point that specifies a glyph from an icon font.
      *
-     * Example: <code>"e001"</code>
+     * Example: <code>setCharCode("e001")</code>
      *
      * @param charCode
      *            the character code to use
@@ -110,7 +110,7 @@ public class FontIcon extends AbstractIcon<FontIcon> {
      * Sets the ligature name that specifies an icon from an icon font with
      * support for ligatures.
      *
-     * Example: <code>"home"</code>
+     * Example: <code>setLigature("home")</code>
      *
      * @param ligature
      *            the ligature to use
@@ -120,7 +120,8 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     }
 
     /**
-     * Gets the hexadecimal code point that specifies a glyph from an icon font.
+     * Gets the ligature name that specifies an icon from an icon font with
+     * support for ligatures.
      *
      * @return the ligature to use
      */

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
@@ -87,9 +87,9 @@ public class FontIcon extends AbstractIcon<FontIcon> {
 
     /**
      * Sets the hexadecimal code point that specifies a glyph from an icon font.
-     * 
+     *
      * Example: <code>"e001"</code>
-     * 
+     *
      * @param charCode
      *            the character code to use
      */
@@ -107,10 +107,11 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     }
 
     /**
-     * Sets the ligature name that specifies an icon from an icon font with support for ligatures.
-     * 
+     * Sets the ligature name that specifies an icon from an icon font with
+     * support for ligatures.
+     *
      * Example: <code>"home"</code>
-     * 
+     *
      * @param ligature
      *            the ligature to use
      */

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
@@ -86,9 +86,10 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     }
 
     /**
-     * Sets the specific glyph from a font to use as an icon. Can be a code
-     * point or a ligature name.
-     *
+     * Sets the hexadecimal code point that specifies a glyph from an icon font.
+     * 
+     * Example: <code>"e001"</code>
+     * 
      * @param charCode
      *            the character code to use
      */
@@ -97,13 +98,33 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     }
 
     /**
-     * Gets the specific glyph from a font to use as an icon. Can be a code
-     * point or a ligature name.
+     * Gets the hexadecimal code point that specifies a glyph from an icon font.
      *
      * @return the character code to use
      */
     public String getCharCode() {
         return getElement().getProperty("char");
+    }
+
+    /**
+     * Sets the ligature name that specifies an icon from an icon font with support for ligatures.
+     * 
+     * Example: <code>"home"</code>
+     * 
+     * @param ligature
+     *            the ligature to use
+     */
+    public void setLigature(String ligature) {
+        getElement().setProperty("ligature", ligature);
+    }
+
+    /**
+     * Gets the hexadecimal code point that specifies a glyph from an icon font.
+     *
+     * @return the ligature to use
+     */
+    public String getLigature() {
+        return getElement().getProperty("ligature");
     }
 
     @Override

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/FontIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/FontIconTest.java
@@ -87,18 +87,35 @@ public class FontIconTest {
     @Test
     public void setCharCode_hasCharCode() {
         var icon = new FontIcon();
-        icon.setCharCode("\uea0e");
-        Assert.assertEquals("\uea0e", icon.getCharCode());
-        Assert.assertEquals("\uea0e", icon.getElement().getProperty("char"));
+        icon.setCharCode("ea0e");
+        Assert.assertEquals("ea0e", icon.getCharCode());
+        Assert.assertEquals("ea0e", icon.getElement().getProperty("char"));
     }
 
     @Test
     public void clearCharCode_hasNoCharCode() {
         var icon = new FontIcon();
-        icon.setCharCode("\uea0e");
+        icon.setCharCode("ea0e");
         icon.setCharCode(null);
         Assert.assertNull(icon.getCharCode());
         Assert.assertNull(icon.getElement().getProperty("char"));
+    }
+
+    @Test
+    public void setLigature_hasLigature() {
+        var icon = new FontIcon();
+        icon.setLigature("home");
+        Assert.assertEquals("home", icon.getLigature());
+        Assert.assertEquals("home", icon.getElement().getProperty("ligature"));
+    }
+
+    @Test
+    public void clearLigature_hasNoLigature() {
+        var icon = new FontIcon();
+        icon.setLigature("home");
+        icon.setLigature(null);
+        Assert.assertNull(icon.getLigature());
+        Assert.assertNull(icon.getElement().getProperty("ligature"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/pull/6452

As a follow-up of the `FontIcon` DX test results, we decided to split the `FontIcon::setChar`, which currently accepts either a code point or a ligature, into separate `FontIcon::setChar` and `FontIcon::setLigature` methods.

Since "char" can no longer be a ligature name, the updated `FontIcon::setChar` method now also supports unprefixed code points (like "ea0e").

Before:
```java
var lumoIcon = new FontIcon();
lumoIcon.setFontFamily("lumo-icons");
lumoIcon.setChar("\uea0e");

var materialIcon = new FontIcon();
materialIcon.setFontFamily("Material Icons");
materialIcon.setChar("face");
```

After:
```java
var lumoIcon = new FontIcon();
lumoIcon.setFontFamily("lumo-icons");
lumoIcon.setChar("ea0e");

var materialIcon = new FontIcon();
materialIcon.setFontFamily("Material Icons");
materialIcon.setLigature("face");
```

## Type of change

Feature