### PR TITLE
refactor: preload items on grid scroll to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Move to the integration tests module of the component
 
 Start the test runner in watch mode
 
-- `npx web-test-runner test/**/*.test.ts --node-resolve --watch`
+- `npx web-test-runner --playwright test/**/*.test.ts --node-resolve --watch`
 
 NOTE: The tests actually import the client module under test from `..integration-tests/frontend/generated/jar-resources`.
 For faster feedback loop you can work on the generated file directly. Just be careful not to lose your changes to it since it's not under version control.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -50,7 +50,13 @@ public class GridScrollToPage extends Div {
                 });
         addRowAndScrollToIndex.setId("add-row-and-scroll-to-index");
 
+        NativeButton setSmallPageSize = new NativeButton(
+                "Set small page size (5)", e -> {
+                    grid.setPageSize(5);
+                });
+        setSmallPageSize.setId("set-small-page-size");
+
         add(grid, scrollToStart, scrollToEnd, scrollToRow500,
-                addRowsAndScrollToEnd, addRowAndScrollToIndex);
+                addRowsAndScrollToEnd, addRowAndScrollToIndex, setSmallPageSize);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -57,6 +57,7 @@ public class GridScrollToPage extends Div {
         setSmallPageSize.setId("set-small-page-size");
 
         add(grid, scrollToStart, scrollToEnd, scrollToRow500,
-                addRowsAndScrollToEnd, addRowAndScrollToIndex, setSmallPageSize);
+                addRowsAndScrollToEnd, addRowAndScrollToIndex,
+                setSmallPageSize);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
@@ -93,15 +93,19 @@ public class GridScrollToIT extends AbstractComponentIT {
     public void grid_addItem_scrollToIndex_twice() {
         $("button").id("add-row-and-scroll-to-index").click();
         // Wait until finished loading
-        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
 
         $("button").id("add-row-and-scroll-to-index").click();
-        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
 
         // Find the content element of the first visible row cell
-        var slot = grid.getCell(grid.getFirstVisibleRowIndex(), 0).findElement(By.tagName("slot"));
-        var content = grid.findElement(By.cssSelector(
-                "vaadin-grid-cell-content[slot='" + slot.getPropertyString("name") + "']"));
+        var slot = grid.getCell(grid.getFirstVisibleRowIndex(), 0)
+                .findElement(By.tagName("slot"));
+        var content = grid
+                .findElement(By.cssSelector("vaadin-grid-cell-content[slot='"
+                        + slot.getPropertyString("name") + "']"));
         // Expect the content element to be displayed
         Assert.assertTrue(content.isDisplayed());
     }
@@ -113,10 +117,12 @@ public class GridScrollToIT extends AbstractComponentIT {
 
         $("button").id("add-row-and-scroll-to-index").click();
         // Wait until finished loading
-        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
 
         $("button").id("add-row-and-scroll-to-index").click();
-        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
@@ -89,4 +89,34 @@ public class GridScrollToIT extends AbstractComponentIT {
                 grid.getCell(grid.getLastVisibleRowIndex(), 0).getText());
     }
 
+    @Test
+    public void grid_addItem_scrollToIndex_twice() {
+        $("button").id("add-row-and-scroll-to-index").click();
+        // Wait until finished loading
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+
+        $("button").id("add-row-and-scroll-to-index").click();
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+
+        // Find the content element of the first visible row cell
+        var slot = grid.getCell(grid.getFirstVisibleRowIndex(), 0).findElement(By.tagName("slot"));
+        var content = grid.findElement(By.cssSelector(
+                "vaadin-grid-cell-content[slot='" + slot.getPropertyString("name") + "']"));
+        // Expect the content element to be displayed
+        Assert.assertTrue(content.isDisplayed());
+    }
+
+    @Test
+    public void grid_smallPageSize_addItem_scrollToIndex_twice() {
+        // Set page size to 5
+        $("button").id("set-small-page-size").click();
+
+        $("button").id("add-row-and-scroll-to-index").click();
+        // Wait until finished loading
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+
+        $("button").id("add-row-and-scroll-to-index").click();
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex()).hasAttribute("loading"));
+    }
+
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -83,7 +83,7 @@ describe('grid connector', () => {
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
       // Grid should have requested new items
-      expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
 
       // Add the requested items
       setRootItems(grid.$connector, items);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -1,5 +1,13 @@
-import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
-import { init, gridConnector, getBodyRowCount, getBodyCellText, setRootItems } from './shared.js';
+import { aTimeout, expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import {
+  init,
+  gridConnector,
+  getBodyRowCount,
+  getBodyCellText,
+  setRootItems,
+  clear,
+  GRID_CONNECTOR_ROOT_REQUEST_DELAY
+} from './shared.js';
 import type { FlowGrid } from './shared.js';
 
 describe('grid connector', () => {
@@ -27,6 +35,69 @@ describe('grid connector', () => {
 
     expect(getBodyRowCount(grid)).to.equal(1);
     expect(getBodyCellText(grid, 0, 0)).to.equal('foo');
+  });
+
+  it('should request new items on clear', async () => {
+    // Add two root items
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo' },
+      { key: '1', name: 'bar' }
+    ]);
+    await nextFrame();
+    grid.$server.setRequestedRange.resetHistory();
+
+    // Clear the items
+    clear(grid.$connector, 0, 2);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+    // Grid should have requested new items
+    expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+
+    // Add the requested items
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo' },
+      { key: '1', name: 'bar' }
+    ]);
+    grid.$server.setRequestedRange.resetHistory();
+
+    // Clear the items again
+    clear(grid.$connector, 0, 2);
+
+    // Add the first item back before the request timeout
+    grid.$connector.set(0, [{ key: '0', name: 'foo' }]);
+    grid.$connector.confirm(-1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+    // Grid should have again requested for the second item
+    expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+  });
+
+  it('should not request for new items if they are available', async () => {
+    // Add one root item
+    setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+    await nextFrame();
+    grid.$server.setRequestedRange.resetHistory();
+
+    // Clear the first item
+    clear(grid.$connector, 0, 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+    // Grid should have requested new items
+    expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+
+    // Add the requested items
+    setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+    grid.$server.setRequestedRange.resetHistory();
+
+    // Clear the first item again
+    clear(grid.$connector, 0, 1);
+    // Add the item back before the request timeout
+    setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+    // Grid should have not requested for items
+    expect(grid.$server.setRequestedRange.calledOnce).to.be.false;
   });
 
   describe('empty grid', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -38,37 +38,38 @@ describe('grid connector', () => {
   });
 
   it('should request new items on clear', async () => {
-    // Add two root items
-    setRootItems(grid.$connector, [
-      { key: '0', name: 'foo' },
-      { key: '1', name: 'bar' }
-    ]);
+    // Use a smaller page size for testing
+    const pageSize = 5;
+    grid.pageSize = pageSize;
+    grid.$connector.reset();
+
+    // Add 10 root items
+    setRootItems(grid.$connector, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
+
     await nextFrame();
     grid.$server.setRequestedRange.resetHistory();
 
     // Clear the items
-    clear(grid.$connector, 0, 2);
+    clear(grid.$connector, 0, 10);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
     // Grid should have requested new items
     expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
 
     // Add the requested items
-    setRootItems(grid.$connector, [
-      { key: '0', name: 'foo' },
-      { key: '1', name: 'bar' }
-    ]);
+    setRootItems(grid.$connector, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
+
     grid.$server.setRequestedRange.resetHistory();
 
     // Clear the items again
-    clear(grid.$connector, 0, 2);
+    clear(grid.$connector, 0, 10);
 
-    // Add the first item back before the request timeout
-    grid.$connector.set(0, [{ key: '0', name: 'foo' }]);
+    // Add the first page items back before the request timeout
+    grid.$connector.set(0, Array.from({ length: 5 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
     grid.$connector.confirm(-1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
-    // Grid should have again requested for the second item
+    // Grid should have requested for the missing items
     expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
   });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -102,7 +102,7 @@ describe('grid connector', () => {
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
       // Grid should have requested for the missing items
-      expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
     });
 
     it('should not request for new items after complete confirm', async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -75,7 +75,8 @@ describe('grid connector', () => {
       setRootItems(grid.$connector, items);
 
       await nextFrame();
-      grid.$server.setRequestedRange.resetHistory();
+      // Grid should not have requested for items yet (all the 10 items were preloaded)
+      expect(grid.$server.setRequestedRange.called).to.be.false;
 
       // Clear the items
       clear(grid.$connector, 0, 10);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -116,7 +116,7 @@ describe('grid connector', () => {
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
       // Grid should not have request for items
-      expect(grid.$server.setRequestedRange.called).to.be.false;
+      expect(grid.$server.setRequestedRange).to.be.not.called;
     });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -37,79 +37,6 @@ describe('grid connector', () => {
     expect(getBodyCellText(grid, 0, 0)).to.equal('foo');
   });
 
-  // TODO: Move the new tests under a shared describe block
-  it('should request new items after incomplete confirm', async () => {
-    // Use a smaller page size for testing
-    const pageSize = 5;
-    grid.pageSize = pageSize;
-    grid.$connector.reset();
-
-    // Add 10 root items
-    setRootItems(grid.$connector, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
-
-    await nextFrame();
-    grid.$server.setRequestedRange.resetHistory();
-
-    // Clear the items
-    clear(grid.$connector, 0, 10);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-
-    // Grid should have requested new items
-    expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
-
-    // Add the requested items
-    setRootItems(grid.$connector, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
-
-    grid.$server.setRequestedRange.resetHistory();
-
-    // Clear the items again
-    clear(grid.$connector, 0, 10);
-
-    // Add the first page items back before the request timeout (partial/incomplete preload)
-    grid.$connector.set(0, Array.from({ length: 5 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
-    grid.$connector.confirm(-1);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-
-    // Grid should have requested for the missing items
-    expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
-  });
-
-  it('should not request for new items after complete confirm', async () => {
-    // Use a smaller page size for testing
-    const pageSize = 5;
-    grid.pageSize = pageSize;
-    grid.$connector.reset();
-
-    // Add 10 root items
-    setRootItems(grid.$connector, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
-
-    await nextFrame();
-    grid.$server.setRequestedRange.resetHistory();
-
-    // Clear the items
-    clear(grid.$connector, 0, 10);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-
-    // Grid should have requested new items
-    expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
-
-    // Add the requested items
-    setRootItems(grid.$connector, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
-
-    grid.$server.setRequestedRange.resetHistory();
-
-    // Clear the items again
-    clear(grid.$connector, 0, 10);
-
-    // Add all the items back before the request timeout
-    grid.$connector.set(0, Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` })));
-    grid.$connector.confirm(-1);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-
-    // Grid should have requested for the missing items
-    expect(grid.$server.setRequestedRange.calledOnce).to.be.false;
-  });
-
   describe('empty grid', () => {
     it('should not have loading state when refreshing grid', async () => {
       setRootItems(grid.$connector, []);
@@ -130,6 +57,64 @@ describe('grid connector', () => {
       grid.clearCache();
       await nextFrame();
 
+      expect(grid.$server.setRequestedRange.called).to.be.false;
+    });
+  });
+
+  // A setup where the grid has requested items, and the server has successfully
+  // responded with a full item set.
+  describe('grid with a requested data range', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ key: `${i}`, name: `foo${i}` }));
+
+    beforeEach(async () => {
+      // Use a smaller page size for testing
+      grid.pageSize = 5;
+      grid.$connector.reset();
+
+      // Add 10 root items
+      setRootItems(grid.$connector, items);
+
+      await nextFrame();
+      grid.$server.setRequestedRange.resetHistory();
+
+      // Clear the items
+      clear(grid.$connector, 0, 10);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+      // Grid should have requested new items
+      expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+
+      // Add the requested items
+      setRootItems(grid.$connector, items);
+
+      grid.$server.setRequestedRange.resetHistory();
+    });
+
+    it('should request new items after incomplete confirm', async () => {
+      // Clear the items again
+      clear(grid.$connector, 0, 10);
+
+      // Add the first page items back before the request timeout (partial/incomplete preload)
+      grid.$connector.set(0, items.slice(0, grid.pageSize));
+      grid.$connector.confirm(-1);
+
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+      // Grid should have requested for the missing items
+      expect(grid.$server.setRequestedRange.calledOnce).to.be.true;
+    });
+
+    it('should not request for new items after complete confirm', async () => {
+      // Clear the items again
+      clear(grid.$connector, 0, 10);
+
+      // Add all the items back before the request timeout
+      grid.$connector.set(0, items);
+      grid.$connector.confirm(-1);
+
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+      // Grid should not have request for items
       expect(grid.$server.setRequestedRange.called).to.be.false;
     });
   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -174,7 +174,6 @@ export function expandItems(gridConnector: GridConnector, items: Item[]): void {
   gridConnector.expandItems(items);
 }
 
-
 /**
  * Clears the given range of the given parent's children.
  */

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -21,6 +21,7 @@ export type GridConnector = {
   reset: () => void;
   doSelection: (items: Item[] | [null], userOriginated: boolean) => void;
   doDeselection: (items: Item[], userOriginated: boolean) => void;
+  clear: (index: number, length: number, parentKey?: string) => void;
 };
 
 export type GridServer = {
@@ -70,6 +71,7 @@ const Vaadin = window.Vaadin as Vaadin;
 export const gridConnector = Vaadin.Flow.gridConnector;
 
 export const GRID_CONNECTOR_PARENT_REQUEST_DELAY = 50;
+export const GRID_CONNECTOR_ROOT_REQUEST_DELAY = 150;
 
 /**
  * Initializes the grid connector and the grid server mock.
@@ -170,4 +172,12 @@ export function setChildItems(gridConnector: GridConnector, parent: Item, items:
 export function expandItems(gridConnector: GridConnector, items: Item[]): void {
   gridConnector.ensureHierarchy();
   gridConnector.expandItems(items);
+}
+
+
+/**
+ * Clears the given range of the given parent's children.
+ */
+export function clear(gridConnector: GridConnector, index: number, length: number, parent?: Item): void {
+  gridConnector.clear(index, length, parent?.key);
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4541,20 +4541,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         int pageSize = getPageSize();
         int firstRootIndex = rowIndex - rowIndex % pageSize;
 
-        // Preload the target page
-        // Add a test that proves this approach invalid
-        // setRequestedRange(firstRootIndex, pageSize);
-
-        // Preload from one page before to one page after the target page
-        // Add a test that proves this approach invalid
-        // setRequestedRange(firstRootIndex - pageSize, pageSize * 3);
-
         // Preload from one page before to one page after the target page
         setRequestedRange(firstRootIndex - pageSize, pageSize * 3);
-        
+        // Scroll to the requested index        
         getElement().callJsFunction("scrollToIndex", rowIndex);
-        // clear the lastRequestedRanges from connector
-        getElement().executeJs("this.$connector.clearLastRequestedRanges()");
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4538,7 +4538,23 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
+        int pageSize = getPageSize();
+        int firstRootIndex = rowIndex - rowIndex % pageSize;
+
+        // Preload the target page
+        // Add a test that proves this approach invalid
+        // setRequestedRange(firstRootIndex, pageSize);
+
+        // Preload from one page before to one page after the target page
+        // Add a test that proves this approach invalid
+        // setRequestedRange(firstRootIndex - pageSize, pageSize * 3);
+
+        // Preload from one page before to one page after the target page
+        setRequestedRange(firstRootIndex - pageSize, pageSize * 3);
+        
         getElement().callJsFunction("scrollToIndex", rowIndex);
+        // clear the lastRequestedRanges from connector
+        getElement().executeJs("this.$connector.clearLastRequestedRanges()");
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4538,11 +4538,30 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
+        // Grid's page size
         int pageSize = getPageSize();
-        int firstRootIndex = rowIndex - rowIndex % pageSize;
+        // A rough approximation of the viewport size in rows. This affects the
+        // count of preloaded rows.
+        int viewportSizeEstimate = 40;
 
-        // Preload from one page before to one page after the target page
-        setRequestedRange(firstRootIndex - pageSize, pageSize * 3);
+        // Get the index of the first item on the page that contains the
+        // requested index
+        int targetPageStartIndex = rowIndex - rowIndex % pageSize;
+
+        // The last index we want to include in the preloaded range
+        int lastIndex = rowIndex + viewportSizeEstimate;
+
+        // Get the index of the last item on the page that contains the last
+        // index we want to preload
+        int lastIndexPageStartIndex = lastIndex - lastIndex % pageSize;
+        int lastIndexPageEndIndex = lastIndexPageStartIndex + pageSize - 1;
+
+        // Preloaded items count
+        int preloadedItemsCount = lastIndexPageEndIndex - targetPageStartIndex
+                + 1;
+        // Preload the items
+        setRequestedRange(targetPageStartIndex, preloadedItemsCount);
+
         // Scroll to the requested index
         getElement().callJsFunction("scrollToIndex", rowIndex);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4543,7 +4543,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         // Preload from one page before to one page after the target page
         setRequestedRange(firstRootIndex - pageSize, pageSize * 3);
-        // Scroll to the requested index        
+        // Scroll to the requested index
         getElement().callJsFunction("scrollToIndex", rowIndex);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -869,11 +869,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             updateGridEffectiveSize();
           }
 
-          // TODO: Document and test
-          if (treePageCallbacks[parentKey] && Object.keys(treePageCallbacks[parentKey]).length) {
-            delete lastRequestedRanges[parentKey];
-          }
-
           // Let server know we're done
           grid.$server.confirmParentUpdate(id, parentKey);
 
@@ -924,8 +919,15 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           }
 
-          // TODO: Document
           if (Object.keys(rootPageCallbacks).length) {
+            // There are still unresolved callbacks waiting for data to the root level,
+            // which means that the range grid requested items for was only partially filled.
+            //
+            // This can happen for example if you preload some items without knowing exactly
+            // how many items the grid web component is going to request.
+            //
+            // Clear the last requested range for the root level to unblock
+            // any possible data requests for the same range in fetchPage.
             delete lastRequestedRanges[root];
           }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -739,13 +739,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             items.forEach((item) => grid.closeItemDetails(item));
             delete cache[pkey][page];
 
-            const lastRequestedRange = lastRequestedRanges[pkey];
-            if (lastRequestedRange && page >= lastRequestedRange[0] && page <= lastRequestedRange[1]) {
-              // A cached page inside the lastRequestedRange was cleared so the lastRequestedRange is no longer valid.
-              // Delete the range to unblock any possible data requests for the same range in fetchPage.
-              delete lastRequestedRanges[pkey];
-            }
-
             const updatedItems = updateGridCache(page, parentKey);
             if (updatedItems) {
               itemsUpdated(updatedItems);
@@ -925,6 +918,13 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
               delete rootPageCallbacks[page];
               callback([]);
             }
+          }
+
+          const hasLoadingRows = grid._getRenderedRows().some((row) => row.hasAttribute('loading'));
+          if (hasLoadingRows) {
+            // TODO: Describe better!
+            // The grid is still loading, make sure any requests will not be blocked due to unchanged lastRequestedRanges
+            delete lastRequestedRanges[root];
           }
 
           // Let server know we're done

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -923,6 +923,12 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           grid.$server.confirmUpdate(id);
         });
 
+        // This is only a prototype to try out https://github.com/vaadin/flow-components/issues/5229#issuecomment-1655188669
+        // Needs a cleaner solution for the final implementation
+        grid.$connector.clearLastRequestedRanges = () => {
+          deleteObjectContents(lastRequestedRanges);
+        }
+
         grid.$connector.ensureHierarchy = tryCatchWrapper(function () {
           for (let parentKey in cache) {
             if (parentKey !== root) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -738,7 +738,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
             items.forEach((item) => grid.closeItemDetails(item));
             delete cache[pkey][page];
-
             const updatedItems = updateGridCache(page, parentKey);
             if (updatedItems) {
               itemsUpdated(updatedItems);
@@ -870,6 +869,11 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             updateGridEffectiveSize();
           }
 
+          // TODO: Document and test
+          if (treePageCallbacks[parentKey] && Object.keys(treePageCallbacks[parentKey]).length) {
+            delete lastRequestedRanges[parentKey];
+          }
+
           // Let server know we're done
           grid.$server.confirmParentUpdate(id, parentKey);
 
@@ -920,10 +924,8 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
           }
 
-          const hasLoadingRows = grid._getRenderedRows().some((row) => row.hasAttribute('loading'));
-          if (hasLoadingRows) {
-            // TODO: Describe better!
-            // The grid is still loading, make sure any requests will not be blocked due to unchanged lastRequestedRanges
+          // TODO: Document
+          if (Object.keys(rootPageCallbacks).length) {
             delete lastRequestedRanges[root];
           }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.grid;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import com.vaadin.flow.internal.Range;
+
+public class GridScrollTest {
+
+    private Grid<String> grid;
+
+    @Before
+    public void setUp() {
+        grid = new Grid<>();
+        grid.setPageSize(50);
+        grid.getElement().setProperty("size", 1000);
+    }
+
+    @Test
+    public void scrollToStart_preloadOnePage() {
+        grid.scrollToIndex(0);
+        Assert.assertEquals("0-50", getRequestedRange(grid));
+    }
+
+    @Test
+    public void scrollToEnd_preloadOnePage() {
+        grid.scrollToIndex(950);
+        Assert.assertEquals("950-1000", getRequestedRange(grid));
+    }
+
+    @Test
+    public void scrollToStartOfPage_preloadOnePage() {
+        grid.scrollToIndex(500);
+        Assert.assertEquals("500-550", getRequestedRange(grid));
+    }
+
+    @Test
+    public void scrollToSecondIndexOfPage_preloadOnePage() {
+        grid.scrollToIndex(501);
+        Assert.assertEquals("500-550", getRequestedRange(grid));
+    }
+
+    @Test
+    public void scrollToSecondLastIndexOfPage_preloadTwoPages() {
+        grid.scrollToIndex(499);
+        Assert.assertEquals("450-550", getRequestedRange(grid));
+    }
+
+    @Test
+    public void smallPageSize_scrollToIndex_preloadMultiplePages() {
+        grid.setPageSize(5);
+        grid.scrollToIndex(499);
+        Assert.assertEquals("495-540", getRequestedRange(grid));
+    }
+
+    private String getRequestedRange(Grid<String> grid) {
+        try {
+            var communicator = grid.getDataCommunicator();
+            var requestedRangeField = communicator.getClass()
+                    .getDeclaredField("requestedRange");
+            requestedRangeField.setAccessible(true);
+            Range requestedRange = (Range) requestedRangeField
+                    .get(communicator);
+            return requestedRange.getStart() + "-" + requestedRange.getEnd();
+
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -29,7 +29,6 @@ public class GridScrollTest {
     public void setUp() {
         grid = new Grid<>();
         grid.setPageSize(50);
-        grid.getElement().setProperty("size", 1000);
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR re-implements preloading of items on scrollToIndex. The [previous implementation](https://github.com/vaadin/flow-components/pull/4854) was [reverted](https://github.com/vaadin/flow-components/pull/5228) due to the regressions it caused.

The new implementation:
- Makes sure that the preloaded page ranges are valid on the root level based on the current page size. For example, if you scroll to index 25 and the page size is 50, 25-75 is not a valid page range to preload because the page doesn't start at index 25. In this case, the grid should preload a range from 0-100 (pages 0-50 and 50-100).
- Makes sure the `lastRequestedRanges` record for the root level is cleared if it ends up in an invalid state where the last requested range is only partially covered (For example, grid web component expects 4 pages but only 2 are preloaded. If the property was not cleared, the connector would be blocked from making another data request to the server for the remaining 2 pages).

Fixes https://github.com/vaadin/flow-components/issues/5229

## Type of change

Performance enhancement