### PR TITLE
test(IntegerField): use unparsable-change instead of validated event

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
@@ -16,49 +16,23 @@
 package com.vaadin.flow.component.textfield.tests.validation;
 
 import com.vaadin.flow.component.textfield.IntegerField;
-import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
 
-@Route("vaadin-integer-field/validation/binder")
-public class IntegerFieldValidationBinderPage
+@Route("vaadin-integer-field/validation/basic")
+public class IntegerFieldBasicValidationPage
         extends AbstractValidationPage<IntegerField> {
+    public static final String REQUIRED_BUTTON = "required-button";
     public static final String STEP_INPUT = "step-input";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
-    public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
-
-    public static class Bean {
-        private Integer property;
-
-        public Integer getProperty() {
-            return property;
-        }
-
-        public void setProperty(Integer property) {
-            this.property = property;
-        }
-    }
-
-    protected Binder<Bean> binder;
-
-    private Integer expectedValue;
-
-    public IntegerFieldValidationBinderPage() {
+    public IntegerFieldBasicValidationPage() {
         super();
 
-        binder = new Binder<>(Bean.class);
-        binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
-                .withValidator(value -> value.equals(expectedValue),
-                        UNEXPECTED_VALUE_ERROR_MESSAGE)
-                .bind("property");
-
-        add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
-            expectedValue = Integer.parseInt(event.getValue());
+        add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
+            testField.setRequiredIndicatorVisible(true);
         }));
 
         add(createInput(STEP_INPUT, "Set step", event -> {
@@ -82,6 +56,12 @@ public class IntegerFieldValidationBinderPage
     }
 
     protected IntegerField createTestField() {
-        return new IntegerField();
+        return new IntegerField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationPage.java
@@ -16,23 +16,53 @@
 package com.vaadin.flow.component.textfield.tests.validation;
 
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
 
-@Route("vaadin-integer-field/validation/basic")
-public class IntegerFieldValidationBasicPage
+@Route("vaadin-integer-field/validation/binder")
+public class IntegerFieldBinderValidationPage
         extends AbstractValidationPage<IntegerField> {
-    public static final String REQUIRED_BUTTON = "required-button";
     public static final String STEP_INPUT = "step-input";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
+    public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
-    public IntegerFieldValidationBasicPage() {
+    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+
+    public static class Bean {
+        private Integer property;
+
+        public Integer getProperty() {
+            return property;
+        }
+
+        public void setProperty(Integer property) {
+            this.property = property;
+        }
+    }
+
+    protected Binder<Bean> binder;
+
+    private Integer expectedValue;
+
+    public IntegerFieldBinderValidationPage() {
         super();
 
-        add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+        binder = new Binder<>(Bean.class);
+        binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
+                .withValidator(value -> value.equals(expectedValue),
+                        UNEXPECTED_VALUE_ERROR_MESSAGE)
+                .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
+
+        add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
+            expectedValue = Integer.parseInt(event.getValue());
         }));
 
         add(createInput(STEP_INPUT, "Set step", event -> {
@@ -52,6 +82,10 @@ public class IntegerFieldValidationBasicPage
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();
+        }));
+
+        add(createButton(RESET_BEAN_BUTTON, "Reset bean", event -> {
+            binder.setBean(new Bean());
         }));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerBinderValidationPage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-integer-field/validation/eager-binder")
+public class IntegerFieldEagerBinderValidationPage
+        extends AbstractValidationPage<IntegerField> {
+    public static class Bean {
+        private Integer property;
+
+        public Integer getProperty() {
+            return property;
+        }
+
+        public void setProperty(Integer property) {
+            this.property = property;
+        }
+    }
+
+    public IntegerFieldEagerBinderValidationPage() {
+        super();
+
+        testField.setValueChangeMode(ValueChangeMode.EAGER);
+
+        Binder<Bean> binder = new Binder<>(Bean.class);
+        binder.forField(testField).bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
+    }
+
+    protected IntegerField createTestField() {
+        return new IntegerField();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerValidationPage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-integer-field/validation/eager")
+public class IntegerFieldEagerValidationPage
+        extends AbstractValidationPage<IntegerField> {
+    public IntegerFieldEagerValidationPage() {
+        super();
+        testField.setValueChangeMode(ValueChangeMode.EAGER);
+    }
+
+    protected IntegerField createTestField() {
+        return new IntegerField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
@@ -22,11 +23,11 @@ import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.validation.AbstractValidationIT;
 
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.MIN_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.MAX_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.STEP_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.REQUIRED_BUTTON;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBasicPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.MIN_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.MAX_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.STEP_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.CLEAR_VALUE_BUTTON;
 
 @TestPath("vaadin-integer-field/validation/basic")
 public class IntegerFieldBasicValidationIT
@@ -40,6 +41,7 @@ public class IntegerFieldBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -49,8 +51,9 @@ public class IntegerFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -58,21 +61,16 @@ public class IntegerFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+
+        resetValidationCount();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void min_triggerBlur_assertValidity() {
-        $("input").id(MIN_INPUT).sendKeys("2", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -80,25 +78,30 @@ public class IntegerFieldBasicValidationIT
         $("input").id(MIN_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
 
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
 
-    @Test
-    public void max_triggerBlur_assertValidity() {
-        $("input").id(MAX_INPUT).sendKeys("2", Keys.ENTER);
+        resetValidationCount();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
+        testField.setValue("");
+        assertValidationCount(1);
         assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -106,25 +109,30 @@ public class IntegerFieldBasicValidationIT
         $("input").id(MAX_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
 
-    @Test
-    public void step_triggerBlur_assertValidity() {
-        $("input").id(STEP_INPUT).sendKeys("2", Keys.ENTER);
+        resetValidationCount();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
+        testField.setValue("");
+        assertValidationCount(1);
         assertClientValid();
+        assertServerValid();
     }
 
     @Test
@@ -132,31 +140,59 @@ public class IntegerFieldBasicValidationIT
         $("input").id(STEP_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
+        resetValidationCount();
+
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -172,34 +208,55 @@ public class IntegerFieldBasicValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMaxInteger_assertValidity() {
-        testField.sendKeys("999999999999", Keys.TAB);
+    public void maxIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMinInteger_assertValidity() {
-        testField.sendKeys("-999999999999", Keys.TAB);
+    public void minIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("-999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("2");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -220,7 +277,8 @@ public class IntegerFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("2");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
@@ -22,13 +23,14 @@ import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.validation.AbstractValidationIT;
 
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.STEP_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.MIN_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.MAX_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.EXPECTED_VALUE_INPUT;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.CLEAR_VALUE_BUTTON;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.REQUIRED_ERROR_MESSAGE;
-import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldValidationBinderPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.STEP_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.MIN_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.MAX_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.RESET_BEAN_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
 @TestPath("vaadin-integer-field/validation/binder")
 public class IntegerFieldBinderValidationIT
@@ -43,9 +45,9 @@ public class IntegerFieldBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -53,13 +55,30 @@ public class IntegerFieldBinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
+        resetValidationCount();
+
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void required_setValue_resetBean_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("1234", Keys.ENTER);
+
+        testField.setValue("1234");
+        assertServerValid();
+        assertClientValid();
+
+        $("button").id(RESET_BEAN_BUTTON).click();
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -69,20 +88,36 @@ public class IntegerFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -92,20 +127,36 @@ public class IntegerFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("3");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -115,39 +166,69 @@ public class IntegerFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("1");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         // Binder validation fails:
         testField.setValue("2");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
+        resetValidationCount();
+
         // Both validations pass:
         testField.setValue("4");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+
+        resetValidationCount();
+
+        // Binder validation fails:
+        testField.setValue("");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
     public void badInput_changeValue_assertValidity() {
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("2", Keys.ENTER);
 
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         testField.setValue("2");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
-        testField.sendKeys("--2", Keys.TAB);
+        resetValidationCount();
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -166,31 +247,53 @@ public class IntegerFieldBinderValidationIT
 
     @Test
     public void badInput_setValue_clearValue_assertValidity() {
-        testField.sendKeys("--2", Keys.TAB);
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
 
+        resetValidationCount();
+
         $("button").id(CLEAR_VALUE_BUTTON).click();
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMaxInteger_assertValidity() {
-        testField.sendKeys("999999999999", Keys.TAB);
+    public void maxIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void integerOverflow_setValueExceedingMinInteger_assertValidity() {
-        testField.sendKeys("-999999999999", Keys.TAB);
+    public void minIntegerOverflow_changeValue_assertValidity() {
+        testField.setValue("-999999999999");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage("");
+
+        resetValidationCount();
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     protected IntegerFieldElement getTestField() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerBinderValidationIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+
+@TestPath("vaadin-integer-field/validation/eager-binder")
+public class IntegerFieldEagerBinderValidationIT
+        extends AbstractValidationIT<IntegerFieldElement> {
+    @Test
+    public void enterChars_fieldValidatesOnEveryChar() {
+        // Entered: -
+        testField.sendKeys("-");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered: -2
+        testField.sendKeys("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        // Entered: -
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered:
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    protected IntegerFieldElement getTestField() {
+        return $(IntegerFieldElement.class).first();
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldEagerValidationIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests.validation;
+
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.textfield.testbench.IntegerFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+
+@TestPath("vaadin-integer-field/validation/eager")
+public class IntegerFieldEagerValidationIT
+        extends AbstractValidationIT<IntegerFieldElement> {
+    @Test
+    public void enterChars_fieldValidatesOnEveryChar() {
+        // Entered: -
+        testField.sendKeys("-");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered: -2
+        testField.sendKeys("2");
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+
+        resetValidationCount();
+
+        // Entered: -
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+
+        resetValidationCount();
+
+        // Entered:
+        testField.sendKeys(Keys.BACK_SPACE);
+        assertValidationCount(1);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    protected IntegerFieldElement getTestField() {
+        return $(IntegerFieldElement.class).first();
+    }
+}


### PR DESCRIPTION
## Description

The PR contains changes to the IntegerField validation tests as a follow-up to https://github.com/vaadin/flow-components/pull/5564

## Type of change

- [x] Internal
