### PR TITLE
fix: ignore removed nodes in flow component directive

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
@@ -138,7 +138,7 @@ describe('flow-component-renderer', () => {
     component.nodeId = 1;
     await nextFrame();
 
-    // getByNodeId should only have been called for node id 1 only
+    // getByNodeId should only have been called for node id 1
     getByNodeId.getCalls().forEach((call) => expect(call.args[0]).to.equal(1));
     expect(component.firstElementChild).to.equal(elements[1]);
   });

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
@@ -1,16 +1,17 @@
 import type {} from '@web/test-runner-mocha';
 import '../frontend/generated/jar-resources/flow-component-renderer.js';
-import { render, html } from 'lit';
+import { render, html, LitElement } from 'lit';
 import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import sinon from 'sinon';
 
 type Vaadin = {
   FlowComponentHost: {
-    getNode: (appId: string, nodeId: number) => HTMLElement;
+    getNode: (appId: string, nodeId?: number) => HTMLElement;
   };
   Flow: {
     clients: {
       [appId: string]: {
-        getByNodeId: (nodeId: number) => HTMLElement;
+        getByNodeId: ((nodeId: number) => HTMLElement) & sinon.SinonSpy;
       };
     };
   };
@@ -22,6 +23,27 @@ declare global {
   }
 }
 
+interface TestComponent extends LitElement {
+  nodeId?: number;
+}
+
+class TestComponent extends LitElement {
+  static get properties() {
+    return {
+      nodeId: { type: Number }
+    };
+  }
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  render() {
+    return html`${window.Vaadin.FlowComponentHost.getNode('ROOT', this.nodeId)}`;
+  }
+}
+customElements.define('test-component', TestComponent);
+
 describe('flow-component-renderer', () => {
   let elements: { [key: number]: HTMLElement };
 
@@ -29,9 +51,9 @@ describe('flow-component-renderer', () => {
     window.Vaadin.Flow = {
       clients: {
         ROOT: {
-          getByNodeId: (nodeId: number) => {
+          getByNodeId: sinon.spy((nodeId: number) => {
             return elements[nodeId];
-          }
+          })
         }
       }
     };
@@ -66,5 +88,95 @@ describe('flow-component-renderer', () => {
     render(html`${window.Vaadin.FlowComponentHost.getNode('ROOT', undefined)}`, container);
     await nextFrame();
     expect(container.firstElementChild).to.equal(null);
+  });
+
+  it('should not try to re-render a removed node', async () => {
+    const { getByNodeId } = window.Vaadin.Flow.clients.ROOT;
+    const component = fixtureSync<TestComponent>(`<test-component></test-component>`);
+
+    // Create an element to render
+    elements[0] = document.createElement('button');
+    component.nodeId = 0;
+    await nextFrame();
+
+    // Remove the element (simulate removing from the Flow's registry)
+    delete elements[0];
+
+    // Render once again with the old node id (this can happen if Grid's items haven't
+    // yet been updated not to include the removed node id and re-render is invoked)
+    component.requestUpdate();
+    await nextFrame();
+
+    getByNodeId.resetHistory();
+    // Finally, render with undefined node id (the Grid's items have been updated)
+    component.nodeId = undefined;
+
+    await nextFrame();
+    expect(getByNodeId).to.not.have.been.called;
+    expect(component.firstElementChild).to.equal(null);
+  });
+
+  it('should not try to re-render a replaced node', async () => {
+    const { getByNodeId } = window.Vaadin.Flow.clients.ROOT;
+    const component = fixtureSync<TestComponent>(`<test-component></test-component>`);
+
+    // Create an element to render
+    elements[0] = document.createElement('button');
+    component.nodeId = 0;
+    await nextFrame();
+
+    // Remove the element
+    delete elements[0];
+    // Add new element
+    elements[1] = document.createElement('button');
+    // Render once again with the old node id
+    component.requestUpdate();
+    await nextFrame();
+
+    getByNodeId.resetHistory();
+    // Finally, render with the new node id
+    component.nodeId = 1;
+    await nextFrame();
+
+    // getByNodeId should only have been called for node id 1 only
+    getByNodeId.getCalls().forEach((call) => expect(call.args[0]).to.equal(1));
+    expect(component.firstElementChild).to.equal(elements[1]);
+  });
+
+  it('should not replace new synchronous node with the old lazily added node', async () => {
+    const component = fixtureSync<TestComponent>(`<test-component></test-component>`);
+
+    // Try to render a lazily added node (not added to the Flow's registry yet)
+    component.nodeId = 0;
+    await nextFrame();
+
+    // Add and render a new node synchronously
+    elements[1] = document.createElement('button');
+    component.nodeId = 1;
+    await nextFrame();
+
+    // Add the lazy node to the Flow's registry
+    elements[0] = document.createElement('button');
+    await nextFrame();
+
+    // The new node should still be rendered
+    expect(component.firstElementChild).to.equal(elements[1]);
+    expect(component.contains(elements[0])).to.be.false;
+  });
+
+  it('should not try to re-render an old node after disconnect', async () => {
+    const { getByNodeId } = window.Vaadin.Flow.clients.ROOT;
+    const component = fixtureSync<TestComponent>(`<test-component></test-component>`);
+
+    // Try to render a lazily added node
+    component.nodeId = 0;
+    await nextFrame();
+
+    // Disconnect
+    component.remove();
+    getByNodeId.resetHistory();
+    await nextFrame();
+
+    expect(getByNodeId).to.not.have.been.called;
   });
 });

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
@@ -173,8 +173,8 @@ describe('flow-component-renderer', () => {
     await nextFrame();
 
     // Disconnect
-    component.remove();
     getByNodeId.resetHistory();
+    component.remove();
     await nextFrame();
 
     expect(getByNodeId).to.not.have.been.called;

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -1,7 +1,8 @@
 import { noChange } from 'lit';
-import { directive, Directive, PartType } from 'lit/directive.js';
+import { directive, PartType } from 'lit/directive.js';
+import { AsyncDirective } from 'lit/async-directive.js';
 
-class FlowComponentDirective extends Directive {
+class FlowComponentDirective extends AsyncDirective {
   constructor(partInfo) {
     super(partInfo);
     if (partInfo.type !== PartType.CHILD) {
@@ -21,9 +22,11 @@ class FlowComponentDirective extends Directive {
     const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
+    clearTimeout(this.__nodeRetryTimeout);
+
     if (hasNewNodeId && !newNode) {
       // If the node is not found, try again later.
-      setTimeout(() => this.updateContent(part, appid, nodeid));
+      this.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -45,6 +48,10 @@ class FlowComponentDirective extends Directive {
       return;
     }
     return startNode.nextSibling;
+  }
+
+  disconnected() {
+    clearTimeout(this.__nodeRetryTimeout);
   }
 }
 


### PR DESCRIPTION
## Description

There's currently an issue in flow-component-directive that can cause an infinite loop in case a re-render is requested for a node that has already been removed from the Flow client registry.

The bug can be reproduced on the `/vaadin-grid/treegrid-component-renderer` IT page by sorting the first column. The issue is sneaky because the user doesn't necessarily notice there's an infinite loop running behind the scene, but you can catch it with a debugger.

This PR fixes the issue by storing the id of a node render retry timeout, and then clearing the timeout whenever the directive is requested to update (and also on disconnect).

## Type of change

Bugfix