### PR TITLE
feat: grid column header and footer part names

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -342,42 +342,4 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
                         .collect(Collectors.toList()));
         return columnChildren;
     }
-
-    /**
-     * Sets a custom part name for the header cell.
-     *
-     * @param headerPartName
-     *            the part name to set
-     */
-    public void setHeaderPartName(String headerPartName) {
-        getElement().setProperty("headerPartName", headerPartName);
-    }
-
-    /**
-     * Gets the custom part name of the header cell.
-     *
-     * @return the part name
-     */
-    public String getHeaderPartName() {
-        return getElement().getProperty("headerPartName");
-    }
-
-    /**
-     * Sets a custom part name for the footer cell.
-     *
-     * @param footerPartName
-     *            the part name to set
-     */
-    public void setFooterPartName(String footerPartName) {
-        getElement().setProperty("footerPartName", footerPartName);
-    }
-
-    /**
-     * Gets the custom part name of the footer cell.
-     *
-     * @return the part name
-     */
-    public String getFooterPartName() {
-        return getElement().getProperty("footerPartName");
-    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -342,4 +342,42 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
                         .collect(Collectors.toList()));
         return columnChildren;
     }
+
+    /**
+     * Sets a custom part name for the header cell.
+     *
+     * @param headerPartName
+     *            the part name to set
+     */
+    public void setHeaderPartName(String headerPartName) {
+        getElement().setProperty("headerPartName", headerPartName);
+    }
+
+    /**
+     * Gets the custom part name of the header cell.
+     *
+     * @return the part name
+     */
+    public String getHeaderPartName() {
+        return getElement().getProperty("headerPartName");
+    }
+
+    /**
+     * Sets a custom part name for the footer cell.
+     *
+     * @param footerPartName
+     *            the part name to set
+     */
+    public void setFooterPartName(String footerPartName) {
+        getElement().setProperty("footerPartName", footerPartName);
+    }
+
+    /**
+     * Gets the custom part name of the footer cell.
+     *
+     * @return the part name
+     */
+    public String getFooterPartName() {
+        return getElement().getProperty("footerPartName");
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
@@ -99,6 +99,21 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
          */
         public abstract void setComponent(Component component);
 
+        /**
+         * Sets a custom part name for the cell.
+         *
+         * @param partName
+         *            the part name to set
+         */
+        public abstract void setPartName(String partName);
+
+        /**
+         * Gets the custom part name of the cell.
+         *
+         * @return the part name
+         */
+        public abstract String getPartName();
+
     }
 
     protected ColumnLayer layer;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnBase.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnBase.java
@@ -145,6 +145,50 @@ interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
     }
 
     /**
+     * Sets a custom part name for the header cell.
+     *
+     * @param headerPartName
+     *            the part name to set
+     * @return this column, for method chaining
+     */
+    @SuppressWarnings("unchecked")
+    default T setHeaderPartName(String headerPartName) {
+        getElement().setProperty("headerPartName", headerPartName);
+        return (T) this;
+    }
+
+    /**
+     * Gets the custom part name of the header cell.
+     *
+     * @return the part name
+     */
+    default String getHeaderPartName() {
+        return getElement().getProperty("headerPartName");
+    }
+
+    /**
+     * Sets a custom part name for the footer cell.
+     *
+     * @param footerPartName
+     *            the part name to set
+     * @return this column, for method chaining
+     */
+    @SuppressWarnings("unchecked")
+    default T setFooterPartName(String footerPartName) {
+        getElement().setProperty("footerPartName", footerPartName);
+        return (T) this;
+    }
+
+    /**
+     * Gets the custom part name of the footer cell.
+     *
+     * @return the part name
+     */
+    default String getFooterPartName() {
+        return getElement().getProperty("footerPartName");
+    }
+
+    /**
      * Gets the underlying column element.
      * <p>
      * <strong>It is highly discouraged to directly use the API exposed by the

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
@@ -64,6 +64,16 @@ public class FooterRow extends AbstractRow<FooterCell> {
             getColumn().setFooterComponent(component);
         }
 
+        @Override
+        public void setPartName(String partName) {
+            getColumn().setFooterPartName(partName);
+        }
+
+        @Override
+        public String getPartName() {
+            return getColumn().getFooterPartName();
+        }
+
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -73,6 +73,16 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
             getColumn().setHeaderComponent(component);
         }
 
+        @Override
+        public void setPartName(String partName) {
+            getColumn().setHeaderPartName(partName);
+        }
+
+        @Override
+        public String getPartName() {
+            return getColumn().getHeaderPartName();
+        }
+
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1035,6 +1035,12 @@ public class HeaderFooterTest {
     }
 
     @Test
+    public void setHeaderPartName_setFooterPartName_isChainable() {
+        firstColumn.setHeaderPartName("foo").setFrozen(true);
+        firstColumn.setFooterPartName("foo").setFrozen(true);
+    }
+
+    @Test
     public void columnGroupHasNoHeaderPartName() {
         grid.appendHeaderRow();
         var headerCell = grid.prependHeaderRow().join(firstColumn,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1004,6 +1004,76 @@ public class HeaderFooterTest {
                 joinedCell.getColumn().getTextAlign());
     }
 
+    @Test
+    public void columnHasNoHeaderPartName() {
+        Assert.assertEquals(null, firstColumn.getHeaderPartName());
+        Assert.assertEquals(null,
+                firstColumn.getElement().getProperty("headerPartName"));
+    }
+
+    @Test
+    public void setHeaderPartName_columnHasHeaderPartName() {
+        firstColumn.setHeaderPartName("foo");
+        Assert.assertEquals("foo", firstColumn.getHeaderPartName());
+        Assert.assertEquals("foo",
+                firstColumn.getElement().getProperty("headerPartName"));
+    }
+
+    @Test
+    public void columnHasNoFooterPartName() {
+        Assert.assertEquals(null, firstColumn.getFooterPartName());
+        Assert.assertEquals(null,
+                firstColumn.getElement().getProperty("footerPartName"));
+    }
+
+    @Test
+    public void setFooterPartName_columnHasFooterPartName() {
+        firstColumn.setFooterPartName("foo");
+        Assert.assertEquals("foo", firstColumn.getFooterPartName());
+        Assert.assertEquals("foo",
+                firstColumn.getElement().getProperty("footerPartName"));
+    }
+
+    @Test
+    public void columnGroupHasNoHeaderPartName() {
+        grid.appendHeaderRow();
+        var headerCell = grid.prependHeaderRow().join(firstColumn,
+                secondColumn);
+        Assert.assertEquals(null, headerCell.getPartName());
+        Assert.assertEquals(null, headerCell.getColumn().getElement()
+                .getProperty("headerPartName"));
+    }
+
+    @Test
+    public void setHeaderPartName_columnGroupHasHeaderPartName() {
+        grid.appendHeaderRow();
+        var headerCell = grid.prependHeaderRow().join(firstColumn,
+                secondColumn);
+        headerCell.setPartName("foo");
+        Assert.assertEquals("foo", headerCell.getPartName());
+        Assert.assertEquals("foo", headerCell.getColumn().getElement()
+                .getProperty("headerPartName"));
+    }
+
+    @Test
+    public void columnGroupHasNoFooterPartName() {
+        grid.appendFooterRow();
+        var footerCell = grid.appendFooterRow().join(firstColumn, secondColumn);
+        Assert.assertEquals(null, footerCell.getPartName());
+        Assert.assertEquals(null, footerCell.getColumn().getElement()
+                .getProperty("footerPartName"));
+    }
+
+    @Test
+    public void setFooterPartName_columnGroupHasFooterPartName() {
+        grid.appendFooterRow();
+        var footerCell = grid.appendFooterRow().join(firstColumn, secondColumn);
+        footerCell.setPartName("foo");
+        Assert.assertEquals("foo", footerCell.getPartName());
+        Assert.assertEquals("foo", footerCell.getColumn().getElement()
+                .getProperty("footerPartName"));
+    }
+
     private void assertHeaderRowOrder(HeaderRow... rows) {
         Assert.assertEquals("Grid returned unexpected amount of header rows",
                 rows.length, grid.getHeaderRows().size());


### PR DESCRIPTION
## Description

Add support for setting custom `part` names to Grid header and footer cells.

Part of https://github.com/vaadin/web-components/issues/1434

Depends on https://github.com/vaadin/web-components/pull/6629

## Type of change

Feature