### PR TITLE
fix!(BigDecimalField): use custom logic instead of validated event

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationPage.java
@@ -38,6 +38,12 @@ public class BigDecimalFieldBasicValidationPage
     }
 
     protected BigDecimalField createTestField() {
-        return new BigDecimalField();
+        return new BigDecimalField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationPage.java
@@ -27,6 +27,7 @@ public class BigDecimalFieldBinderValidationPage
         extends AbstractValidationPage<BigDecimalField> {
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
+    public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
     public static class Bean {
         private BigDecimal property;
@@ -48,9 +49,16 @@ public class BigDecimalFieldBinderValidationPage
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();
+        }));
+
+        add(createButton(RESET_BEAN_BUTTON, "Reset bean", event -> {
+            binder.setBean(new Bean());
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationPage.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
+import java.math.BigDecimal;
+
 import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -25,13 +27,13 @@ import com.vaadin.tests.validation.AbstractValidationPage;
 public class BigDecimalFieldEagerBinderValidationPage
         extends AbstractValidationPage<BigDecimalField> {
     public static class Bean {
-        private Integer property;
+        private BigDecimal property;
 
-        public Integer getProperty() {
+        public BigDecimal getProperty() {
             return property;
         }
 
-        public void setProperty(Integer property) {
+        public void setProperty(BigDecimal property) {
             this.property = property;
         }
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationPage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-big-decimal-field/validation/eager-binder")
+public class BigDecimalFieldEagerBinderValidationPage
+        extends AbstractValidationPage<BigDecimalField> {
+    public static class Bean {
+        private Integer property;
+
+        public Integer getProperty() {
+            return property;
+        }
+
+        public void setProperty(Integer property) {
+            this.property = property;
+        }
+    }
+
+    public BigDecimalFieldEagerBinderValidationPage() {
+        super();
+
+        testField.setValueChangeMode(ValueChangeMode.EAGER);
+
+        Binder<Bean> binder = new Binder<>(Bean.class);
+        binder.forField(testField).bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
+    }
+
+    protected BigDecimalField createTestField() {
+        return new BigDecimalField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerValidationPage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-big-decimal-field/validation/eager")
+public class BigDecimalFieldEagerValidationPage
+        extends AbstractValidationPage<BigDecimalField> {
+    public BigDecimalFieldEagerValidationPage() {
+        super();
+        testField.setValueChangeMode(ValueChangeMode.EAGER);
+    }
+
+    protected BigDecimalField createTestField() {
+        return new BigDecimalField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
@@ -37,6 +37,7 @@ public class BigDecimalFieldBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -46,8 +47,9 @@ public class BigDecimalFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -55,27 +57,45 @@ public class BigDecimalFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -91,11 +111,15 @@ public class BigDecimalFieldBasicValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
@@ -104,7 +128,8 @@ public class BigDecimalFieldBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("1234");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -125,7 +150,8 @@ public class BigDecimalFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("1234");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationIT.java
@@ -24,6 +24,7 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.RESET_BEAN_BUTTON;
 
 @TestPath("vaadin-big-decimal-field/validation/binder")
 public class BigDecimalFieldBinderValidationIT
@@ -38,38 +39,68 @@ public class BigDecimalFieldBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
     public void required_changeValue_assertValidity() {
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void badInput_changeValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage("");
-
-        testField.setValue("2");
+    public void required_setValue_resetBean_assertValidity() {
+        testField.setValue("1234");
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        $("button").id(RESET_BEAN_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void badInput_changeValue_assertValidity() {
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -86,7 +117,7 @@ public class BigDecimalFieldBinderValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationIT.java
@@ -27,6 +27,23 @@ public class BigDecimalFieldEagerBinderValidationIT
         extends AbstractValidationIT<BigDecimalFieldElement> {
     @Test
     public void enterChars_fieldValidatesOnEveryChar() {
+        // Entered: 2
+        testField.sendKeys("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        // Entered:
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void badInput_enterChars_fieldValidatesOnEveryChar() {
         // Entered: -
         testField.sendKeys("-");
         assertValidationCount(1);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerBinderValidationIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.BigDecimalFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+
+@TestPath("vaadin-big-decimal-field/validation/eager-binder")
+public class BigDecimalFieldEagerBinderValidationIT
+        extends AbstractValidationIT<BigDecimalFieldElement> {
+    @Test
+    public void enterChars_fieldValidatesOnEveryChar() {
+        // Entered: -
+        testField.sendKeys("-");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered: -2
+        testField.sendKeys("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        // Entered: -
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered:
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    protected BigDecimalFieldElement getTestField() {
+        return $(BigDecimalFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerValidationIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.BigDecimalFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+
+@TestPath("vaadin-big-decimal-field/validation/eager")
+public class BigDecimalFieldEagerValidationIT
+        extends AbstractValidationIT<BigDecimalFieldElement> {
+    @Test
+    public void enterChars_fieldValidatesOnEveryChar() {
+        // Entered: -
+        testField.sendKeys("-");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered: -2
+        testField.sendKeys("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        // Entered: -
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered:
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    protected BigDecimalFieldElement getTestField() {
+        return $(BigDecimalFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldEagerValidationIT.java
@@ -27,6 +27,23 @@ public class BigDecimalFieldEagerValidationIT
         extends AbstractValidationIT<BigDecimalFieldElement> {
     @Test
     public void enterChars_fieldValidatesOnEveryChar() {
+        // Entered: 2
+        testField.sendKeys("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        // Entered:
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void badInput_enterChars_fieldValidatesOnEveryChar() {
         // Entered: -
         testField.sendKeys("-");
         assertValidationCount(1);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -101,6 +101,14 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
+
+        getElement().addEventListener("has-input-value-changed", e -> {
+            if (getValueChangeMode().equals(ValueChangeMode.EAGER)
+                    && valueEquals(getValue(), getEmptyValue())) {
+                validate();
+                fireValidationStatusChangeEvent();
+            }
+        });
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -322,7 +322,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     @Override
     public Registration addValidationStatusChangeListener(
             ValidationStatusChangeListener<BigDecimal> listener) {
-        return Registration.addAndRemove(validationStatusChangeListeners, listener);
+        return Registration.addAndRemove(validationStatusChangeListeners,
+                listener);
     }
 
     /**
@@ -334,7 +335,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     private void fireValidationStatusChangeEvent() {
         ValidationStatusChangeEvent<BigDecimal> event = new ValidationStatusChangeEvent<>(
                 this, !isInvalid());
-        validationStatusChangeListeners.forEach(listener -> listener.validationStatusChanged(event));
+        validationStatusChangeListeners
+                .forEach(listener -> listener.validationStatusChanged(event));
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -17,11 +17,10 @@ package com.vaadin.flow.component.textfield;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Synchronize;
@@ -84,7 +83,7 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
     private boolean manualValidationEnabled = false;
 
-    private final Collection<ValidationStatusChangeListener<BigDecimal>> validationStatusChangeListeners = new ArrayList<>();
+    private final CopyOnWriteArrayList<ValidationStatusChangeListener<BigDecimal>> validationStatusChangeListeners = new CopyOnWriteArrayList<>();
 
     /**
      * Constructs an empty {@code BigDecimalField}.
@@ -323,8 +322,7 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     @Override
     public Registration addValidationStatusChangeListener(
             ValidationStatusChangeListener<BigDecimal> listener) {
-        validationStatusChangeListeners.add(listener);
-        return () -> validationStatusChangeListeners.remove(listener);
+        return Registration.addAndRemove(validationStatusChangeListeners, listener);
     }
 
     /**
@@ -336,8 +334,7 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     private void fireValidationStatusChangeEvent() {
         ValidationStatusChangeEvent<BigDecimal> event = new ValidationStatusChangeEvent<>(
                 this, !isInvalid());
-        validationStatusChangeListeners
-                .forEach(listener -> listener.validationStatusChanged(event));
+        validationStatusChangeListeners.forEach(listener -> listener.validationStatusChanged(event));
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.textfield;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -82,6 +84,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
     private boolean manualValidationEnabled = false;
 
+    private final Collection<ValidationStatusChangeListener<BigDecimal>> validationStatusChangeListeners = new ArrayList<>();
+
     /**
      * Constructs an empty {@code BigDecimalField}.
      */
@@ -97,8 +101,6 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -237,13 +239,27 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         if (isValueRemainedEmpty && isInputValuePresent) {
             // Clear the input element from possible bad input.
             getElement().executeJs("this._inputElementValue = ''");
-            fireEvent(new ClientValidatedEvent(this, false));
+            validate();
+            fireValidationStatusChangeEvent();
         } else {
             // Restore the input element's value in case it was cleared
             // in the above branch. That can happen when setValue(null)
             // and setValue(...) are subsequently called within one round-trip
             // and there was bad input.
             getElement().executeJs("this._inputElementValue = this.value");
+        }
+    }
+
+    @Override
+    protected void setModelValue(BigDecimal newModelValue, boolean fromClient) {
+        BigDecimal oldModelValue = getValue();
+
+        super.setModelValue(newModelValue, fromClient);
+
+        if (fromClient && valueEquals(oldModelValue, getEmptyValue())
+                && valueEquals(newModelValue, getEmptyValue())) {
+            validate();
+            fireValidationStatusChangeEvent();
         }
     }
 
@@ -299,10 +315,21 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     @Override
     public Registration addValidationStatusChangeListener(
             ValidationStatusChangeListener<BigDecimal> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<BigDecimal>(this,
-                                !isInvalid())));
+        validationStatusChangeListeners.add(listener);
+        return () -> validationStatusChangeListeners.remove(listener);
+    }
+
+    /**
+     * Notifies Binder that it needs to revalidate the component since the
+     * component's validity state may have changed. Note, there is no need to
+     * notify Binder separately in the case of a ValueChangeEvent, as Binder
+     * already listens to this event and revalidates automatically.
+     */
+    private void fireValidationStatusChangeEvent() {
+        ValidationStatusChangeEvent<BigDecimal> event = new ValidationStatusChangeEvent<>(
+                this, !isInvalid());
+        validationStatusChangeListeners
+                .forEach(listener -> listener.validationStatusChanged(event));
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -100,14 +100,6 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
-
-        getElement().addEventListener("has-input-value-changed", e -> {
-            if (getValueChangeMode().equals(ValueChangeMode.EAGER)
-                    && valueEquals(getValue(), getEmptyValue())) {
-                validate();
-                fireValidationStatusChangeEvent();
-            }
-        });
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
@@ -27,7 +27,8 @@ public class BigDecimalFieldBasicValidationTest
     @Test
     public void addValidationStatusChangeListener_addAnotherListenerOnInvocation_noExceptions() {
         testField.addValidationStatusChangeListener(event1 -> {
-            testField.addValidationStatusChangeListener(event2 -> {});
+            testField.addValidationStatusChangeListener(event2 -> {
+            });
         });
 
         // Trigger ValidationStatusChangeEvent

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
@@ -17,11 +17,24 @@ package com.vaadin.flow.component.textfield.validation;
 
 import java.math.BigDecimal;
 
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BigDecimalFieldBasicValidationTest
         extends AbstractBasicValidationTest<BigDecimalField, BigDecimal> {
+    @Test
+    public void addValidationStatusChangeListener_addAnotherListenerOnInvocation_noExceptions() {
+        testField.addValidationStatusChangeListener(event1 -> {
+            testField.addValidationStatusChangeListener(event2 -> {});
+        });
+
+        // Trigger ValidationStatusChangeEvent
+        testField.getElement().setProperty("_hasInputValue", true);
+        testField.clear();
+    }
+
     protected BigDecimalField createTestField() {
         return new BigDecimalField();
     }


### PR DESCRIPTION
## Description

The PR refactors BigDecimalField to make it trigger validation whenever a `value-changed` event is received from the client while the value still remains empty on the server, instead of relying on the `validated` event.

Depends on
- https://github.com/vaadin/flow-components/pull/5590

> **Warning**
> It's a behavior altering change because it removes validation on blur.

Part of #5537 

## Type of change

- [x] Bugfix
