### PR TITLE
fix: make sure to get direct children in SplitterDragendEvent

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitterPositionView.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitterPositionView.java
@@ -38,7 +38,11 @@ public class SplitterPositionView extends Div {
         NativeButton buttonLayoutComponent = new NativeButton(
                 "Create layout component", e -> add(new LayoutComponent()));
         buttonLayoutComponent.setId("createLayoutComponent");
-        add(buttonJava, buttonElement, buttonLayoutComponent);
+        NativeButton nestedSplitLayoutButton = new NativeButton(
+                "nested split layout", e -> createNestedSplitLayout());
+        nestedSplitLayoutButton.setId("nested-split-layout-button");
+        add(buttonJava, buttonElement, buttonLayoutComponent,
+                nestedSplitLayoutButton);
     }
 
     private void createLayoutJavaApi() {
@@ -82,5 +86,28 @@ public class SplitterPositionView extends Div {
         layout.addSplitterDragendListener(e -> showSplitterPosition
                 .setText(String.valueOf(e.getSource().getSplitterPosition())));
         add(setSplitterPosition, layout, showSplitterPosition);
+    }
+
+    private void createNestedSplitLayout() {
+        Span childPrimary = new Span("child-primary");
+        Span childSecondary = new Span("child-secondary");
+        Div parentSecondary = new Div();
+
+        SplitLayout childLayout = new SplitLayout(childPrimary, childSecondary);
+        childLayout.setId("child-layout");
+        SplitLayout parentLayout = new SplitLayout(childLayout, parentSecondary,
+                SplitLayout.Orientation.VERTICAL);
+        parentLayout.setId("parent-layout");
+        parentLayout.setHeight("500px");
+
+        Span splitterPosition = new Span();
+        splitterPosition.setId("splitter-position");
+        NativeButton parentSplitterPositionButton = new NativeButton(
+                "parent splitter position", e -> splitterPosition
+                        .setText("" + parentLayout.getSplitterPosition()));
+        parentSplitterPositionButton.setId("splitter-position-button");
+        parentSecondary.add(parentSplitterPositionButton, splitterPosition);
+
+        add(parentLayout);
     }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
@@ -77,6 +78,28 @@ public class SplitterPositionIT extends AbstractComponentIT {
                 .id("mainContentInLayoutComponent")
                 .getPropertyString("style", "width");
         Assert.assertEquals("100%", width);
+    }
+
+    @Test
+    public void nestedSplitLayouts_moveParentSplitter_getSplitterPosition() {
+        $(NativeButtonElement.class).id("nested-split-layout-button").click();
+        var split = $(SplitLayoutElement.class).id("parent-layout");
+        WebElement splitter = (WebElement) executeScript(
+                "return arguments[0].$.splitter", split);
+
+        // Move splitter by 150px
+        Actions resizeAction = new Actions(getDriver());
+        resizeAction.dragAndDropBy(splitter, 0, 150);
+        resizeAction.perform();
+
+        $(NativeButtonElement.class).id("splitter-position-button").click();
+        var splitPosition = Double.parseDouble(
+                $(TestBenchElement.class).id("splitter-position").getText());
+
+        // The split layout has 500px height, so the splitter is about at 250px
+        // Moving it 150px down, it would be at 400px (around 80% of the layout)
+        Assert.assertTrue(splitPosition > 80);
+        Assert.assertTrue(splitPosition < 81);
     }
 
     private void testSplitterPosition(String testId) {

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -82,7 +82,8 @@ public class SplitLayout extends Component
                 e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
         addSplitterDragendListener(
                 e -> this.splitterPosition = calcNewSplitterPosition(
-                        e.primaryComponentWidth, e.secondaryComponentWidth));
+                        e.primaryComponentFlexBasis,
+                        e.secondaryComponentFlexBasis));
     }
 
     /**
@@ -337,18 +338,18 @@ public class SplitLayout extends Component
     public static class SplitterDragendEvent
             extends ComponentEvent<SplitLayout> {
 
-        private static final String PRIMARY_FLEX_BASIS = "element.querySelector('[slot=\"primary\"]').style.flexBasis";
-        private static final String SECONDARY_FLEX_BASIS = "element.querySelector('[slot=\"secondary\"]').style.flexBasis";
+        private static final String PRIMARY_FLEX_BASIS = "element.querySelector(':scope > [slot=\"primary\"]').style.flexBasis";
+        private static final String SECONDARY_FLEX_BASIS = "element.querySelector(':scope > [slot=\"secondary\"]').style.flexBasis";
 
-        String primaryComponentWidth;
-        String secondaryComponentWidth;
+        String primaryComponentFlexBasis;
+        String secondaryComponentFlexBasis;
 
         public SplitterDragendEvent(SplitLayout source, boolean fromClient,
-                @EventData(PRIMARY_FLEX_BASIS) String primaryComponentWidth,
-                @EventData(SECONDARY_FLEX_BASIS) String secondaryComponentWidth) {
+                @EventData(PRIMARY_FLEX_BASIS) String primaryComponentFlexBasis,
+                @EventData(SECONDARY_FLEX_BASIS) String secondaryComponentFlexBasis) {
             super(source, fromClient);
-            this.primaryComponentWidth = primaryComponentWidth;
-            this.secondaryComponentWidth = secondaryComponentWidth;
+            this.primaryComponentFlexBasis = primaryComponentFlexBasis;
+            this.secondaryComponentFlexBasis = secondaryComponentFlexBasis;
         }
 
     }
@@ -380,31 +381,33 @@ public class SplitLayout extends Component
         }
     }
 
-    private Double calcNewSplitterPosition(String primaryWidth,
-            String secondaryWidth) {
+    private Double calcNewSplitterPosition(String primaryFlexBasis,
+            String secondaryFlexBasis) {
         // set current splitter position value
         Double splitterPositionValue = this.splitterPosition;
 
-        if (primaryWidth == null || secondaryWidth == null) {
+        if (primaryFlexBasis == null || secondaryFlexBasis == null) {
             return splitterPositionValue;
         }
 
-        if (primaryWidth.endsWith("px")) {
+        if (primaryFlexBasis.endsWith("px")) {
             // When moving the splitter, the client side sets pixel values.
-            double pWidth = Double.parseDouble(primaryWidth.replace("px", ""));
-            double sWidth = Double
-                    .parseDouble(secondaryWidth.replace("px", ""));
+            double pFlexBasis = Double
+                    .parseDouble(primaryFlexBasis.replace("px", ""));
+            double sFlexBasis = Double
+                    .parseDouble(secondaryFlexBasis.replace("px", ""));
 
-            splitterPositionValue = (pWidth * 100) / (pWidth + sWidth);
+            splitterPositionValue = (pFlexBasis * 100)
+                    / (pFlexBasis + sFlexBasis);
             splitterPositionValue = round(splitterPositionValue);
-        } else if (primaryWidth.endsWith("%")) {
+        } else if (primaryFlexBasis.endsWith("%")) {
             splitterPositionValue = Double
-                    .parseDouble(primaryWidth.replace("%", ""));
+                    .parseDouble(primaryFlexBasis.replace("%", ""));
             splitterPositionValue = round(splitterPositionValue);
         } else {
             throw new IllegalArgumentException(
-                    "Given width values are not supported: " + primaryWidth
-                            + " / " + secondaryWidth);
+                    "Given flex basis values are not supported: "
+                            + primaryFlexBasis + " / " + secondaryFlexBasis);
         }
 
         return splitterPositionValue;


### PR DESCRIPTION
## Description

Change the `@EventData` selector to query for the direct children of the `SplitLayout` to avoid returning the wrong values in case a nested split layout is in one of the slots.

Also refactored to change the names of the variables, because they don't map to widths in case of vertical splits.

Fix #5602

## Type of change

- [X] Bugfix
- [ ] Feature
