### PR TITLE
fix: ignore ancestor enabled state in tabs internal logic

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -671,7 +671,8 @@ public class Tabs extends Component
             return;
         }
 
-        if (currentlySelected == null || currentlySelected.isEnabled()) {
+        if (currentlySelected == null
+                || currentlySelected.getElement().getNode().isEnabledSelf()) {
             selectedTab = currentlySelected;
             getChildren().filter(Tab.class::isInstance).map(Tab.class::cast)
                     .forEach(tab -> tab.setSelected(false));
@@ -689,7 +690,7 @@ public class Tabs extends Component
     }
 
     private void updateEnabled(Tab tab) {
-        boolean enabled = tab.isEnabled();
+        boolean enabled = tab.getElement().getNode().isEnabledSelf();
         Serializable rawValue = tab.getElement().getPropertyRaw("disabled");
         if (rawValue instanceof Boolean) {
             // convert the boolean value to a String to force update the

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
 
@@ -217,5 +218,48 @@ public class TabsTest {
 
         // assertion here just to make sure tabs were really set
         Assert.assertNotNull(tabs.getSelectedTab());
+    }
+
+    @Test
+    public void addTabsToDisabledContainer_reEnable_tabsShouldBeEnabled() {
+        var container = new Div();
+        var tabs = new Tabs();
+        container.add(tabs);
+        var tab1 = new Tab("Tab one");
+        var tab2 = new Tab("Tab two");
+
+        container.setEnabled(false);
+        tabs.add(tab1, tab2);
+        container.setEnabled(true);
+
+        Assert.assertTrue(tab1.isEnabled());
+        Assert.assertTrue(tab2.isEnabled());
+    }
+
+    @Test
+    public void addTabsToDisabledContainer_reEnable_shouldHaveSelectedTab() {
+        var container = new Div();
+        var tabs = new Tabs();
+        container.add(tabs);
+        var tab1 = new Tab("Tab one");
+        var tab2 = new Tab("Tab two");
+
+        container.setEnabled(false);
+        tabs.add(tab1, tab2);
+        container.setEnabled(true);
+
+        Assert.assertEquals(tab1, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void addDisabledTab_shouldNotHaveSelectedTab() {
+        var tabs = new Tabs();
+        var tab1 = new Tab("Tab one");
+
+        tab1.setEnabled(false);
+        tabs.add(tab1);
+        tabs.setSelectedIndex(0);
+
+        Assert.assertEquals(null, tabs.getSelectedTab());
     }
 }


### PR DESCRIPTION
## Description

Certain [internal logic](https://github.com/vaadin/flow-components/blob/51aefa5f2512be6644b031da1aadcb55e6725a52/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java#L674) of `Tabs` currently uses `isEnabled()` to determine if the currently selected tab is enabled or not. Using `isEnabled()` is problematic for this purpose because it also [traverses the node's ancestors](https://github.com/vaadin/flow/blob/cb63006b56777d46c881d41bc416d8d7189cd47d/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java#L1158) and assumes a tab is disabled even if the tab itself was actually enabled but one of its ancestor containers wasn't.

This PR addresses the issue by changing the logic to use [`isEnabledSelf()`](https://github.com/vaadin/flow/blob/cb63006b56777d46c881d41bc416d8d7189cd47d/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java#L1175) instead.

Fixes https://github.com/vaadin/flow-components/issues/5469

## Type of change

Bugfix