### PR TITLE
test: refresh cell after conversion to formula cell

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -43,7 +43,10 @@ public class FormulasTest {
 
         spreadsheet.createFormulaCell(0, 0, "1+1");
 
-        Assert.assertNotEquals("foo", cell.getStringCellValue());
+        spreadsheet.refreshCells(cell);
+
+        Assert.assertThrows(IllegalStateException.class, cell::getStringCellValue);
+        Assert.assertEquals(2, cell.getNumericCellValue(), 0);
         Assert.assertEquals("1+1", cell.getCellFormula());
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -45,7 +45,8 @@ public class FormulasTest {
 
         spreadsheet.refreshCells(cell);
 
-        Assert.assertThrows(IllegalStateException.class, cell::getStringCellValue);
+        Assert.assertThrows(IllegalStateException.class,
+                cell::getStringCellValue);
         Assert.assertEquals(2, cell.getNumericCellValue(), 0);
         Assert.assertEquals("1+1", cell.getCellFormula());
     }


### PR DESCRIPTION
## Description

With an Apache POI version bump [PR](https://github.com/vaadin/flow-components/pull/5525), a formula cell [test](https://github.com/vaadin/flow-components/blob/main/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java#L40-L48) fails. It seems that it is resolved when the cell is explicitly refreshed after being converted into a formula cell.

This PR updates the test to refresh the cell, and assert the values accordingly.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Test

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.