### PR TITLE
fix!(NumberField): use unparsable-change instead of validated event

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
@@ -16,49 +16,23 @@
 package com.vaadin.flow.component.textfield.tests.validation;
 
 import com.vaadin.flow.component.textfield.IntegerField;
-import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
 
-@Route("vaadin-integer-field/validation/binder")
-public class IntegerFieldValidationBinderPage
+@Route("vaadin-integer-field/validation/basic")
+public class IntegerFieldBasicValidationPage
         extends AbstractValidationPage<IntegerField> {
+    public static final String REQUIRED_BUTTON = "required-button";
     public static final String STEP_INPUT = "step-input";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
-    public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
-
-    public static class Bean {
-        private Integer property;
-
-        public Integer getProperty() {
-            return property;
-        }
-
-        public void setProperty(Integer property) {
-            this.property = property;
-        }
-    }
-
-    protected Binder<Bean> binder;
-
-    private Integer expectedValue;
-
-    public IntegerFieldValidationBinderPage() {
+    public IntegerFieldBasicValidationPage() {
         super();
 
-        binder = new Binder<>(Bean.class);
-        binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
-                .withValidator(value -> value.equals(expectedValue),
-                        UNEXPECTED_VALUE_ERROR_MESSAGE)
-                .bind("property");
-
-        add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
-            expectedValue = Integer.parseInt(event.getValue());
+        add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
+            testField.setRequiredIndicatorVisible(true);
         }));
 
         add(createInput(STEP_INPUT, "Set step", event -> {
@@ -82,6 +56,12 @@ public class IntegerFieldValidationBinderPage
     }
 
     protected IntegerField createTestField() {
-        return new IntegerField();
+        return new IntegerField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationPage.java
@@ -16,23 +16,53 @@
 package com.vaadin.flow.component.textfield.tests.validation;
 
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
 
-@Route("vaadin-integer-field/validation/basic")
-public class IntegerFieldValidationBasicPage
+@Route("vaadin-integer-field/validation/binder")
+public class IntegerFieldBinderValidationPage
         extends AbstractValidationPage<IntegerField> {
-    public static final String REQUIRED_BUTTON = "required-button";
     public static final String STEP_INPUT = "step-input";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
+    public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
-    public IntegerFieldValidationBasicPage() {
+    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+
+    public static class Bean {
+        private Integer property;
+
+        public Integer getProperty() {
+            return property;
+        }
+
+        public void setProperty(Integer property) {
+            this.property = property;
+        }
+    }
+
+    protected Binder<Bean> binder;
+
+    private Integer expectedValue;
+
+    public IntegerFieldBinderValidationPage() {
         super();
 
-        add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+        binder = new Binder<>(Bean.class);
+        binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
+                .withValidator(value -> value.equals(expectedValue),
+                        UNEXPECTED_VALUE_ERROR_MESSAGE)
+                .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
+
+        add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
+            expectedValue = Integer.parseInt(event.getValue());
         }));
 
         add(createInput(STEP_INPUT, "Set step", event -> {
@@ -52,6 +82,10 @@ public class IntegerFieldValidationBasicPage
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();
+        }));
+
+        add(createButton(RESET_BEAN_BUTTON, "Reset bean", event -> {
+            binder.setBean(new Bean());
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationPage.java
@@ -56,6 +56,12 @@ public class NumberFieldBasicValidationPage
     }
 
     protected NumberField createTestField() {
-        return new NumberField();
+        return new NumberField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationPage.java
@@ -28,6 +28,7 @@ public class NumberFieldBinderValidationPage
     public static final String MAX_INPUT = "max-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
+    public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
@@ -56,6 +57,9 @@ public class NumberFieldBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = Double.parseDouble(event.getValue());
@@ -78,6 +82,10 @@ public class NumberFieldBinderValidationPage
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();
+        }));
+
+        add(createButton(RESET_BEAN_BUTTON, "Reset bean", event -> {
+            binder.setBean(new Bean());
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
@@ -22,11 +23,11 @@ import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.validation.AbstractValidationIT;
 
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.MIN_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.MAX_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.STEP_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.REQUIRED_BUTTON;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.MIN_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.MAX_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.STEP_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-integer-field/validation/basic")
 public class IntegerFieldBasicValidationIT
@@ -40,6 +41,7 @@ public class IntegerFieldBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -49,8 +51,9 @@ public class IntegerFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -58,21 +61,16 @@ public class IntegerFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+
+        resetValidationCount();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void min_triggerBlur_assertValidity() {
-        $("input").id(MIN_INPUT).sendKeys("2", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -80,25 +78,30 @@ public class IntegerFieldBasicValidationIT
         $("input").id(MIN_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
 
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
 
-    @Test
-    public void max_triggerBlur_assertValidity() {
-        $("input").id(MAX_INPUT).sendKeys("2", Keys.ENTER);
+        resetValidationCount();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
+        testField.setValue("");
+        assertValidationCount(1);
         assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -106,25 +109,30 @@ public class IntegerFieldBasicValidationIT
         $("input").id(MAX_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
 
-    @Test
-    public void step_triggerBlur_assertValidity() {
-        $("input").id(STEP_INPUT).sendKeys("2", Keys.ENTER);
+        resetValidationCount();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
+        testField.setValue("");
+        assertValidationCount(1);
         assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -132,31 +140,59 @@ public class IntegerFieldBasicValidationIT
         $("input").id(STEP_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
+        resetValidationCount();
+
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -172,34 +208,55 @@ public class IntegerFieldBasicValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMaxInteger_assertValidity() {
-        testField.sendKeys("999999999999", Keys.TAB);
+    public void maxIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMinInteger_assertValidity() {
-        testField.sendKeys("-999999999999", Keys.TAB);
+    public void minIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("-999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("2");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -220,7 +277,8 @@ public class IntegerFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("2");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -227,8 +227,9 @@ public class IntegerFieldBinderValidationIT
 
         testField.setValue("");
         assertValidationCount(1);
-        assertServerValid();
-        assertClientValid();
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
@@ -22,13 +23,14 @@ import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.validation.AbstractValidationIT;
 
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.STEP_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.MIN_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.MAX_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.EXPECTED_VALUE_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.CLEAR_VALUE_BUTTON;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.REQUIRED_ERROR_MESSAGE;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.STEP_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.MIN_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.MAX_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.RESET_BEAN_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
 @TestPath("vaadin-integer-field/validation/binder")
 public class IntegerFieldBinderValidationIT
@@ -43,9 +45,9 @@ public class IntegerFieldBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -53,13 +55,30 @@ public class IntegerFieldBinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void required_setValue_resetBean_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
+
+        testField.setValue("1234");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(RESET_BEAN_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -69,20 +88,36 @@ public class IntegerFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -92,20 +127,36 @@ public class IntegerFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -115,39 +166,69 @@ public class IntegerFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("4");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2", Keys.ENTER);
 
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -166,31 +247,53 @@ public class IntegerFieldBinderValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMaxInteger_assertValidity() {
-        testField.sendKeys("999999999999", Keys.TAB);
+    public void maxIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMinInteger_assertValidity() {
-        testField.sendKeys("-999999999999", Keys.TAB);
+    public void minIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("-999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     protected IntegerFieldElement getTestField() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
@@ -40,6 +40,7 @@ public class NumberFieldBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -49,8 +50,9 @@ public class NumberFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -58,21 +60,16 @@ public class NumberFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+
+        resetValidationCount();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void min_triggerBlur_assertValidity() {
-        $("input").id(MIN_INPUT).sendKeys("2", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -80,25 +77,30 @@ public class NumberFieldBasicValidationIT
         $("input").id(MIN_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("1.8");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
 
         testField.setValue("2.2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
 
-    @Test
-    public void max_triggerBlur_assertValidity() {
-        $("input").id(MAX_INPUT).sendKeys("2", Keys.ENTER);
+        resetValidationCount();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
+        testField.setValue("");
+        assertValidationCount(1);
         assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -106,25 +108,30 @@ public class NumberFieldBasicValidationIT
         $("input").id(MAX_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("2.2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
 
         testField.setValue("1.8");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
 
-    @Test
-    public void step_triggerBlur_assertValidity() {
-        $("input").id(STEP_INPUT).sendKeys("2", Keys.ENTER);
+        resetValidationCount();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
+        testField.setValue("");
+        assertValidationCount(1);
         assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -132,31 +139,59 @@ public class NumberFieldBasicValidationIT
         $("input").id(STEP_INPUT).sendKeys("1.5", Keys.ENTER);
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("1.5");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -172,11 +207,15 @@ public class NumberFieldBasicValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
@@ -185,7 +224,8 @@ public class NumberFieldBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("2");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -206,7 +246,8 @@ public class NumberFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("2");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
@@ -27,6 +27,7 @@ import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBi
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.RESET_BEAN_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.NumberFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -43,9 +44,9 @@ public class NumberFieldBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -53,13 +54,30 @@ public class NumberFieldBinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void required_setValue_resetBean_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
+
+        testField.setValue("1234");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(RESET_BEAN_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -69,20 +87,36 @@ public class NumberFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("1.8");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("2.2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -92,20 +126,36 @@ public class NumberFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("2.2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("1.8");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -115,39 +165,70 @@ public class NumberFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("1.5");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2", Keys.ENTER);
 
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -166,12 +247,16 @@ public class NumberFieldBinderValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -17,6 +17,8 @@
 package com.vaadin.flow.component.textfield;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Objects;
 
 import com.vaadin.flow.component.AttachEvent;
@@ -57,6 +59,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
     private boolean manualValidationEnabled = false;
 
+    private final Collection<ValidationStatusChangeListener<T>> validationStatusChangeListeners = new ArrayList<>();
+
     /**
      * Sets up the common logic for number fields.
      *
@@ -91,7 +95,10 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
         addValueChangeListener(e -> validate());
 
-        addClientValidatedEventListener(e -> validate());
+        getElement().addEventListener("unparsable-change", e -> {
+            validate();
+            fireValidationStatusChangeEvent();
+        });
     }
 
     /**
@@ -161,7 +168,26 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             // `executeJs` can end up invoked after a non-empty value is set.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
-            fireEvent(new ClientValidatedEvent(this, false));
+            validate();
+            fireValidationStatusChangeEvent();
+        }
+    }
+
+    @Override
+    protected void setModelValue(T newModelValue, boolean fromClient) {
+        T oldModelValue = getValue();
+
+        super.setModelValue(newModelValue, fromClient);
+
+        // Triggers validation when an unparsable or empty value changes to a
+        // value that is parsable on the client but still unparsable on the
+        // server, which can happen for example due to the difference in Integer
+        // limit in Java and JavaScript. In this case, there is no
+        // ValueChangeEvent and no unparsable-change event.
+        if (fromClient && valueEquals(oldModelValue, getEmptyValue())
+                && valueEquals(newModelValue, getEmptyValue())) {
+            validate();
+            fireValidationStatusChangeEvent();
         }
     }
 
@@ -251,10 +277,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
     @Override
     public Registration addValidationStatusChangeListener(
             ValidationStatusChangeListener<T> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<T>(this,
-                                !isInvalid())));
+        validationStatusChangeListeners.add(listener);
+        return () -> validationStatusChangeListeners.remove(listener);
     }
 
     private ValidationResult checkValidity(T value) {
@@ -305,6 +329,19 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             setInvalid(requiredValidation.isError()
                     || checkValidity(value).isError());
         }
+    }
+
+    /**
+     * Notifies Binder that it needs to revalidate the component since the
+     * component's validity state may have changed. Note, there is no need to
+     * notify Binder separately in the case of a ValueChangeEvent, as Binder
+     * already listens to this event and revalidates automatically.
+     */
+    private void fireValidationStatusChangeEvent() {
+        ValidationStatusChangeEvent<T> event = new ValidationStatusChangeEvent<>(
+                this, !isInvalid());
+        validationStatusChangeListeners
+                .forEach(listener -> listener.validationStatusChanged(event));
     }
 
     private boolean isValidByStep(T value) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/IntegerFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/IntegerFieldBasicValidationTest.java
@@ -15,11 +15,25 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class IntegerFieldBasicValidationTest
         extends AbstractBasicValidationTest<IntegerField, Integer> {
+    @Test
+    public void addValidationStatusChangeListener_addAnotherListenerOnInvocation_noExceptions() {
+        testField.addValidationStatusChangeListener(event1 -> {
+            testField.addValidationStatusChangeListener(event2 -> {
+            });
+        });
+
+        // Trigger ValidationStatusChangeEvent
+        testField.getElement().setProperty("_hasInputValue", true);
+        testField.clear();
+    }
+
     protected IntegerField createTestField() {
         return new IntegerField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/NumberFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/NumberFieldBasicValidationTest.java
@@ -15,11 +15,25 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class NumberFieldBasicValidationTest
         extends AbstractBasicValidationTest<NumberField, Double> {
+    @Test
+    public void addValidationStatusChangeListener_addAnotherListenerOnInvocation_noExceptions() {
+        testField.addValidationStatusChangeListener(event1 -> {
+            testField.addValidationStatusChangeListener(event2 -> {
+            });
+        });
+
+        // Trigger ValidationStatusChangeEvent
+        testField.getElement().setProperty("_hasInputValue", true);
+        testField.clear();
+    }
+
     protected NumberField createTestField() {
         return new NumberField();
     }


### PR DESCRIPTION
## Description

The PR refactors NumberField and IntegerField to make them trigger validation on `unparsable-change` event instead of the `validated` event.

Depends on 
- https://github.com/vaadin/web-components/pull/6599
- https://github.com/vaadin/flow-components/pull/5570
- https://github.com/vaadin/flow-components/pull/5590

Precedes:
- #5592 

> **Warning**
> It's a behavior altering change because it removes validation on blur.

Part of #5537 

## Type of change

- [x] Bugfix
