### PR TITLE
fix: ensure client-side value property is initialized

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
@@ -309,7 +309,7 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
         if ((getElement().getProperty("value") == null
-                || !isInitialValueOptional) && initialValue != null) {
+                || !isInitialValueOptional)) {
             setPresentationValue(initialValue);
         }
     }
@@ -349,7 +349,7 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
         super("value", defaultValue, elementPropertyType, presentationToModel,
                 modelToPresentation);
         if ((getElement().getProperty("value") == null
-                || !isInitialValueOptional) && initialValue != null) {
+                || !isInitialValueOptional)) {
             setPresentationValue(initialValue);
         }
     }
@@ -377,7 +377,7 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
             boolean acceptNullValues, boolean isInitialValueOptional) {
         super("value", defaultValue, acceptNullValues);
         if ((getElement().getProperty("value") == null
-                || !isInitialValueOptional) && initialValue != null) {
+                || !isInitialValueOptional)) {
             setPresentationValue(initialValue);
         }
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -16,15 +16,23 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.math.BigDecimal;
 import java.util.Locale;
@@ -52,9 +60,39 @@ public class BigDecimalFieldTest extends TextFieldTest {
 
     @Override
     @Test
-    public void initialValuePropertyValue() {
-        assertEquals(field.getEmptyValue(),
-                field.getElement().getProperty("value"));
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
+        BigDecimalField bigDecimalField = new BigDecimalField();
+        Assert.assertNull(bigDecimalField.getValue());
+        Assert.assertEquals("",
+                bigDecimalField.getElement().getProperty("value"));
+    }
+
+    @Override
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {}
+
+    @Override
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-big-decimal-field");
+        element.setProperty("value", "1");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(BigDecimalField.class))
+                .thenAnswer(invocation -> new BigDecimalField());
+
+        BigDecimalField bigDecimalField = Component.from(element, BigDecimalField.class);
+        Assert.assertEquals("1",
+                bigDecimalField.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -69,7 +69,8 @@ public class BigDecimalFieldTest extends TextFieldTest {
 
     @Override
     @Test
-    public void initialValueIsNull_valuePropertyHasEmptyString() {}
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+    }
 
     @Override
     @Test
@@ -90,7 +91,8 @@ public class BigDecimalFieldTest extends TextFieldTest {
         Mockito.when(instantiator.createComponent(BigDecimalField.class))
                 .thenAnswer(invocation -> new BigDecimalField());
 
-        BigDecimalField bigDecimalField = Component.from(element, BigDecimalField.class);
+        BigDecimalField bigDecimalField = Component.from(element,
+                BigDecimalField.class);
         Assert.assertEquals("1",
                 bigDecimalField.getElement().getProperty("value"));
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -63,8 +63,7 @@ public class EmailFieldTest {
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         EmailField emailField = new EmailField();
         Assert.assertEquals("", emailField.getValue());
-        Assert.assertEquals("",
-                emailField.getElement().getProperty("value"));
+        Assert.assertEquals("", emailField.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -16,17 +16,25 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,9 +60,40 @@ public class EmailFieldTest {
     }
 
     @Test
-    public void initialValuePropertyValue() {
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         EmailField emailField = new EmailField();
-        assertEquals(emailField.getEmptyValue(),
+        Assert.assertEquals("", emailField.getValue());
+        Assert.assertEquals("",
+                emailField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        EmailField emailField = new EmailField((String) null);
+        Assert.assertEquals("", emailField.getValue());
+        Assert.assertEquals("", emailField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-email-field");
+        element.setProperty("value", "foo@example.com");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(EmailField.class))
+                .thenAnswer(invocation -> new EmailField());
+
+        EmailField emailField = Component.from(element, EmailField.class);
+        Assert.assertEquals("foo@example.com",
                 emailField.getElement().getProperty("value"));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -69,13 +69,13 @@ public class IntegerFieldTest extends TextFieldTest {
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         IntegerField integerField = new IntegerField();
         Assert.assertNull(integerField.getValue());
-        Assert.assertEquals("",
-                integerField.getElement().getProperty("value"));
+        Assert.assertEquals("", integerField.getElement().getProperty("value"));
     }
 
     @Override
     @Test
-    public void initialValueIsNull_valuePropertyHasEmptyString() {}
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+    }
 
     @Override
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -16,19 +16,26 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class IntegerFieldTest extends TextFieldTest {
@@ -59,9 +66,39 @@ public class IntegerFieldTest extends TextFieldTest {
 
     @Override
     @Test
-    public void initialValuePropertyValue() {
-        assertEquals(field.getEmptyValue(),
-                field.getElement().getProperty("value"));
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
+        IntegerField integerField = new IntegerField();
+        Assert.assertNull(integerField.getValue());
+        Assert.assertEquals("",
+                integerField.getElement().getProperty("value"));
+    }
+
+    @Override
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {}
+
+    @Override
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-integer-field");
+        element.setProperty("value", "1");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(IntegerField.class))
+                .thenAnswer(invocation -> new IntegerField());
+
+        IntegerField integerField = Component.from(element, IntegerField.class);
+        Assert.assertEquals("1",
+                integerField.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -15,15 +15,23 @@
  */
 package com.vaadin.flow.component.textfield.tests;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 
@@ -51,9 +59,39 @@ public class NumberFieldTest extends TextFieldTest {
 
     @Override
     @Test
-    public void initialValuePropertyValue() {
-        assertEquals(field.getEmptyValue(),
-                field.getElement().getProperty("value"));
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
+        NumberField numberField = new NumberField();
+        Assert.assertNull(numberField.getValue());
+        Assert.assertEquals("",
+                numberField.getElement().getProperty("value"));
+    }
+
+    @Override
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {}
+
+    @Override
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-number-field");
+        element.setProperty("value", "1");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(NumberField.class))
+                .thenAnswer(invocation -> new NumberField());
+
+        NumberField numberField = Component.from(element, NumberField.class);
+        Assert.assertEquals("1",
+                numberField.getElement().getProperty("value"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -62,13 +62,13 @@ public class NumberFieldTest extends TextFieldTest {
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         NumberField numberField = new NumberField();
         Assert.assertNull(numberField.getValue());
-        Assert.assertEquals("",
-                numberField.getElement().getProperty("value"));
+        Assert.assertEquals("", numberField.getElement().getProperty("value"));
     }
 
     @Override
     @Test
-    public void initialValueIsNull_valuePropertyHasEmptyString() {}
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+    }
 
     @Override
     @Test
@@ -90,8 +90,7 @@ public class NumberFieldTest extends TextFieldTest {
                 .thenAnswer(invocation -> new NumberField());
 
         NumberField numberField = Component.from(element, NumberField.class);
-        Assert.assertEquals("1",
-                numberField.getElement().getProperty("value"));
+        Assert.assertEquals("1", numberField.getElement().getProperty("value"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -16,16 +16,24 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -51,9 +59,40 @@ public class PasswordFieldTest {
     }
 
     @Test
-    public void initialValuePropertyValue() {
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         PasswordField passwordField = new PasswordField();
-        assertEquals(passwordField.getEmptyValue(),
+        Assert.assertEquals("", passwordField.getValue());
+        Assert.assertEquals("",
+                passwordField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        PasswordField passwordField = new PasswordField((String) null);
+        Assert.assertEquals("", passwordField.getValue());
+        Assert.assertEquals("", passwordField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-password-field");
+        element.setProperty("value", "test");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(PasswordField.class))
+                .thenAnswer(invocation -> new PasswordField());
+
+        PasswordField passwordField = Component.from(element, PasswordField.class);
+        Assert.assertEquals("test",
                 passwordField.getElement().getProperty("value"));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -70,7 +70,8 @@ public class PasswordFieldTest {
     public void initialValueIsNull_valuePropertyHasEmptyString() {
         PasswordField passwordField = new PasswordField((String) null);
         Assert.assertEquals("", passwordField.getValue());
-        Assert.assertEquals("", passwordField.getElement().getProperty("value"));
+        Assert.assertEquals("",
+                passwordField.getElement().getProperty("value"));
     }
 
     @Test
@@ -91,7 +92,8 @@ public class PasswordFieldTest {
         Mockito.when(instantiator.createComponent(PasswordField.class))
                 .thenAnswer(invocation -> new PasswordField());
 
-        PasswordField passwordField = Component.from(element, PasswordField.class);
+        PasswordField passwordField = Component.from(element,
+                PasswordField.class);
         Assert.assertEquals("test",
                 passwordField.getElement().getProperty("value"));
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -63,8 +63,7 @@ public class TextAreaTest {
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         TextArea textArea = new TextArea();
         Assert.assertEquals("", textArea.getValue());
-        Assert.assertEquals("",
-                textArea.getElement().getProperty("value"));
+        Assert.assertEquals("", textArea.getElement().getProperty("value"));
     }
 
     @Test
@@ -93,8 +92,7 @@ public class TextAreaTest {
                 .thenAnswer(invocation -> new TextArea());
 
         TextArea textArea = Component.from(element, TextArea.class);
-        Assert.assertEquals("test",
-                textArea.getElement().getProperty("value"));
+        Assert.assertEquals("test", textArea.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -16,17 +16,25 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextAreaVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,9 +60,40 @@ public class TextAreaTest {
     }
 
     @Test
-    public void initialValuePropertyValue() {
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         TextArea textArea = new TextArea();
-        assertEquals(textArea.getEmptyValue(),
+        Assert.assertEquals("", textArea.getValue());
+        Assert.assertEquals("",
+                textArea.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        TextArea textArea = new TextArea((String) null);
+        Assert.assertEquals("", textArea.getValue());
+        Assert.assertEquals("", textArea.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-text-area");
+        element.setProperty("value", "test");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(TextArea.class))
+                .thenAnswer(invocation -> new TextArea());
+
+        TextArea textArea = Component.from(element, TextArea.class);
+        Assert.assertEquals("test",
                 textArea.getElement().getProperty("value"));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -16,20 +16,30 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ThemeList;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
 
 /**
  * Tests for the {@link TextField}.
@@ -52,9 +62,40 @@ public class TextFieldTest {
     }
 
     @Test
-    public void initialValuePropertyValue() {
+    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         TextField textField = new TextField();
-        assertEquals(textField.getEmptyValue(),
+        Assert.assertEquals("", textField.getValue());
+        Assert.assertEquals("",
+                textField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void initialValueIsNull_valuePropertyHasEmptyString() {
+        TextField textField = new TextField((String) null);
+        Assert.assertEquals("", textField.getValue());
+        Assert.assertEquals("", textField.getElement().getProperty("value"));
+    }
+
+    @Test
+    public void createElementWithValue_createComponentInstanceFromElement_valuePropertyMatchesValue() {
+        Element element = new Element("vaadin-text-field");
+        element.setProperty("value", "test");
+        UI ui = new UI();
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        ui.getInternals().setSession(session);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(session.getService()).thenReturn(service);
+
+        Instantiator instantiator = Mockito.mock(Instantiator.class);
+
+        Mockito.when(service.getInstantiator()).thenReturn(instantiator);
+
+        Mockito.when(instantiator.createComponent(TextField.class))
+                .thenAnswer(invocation -> new TextField());
+
+        TextField textField = Component.from(element, TextField.class);
+        Assert.assertEquals("test",
                 textField.getElement().getProperty("value"));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -65,8 +65,7 @@ public class TextFieldTest {
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         TextField textField = new TextField();
         Assert.assertEquals("", textField.getValue());
-        Assert.assertEquals("",
-                textField.getElement().getProperty("value"));
+        Assert.assertEquals("", textField.getElement().getProperty("value"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Ensures that TextField initializes its client-side value property with an empty string to prevent Polymer from generating `value-changed` events when converting `null` to `""` on its own. Refer to https://github.com/vaadin/flow-components/pull/5581#issuecomment-1764670968 for more details on why this is necessary.

Note, the same fix was applied to DatePicker a while ago: https://github.com/vaadin/flow-components/pull/2878.

Part of #5537 

## Type of change

- [x] Bugfix
