### PR TITLE
refactor: deprecate confirmdialog removal methods

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -823,7 +823,7 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding components.
+     * Confirm dialog does not support multiple components.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
@@ -837,7 +837,7 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding components.
+     * Confirm dialog does not support multiple components.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
@@ -851,7 +851,7 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding components.
+     * Confirm dialog does not support multiple components.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -703,7 +703,7 @@ public class ConfirmDialog extends Component
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
      *
-     * @deprecated not supported
+     * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override
@@ -717,7 +717,7 @@ public class ConfirmDialog extends Component
      * This method is inherited from {@link HasComponents} and has been marked
      * as deprecated to indicate that it is not supported.
      *
-     * @deprecated not supported
+     * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override
@@ -731,7 +731,7 @@ public class ConfirmDialog extends Component
      * This method is inherited from {@link HasComponents} and has been marked
      * as deprecated to indicate that it is not supported.
      *
-     * @deprecated not supported
+     * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override
@@ -745,7 +745,7 @@ public class ConfirmDialog extends Component
      * This method is inherited from {@link HasComponents} and has been marked
      * as deprecated to indicate that it is not supported.
      *
-     * @deprecated not supported
+     * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -701,64 +701,56 @@ public class ConfirmDialog extends Component
      * Confirm dialog does not support replacing content.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
-     * marked as deprecated to indicate that it is not supported. This method
-     * will throw an {@link UnsupportedOperationException}.
+     * marked as deprecated to indicate that it is not supported.
      *
      * @deprecated not supported
      */
     @Deprecated
     @Override
     public void replace(Component oldComponent, Component newComponent) {
-        throw new UnsupportedOperationException(
-                "Confirm dialog does not support replacing content.");
+        // NO-OP
     }
 
     /**
      * Confirm dialog does not support removing content.
      * <p>
      * This method is inherited from {@link HasComponents} and has been marked
-     * as deprecated to indicate that it is not supported. This method will
-     * throw an {@link UnsupportedOperationException}.
+     * as deprecated to indicate that it is not supported.
      *
      * @deprecated not supported
      */
     @Deprecated
     @Override
     public void remove(Component... components) {
-        throw new UnsupportedOperationException(
-                "Confirm dialog does not support removing content.");
+        // NO-OP
     }
 
     /**
      * Confirm dialog does not support removing content.
      * <p>
      * This method is inherited from {@link HasComponents} and has been marked
-     * as deprecated to indicate that it is not supported. This method will
-     * throw an {@link UnsupportedOperationException}.
+     * as deprecated to indicate that it is not supported.
      *
      * @deprecated not supported
      */
     @Deprecated
     @Override
     public void remove(Collection<Component> components) {
-        throw new UnsupportedOperationException(
-                "Confirm dialog does not support removing content.");
+        // NO-OP
     }
 
     /**
      * Confirm dialog does not support removing content.
      * <p>
      * This method is inherited from {@link HasComponents} and has been marked
-     * as deprecated to indicate that it is not supported. This method will
-     * throw an {@link UnsupportedOperationException}.
+     * as deprecated to indicate that it is not supported.
      *
      * @deprecated not supported
      */
     @Deprecated
     @Override
     public void removeAll() {
-        throw new UnsupportedOperationException(
-                "Confirm dialog does not support removing content.");
+        // NO-OP
     }
 
     @Override

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -697,7 +697,8 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding content.
+     * Confirm dialog does not support adding content. Use
+     * {@link #setText(Component)} instead to initialize content as a component.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
@@ -711,7 +712,8 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding content.
+     * Confirm dialog does not support adding content. Use
+     * {@link #setText(Component)} instead to initialize content as a component.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
@@ -725,7 +727,8 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding content.
+     * Confirm dialog does not support adding content. Use
+     * {@link #setText(String)} instead to initialize content as text.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
@@ -781,7 +784,8 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding content.
+     * Confirm dialog does not support adding content. Use
+     * {@link #setText(Component)} instead to initialize content as a component.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.
@@ -795,7 +799,8 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support adding content.
+     * Confirm dialog does not support adding content. Use
+     * {@link #setText(Component)} instead to initialize content as a component.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
      * marked as deprecated to indicate that it is not supported.

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -39,6 +40,7 @@ import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.shared.Registration;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -693,6 +695,70 @@ public class ConfirmDialog extends Component
      */
     public void setCloseOnEsc(boolean closeOnEsc) {
         getElement().setProperty("noCloseOnEsc", !closeOnEsc);
+    }
+
+    /**
+     * Confirm dialog does not support replacing content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported. This method
+     * will throw an {@link UnsupportedOperationException}.
+     *
+     * @deprecated not supported
+     */
+    @Deprecated
+    @Override
+    public void replace(Component oldComponent, Component newComponent) {
+        throw new UnsupportedOperationException(
+                "Confirm dialog does not support replacing content.");
+    }
+
+    /**
+     * Confirm dialog does not support removing content.
+     * <p>
+     * This method is inherited from {@link HasComponents} and has been marked
+     * as deprecated to indicate that it is not supported. This method will
+     * throw an {@link UnsupportedOperationException}.
+     *
+     * @deprecated not supported
+     */
+    @Deprecated
+    @Override
+    public void remove(Component... components) {
+        throw new UnsupportedOperationException(
+                "Confirm dialog does not support removing content.");
+    }
+
+    /**
+     * Confirm dialog does not support removing content.
+     * <p>
+     * This method is inherited from {@link HasComponents} and has been marked
+     * as deprecated to indicate that it is not supported. This method will
+     * throw an {@link UnsupportedOperationException}.
+     *
+     * @deprecated not supported
+     */
+    @Deprecated
+    @Override
+    public void remove(Collection<Component> components) {
+        throw new UnsupportedOperationException(
+                "Confirm dialog does not support removing content.");
+    }
+
+    /**
+     * Confirm dialog does not support removing content.
+     * <p>
+     * This method is inherited from {@link HasComponents} and has been marked
+     * as deprecated to indicate that it is not supported. This method will
+     * throw an {@link UnsupportedOperationException}.
+     *
+     * @deprecated not supported
+     */
+    @Deprecated
+    @Override
+    public void removeAll() {
+        throw new UnsupportedOperationException(
+                "Confirm dialog does not support removing content.");
     }
 
     @Override

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -698,6 +697,118 @@ public class ConfirmDialog extends Component
     }
 
     /**
+     * Confirm dialog does not support adding content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void add(Component... components) {
+        HasOrderedComponents.super.add(components);
+    }
+
+    /**
+     * Confirm dialog does not support adding content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void add(Collection<Component> components) {
+        HasOrderedComponents.super.add(components);
+    }
+
+    /**
+     * Confirm dialog does not support adding content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void add(String text) {
+        HasOrderedComponents.super.add(text);
+    }
+
+    /**
+     * Confirm dialog does not support removing content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void remove(Component... components) {
+        HasOrderedComponents.super.remove(components);
+    }
+
+    /**
+     * Confirm dialog does not support removing content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void remove(Collection<Component> components) {
+        HasOrderedComponents.super.remove(components);
+    }
+
+    /**
+     * Confirm dialog does not support removing content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void removeAll() {
+        HasOrderedComponents.super.removeAll();
+    }
+
+    /**
+     * Confirm dialog does not support adding content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void addComponentAtIndex(int index, Component component) {
+        HasOrderedComponents.super.addComponentAtIndex(index, component);
+    }
+
+    /**
+     * Confirm dialog does not support adding content.
+     * <p>
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
+     *
+     * @deprecated since v24.4, not supported
+     */
+    @Deprecated
+    @Override
+    public void addComponentAsFirst(Component component) {
+        HasOrderedComponents.super.addComponentAsFirst(component);
+    }
+
+    /**
      * Confirm dialog does not support replacing content.
      * <p>
      * This method is inherited from {@link HasOrderedComponents} and has been
@@ -712,45 +823,45 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Confirm dialog does not support removing content.
+     * Confirm dialog does not support adding components.
      * <p>
-     * This method is inherited from {@link HasComponents} and has been marked
-     * as deprecated to indicate that it is not supported.
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
      *
      * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override
-    public void remove(Component... components) {
-        HasOrderedComponents.super.remove(components);
+    public int indexOf(Component component) {
+        return HasOrderedComponents.super.indexOf(component);
     }
 
     /**
-     * Confirm dialog does not support removing content.
+     * Confirm dialog does not support adding components.
      * <p>
-     * This method is inherited from {@link HasComponents} and has been marked
-     * as deprecated to indicate that it is not supported.
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
      *
      * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override
-    public void remove(Collection<Component> components) {
-        HasOrderedComponents.super.remove(components);
+    public int getComponentCount() {
+        return HasOrderedComponents.super.getComponentCount();
     }
 
     /**
-     * Confirm dialog does not support removing content.
+     * Confirm dialog does not support adding components.
      * <p>
-     * This method is inherited from {@link HasComponents} and has been marked
-     * as deprecated to indicate that it is not supported.
+     * This method is inherited from {@link HasOrderedComponents} and has been
+     * marked as deprecated to indicate that it is not supported.
      *
      * @deprecated since v24.4, not supported
      */
     @Deprecated
     @Override
-    public void removeAll() {
-        HasOrderedComponents.super.removeAll();
+    public Component getComponentAt(int index) {
+        return HasOrderedComponents.super.getComponentAt(index);
     }
 
     @Override

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -708,7 +708,7 @@ public class ConfirmDialog extends Component
     @Deprecated
     @Override
     public void replace(Component oldComponent, Component newComponent) {
-        // NO-OP
+        HasOrderedComponents.super.replace(oldComponent, newComponent);
     }
 
     /**
@@ -722,7 +722,7 @@ public class ConfirmDialog extends Component
     @Deprecated
     @Override
     public void remove(Component... components) {
-        // NO-OP
+        HasOrderedComponents.super.remove(components);
     }
 
     /**
@@ -736,7 +736,7 @@ public class ConfirmDialog extends Component
     @Deprecated
     @Override
     public void remove(Collection<Component> components) {
-        // NO-OP
+        HasOrderedComponents.super.remove(components);
     }
 
     /**
@@ -750,7 +750,7 @@ public class ConfirmDialog extends Component
     @Deprecated
     @Override
     public void removeAll() {
-        // NO-OP
+        HasOrderedComponents.super.removeAll();
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR deprecates the removal-related methods that are inherited from `HasComponents` and `HasOrderedComponents` since they are not properly supported.

Part of #5275

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.