### PR TITLE
fix: do not invalidate when clearing a valid value

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
@@ -99,6 +99,17 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setInputValue("1/1/2022");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.setInputValue("INVALID");
         assertServerInvalid();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BinderValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BinderValidationIT.java
@@ -113,6 +113,8 @@ public class BinderValidationIT
 
     @Test
     public void setValue_clearValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2022-01-01", Keys.ENTER);
+
         testField.setInputValue("1/1/2022");
         assertServerValid();
         assertClientValid();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BinderValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BinderValidationIT.java
@@ -112,6 +112,18 @@ public class BinderValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setInputValue("1/1/2022");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.setInputValue("INVALID");
         assertServerInvalid();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.datepicker;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -572,13 +573,20 @@ public class DatePicker
     @Override
     public void setValue(LocalDate value) {
         LocalDate oldValue = getValue();
+        boolean isInputValuePresent = isInputValuePresent();
+
+        // When the value is cleared programmatically, reset hasInputValue
+        // so that the following validation doesn't treat this as bad input.
+        if (Objects.equals(value, getEmptyValue())) {
+            getElement().setProperty("_hasInputValue", false);
+        }
 
         super.setValue(value);
 
         // Clear the input element from possible bad input.
         if (valueEquals(oldValue, getEmptyValue())
                 && valueEquals(value, getEmptyValue())
-                && isInputValuePresent()) {
+                && isInputValuePresent) {
             // The check for value presence guarantees that a non-empty value
             // won't get cleared when setValue(null) and setValue(...) are
             // subsequently called within one round-trip.
@@ -588,7 +596,6 @@ public class DatePicker
             // `executeJs` can end up invoked after a non-empty value is set.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
-            getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.datepicker;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -576,7 +576,7 @@ public class DatePicker
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (Objects.equals(value, getEmptyValue())) {
+        if (valueEquals(value, getEmptyValue())) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -572,13 +572,14 @@ public class DatePicker
     @Override
     public void setValue(LocalDate value) {
         LocalDate oldValue = getValue();
+        boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
+        boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
+        boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
         boolean isInputValuePresent = isInputValuePresent();
-        boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
-                && valueEquals(value, getEmptyValue());
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (valueEquals(value, getEmptyValue())) {
+        if (isNewValueEmpty) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -573,6 +573,8 @@ public class DatePicker
     public void setValue(LocalDate value) {
         LocalDate oldValue = getValue();
         boolean isInputValuePresent = isInputValuePresent();
+        boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
+                && valueEquals(value, getEmptyValue());
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
@@ -583,9 +585,7 @@ public class DatePicker
         super.setValue(value);
 
         // Clear the input element from possible bad input.
-        if (valueEquals(oldValue, getEmptyValue())
-                && valueEquals(value, getEmptyValue())
-                && isInputValuePresent) {
+        if (isValueRemainedEmpty && isInputValuePresent) {
             // The check for value presence guarantees that a non-empty value
             // won't get cleared when setValue(null) and setValue(...) are
             // subsequently called within one round-trip.

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -130,6 +130,18 @@ public class BasicValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        setInputValue(dateInput, "1/1/2000");
+        setInputValue(timeInput, "10:00");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void badInput_changeValue_assertValidity() {
         setInputValue(dateInput, "INVALID");
         setInputValue(timeInput, "INVALID");

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationIT.java
@@ -147,6 +147,22 @@ public class BinderValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2000-01-01T10:00",
+                Keys.ENTER);
+
+        setInputValue(dateInput, "1/1/2000");
+        setInputValue(timeInput, "10:00");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
     public void badInput_changeValue_assertValidity() {
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2000-01-01T10:00",
                 Keys.ENTER);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
@@ -79,6 +79,17 @@ public class BigDecimalFieldBasicValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setValue("2");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationIT.java
@@ -73,6 +73,18 @@ public class BigDecimalFieldBinderValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setValue("2");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -160,6 +160,17 @@ public class IntegerFieldBasicValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setValue("2");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -152,6 +152,8 @@ public class IntegerFieldBinderValidationIT
 
     @Test
     public void setValue_clearValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2", Keys.ENTER);
+
         testField.setValue("2");
         assertServerValid();
         assertClientValid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -151,6 +151,18 @@ public class IntegerFieldBinderValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setValue("2");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
@@ -160,6 +160,17 @@ public class NumberFieldBasicValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setValue("2");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
@@ -152,6 +152,8 @@ public class NumberFieldBinderValidationIT
 
     @Test
     public void setValue_clearValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2", Keys.ENTER);
+
         testField.setValue("2");
         assertServerValid();
         assertClientValid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBinderValidationIT.java
@@ -151,6 +151,18 @@ public class NumberFieldBinderValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.setValue("2");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.sendKeys("--2", Keys.TAB);
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -61,17 +61,19 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * Sets up the common logic for number fields.
      *
      * @param parser
-     *            function to parse the client-side value string into
-     *            server-side value
+     *                    function to parse the client-side value string into
+     *                    server-side value
      * @param formatter
-     *            function to format the server-side value into client-side
-     *            value string
+     *                    function to format the server-side value into client-side
+     *                    value string
      * @param absoluteMin
-     *            the smallest possible value of the number type of the field,
-     *            will be used as the default min value at server-side
+     *                    the smallest possible value of the number type of the
+     *                    field,
+     *                    will be used as the default min value at server-side
      * @param absoluteMax
-     *            the largest possible value of the number type of the field,
-     *            will be used as the default max value at server-side
+     *                    the largest possible value of the number type of the
+     *                    field,
+     *                    will be used as the default max value at server-side
      */
     public AbstractNumberField(SerializableFunction<String, T> parser,
             SerializableFunction<T, String> formatter, double absoluteMin,
@@ -101,8 +103,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * @see #setStep(double)
      *
      * @param stepButtonsVisible
-     *            {@code true} if control buttons should be visible;
-     *            {@code false} if those should be hidden
+     *                           {@code true} if control buttons should be visible;
+     *                           {@code false} if those should be hidden
      */
     public void setStepButtonsVisible(boolean stepButtonsVisible) {
         getElement().setProperty("stepButtonsVisible", stepButtonsVisible);
@@ -132,7 +134,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * {@code getValue()}, fires a value change event.
      *
      * @param value
-     *            the new value
+     *              the new value
      */
     @Override
     public void setValue(T value) {
@@ -140,6 +142,11 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         boolean isInputValuePresent = isInputValuePresent();
         boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
                 && valueEquals(value, getEmptyValue());
+
+        // Reset hasInputValue when the value is cleared programmatically.
+        if (Objects.equals(value, getEmptyValue())) {
+            getElement().setProperty("_hasInputValue", false);
+        }
 
         super.setValue(value);
 
@@ -154,7 +161,6 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             // `executeJs` can end up invoked after a non-empty value is set.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
-            getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }
     }
@@ -211,7 +217,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * Sets the allowed number intervals of the field.
      *
      * @param step
-     *            the double value to set
+     *             the double value to set
      */
     protected void setStep(double step) {
         getElement().setProperty("step", step);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -143,7 +143,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
                 && valueEquals(value, getEmptyValue());
 
-        // Reset hasInputValue when the value is cleared programmatically.
+        // When the value is cleared programmatically, reset hasInputValue
+        // so that the following validation doesn't treat this as bad input.
         if (Objects.equals(value, getEmptyValue())) {
             getElement().setProperty("_hasInputValue", false);
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -143,7 +143,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (Objects.equals(value, getEmptyValue())) {
+        if (valueEquals(value, getEmptyValue())) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -137,13 +137,14 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
     @Override
     public void setValue(T value) {
         T oldValue = getValue();
+        boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
+        boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
+        boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
         boolean isInputValuePresent = isInputValuePresent();
-        boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
-                && valueEquals(value, getEmptyValue());
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (valueEquals(value, getEmptyValue())) {
+        if (isNewValueEmpty) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -61,19 +61,17 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * Sets up the common logic for number fields.
      *
      * @param parser
-     *                    function to parse the client-side value string into
-     *                    server-side value
+     *            function to parse the client-side value string into
+     *            server-side value
      * @param formatter
-     *                    function to format the server-side value into client-side
-     *                    value string
+     *            function to format the server-side value into client-side
+     *            value string
      * @param absoluteMin
-     *                    the smallest possible value of the number type of the
-     *                    field,
-     *                    will be used as the default min value at server-side
+     *            the smallest possible value of the number type of the field,
+     *            will be used as the default min value at server-side
      * @param absoluteMax
-     *                    the largest possible value of the number type of the
-     *                    field,
-     *                    will be used as the default max value at server-side
+     *            the largest possible value of the number type of the field,
+     *            will be used as the default max value at server-side
      */
     public AbstractNumberField(SerializableFunction<String, T> parser,
             SerializableFunction<T, String> formatter, double absoluteMin,
@@ -103,8 +101,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * @see #setStep(double)
      *
      * @param stepButtonsVisible
-     *                           {@code true} if control buttons should be visible;
-     *                           {@code false} if those should be hidden
+     *            {@code true} if control buttons should be visible;
+     *            {@code false} if those should be hidden
      */
     public void setStepButtonsVisible(boolean stepButtonsVisible) {
         getElement().setProperty("stepButtonsVisible", stepButtonsVisible);
@@ -134,7 +132,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * {@code getValue()}, fires a value change event.
      *
      * @param value
-     *              the new value
+     *            the new value
      */
     @Override
     public void setValue(T value) {
@@ -218,7 +216,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
      * Sets the allowed number intervals of the field.
      *
      * @param step
-     *             the double value to set
+     *            the double value to set
      */
     protected void setStep(double step) {
         getElement().setProperty("step", step);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -221,13 +221,14 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     @Override
     public void setValue(BigDecimal value) {
         BigDecimal oldValue = getValue();
+        boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
+        boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
+        boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
         boolean isInputValuePresent = isInputValuePresent();
-        boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
-                && valueEquals(value, getEmptyValue());
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (valueEquals(value, getEmptyValue())) {
+        if (isNewValueEmpty) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -225,7 +225,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
                 && valueEquals(value, getEmptyValue());
 
-        // Reset hasInputValue when the value is cleared programmatically.
+        // When the value is cleared programmatically, reset hasInputValue
+        // so that the following validation doesn't treat this as bad input.
         if (Objects.equals(value, getEmptyValue())) {
             getElement().setProperty("_hasInputValue", false);
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -225,12 +225,16 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
                 && valueEquals(value, getEmptyValue());
 
+        // Reset hasInputValue when the value is cleared programmatically.
+        if (Objects.equals(value, getEmptyValue())) {
+            getElement().setProperty("_hasInputValue", false);
+        }
+
         super.setValue(value);
 
         if (isValueRemainedEmpty && isInputValuePresent) {
             // Clear the input element from possible bad input.
             getElement().executeJs("this._inputElementValue = ''");
-            getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         } else {
             // Restore the input element's value in case it was cleared

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -227,7 +227,7 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (Objects.equals(value, getEmptyValue())) {
+        if (valueEquals(value, getEmptyValue())) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
@@ -99,6 +99,17 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.selectByText("10:00");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.selectByText("INVALID");
         assertServerInvalid();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
@@ -113,6 +113,8 @@ public class BinderValidationIT
 
     @Test
     public void setValue_clearValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("10:00", Keys.ENTER);
+
         testField.selectByText("10:00");
         assertServerValid();
         assertClientValid();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
@@ -112,6 +112,18 @@ public class BinderValidationIT
     }
 
     @Test
+    public void setValue_clearValue_assertValidity() {
+        testField.selectByText("10:00");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
     public void badInput_setValue_clearValue_assertValidity() {
         testField.selectByText("INVALID");
         assertServerInvalid();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -261,7 +261,7 @@ public class TimePicker
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (Objects.equals(value, getEmptyValue())) {
+        if (valueEquals(value, getEmptyValue())) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -255,13 +255,14 @@ public class TimePicker
         }
 
         LocalTime oldValue = getValue();
+        boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
+        boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
+        boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
         boolean isInputValuePresent = isInputValuePresent();
-        boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
-                && valueEquals(value, getEmptyValue());
 
         // When the value is cleared programmatically, reset hasInputValue
         // so that the following validation doesn't treat this as bad input.
-        if (valueEquals(value, getEmptyValue())) {
+        if (isNewValueEmpty) {
             getElement().setProperty("_hasInputValue", false);
         }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -109,7 +109,7 @@ public class TimePicker
      * Convenience constructor to create a time picker with a pre-selected time.
      *
      * @param time
-     *            the pre-selected time in the picker
+     *             the pre-selected time in the picker
      */
     public TimePicker(LocalTime time) {
         this(time, false);
@@ -119,12 +119,15 @@ public class TimePicker
      * Convenience constructor to create a time picker with a pre-selected time.
      *
      * @param time
-     *            the pre-selected time in the picker
+     *                               the pre-selected time in the picker
      * @param isInitialValueOptional
-     *            If {@code isInitialValueOptional} is {@code true} then the
-     *            initial value is used only if element has no {@code "value"}
-     *            property value, otherwise element {@code "value"} property is
-     *            ignored and the initial value is set
+     *                               If {@code isInitialValueOptional} is
+     *                               {@code true} then the
+     *                               initial value is used only if element has no
+     *                               {@code "value"}
+     *                               property value, otherwise element
+     *                               {@code "value"} property is
+     *                               ignored and the initial value is set
      */
     private TimePicker(LocalTime time, boolean isInitialValueOptional) {
         super("value", time, String.class, PARSER, FORMATTER);
@@ -151,7 +154,7 @@ public class TimePicker
      * Convenience constructor to create a time picker with a label.
      *
      * @param label
-     *            the label describing the time picker
+     *              the label describing the time picker
      * @see #setLabel(String)
      */
     public TimePicker(String label) {
@@ -164,9 +167,9 @@ public class TimePicker
      * and a label.
      *
      * @param label
-     *            the label describing the time picker
+     *              the label describing the time picker
      * @param time
-     *            the pre-selected time in the picker
+     *              the pre-selected time in the picker
      */
     public TimePicker(String label, LocalTime time) {
         this(time);
@@ -178,7 +181,7 @@ public class TimePicker
      * {@link ValueChangeListener}.
      *
      * @param listener
-     *            the listener to receive value change events
+     *                 the listener to receive value change events
      * @see #addValueChangeListener(HasValue.ValueChangeListener)
      */
     public TimePicker(
@@ -192,9 +195,9 @@ public class TimePicker
      * and {@link ValueChangeListener}.
      *
      * @param time
-     *            the pre-selected time in the picker
+     *                 the pre-selected time in the picker
      * @param listener
-     *            the listener to receive value change events
+     *                 the listener to receive value change events
      * @see #addValueChangeListener(HasValue.ValueChangeListener)
      */
     public TimePicker(LocalTime time,
@@ -208,11 +211,11 @@ public class TimePicker
      * pre-selected time and a {@link ValueChangeListener}.
      *
      * @param label
-     *            the label describing the time picker
+     *                 the label describing the time picker
      * @param time
-     *            the pre-selected time in the picker
+     *                 the pre-selected time in the picker
      * @param listener
-     *            the listener to receive value change events
+     *                 the listener to receive value change events
      * @see #setLabel(String)
      * @see #addValueChangeListener(HasValue.ValueChangeListener)
      */
@@ -227,7 +230,7 @@ public class TimePicker
      * Sets the label for the time picker.
      *
      * @param label
-     *            value for the {@code label} property in the time picker
+     *              value for the {@code label} property in the time picker
      */
     public void setLabel(String label) {
         getElement().setProperty("label", label == null ? "" : label);
@@ -244,7 +247,7 @@ public class TimePicker
      * in.
      *
      * @param value
-     *            the LocalTime instance representing the selected time, or null
+     *              the LocalTime instance representing the selected time, or null
      */
     @Override
     public void setValue(LocalTime value) {
@@ -259,6 +262,12 @@ public class TimePicker
         boolean isValueRemainedEmpty = valueEquals(oldValue, getEmptyValue())
                 && valueEquals(value, getEmptyValue());
 
+        // When the value is cleared programmatically, reset hasInputValue
+        // so that the following validation doesn't treat this as bad input.
+        if (Objects.equals(value, getEmptyValue())) {
+            getElement().setProperty("_hasInputValue", false);
+        }
+
         super.setValue(value);
 
         // Clear the input element from possible bad input.
@@ -272,7 +281,6 @@ public class TimePicker
             // `executeJs` can end up invoked after a non-empty value is set.
             getElement()
                     .executeJs("if (!this.value) this._inputElementValue = ''");
-            getElement().setProperty("_hasInputValue", false);
             fireEvent(new ClientValidatedEvent(this, false));
         }
     }
@@ -371,7 +379,7 @@ public class TimePicker
      * when the user has not entered a value.
      *
      * @param placeholder
-     *            the placeholder text
+     *                    the placeholder text
      */
     public void setPlaceholder(String placeholder) {
         getElement().setProperty("placeholder",
@@ -392,7 +400,7 @@ public class TimePicker
      * Sets whether the time picker is marked as input required.
      *
      * @param required
-     *            the boolean value to set
+     *                 the boolean value to set
      */
     public void setRequired(boolean required) {
         getElement().setProperty("required", required);
@@ -438,8 +446,8 @@ public class TimePicker
      * if some parts (eg. seconds) is discarded from the value.</em>
      *
      * @param step
-     *            the step to set, not {@code null} and should divide a day or
-     *            an hour evenly
+     *             the step to set, not {@code null} and should divide a day or
+     *             an hour evenly
      */
     public void setStep(Duration step) {
         Objects.requireNonNull(step, "Step cannot be null");
@@ -488,7 +496,7 @@ public class TimePicker
      * webcomponent.
      *
      * @param listener
-     *            the listener
+     *                 the listener
      * @return a {@link Registration} for removing the event listener
      */
     public Registration addInvalidChangeListener(
@@ -551,7 +559,7 @@ public class TimePicker
      * fired.</em>
      *
      * @param locale
-     *            the locale set to the time picker, cannot be [@code null}
+     *               the locale set to the time picker, cannot be [@code null}
      */
     public void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale must not be null.");

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -109,7 +109,7 @@ public class TimePicker
      * Convenience constructor to create a time picker with a pre-selected time.
      *
      * @param time
-     *             the pre-selected time in the picker
+     *            the pre-selected time in the picker
      */
     public TimePicker(LocalTime time) {
         this(time, false);
@@ -119,15 +119,12 @@ public class TimePicker
      * Convenience constructor to create a time picker with a pre-selected time.
      *
      * @param time
-     *                               the pre-selected time in the picker
+     *            the pre-selected time in the picker
      * @param isInitialValueOptional
-     *                               If {@code isInitialValueOptional} is
-     *                               {@code true} then the
-     *                               initial value is used only if element has no
-     *                               {@code "value"}
-     *                               property value, otherwise element
-     *                               {@code "value"} property is
-     *                               ignored and the initial value is set
+     *            If {@code isInitialValueOptional} is {@code true} then the
+     *            initial value is used only if element has no {@code "value"}
+     *            property value, otherwise element {@code "value"} property is
+     *            ignored and the initial value is set
      */
     private TimePicker(LocalTime time, boolean isInitialValueOptional) {
         super("value", time, String.class, PARSER, FORMATTER);
@@ -154,7 +151,7 @@ public class TimePicker
      * Convenience constructor to create a time picker with a label.
      *
      * @param label
-     *              the label describing the time picker
+     *            the label describing the time picker
      * @see #setLabel(String)
      */
     public TimePicker(String label) {
@@ -167,9 +164,9 @@ public class TimePicker
      * and a label.
      *
      * @param label
-     *              the label describing the time picker
+     *            the label describing the time picker
      * @param time
-     *              the pre-selected time in the picker
+     *            the pre-selected time in the picker
      */
     public TimePicker(String label, LocalTime time) {
         this(time);
@@ -181,7 +178,7 @@ public class TimePicker
      * {@link ValueChangeListener}.
      *
      * @param listener
-     *                 the listener to receive value change events
+     *            the listener to receive value change events
      * @see #addValueChangeListener(HasValue.ValueChangeListener)
      */
     public TimePicker(
@@ -195,9 +192,9 @@ public class TimePicker
      * and {@link ValueChangeListener}.
      *
      * @param time
-     *                 the pre-selected time in the picker
+     *            the pre-selected time in the picker
      * @param listener
-     *                 the listener to receive value change events
+     *            the listener to receive value change events
      * @see #addValueChangeListener(HasValue.ValueChangeListener)
      */
     public TimePicker(LocalTime time,
@@ -211,11 +208,11 @@ public class TimePicker
      * pre-selected time and a {@link ValueChangeListener}.
      *
      * @param label
-     *                 the label describing the time picker
+     *            the label describing the time picker
      * @param time
-     *                 the pre-selected time in the picker
+     *            the pre-selected time in the picker
      * @param listener
-     *                 the listener to receive value change events
+     *            the listener to receive value change events
      * @see #setLabel(String)
      * @see #addValueChangeListener(HasValue.ValueChangeListener)
      */
@@ -230,7 +227,7 @@ public class TimePicker
      * Sets the label for the time picker.
      *
      * @param label
-     *              value for the {@code label} property in the time picker
+     *            value for the {@code label} property in the time picker
      */
     public void setLabel(String label) {
         getElement().setProperty("label", label == null ? "" : label);
@@ -247,7 +244,7 @@ public class TimePicker
      * in.
      *
      * @param value
-     *              the LocalTime instance representing the selected time, or null
+     *            the LocalTime instance representing the selected time, or null
      */
     @Override
     public void setValue(LocalTime value) {
@@ -379,7 +376,7 @@ public class TimePicker
      * when the user has not entered a value.
      *
      * @param placeholder
-     *                    the placeholder text
+     *            the placeholder text
      */
     public void setPlaceholder(String placeholder) {
         getElement().setProperty("placeholder",
@@ -400,7 +397,7 @@ public class TimePicker
      * Sets whether the time picker is marked as input required.
      *
      * @param required
-     *                 the boolean value to set
+     *            the boolean value to set
      */
     public void setRequired(boolean required) {
         getElement().setProperty("required", required);
@@ -446,8 +443,8 @@ public class TimePicker
      * if some parts (eg. seconds) is discarded from the value.</em>
      *
      * @param step
-     *             the step to set, not {@code null} and should divide a day or
-     *             an hour evenly
+     *            the step to set, not {@code null} and should divide a day or
+     *            an hour evenly
      */
     public void setStep(Duration step) {
         Objects.requireNonNull(step, "Step cannot be null");
@@ -496,7 +493,7 @@ public class TimePicker
      * webcomponent.
      *
      * @param listener
-     *                 the listener
+     *            the listener
      * @return a {@link Registration} for removing the event listener
      */
     public Registration addInvalidChangeListener(
@@ -559,7 +556,7 @@ public class TimePicker
      * fired.</em>
      *
      * @param locale
-     *               the locale set to the time picker, cannot be [@code null}
+     *            the locale set to the time picker, cannot be [@code null}
      */
     public void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale must not be null.");


### PR DESCRIPTION
## Description

The PR prevents field components that support bad input from invalidating when clearing a valid value programmatically.

Depends on 
- #5586 

Fixes #5462 

Part of #5537 

## Type of change

- [x] Bugfix
