### PR TITLE
fix: ensure all SplitLayout constructors call to addSplitterDragendListener

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -79,10 +79,10 @@ public class SplitLayout extends Component
     public SplitLayout(Orientation orientation) {
         setOrientation(orientation);
         addAttachListener(
-            e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
+                e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
         addSplitterDragendListener(
-            e -> this.splitterPosition = calcNewSplitterPosition(
-                e.primaryComponentWidth, e.secondaryComponentWidth));
+                e -> this.splitterPosition = calcNewSplitterPosition(
+                        e.primaryComponentWidth, e.secondaryComponentWidth));
     }
 
     /**

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -67,12 +67,22 @@ public class SplitLayout extends Component
      * Constructs an empty SplitLayout.
      */
     public SplitLayout() {
-        setOrientation(Orientation.HORIZONTAL);
+        this(Orientation.HORIZONTAL);
+    }
+
+    /**
+     * Constructs a SplitLayout with the orientation.
+     *
+     * @param orientation
+     *            the orientation set to the layout
+     */
+    public SplitLayout(Orientation orientation) {
+        setOrientation(orientation);
         addAttachListener(
-                e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
+            e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
         addSplitterDragendListener(
-                e -> this.splitterPosition = calcNewSplitterPosition(
-                        e.primaryComponentWidth, e.secondaryComponentWidth));
+            e -> this.splitterPosition = calcNewSplitterPosition(
+                e.primaryComponentWidth, e.secondaryComponentWidth));
     }
 
     /**
@@ -86,21 +96,7 @@ public class SplitLayout extends Component
      */
     public SplitLayout(Component primaryComponent,
             Component secondaryComponent) {
-        this();
-        addToPrimary(primaryComponent);
-        addToSecondary(secondaryComponent);
-    }
-
-    /**
-     * Constructs a SplitLayout with the orientation.
-     *
-     * @param orientation
-     *            the orientation set to the layout
-     */
-    public SplitLayout(Orientation orientation) {
-        setOrientation(orientation);
-        addAttachListener(
-                e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
+        this(primaryComponent, secondaryComponent, Orientation.HORIZONTAL);
     }
 
     /**
@@ -116,8 +112,9 @@ public class SplitLayout extends Component
      */
     public SplitLayout(Component primaryComponent, Component secondaryComponent,
             Orientation orientation) {
-        this(primaryComponent, secondaryComponent);
-        setOrientation(orientation);
+        this(orientation);
+        addToPrimary(primaryComponent);
+        addToSecondary(secondaryComponent);
     }
 
     /**

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.splitlayout.tests;
 
+import com.vaadin.flow.component.html.Div;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -78,6 +79,60 @@ public class SplitLayoutUnitTest {
                 splitLayout, true, "58.23%", "41.77%"));
 
         Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
+    }
+
+    @Test
+    public void constructorDefault() {
+        SplitLayout splitLayout = new SplitLayout();
+
+        Assert.assertEquals(SplitLayout.Orientation.HORIZONTAL, splitLayout.getOrientation());
+    }
+
+    @Test
+    public void constructorWithOrientation() {
+        SplitLayout splitLayout = new SplitLayout(SplitLayout.Orientation.VERTICAL);
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
+            splitLayout, true, "58.23%", "41.77%"));
+
+        Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
+        Assert.assertEquals(SplitLayout.Orientation.VERTICAL, splitLayout.getOrientation());
+    }
+
+    @Test
+    public void constructorWithComponents() {
+        var primaryComponent= new Div();
+        var secondaryComponent = new Div();
+        SplitLayout splitLayout = new SplitLayout(primaryComponent, secondaryComponent);
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
+            splitLayout, true, "58.23%", "41.77%"));
+
+        Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
+        Assert.assertEquals(primaryComponent, splitLayout.getPrimaryComponent());
+        Assert.assertEquals(secondaryComponent, splitLayout.getSecondaryComponent());
+        Assert.assertEquals(SplitLayout.Orientation.HORIZONTAL, splitLayout.getOrientation());
+    }
+
+    @Test
+    public void constructorWithComponentsAndOrientation() {
+        var primaryComponent= new Div();
+        var secondaryComponent = new Div();
+        SplitLayout splitLayout = new SplitLayout(primaryComponent,secondaryComponent, SplitLayout.Orientation.VERTICAL);
+        double splitterPosition = 45.66;
+        splitLayout.setSplitterPosition(splitterPosition);
+
+        ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
+            splitLayout, true, "58.23%", "41.77%"));
+
+        Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
+        Assert.assertEquals(primaryComponent, splitLayout.getPrimaryComponent());
+        Assert.assertEquals(secondaryComponent, splitLayout.getSecondaryComponent());
+        Assert.assertEquals(SplitLayout.Orientation.VERTICAL, splitLayout.getOrientation());
     }
 
     @Test

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -85,54 +85,65 @@ public class SplitLayoutUnitTest {
     public void constructorDefault() {
         SplitLayout splitLayout = new SplitLayout();
 
-        Assert.assertEquals(SplitLayout.Orientation.HORIZONTAL, splitLayout.getOrientation());
+        Assert.assertEquals(SplitLayout.Orientation.HORIZONTAL,
+                splitLayout.getOrientation());
     }
 
     @Test
     public void constructorWithOrientation() {
-        SplitLayout splitLayout = new SplitLayout(SplitLayout.Orientation.VERTICAL);
+        SplitLayout splitLayout = new SplitLayout(
+                SplitLayout.Orientation.VERTICAL);
         double splitterPosition = 45.66;
         splitLayout.setSplitterPosition(splitterPosition);
 
         ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
-            splitLayout, true, "58.23%", "41.77%"));
+                splitLayout, true, "58.23%", "41.77%"));
 
         Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
-        Assert.assertEquals(SplitLayout.Orientation.VERTICAL, splitLayout.getOrientation());
+        Assert.assertEquals(SplitLayout.Orientation.VERTICAL,
+                splitLayout.getOrientation());
     }
 
     @Test
     public void constructorWithComponents() {
-        var primaryComponent= new Div();
+        var primaryComponent = new Div();
         var secondaryComponent = new Div();
-        SplitLayout splitLayout = new SplitLayout(primaryComponent, secondaryComponent);
+        SplitLayout splitLayout = new SplitLayout(primaryComponent,
+                secondaryComponent);
         double splitterPosition = 45.66;
         splitLayout.setSplitterPosition(splitterPosition);
 
         ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
-            splitLayout, true, "58.23%", "41.77%"));
+                splitLayout, true, "58.23%", "41.77%"));
 
         Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
-        Assert.assertEquals(primaryComponent, splitLayout.getPrimaryComponent());
-        Assert.assertEquals(secondaryComponent, splitLayout.getSecondaryComponent());
-        Assert.assertEquals(SplitLayout.Orientation.HORIZONTAL, splitLayout.getOrientation());
+        Assert.assertEquals(primaryComponent,
+                splitLayout.getPrimaryComponent());
+        Assert.assertEquals(secondaryComponent,
+                splitLayout.getSecondaryComponent());
+        Assert.assertEquals(SplitLayout.Orientation.HORIZONTAL,
+                splitLayout.getOrientation());
     }
 
     @Test
     public void constructorWithComponentsAndOrientation() {
-        var primaryComponent= new Div();
+        var primaryComponent = new Div();
         var secondaryComponent = new Div();
-        SplitLayout splitLayout = new SplitLayout(primaryComponent,secondaryComponent, SplitLayout.Orientation.VERTICAL);
+        SplitLayout splitLayout = new SplitLayout(primaryComponent,
+                secondaryComponent, SplitLayout.Orientation.VERTICAL);
         double splitterPosition = 45.66;
         splitLayout.setSplitterPosition(splitterPosition);
 
         ComponentUtil.fireEvent(splitLayout, new SplitterDragendEvent(
-            splitLayout, true, "58.23%", "41.77%"));
+                splitLayout, true, "58.23%", "41.77%"));
 
         Assert.assertEquals(58.23, splitLayout.getSplitterPosition(), 0);
-        Assert.assertEquals(primaryComponent, splitLayout.getPrimaryComponent());
-        Assert.assertEquals(secondaryComponent, splitLayout.getSecondaryComponent());
-        Assert.assertEquals(SplitLayout.Orientation.VERTICAL, splitLayout.getOrientation());
+        Assert.assertEquals(primaryComponent,
+                splitLayout.getPrimaryComponent());
+        Assert.assertEquals(secondaryComponent,
+                splitLayout.getSecondaryComponent());
+        Assert.assertEquals(SplitLayout.Orientation.VERTICAL,
+                splitLayout.getOrientation());
     }
 
     @Test


### PR DESCRIPTION
## Description

Organize the constructor such that all call to the `SplitLayout(Orientation)`, which ensures that the component is initialized correctly with all constructors.

Fixes #5563

## Type of change

- [X] Bugfix
- [ ] Feature
