### PR TITLE
fix: set element renderer initially only if container is attached

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/ComponentRendererInNewThreadPage.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/ComponentRendererInNewThreadPage.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.renderer.tests;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasText;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.communication.PushMode;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Page created for testing purposes. Not suitable for demos.
+ *
+ * @author Vaadin Ltd.
+ *
+ */
+@Route("vaadin-renderer-flow/component-renderer-in-new-thread")
+public class ComponentRendererInNewThreadPage extends Div {
+
+    private final AtomicInteger nullUiCountOnTemplateExpression = new AtomicInteger(
+            0);
+    private final AtomicInteger nonNullUiCountOnTemplateExpression = new AtomicInteger(
+            0);
+
+    public ComponentRendererInNewThreadPage() {
+        UI.getCurrent().getPushConfiguration().setPushMode(PushMode.AUTOMATIC);
+        NativeButton addComponentButton = new NativeButton("Add component",
+                e -> {
+                    LongRunningTask longRunningTask = new LongRunningTask(
+                            component -> e.getSource().getUI()
+                                    .ifPresent(ui -> ui.access(() -> {
+                                        add(component);
+
+                                        Span nullUiCountOnTemplateExpressionLog = new Span(
+                                                nullUiCountOnTemplateExpression
+                                                        .toString());
+                                        nullUiCountOnTemplateExpressionLog
+                                                .setId("null-ui-count");
+
+                                        Span nonNullUiCountOnTemplateExpressionLog = new Span(
+                                                nonNullUiCountOnTemplateExpression
+                                                        .toString());
+                                        nonNullUiCountOnTemplateExpressionLog
+                                                .setId("non-null-ui-count");
+
+                                        add(nullUiCountOnTemplateExpressionLog,
+                                                nonNullUiCountOnTemplateExpressionLog);
+                                    })));
+                    longRunningTask.start();
+                });
+        addComponentButton.setId("add-component");
+        add(addComponentButton);
+    }
+
+    class LongRunningTask extends Thread {
+        private final Consumer<Component> finishedCallback;
+
+        public LongRunningTask(Consumer<Component> finishedCallback) {
+            this.finishedCallback = finishedCallback;
+        }
+
+        @Override
+        public void run() {
+            LitRendererTestComponent component = new LitRendererTestComponent();
+            component.setItems("Item");
+            RendererWithCustomTemplateExpression renderer = new RendererWithCustomTemplateExpression(
+                    NativeLabel::new, HasText::setText);
+            component.setRenderer(renderer);
+            finishedCallback.accept(component);
+        }
+    }
+
+    class RendererWithCustomTemplateExpression
+            extends ComponentRenderer<NativeLabel, String> {
+
+        public RendererWithCustomTemplateExpression(
+                SerializableSupplier<NativeLabel> componentSupplier,
+                SerializableBiConsumer<NativeLabel, String> itemConsumer) {
+            super(componentSupplier, itemConsumer);
+        }
+
+        @Override
+        protected String getTemplateExpression() {
+            if (UI.getCurrent() == null) {
+                nullUiCountOnTemplateExpression.incrementAndGet();
+            } else {
+                nonNullUiCountOnTemplateExpression.incrementAndGet();
+            }
+            return "DummyExpression";
+        }
+    }
+}

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/ComponentRendererInNewThreadIT.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/ComponentRendererInNewThreadIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.renderer.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-renderer-flow/component-renderer-in-new-thread")
+public class ComponentRendererInNewThreadIT extends AbstractComponentIT {
+
+    @Test
+    public void componentRendererInNewThread_uiNotNullWhileTemplateExpressionIsCalculated() {
+        open();
+        findElement(By.id("add-component")).click();
+
+        waitUntil(driver -> findElement(By.id("null-ui-count")) != null
+                && findElement(By.id("non-null-ui-count")) != null, 2);
+
+        Assert.assertEquals("0", findElement(By.id("null-ui-count")).getText());
+        Assert.assertNotEquals("0",
+                findElement(By.id("non-null-ui-count")).getText());
+    }
+}

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -223,10 +223,10 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
                     returnChannel, clientCallablesArray, propertyNamespace);
         }));
         // Call once initially
-        container.getNode().runWhenAttached(e -> {
+        if (container.getNode().isAttached()) {
             setElementRenderer(container, rendererName, getTemplateExpression(),
                     returnChannel, clientCallablesArray, propertyNamespace);
-        });
+        }
 
         // Get the renderer function cleared when the LitRenderer is
         // unregistered

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -223,8 +223,10 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
                     returnChannel, clientCallablesArray, propertyNamespace);
         }));
         // Call once initially
-        setElementRenderer(container, rendererName, getTemplateExpression(),
-                returnChannel, clientCallablesArray, propertyNamespace);
+        container.getNode().runWhenAttached(e -> {
+            setElementRenderer(container, rendererName, getTemplateExpression(),
+                    returnChannel, clientCallablesArray, propertyNamespace);
+        });
 
         // Get the renderer function cleared when the LitRenderer is
         // unregistered


### PR DESCRIPTION
## Description

When a grid witch a component column is initialized in a new thread, the template expression is determined while `UI.getCurrent()` is still `null` for that thread. `ComponentRenderer` uses it to get `appid`, so when the grid is finally added and rendered, the template expression will have the wrong `appid` and functionalities like `getNodeById` will break.

This PR makes it so that the element renderer is initially set only if the container element is attached. This way, the UI is already defined when the template expression is calculated and the grid is rendered correctly.

Fixes #5493 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.