### PR TITLE
fix: ignore ancestor enabled state in tabs internal logic (#5506)

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -484,7 +484,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
             return;
         }
 
-        if (currentlySelected == null || currentlySelected.isEnabled()) {
+        if (currentlySelected == null
+                || currentlySelected.getElement().getNode().isEnabledSelf()) {
             selectedTab = currentlySelected;
             getChildren().filter(Tab.class::isInstance).map(Tab.class::cast)
                     .forEach(tab -> tab.setSelected(false));
@@ -502,7 +503,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     }
 
     private void updateEnabled(Tab tab) {
-        boolean enabled = tab.isEnabled();
+        boolean enabled = tab.getElement().getNode().isEnabledSelf();
         Serializable rawValue = tab.getElement().getPropertyRaw("disabled");
         if (rawValue instanceof Boolean) {
             // convert the boolean value to a String to force update the

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -22,6 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
 
@@ -192,5 +193,48 @@ public class TabsTest {
         tabs.remove(tab2);
         Assert.assertNull("should not select other tab if current tab removed",
                 tabs.getSelectedTab());
+    }
+
+    @Test
+    public void addTabsToDisabledContainer_reEnable_tabsShouldBeEnabled() {
+        var container = new Div();
+        var tabs = new Tabs();
+        container.add(tabs);
+        var tab1 = new Tab("Tab one");
+        var tab2 = new Tab("Tab two");
+
+        container.setEnabled(false);
+        tabs.add(tab1, tab2);
+        container.setEnabled(true);
+
+        Assert.assertTrue(tab1.isEnabled());
+        Assert.assertTrue(tab2.isEnabled());
+    }
+
+    @Test
+    public void addTabsToDisabledContainer_reEnable_shouldHaveSelectedTab() {
+        var container = new Div();
+        var tabs = new Tabs();
+        container.add(tabs);
+        var tab1 = new Tab("Tab one");
+        var tab2 = new Tab("Tab two");
+
+        container.setEnabled(false);
+        tabs.add(tab1, tab2);
+        container.setEnabled(true);
+
+        Assert.assertEquals(tab1, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void addDisabledTab_shouldNotHaveSelectedTab() {
+        var tabs = new Tabs();
+        var tab1 = new Tab("Tab one");
+
+        tab1.setEnabled(false);
+        tabs.add(tab1);
+        tabs.setSelectedIndex(0);
+
+        Assert.assertEquals(null, tabs.getSelectedTab());
     }
 }


### PR DESCRIPTION
## Description

Manually cherry-pick #5506 to 23.3