### PR TITLE
fix: do not override geteditorvalue for custom editor

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
@@ -44,8 +44,10 @@ public class MainView extends VerticalLayout {
         mapLists(personList, cityList);
         grid.setItems(personList);
 
-        grid.addCellEditStartedListener(
-                e -> eventsPanel.add(e.getItem().toString()));
+        grid.addCellEditStartedListener(e -> eventsPanel
+                .add("CellEditStarted - " + e.getItem().toString()));
+        grid.addItemPropertyChangedListener(e -> eventsPanel
+                .add("ItemPropertyChanged - " + e.getItem().toString()));
 
         grid.addColumn(Person::getAge).setHeader("Age");
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -136,9 +136,13 @@ public class BasicIT extends AbstractParallelTest {
     @Test
     public void cellEditStartedListenerCalledOnce() {
         assertCellEnterEditModeOnDoubleClick(0, 2, "vaadin-combo-box");
+        String eventsPanelText = getPanelText("events-panel");
         Assert.assertEquals(1,
-                getPanelText("events-panel").split("CellEditStarted").length
-                        - 1);
+                eventsPanelText.split("CellEditStarted").length - 1);
+        Assert.assertTrue(eventsPanelText
+                .contains("Person{id=1, age=23, name='Person 1', "
+                        + "isSubscriber=false, email='person1@vaadin.com', "
+                        + "department=sales, city='City 1', employmentYear=2019}"));
     }
 
     @Test

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -136,10 +136,9 @@ public class BasicIT extends AbstractParallelTest {
     @Test
     public void cellEditStartedListenerCalledOnce() {
         assertCellEnterEditModeOnDoubleClick(0, 2, "vaadin-combo-box");
-        Assert.assertEquals("Person{id=1, age=23, name='Person 1', "
-                + "isSubscriber=false, email='person1@vaadin.com', "
-                + "department=sales, city='City 1', employmentYear=2019}",
-                getPanelText("events" + "-panel"));
+        Assert.assertEquals(1,
+                getPanelText("events-panel").split("CellEditStarted").length
+                        - 1);
     }
 
     @Test
@@ -276,6 +275,19 @@ public class BasicIT extends AbstractParallelTest {
         selectedText = (String) getCommandExecutor()
                 .executeScript("return document.getSelection().toString()");
         Assert.assertEquals("2019", selectedText);
+    }
+
+    @Test
+    public void customField_startEditing_doNotChangeValue_itemPropertyChangeListenerNotCalled() {
+        GridTHTDElement cell = grid.getCell(0, 6);
+        assertCellEnterEditModeOnDoubleClick(0, 6, "vaadin-text-field", grid,
+                true);
+
+        TestBenchElement input = cell.$("input").first();
+        input.sendKeys(Keys.ENTER);
+
+        Assert.assertFalse(
+                getPanelText("events-panel").contains("ItemPropertyChanged"));
     }
 
     private void assertCellEnterEditModeOnDoubleClick(Integer rowIndex,

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -44,9 +44,6 @@
         // Not needed in case of custom editor as value is set on server-side.
         // Overridden in order to avoid blinking of the cell content.
         column._setEditorValue = function (editor, value) {};
-        column._getEditorValue = function (editor) {
-          return;
-        };
       })(column, component),
 
     patchEditModeRenderer: (column) =>


### PR DESCRIPTION
## Description

In the GridPro connector, `getEditorValue` from the web component is overridden to do nothing an return. The comment there suggests that that block was introduced to prevent flickering. This override interferes with the item property change event mechanism since it is used to determine whether there has been a change. With the current way, it always returns `undefined`, causing the comparison to fail and an unwanted event to be fired. 

This PR removes the override. The flickering does not appear to be there even without the override.

Fixes #5529 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.