### PR TITLE
feat: reflect class name set on item to root level button in MenuBar

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -58,6 +58,7 @@
         component: child,
         checked: child._checked,
         keepOpen: child._keepOpen,
+        className: child.className,
         theme: child.__theme
       };
       // Do not hardcode tag name to allow `vaadin-menu-bar-item`

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -150,19 +150,19 @@ public class MenuBarTestPage extends Div {
         toggleSubItemThemeButton.setId("toggle-sub-theme");
 
         NativeButton toggleClassNameButton = new NativeButton(
-            "toggle item class", e -> {
-            if (item1.hasClassName(MENU_ITEM_CLASSNAME)) {
-                item1.removeClassName(MENU_ITEM_CLASSNAME);
-            } else {
-                item1.addClassName(MENU_ITEM_CLASSNAME);
-            }
-        });
+                "toggle item class", e -> {
+                    if (item1.hasClassName(MENU_ITEM_CLASSNAME)) {
+                        item1.removeClassName(MENU_ITEM_CLASSNAME);
+                    } else {
+                        item1.addClassName(MENU_ITEM_CLASSNAME);
+                    }
+                });
         toggleClassNameButton.setId("toggle-item1-class-name");
 
-        NativeButton setItemClassNameButton = new NativeButton(
-            "set item class", e -> {
-            item1.setClassName(MENU_ITEM_CLASSNAME_SET);
-        });
+        NativeButton setItemClassNameButton = new NativeButton("set item class",
+                e -> {
+                    item1.setClassName(MENU_ITEM_CLASSNAME_SET);
+                });
         setItemClassNameButton.setId("set-item1-class-name");
 
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
@@ -171,6 +171,7 @@ public class MenuBarTestPage extends Div {
                 toggleItem2VisibilityButton, checkedButton,
                 toggleAttachedButton, setI18nButton, toggleAttachedButton,
                 toggleMenuBarThemeButton, toggleItem1ThemeButton,
-                toggleSubItemThemeButton, toggleClassNameButton, setItemClassNameButton);
+                toggleSubItemThemeButton, toggleClassNameButton,
+                setItemClassNameButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -32,6 +32,9 @@ public class MenuBarTestPage extends Div {
     public static final String MENU_ITEM_THEME = "menu-item-theme";
     public static final String SUB_ITEM_THEME = "sub-item-theme";
 
+    public static final String MENU_ITEM_CLASSNAME = "menu-item-class-name";
+    public static final String MENU_ITEM_CLASSNAME_SET = "item1-class-name-set";
+
     public MenuBarTestPage() {
         MenuBar menuBar = new MenuBar();
         add(menuBar);
@@ -146,12 +149,28 @@ public class MenuBarTestPage extends Div {
                 });
         toggleSubItemThemeButton.setId("toggle-sub-theme");
 
+        NativeButton toggleClassNameButton = new NativeButton(
+            "toggle item class", e -> {
+            if (item1.hasClassName(MENU_ITEM_CLASSNAME)) {
+                item1.removeClassName(MENU_ITEM_CLASSNAME);
+            } else {
+                item1.addClassName(MENU_ITEM_CLASSNAME);
+            }
+        });
+        toggleClassNameButton.setId("toggle-item1-class-name");
+
+        NativeButton setItemClassNameButton = new NativeButton(
+            "set item class", e -> {
+            item1.setClassName(MENU_ITEM_CLASSNAME_SET);
+        });
+        setItemClassNameButton.setId("set-item1-class-name");
+
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableItemButton, toggleItem1VisibilityButton,
                 toggleItem2VisibilityButton, checkedButton,
                 toggleAttachedButton, setI18nButton, toggleAttachedButton,
                 toggleMenuBarThemeButton, toggleItem1ThemeButton,
-                toggleSubItemThemeButton);
+                toggleSubItemThemeButton, toggleClassNameButton, setItemClassNameButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -32,8 +32,8 @@ public class MenuBarTestPage extends Div {
     public static final String MENU_ITEM_THEME = "menu-item-theme";
     public static final String SUB_ITEM_THEME = "sub-item-theme";
 
-    public static final String MENU_ITEM_CLASSNAME = "menu-item-class-name";
-    public static final String MENU_ITEM_CLASSNAME_SET = "item1-class-name-set";
+    public static final String MENU_ITEM_FIRST_CLASS_NAME = "menu-item-first-class-name";
+    public static final String MENU_ITEM_SECOND_CLASS_NAME = "menu-item-second-class-name";
 
     public MenuBarTestPage() {
         MenuBar menuBar = new MenuBar();
@@ -151,19 +151,38 @@ public class MenuBarTestPage extends Div {
 
         NativeButton toggleClassNameButton = new NativeButton(
                 "toggle item class", e -> {
-                    if (item1.hasClassName(MENU_ITEM_CLASSNAME)) {
-                        item1.removeClassName(MENU_ITEM_CLASSNAME);
+                    if (item1.hasClassName(MENU_ITEM_FIRST_CLASS_NAME)) {
+                        item1.removeClassName(MENU_ITEM_FIRST_CLASS_NAME);
                     } else {
-                        item1.addClassName(MENU_ITEM_CLASSNAME);
+                        item1.addClassName(MENU_ITEM_FIRST_CLASS_NAME);
                     }
                 });
         toggleClassNameButton.setId("toggle-item1-class-name");
 
         NativeButton setItemClassNameButton = new NativeButton("set item class",
                 e -> {
-                    item1.setClassName(MENU_ITEM_CLASSNAME_SET);
+                    item1.setClassName(MENU_ITEM_SECOND_CLASS_NAME);
                 });
         setItemClassNameButton.setId("set-item1-class-name");
+
+        NativeButton setUnsetClassNameButton = new NativeButton(
+                "set/unset item class", e -> {
+                    item1.setClassName(MENU_ITEM_FIRST_CLASS_NAME,
+                            !item1.hasClassName(MENU_ITEM_FIRST_CLASS_NAME));
+                });
+        setUnsetClassNameButton.setId("set-unset-item1-class-name");
+
+        NativeButton addRemoveMultipleClassNames = new NativeButton(
+                "toggle multiple classes", e -> {
+                    if (item1.hasClassName(MENU_ITEM_FIRST_CLASS_NAME)) {
+                        item1.removeClassNames(MENU_ITEM_FIRST_CLASS_NAME,
+                                MENU_ITEM_SECOND_CLASS_NAME);
+                    } else {
+                        item1.addClassNames(MENU_ITEM_FIRST_CLASS_NAME,
+                                MENU_ITEM_SECOND_CLASS_NAME);
+                    }
+                });
+        addRemoveMultipleClassNames.setId("add-remove-multiple-classes");
 
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
@@ -172,6 +191,7 @@ public class MenuBarTestPage extends Div {
                 toggleAttachedButton, setI18nButton, toggleAttachedButton,
                 toggleMenuBarThemeButton, toggleItem1ThemeButton,
                 toggleSubItemThemeButton, toggleClassNameButton,
-                setItemClassNameButton);
+                setItemClassNameButton, setUnsetClassNameButton,
+                addRemoveMultipleClassNames);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -442,6 +442,33 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void toggleMenuItemClassName_classNameIsToggled() {
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("class"));
+        click("toggle-item1-class-name");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertEquals(menuButton1.getAttribute("class"),
+            MenuBarTestPage.MENU_ITEM_CLASSNAME);
+        click("toggle-item1-class-name");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("class"));
+    }
+
+    @Test
+    public void setMenuItemClassName_classNameIsSet() {
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("class"));
+        click("toggle-item1-class-name");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertEquals(menuButton1.getAttribute("class"),
+            MenuBarTestPage.MENU_ITEM_CLASSNAME);
+        click("set-item1-class-name");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertEquals(menuButton1.getAttribute("class"),
+            MenuBarTestPage.MENU_ITEM_CLASSNAME_SET);
+    }
+
+    @Test
     public void setMenuItemTheme_toggleVisibility_themeIsPreserved() {
         click("toggle-item-1-theme");
         click("toggle-item-1-visibility");

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -448,7 +448,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("class"),
-            MenuBarTestPage.MENU_ITEM_CLASSNAME);
+                MenuBarTestPage.MENU_ITEM_CLASSNAME);
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertFalse(menuButton1.hasAttribute("class"));
@@ -461,11 +461,11 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("class"),
-            MenuBarTestPage.MENU_ITEM_CLASSNAME);
+                MenuBarTestPage.MENU_ITEM_CLASSNAME);
         click("set-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("class"),
-            MenuBarTestPage.MENU_ITEM_CLASSNAME_SET);
+                MenuBarTestPage.MENU_ITEM_CLASSNAME_SET);
     }
 
     @Test

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -448,7 +448,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_CLASSNAME);
+                MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME);
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertFalse(menuButton1.hasAttribute("class"));
@@ -461,11 +461,42 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_CLASSNAME);
+                MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME);
         click("set-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_CLASSNAME_SET);
+                MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME);
+    }
+
+    @Test
+    public void toggleMenuItemClassNameWithSetClassName_classNameIsToggled() {
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("class"));
+        click("set-unset-item1-class-name");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertEquals(menuButton1.getAttribute("class"),
+                MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME);
+        click("set-unset-item1-class-name");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("class"));
+    }
+
+    @Test
+    public void toggleMultipleItemClassName_classNamesAreToggled() {
+        TestBenchElement menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.hasAttribute("class"));
+        click("add-remove-multiple-classes");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertTrue(menuButton1.getAttribute("class")
+                .contains(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME));
+        Assert.assertTrue(menuButton1.getAttribute("class")
+                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
+        click("add-remove-multiple-classes");
+        menuButton1 = menuBar.getButtons().get(0);
+        Assert.assertFalse(menuButton1.getAttribute("class")
+                .contains(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME));
+        Assert.assertFalse(menuButton1.getAttribute("class")
+                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
     }
 
     @Test

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -62,4 +62,65 @@ class MenuBarRootItem extends MenuBarItem {
         super.removeThemeNames(themeNames);
         menuBar.updateButtons();
     }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void addClassName(String className) {
+        super.addClassName(className);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void addClassNames(String... classNames) {
+        super.addClassNames(classNames);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void setClassName(String className) {
+        super.setClassName(className);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void setClassName(String className, boolean set) {
+        super.setClassName(className, set);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public boolean removeClassName(String className) {
+        var result = super.removeClassName(className);
+        updateClassName();
+        return result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void removeClassNames(String... classNames) {
+        super.removeClassNames(classNames);
+        updateClassName();
+    }
+
+    private void updateClassName() {
+        getElement().executeJs(
+                "window.Vaadin.Flow.menubarConnector.setClassName(this)");
+        menuBar.updateButtons();
+    }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -103,9 +103,18 @@ import './contextMenuConnector.js';
     };
   }
 
+  function setClassName (component) {
+    if (component._item) {
+      component._item.className = component.className;
+    }
+  }
+
   window.Vaadin.Flow.menubarConnector = {
     initLazy(...args) {
       return tryCatchWrapper(initLazy)(...args);
+    },
+    setClassName(...args) {
+      return tryCatchWrapper(setClassName)(...args);
     }
   };
 })();


### PR DESCRIPTION
## Description

Add functionality to copy the class name value defined on a `MenuBar` item to its parent button on the root level.
That allows users to specify selectors for the button and for the item to style the components
differently.

Fixes https://github.com/vaadin/web-components/issues/5342

## Type of change

- [ ] Bugfix
- [X] Feature
