### PR TITLE
chore: remove unused connector logic

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -901,11 +901,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
                 grid.requestContentUpdate();
               }
 
-              // Makes sure to push all new rows before this stack execution is done so any timeout expiration called after will be applied on a fully updated grid
-              //Resolves https://github.com/vaadin/vaadin-grid-flow/issues/511
-              if (grid._debounceIncreasePool) {
-                grid._debounceIncreasePool.flush();
-              }
             } else if (callback && grid.size === 0) {
               // The grid has 0 items => resolve the callback with an empty array
               delete rootPageCallbacks[page];


### PR DESCRIPTION
## Description

Remove an unnecessary check from the grid connector. `<vaadin-grid>` had the [`_debounceIncreasePool` debouncer in version 20](https://github.com/vaadin/web-components/blob/03da16363a1e41e29361cf0ac6d2664d9d801c19/packages/vaadin-grid/src/vaadin-grid-scroller.js#L181), but it's [removed](https://github.com/vaadin/web-components/commit/7d61135602943079c6029e1f6971e20d42aa5884) since version 21.