### PR TITLE
fix!(TextField): remove validated event subscription

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationIT.java
@@ -46,6 +46,7 @@ public abstract class AbstractValidationIT<T extends TestBenchElement>
                 .parseInt($("div").id(SERVER_VALIDATION_COUNTER).getText());
         Assert.assertEquals("The field should have validated " + expected
                 + " times on the server-side", expected, actual);
+        resetValidationCount();
     }
 
     protected void resetValidationCount() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationPage.java
@@ -49,7 +49,14 @@ public class EmailFieldBasicValidationPage
         }));
     }
 
+    @Override
     protected EmailField createTestField() {
-        return new EmailField();
+        return new EmailField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationPage.java
@@ -55,6 +55,9 @@ public class EmailFieldBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = event.getValue();
@@ -75,6 +78,7 @@ public class EmailFieldBinderValidationPage
         }));
     }
 
+    @Override
     protected EmailField createTestField() {
         return new EmailField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationPage.java
@@ -49,7 +49,14 @@ public class PasswordFieldBasicValidationPage
         }));
     }
 
+    @Override
     protected PasswordField createTestField() {
-        return new PasswordField();
+        return new PasswordField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBinderValidationPage.java
@@ -56,7 +56,7 @@ public class PasswordFieldBinderValidationPage
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
         binder.addStatusChangeListener(event -> {
-             incrementServerValidationCounter();
+            incrementServerValidationCounter();
         });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
@@ -80,6 +80,6 @@ public class PasswordFieldBinderValidationPage
 
     @Override
     protected PasswordField createTestField() {
-        return new PasswordField() ;
+        return new PasswordField();
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBinderValidationPage.java
@@ -55,6 +55,9 @@ public class PasswordFieldBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+             incrementServerValidationCounter();
+        });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = event.getValue();
@@ -75,7 +78,8 @@ public class PasswordFieldBinderValidationPage
         }));
     }
 
+    @Override
     protected PasswordField createTestField() {
-        return new PasswordField();
+        return new PasswordField() ;
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationPage.java
@@ -49,7 +49,14 @@ public class TextAreaBasicValidationPage
         }));
     }
 
+    @Override
     protected TextArea createTestField() {
-        return new TextArea();
+        return new TextArea() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationPage.java
@@ -55,6 +55,9 @@ public class TextAreaBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = event.getValue();
@@ -75,6 +78,7 @@ public class TextAreaBinderValidationPage
         }));
     }
 
+    @Override
     protected TextArea createTestField() {
         return new TextArea();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationPage.java
@@ -49,7 +49,14 @@ public class TextFieldBasicValidationPage
         }));
     }
 
+    @Override
     protected TextField createTestField() {
-        return new TextField();
+        return new TextField() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationPage.java
@@ -55,6 +55,9 @@ public class TextFieldBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = event.getValue();
@@ -75,6 +78,7 @@ public class TextFieldBinderValidationPage
         }));
     }
 
+    @Override
     protected TextField createTestField() {
         return new TextField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
@@ -39,6 +39,7 @@ public class EmailFieldBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -48,8 +49,9 @@ public class EmailFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -57,21 +59,14 @@ public class EmailFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("john@vaadin.com");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void minLength_triggerBlur_assertValidity() {
-        $("input").id(MIN_LENGTH_INPUT).sendKeys("13", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -79,14 +74,17 @@ public class EmailFieldBasicValidationIT
         $("input").id(MIN_LENGTH_INPUT).sendKeys("13", Keys.ENTER);
 
         testField.setValue("a@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("aa@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("aaa@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -96,32 +94,30 @@ public class EmailFieldBasicValidationIT
         $("input").id(MAX_LENGTH_INPUT).sendKeys("13", Keys.ENTER);
 
         testField.setValue("aaa@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("aa@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("a@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
-
-    @Test
-    public void defaultPattern_triggerBlur_assertValidity() {
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
     public void defaultPattern_changeValue_assertValidity() {
         testField.setValue("arbitrary string");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("john@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -132,10 +128,12 @@ public class EmailFieldBasicValidationIT
                 Keys.ENTER);
 
         testField.setValue("2222@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("john@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -144,7 +142,8 @@ public class EmailFieldBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("john@vaadin.com");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -165,13 +164,15 @@ public class EmailFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("john@vaadin.com");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 
         assertServerInvalid();
     }
 
+    @Override
     protected EmailFieldElement getTestField() {
         return $(EmailFieldElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationIT.java
@@ -42,9 +42,9 @@ public class EmailFieldBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -53,10 +53,12 @@ public class EmailFieldBinderValidationIT
                 Keys.ENTER);
 
         testField.setValue("john@vaadin.com");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
@@ -70,18 +72,21 @@ public class EmailFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("a@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("aa@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("aaa@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -94,18 +99,21 @@ public class EmailFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("aaa@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("aa@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("a@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -116,11 +124,13 @@ public class EmailFieldBinderValidationIT
                 Keys.ENTER);
 
         testField.setValue("arbitrary string");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         testField.setValue("john@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -134,22 +144,26 @@ public class EmailFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("2222@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("oliver@vaadin.com");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("john@vaadin.com");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
 
+    @Override
     protected EmailFieldElement getTestField() {
         return $(EmailFieldElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
@@ -42,6 +42,7 @@ public class PasswordFieldBasicValidationIT
         testField.sendKeys(Keys.TAB);
         // Tab out of the field
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -54,8 +55,9 @@ public class PasswordFieldBasicValidationIT
         testField.sendKeys(Keys.TAB);
         // Tab out of the field
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -63,24 +65,14 @@ public class PasswordFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("Value");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void minLength_triggerBlur_assertValidity() {
-        $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
-
-        // Tab to the show button
-        testField.sendKeys(Keys.TAB);
-        // Tab out of the field
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -88,14 +80,17 @@ public class PasswordFieldBasicValidationIT
         $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -105,28 +100,19 @@ public class PasswordFieldBasicValidationIT
         $("input").id(MAX_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
-
-    @Test
-    public void pattern_triggerBlur_assertValidity() {
-        $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
-
-        // Tab to the show button
-        testField.sendKeys(Keys.TAB);
-        // Tab out of the field
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -134,10 +120,12 @@ public class PasswordFieldBasicValidationIT
         $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
 
         testField.setValue("Word");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -146,8 +134,8 @@ public class PasswordFieldBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("Value");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -168,14 +156,15 @@ public class PasswordFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("Value");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 
         assertServerInvalid();
     }
 
+    @Override
     protected PasswordFieldElement getTestField() {
         return $(PasswordFieldElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBinderValidationIT.java
@@ -45,9 +45,9 @@ public class PasswordFieldBinderValidationIT
         testField.sendKeys(Keys.TAB);
         // Tab out of the field
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -55,10 +55,12 @@ public class PasswordFieldBinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("Value", Keys.ENTER);
 
         testField.setValue("Value");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
@@ -71,18 +73,21 @@ public class PasswordFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -94,18 +99,21 @@ public class PasswordFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -117,22 +125,26 @@ public class PasswordFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("Word");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("12");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("1234");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
 
+    @Override
     protected PasswordFieldElement getTestField() {
         return $(PasswordFieldElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
@@ -38,6 +38,7 @@ public class TextAreaBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -47,8 +48,9 @@ public class TextAreaBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -56,21 +58,14 @@ public class TextAreaBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("Value");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void minLength_triggerBlur_assertValidity() {
-        $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -78,14 +73,17 @@ public class TextAreaBasicValidationIT
         $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -95,25 +93,19 @@ public class TextAreaBasicValidationIT
         $("input").id(MAX_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
-
-    @Test
-    public void pattern_triggerBlur_assertValidity() {
-        $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -121,10 +113,12 @@ public class TextAreaBasicValidationIT
         $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
 
         testField.setValue("Word");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -133,7 +127,8 @@ public class TextAreaBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("Value");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -154,13 +149,15 @@ public class TextAreaBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("Value");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 
         assertServerInvalid();
     }
 
+    @Override
     protected TextAreaElement getTestField() {
         return $(TextAreaElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationIT.java
@@ -41,9 +41,9 @@ public class TextAreaBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -51,10 +51,12 @@ public class TextAreaBinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("Value", Keys.ENTER);
 
         testField.setValue("Value");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
@@ -67,18 +69,21 @@ public class TextAreaBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -90,18 +95,21 @@ public class TextAreaBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -113,22 +121,26 @@ public class TextAreaBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("Word");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("12");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("1234");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
 
+    @Override
     protected TextAreaElement getTestField() {
         return $(TextAreaElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
@@ -39,6 +39,7 @@ public class TextFieldBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -48,8 +49,9 @@ public class TextFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -57,21 +59,14 @@ public class TextFieldBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.setValue("Value");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-    }
-
-    @Test
-    public void minLength_triggerBlur_assertValidity() {
-        $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -79,14 +74,17 @@ public class TextFieldBasicValidationIT
         $("input").id(MIN_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -96,25 +94,19 @@ public class TextFieldBasicValidationIT
         $("input").id(MAX_LENGTH_INPUT).sendKeys("2", Keys.ENTER);
 
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
 
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-    }
-
-    @Test
-    public void pattern_triggerBlur_assertValidity() {
-        $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
-
-        testField.sendKeys(Keys.TAB);
-        assertServerValid();
-        assertClientValid();
     }
 
     @Test
@@ -122,10 +114,12 @@ public class TextFieldBasicValidationIT
         $("input").id(PATTERN_INPUT).sendKeys("^\\d+$", Keys.ENTER);
 
         testField.setValue("Word");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
 
         testField.setValue("1234");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -134,7 +128,8 @@ public class TextFieldBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("Value");
+        testField.setValue("");
 
         detachAndReattachField();
 
@@ -155,13 +150,15 @@ public class TextFieldBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.setValue("Value");
+        testField.setValue("");
 
         executeScript("arguments[0].invalid = false", testField);
 
         assertServerInvalid();
     }
 
+    @Override
     protected TextFieldElement getTestField() {
         return $(TextFieldElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationIT.java
@@ -42,9 +42,9 @@ public class TextFieldBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -52,10 +52,12 @@ public class TextFieldBinderValidationIT
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("Value", Keys.ENTER);
 
         testField.setValue("Value");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.setValue("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
@@ -68,18 +70,21 @@ public class TextFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -91,18 +96,21 @@ public class TextFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("AAA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("AA");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("A");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
@@ -114,22 +122,26 @@ public class TextFieldBinderValidationIT
 
         // Constraint validation fails:
         testField.setValue("Word");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage("");
 
         // Binder validation fails:
         testField.setValue("12");
+        assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Both validations pass:
         testField.setValue("1234");
+        assertValidationCount(1);
         assertClientValid();
         assertServerValid();
     }
 
+    @Override
     protected TextFieldElement getTestField() {
         return $(TextFieldElement.class).first();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -69,8 +69,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -291,15 +289,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
     @Override
     public Validator<String> getDefaultValidator() {
         return (value, context) -> getValidationSupport().checkValidity(value);
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<String> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<String>(this,
-                                !isInvalid())));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -80,8 +80,6 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -314,15 +312,6 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
     @Override
     public Validator<String> getDefaultValidator() {
         return (value, context) -> getValidationSupport().checkValidity(value);
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<String> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<String>(this,
-                                !isInvalid())));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -79,8 +79,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -319,14 +317,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
     @Override
     public Validator<String> getDefaultValidator() {
         return (value, context) -> getValidationSupport().checkValidity(value);
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<String> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<>(this, !isInvalid())));
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -78,8 +78,6 @@ public class TextField extends TextFieldBase<TextField, String>
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -318,15 +316,6 @@ public class TextField extends TextFieldBase<TextField, String>
     @Override
     public Validator<String> getDefaultValidator() {
         return (value, context) -> getValidationSupport().checkValidity(value);
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<String> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<String>(this,
-                                !isInvalid())));
     }
 
     @Override


### PR DESCRIPTION
## Description

The PR removes the subscription to the `validated` event from the remaining text field components.

> **Warning**
> It's a behavior altering change because it removes validation on blur.

Part of #5537 

## Type of change

- [x] Bugfix
