### PR TITLE
test: update DetachReattachIT to check for initial value

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/tests/RichTextEditorDetachReattachIT.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/tests/RichTextEditorDetachReattachIT.java
@@ -16,9 +16,15 @@ public class RichTextEditorDetachReattachIT extends AbstractComponentIT {
 
     @Test
     public void detach_reattach_htmlValueInitialized() {
+        assertHtmlValue();
+
         $("button").id("detach").click();
         $("button").id("attach").click();
 
+        assertHtmlValue();
+    }
+
+    private void assertHtmlValue() {
         RichTextEditorElement editor = $(RichTextEditorElement.class).first();
 
         Assert.assertEquals("<h1>foo</h1>",


### PR DESCRIPTION
## Description

Added a check to cover an initially set HTML value for a view containing this code:

```java
RichTextEditor editor = new RichTextEditor();
editor.setValue("<h1>foo</h1>");
```

This change is intended to cover the scenario implemented in https://github.com/vaadin/web-components/pull/6506

## Type of change

- Test