### PR TITLE
fix: do not detach and reattach content on re-render

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/SubDialogPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/SubDialogPage.java
@@ -1,0 +1,52 @@
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.Scroller;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-dialog/sub-dialog")
+public class SubDialogPage extends VerticalLayout {
+
+    public SubDialogPage() {
+        // Create a dialog and a button to open it
+        var dialog = new Dialog();
+        var dialogButton = new Button("Open dialog", e -> {
+            dialog.open();
+        });
+        dialogButton.setId("open-dialog");
+
+        // Create a button to open a sub-dialog
+        var subDialogButton = new Button("Open sub-dialog", e -> {
+            var subDialog = new Dialog();
+            subDialog.add(new Span("Sub-dialog"));
+            subDialog.open();
+        });
+        subDialogButton.setId("open-sub-dialog");
+
+        // Create a scroller with a long text
+        var longText = new Span();
+        longText.setText(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec euismod, "
+                        + "nunc id aliquam ultricies, diam magna mollis nisl, ut aliquet elit "
+                        + "nisl in diam. Nulla facilisi. Donec euismod, nunc id aliquam ultricies, "
+                        + "diam magna mollis nisl, ut aliquet elit nisl in diam. Nulla facilisi. "
+                        + "Donec euismod, nunc id aliquam ultricies, diam magna mollis nisl, ut "
+                        + "aliquet elit nisl in diam. Nulla facilisi. Donec euismod, nunc id aliquam "
+                        + "ultricies, diam magna mollis nisl, ut aliquet elit nisl in diam. Nulla "
+                        + "facilisi. Donec euismod, nunc id aliquam ultricies, diam magna mollis "
+                        + "nisl, ut aliquet elit nisl in diam. Nulla facilisi.");
+
+        var scroller = new Scroller(longText);
+        scroller.setId("scroller");
+        scroller.setHeight("120px");
+        scroller.setWidth("200px");
+
+        dialog.add(subDialogButton, scroller);
+
+        add(dialogButton);
+    }
+
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/SubDialogIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/SubDialogIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dialog.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("vaadin-dialog/sub-dialog")
+public class SubDialogIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void openSubDialog_dialogContentNotChanged() {
+        // Open dialog
+        clickElementWithJs("open-dialog");
+
+        // Scroll the scroller inside the dialog
+        var scroller = ((TestBenchElement) findElement(By.id("scroller")));
+        scroller.scroll(100);
+        Assert.assertEquals("100", scroller.getPropertyString("scrollTop"));
+
+        // Open the sub dialog
+        clickElementWithJs("open-sub-dialog");
+
+        // Expect the scroller scroll position to not have changed
+        Assert.assertEquals("100", scroller.getPropertyString("scrollTop"));
+    }
+
+}

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -4,6 +4,7 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { idlePeriod } from '@polymer/polymer/lib/utils/async.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flowComponentDirective } from './flow-component-directive.js';
+import { render, html as litHtml } from 'lit';
 
 /**
  * Returns the requested node from the Flow client.
@@ -33,8 +34,7 @@ function getNode(appid, nodeid) {
  * @param {Element} root
  */
 function setChildNodes(appid, nodeIds, root) {
-  root.textContent = '';
-  root.append(...nodeIds.map(id => getNodeInternal(appid, id)));
+  render(litHtml`${nodeIds.map(id => getNodeInternal(appid, id))}`, root);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5615

The current implementation of `setChildNodes` in `flow-component-renderer` always clears the root of the content and then adds the desired content back. This causes a detach-reattach for all content nodes on re-render, which can have unexpected side effects such as losing the scroll position. This issue affects Dialog and Notification.

This PR fixes the issue by changing the function to use `lit`, which handles the re-renders more gracefully so that the content nodes don't get unnecessarily detached.

## Type of change

Bugfix