### PR TITLE
fix: flush grid virtualizer until row count stabilizes

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandedAutoWidthPreserveOnRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandedAutoWidthPreserveOnRefreshPage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import java.util.List;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/treegrid-expanded-auto-width-preserve-on-refresh")
+@PreserveOnRefresh
+public class TreeGridExpandedAutoWidthPreserveOnRefreshPage
+        extends VerticalLayout {
+
+    public TreeGridExpandedAutoWidthPreserveOnRefreshPage() {
+        var grid = new TreeGrid<String>();
+        grid.setAllRowsVisible(true);
+        grid.addHierarchyColumn(String::toString).setHeader("Name")
+                .setAutoWidth(true).setFlexGrow(0);
+
+        var items = List.of("Item 1", "Parent 1");
+        grid.setItems(items, item -> {
+            if (item.startsWith("Parent")) {
+                var index = Integer.parseInt(item.split(" ")[1]);
+                if (index < 6) {
+                    return List.of("Parent " + (index + 1));
+                } else {
+                    return List.of("Item");
+                }
+            }
+            return List.of();
+        });
+        grid.expandRecursively(items, Integer.MAX_VALUE);
+
+        add(grid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandedAutoWidthPreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandedAutoWidthPreserveOnRefreshIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-grid/treegrid-expanded-auto-width-preserve-on-refresh")
+public class TreeGridExpandedAutoWidthPreserveOnRefreshIT
+        extends AbstractTreeGridIT {
+
+    @Before
+    public void before() {
+        open();
+    }
+
+    @Test
+    public void refresh_expectSameColumnWidth() {
+        var grid = $(TreeGridElement.class).first();
+        var columnOffsetWidth = grid.getCell(0, 0)
+                .getPropertyInteger("offsetWidth");
+
+        getDriver().navigate().refresh();
+
+        grid = $(TreeGridElement.class).first();
+        Assert.assertEquals(columnOffsetWidth,
+                grid.getCell(0, 0).getPropertyInteger("offsetWidth"));
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -92,6 +92,26 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
             return level;
           });
+          
+          const recalculateColumnWidthsOriginal = Grid.prototype._recalculateColumnWidths;
+          Grid.prototype._recalculateColumnWidths = function (cols) {
+            // Flush until row count stabilizes
+            // Temporary fix for https://github.com/vaadin/flow-components/issues/5595
+            let previousRowCount;
+            while (previousRowCount !== this.$.items.childElementCount) {
+              previousRowCount = this.$.items.childElementCount;
+              
+              // Flush the debouncer
+              this.__virtualizer.flush();
+              if (ensureSubCacheDebouncer) {
+                // Flush pending ensureSubCache calls
+                ensureSubCacheDebouncer.flush();
+              }
+            }
+
+            recalculateColumnWidthsOriginal.call(this, cols);
+          };
+
         }
 
         const rootPageCallbacks = {};

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -94,14 +94,14 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           });
           
           const recalculateColumnWidthsOriginal = Grid.prototype._recalculateColumnWidths;
-          Grid.prototype._recalculateColumnWidths = function (cols) {
+          Grid.prototype._recalculateColumnWidths = function(cols) {
             // Flush until row count stabilizes
             // Temporary fix for https://github.com/vaadin/flow-components/issues/5595
             let previousRowCount;
             while (previousRowCount !== this.$.items.childElementCount) {
               previousRowCount = this.$.items.childElementCount;
               
-              // Flush the debouncer
+              // Flush the virtualizer
               this.__virtualizer.flush();
               if (ensureSubCacheDebouncer) {
                 // Flush pending ensureSubCache calls


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5595

The related [fix](https://github.com/vaadin/web-components/pull/6684) for V24 does not fix the issue in V23 because the component has changed between the major versions. This is why a different fix is required.

## Type of change

Bugfix