### PR TITLE
fix: remove slot attribute from children in SlotUtils.clearSlot

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/SlotUtils.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/SlotUtils.java
@@ -15,15 +15,14 @@
  */
 package com.vaadin.flow.component.shared;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.dom.Element;
-
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Util methods for handling child elements inside slots.
@@ -56,8 +55,10 @@ public class SlotUtils {
      *            the name of the slot to clear
      */
     public static void clearSlot(HasElement parent, String slot) {
-        getElementsInSlot(parent, slot).collect(Collectors.toList())
-                .forEach(parent.getElement()::removeChild);
+        getElementsInSlot(parent, slot).toList().forEach(element -> {
+            element.removeAttribute("slot");
+            parent.getElement().removeChild(element);
+        });
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/SlotUtilsTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/SlotUtilsTest.java
@@ -15,15 +15,15 @@
  */
 package com.vaadin.flow.component.shared;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.dom.Element;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for the {@link SlotUtils}.
@@ -151,5 +151,21 @@ public class SlotUtilsTest {
     @Test
     public void setSlot_nullAsElement_doesNotThrow() {
         SlotUtils.setSlot(parent, TEST_SLOT, new Element("div"), null);
+    }
+
+    @Test
+    public void addToSlot_slotAttributeAddedInChild() {
+        var slotComponent = new TestComponent();
+        SlotUtils.addToSlot(parent, TEST_SLOT, slotComponent);
+        Assert.assertEquals(TEST_SLOT,
+                slotComponent.getElement().getAttribute("slot"));
+    }
+
+    @Test
+    public void clearSlot_slotAttributeRemovedFromChild() {
+        var slotComponent = new TestComponent();
+        SlotUtils.addToSlot(parent, TEST_SLOT, slotComponent);
+        SlotUtils.clearSlot(parent, TEST_SLOT);
+        Assert.assertNull(slotComponent.getElement().getAttribute("slot"));
     }
 }


### PR DESCRIPTION
## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes #5429

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.
