### PR TITLE
fix: avoid a concurrent modification in native button renderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NativeButtonRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NativeButtonRenderer.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.data.renderer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
@@ -42,7 +43,7 @@ import com.vaadin.flow.shared.Registration;
 public class NativeButtonRenderer<SOURCE> extends BasicRenderer<SOURCE, String>
         implements ClickableRenderer<SOURCE> {
 
-    private List<ItemClickListener<SOURCE>> listeners = new ArrayList<>(1);
+    private List<ItemClickListener<SOURCE>> listeners = new CopyOnWriteArrayList<>();
 
     /**
      * Creates a new button renderer with the specified label. The label is the

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NativeButtonRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/NativeButtonRenderer.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.data.renderer;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/NativeButtonRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/NativeButtonRendererTest.java
@@ -16,13 +16,18 @@
 package com.vaadin.flow.data.renderer;
 
 import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.data.provider.DataGenerator;
 import com.vaadin.flow.data.provider.KeyMapper;
+import com.vaadin.flow.data.renderer.ClickableRenderer.ItemClickListener;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -57,6 +62,36 @@ public class NativeButtonRendererTest {
         dataGenerator.generateData("something", json);
         Assert.assertTrue("The button should be disabled",
                 json.getBoolean(keyForDisabled));
+    }
+
+    @Test
+    public void removeListenerInListener_shouldNotThrowException() {
+        // Create a new renderer
+        var renderer = new NativeButtonRenderer<String>("Label");
+
+        // Create and add a listener that removes itself
+        var registration = new AtomicReference<Registration>();
+        ItemClickListener<String> listener = e -> registration.get().remove();
+        registration.set(renderer.addItemClickListener(listener));
+
+        // Invoke the listener
+        invokeClickListeners(renderer);
+    }
+
+    private void invokeClickListeners(NativeButtonRenderer<String> renderer) {
+        try {
+            var clientCallablesField = LitRenderer.class
+                    .getDeclaredField("clientCallables");
+            clientCallablesField.setAccessible(true);
+            var clientCallables = (Map<String, SerializableBiConsumer<String, JsonObject>>) clientCallablesField
+                    .get(renderer);
+            clientCallables.values()
+                    .forEach(listener -> listener.accept("foo", null));
+        } catch (NoSuchFieldException | IllegalArgumentException
+                | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
     }
 
     private void mockDisabled(Element container) {


### PR DESCRIPTION
## Description

Use `CopyOnWriteArrayList` in `NativeButtonRenderer` to avoid a possible concurrent modification exception.

## Type of change

Bugfix