### PR TITLE
fix!(TimePicker): use unparsable-change instead of validated event

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationPage.java
@@ -36,6 +36,12 @@ public class BasicValidationPage extends AbstractValidationPage<TimePicker> {
     }
 
     protected TimePicker createTestField() {
-        return new TimePicker();
+        return new TimePicker() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationPage.java
@@ -13,6 +13,7 @@ public class BinderValidationPage extends AbstractValidationPage<TimePicker> {
     public static final String MAX_INPUT = "max-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
+    public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
@@ -41,6 +42,9 @@ public class BinderValidationPage extends AbstractValidationPage<TimePicker> {
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected time", event -> {
             LocalTime value = LocalTime.parse(event.getValue());
@@ -59,6 +63,10 @@ public class BinderValidationPage extends AbstractValidationPage<TimePicker> {
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();
+        }));
+
+        add(createButton(RESET_BEAN_BUTTON, "Reset bean", event -> {
+            binder.setBean(new Bean());
         }));
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
@@ -23,6 +23,7 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -32,8 +33,9 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -41,10 +43,14 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.selectByText("12:00");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.selectByText("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
     }
@@ -54,14 +60,28 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         $("input").id(MIN_INPUT).sendKeys("11:00", Keys.ENTER);
 
         testField.selectByText("10:00");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.selectByText("11:00");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
+        resetValidationCount();
+
         testField.selectByText("12:00");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
+
+        resetValidationCount();
+
+        testField.selectByText("");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -71,14 +91,28 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         $("input").id(MAX_INPUT).sendKeys("11:00", Keys.ENTER);
 
         testField.selectByText("12:00");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.selectByText("11:00");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
+        resetValidationCount();
+
         testField.selectByText("10:00");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
+
+        resetValidationCount();
+
+        testField.selectByText("");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -86,16 +120,30 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     @Test
     public void badInput_changeValue_assertValidity() {
         testField.selectByText("INVALID");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         testField.selectByText("10:00");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.selectByText("INVALID");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.selectByText("");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -112,10 +160,14 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.selectByText("INVALID");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
@@ -124,7 +176,8 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("10:00");
+        testField.selectByText("");
 
         detachAndReattachField();
 
@@ -145,7 +198,8 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("10:00");
+        testField.selectByText("");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
@@ -13,6 +13,7 @@ import static com.vaadin.flow.component.timepicker.tests.validation.BinderValida
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.RESET_BEAN_BUTTON;
 
 @TestPath("vaadin-time-picker/validation/binder")
 public class BinderValidationIT
@@ -27,9 +28,9 @@ public class BinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -37,13 +38,30 @@ public class BinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("10:00", Keys.ENTER);
 
         testField.selectByText("10:00");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.selectByText("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void required_setValue_resetBean_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("10:00", Keys.ENTER);
+
+        testField.selectByText("10:00");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(RESET_BEAN_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -53,20 +71,36 @@ public class BinderValidationIT
 
         // Constraint validation fails:
         testField.selectByText("10:00");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.selectByText("11:00");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.selectByText("12:00");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.selectByText("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -76,20 +110,36 @@ public class BinderValidationIT
 
         // Constraint validation fails:
         testField.selectByText("12:00");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.selectByText("11:00");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.selectByText("10:00");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.selectByText("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -97,18 +147,33 @@ public class BinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("10:00", Keys.ENTER);
 
         testField.selectByText("INVALID");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         testField.selectByText("10:00");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.selectByText("INVALID");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.selectByText("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -128,11 +193,15 @@ public class BinderValidationIT
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.selectByText("INVALID");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -18,11 +18,10 @@ package com.vaadin.flow.component.timepicker;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AbstractField;
@@ -100,7 +99,7 @@ public class TimePicker
 
     private boolean manualValidationEnabled = false;
 
-    private final Collection<ValidationStatusChangeListener<LocalTime>> validationStatusChangeListeners = new ArrayList<>();
+    private final CopyOnWriteArrayList<ValidationStatusChangeListener<LocalTime>> validationStatusChangeListeners = new CopyOnWriteArrayList<>();
 
     /**
      * Default constructor.
@@ -329,8 +328,8 @@ public class TimePicker
     @Override
     public Registration addValidationStatusChangeListener(
             ValidationStatusChangeListener<LocalTime> listener) {
-        validationStatusChangeListeners.add(listener);
-        return () -> validationStatusChangeListeners.remove(listener);
+        return Registration.addAndRemove(validationStatusChangeListeners,
+                listener);
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
@@ -17,11 +17,25 @@ package com.vaadin.flow.component.timepicker.tests.validation;
 
 import java.time.LocalTime;
 
+import org.junit.Test;
+
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
         extends AbstractBasicValidationTest<TimePicker, LocalTime> {
+    @Test
+    public void addValidationStatusChangeListener_addAnotherListenerOnInvocation_noExceptions() {
+        testField.addValidationStatusChangeListener(event1 -> {
+            testField.addValidationStatusChangeListener(event2 -> {
+            });
+        });
+
+        // Trigger ValidationStatusChangeEvent
+        testField.getElement().setProperty("_hasInputValue", true);
+        testField.clear();
+    }
+
     protected TimePicker createTestField() {
         return new TimePicker();
     }


### PR DESCRIPTION
## Description

The PR refactors TimePicker to make it trigger validation on `unparsable-change` event instead of the `validated` event.

Depends on 
- https://github.com/vaadin/web-components/pull/6604
- https://github.com/vaadin/flow-components/pull/5570

> **Warning**
> It's a behavior altering change because it removes validation on blur.

Part of #5537 

## Type of change

- [x] Bugfix
