### PR TITLE
fix!: remove validated event subscription

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationPage.java
@@ -19,7 +19,13 @@ public class BasicValidationPage
 
     @Override
     protected CheckboxGroup<String> createTestField() {
-        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
         checkboxGroup.setItems(List.of("foo", "bar", "baz"));
 
         return checkboxGroup;

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/validation/BinderValidationPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/validation/BinderValidationPage.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
 
 import java.util.List;
+import java.util.Set;
 
 @Route("vaadin-checkbox-group/validation/binder")
 public class BinderValidationPage
@@ -14,13 +15,13 @@ public class BinderValidationPage
     public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
 
     public static class Bean {
-        private String property;
+        private Set<String> property;
 
-        public String getProperty() {
+        public Set<String> getProperty() {
             return property;
         }
 
-        public void setProperty(String property) {
+        public void setProperty(Set<String> property) {
             this.property = property;
         }
     }
@@ -33,6 +34,9 @@ public class BinderValidationPage
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
@@ -22,6 +22,7 @@ public class BasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.$(CheckboxElement.class).last().sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -31,8 +32,9 @@ public class BasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.$(CheckboxElement.class).last().sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -40,10 +42,12 @@ public class BasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.deselectByText("foo");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
     }
@@ -52,7 +56,8 @@ public class BasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.$(CheckboxElement.class).last().sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.deselectByText("foo");
 
         detachAndReattachField();
 
@@ -73,7 +78,8 @@ public class BasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.$(CheckboxElement.class).last().sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.deselectByText("foo");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BinderValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BinderValidationIT.java
@@ -23,18 +23,20 @@ public class BinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.$(CheckboxElement.class).last().sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
     public void required_changeValue_assertValidity() {
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.deselectByText("foo");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -48,8 +48,6 @@ import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.binder.HasValidator;
-import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
-import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
@@ -131,8 +129,6 @@ public class CheckboxGroup<T>
                 CheckboxGroup::modelToPresentation);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -805,13 +801,5 @@ public class CheckboxGroup<T>
 
             setInvalid(isInvalid);
         }
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<Set<T>> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<>(this, !isInvalid())));
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationPage.java
@@ -28,7 +28,13 @@ public class ComboBoxBasicValidationPage
 
     @Override
     protected ComboBox<String> createTestField() {
-        ComboBox<String> comboBox = new ComboBox<>();
+        ComboBox<String> comboBox = new ComboBox<>() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
         comboBox.setItems(List.of("foo", "bar", "baz"));
 
         return comboBox;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBinderValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBinderValidationPage.java
@@ -40,6 +40,9 @@ public class ComboBoxBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createButton(ENABLE_CUSTOM_VALUE_BUTTON, "Enable custom values",
                 event -> {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationPage.java
@@ -28,7 +28,13 @@ public class MultiSelectComboBoxBasicValidationPage
 
     @Override
     protected MultiSelectComboBox<String> createTestField() {
-        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
         comboBox.setItems(List.of("foo", "bar", "baz"));
 
         return comboBox;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBinderValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBinderValidationPage.java
@@ -41,6 +41,9 @@ public class MultiSelectComboBoxBinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
 
         add(createButton(ENABLE_CUSTOM_VALUE_BUTTON, "Enable custom values",
                 event -> {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
@@ -22,6 +22,7 @@ public class ComboBoxBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -31,8 +32,9 @@ public class ComboBoxBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -40,29 +42,33 @@ public class ComboBoxBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.clear();
-        assertServerInvalid();
-        assertClientInvalid();
-
-        // Try enter custom value
-        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
     }
 
     @Test
-    public void required_customValuesAllowed_assertValidity() {
+    public void required_enterCustomValue_assertValidity() {
+        $("button").id(REQUIRED_BUTTON).click();
+
+        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void required_customValuesAllowed_enterCustomValue_assertValidity() {
         $("button").id(REQUIRED_BUTTON).click();
         $("button").id(ENABLE_CUSTOM_VALUE_BUTTON).click();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-
         testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
@@ -71,7 +77,8 @@ public class ComboBoxBasicValidationIT
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.clear();
 
         detachAndReattachField();
 
@@ -92,7 +99,8 @@ public class ComboBoxBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.clear();
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBinderValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBinderValidationIT.java
@@ -25,9 +25,9 @@ public class ComboBoxBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -36,47 +36,58 @@ public class ComboBoxBinderValidationIT
 
         // Binder validation fails
         testField.selectByText("bar");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Binder validation passes
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         // Required fails
         testField.clear();
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
-
-        // Try enter custom value, required fails
-        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void required_customValuesAllowed_changeValue_assertValidity() {
+    public void required_enterCustomValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("foo", Keys.ENTER);
+
+        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void required_customValuesAllowed_enterCustomValue_assertValidity() {
         $("button").id(ENABLE_CUSTOM_VALUE_BUTTON).click();
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("custom", Keys.ENTER);
 
         // Binder validation fails
         testField.sendKeys("invalid", Keys.TAB);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Binder validation passes
         testField.clear();
+        assertValidationCount(1);
         testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         // Required fails
         testField.clear();
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
@@ -22,6 +22,7 @@ public class MultiSelectComboBoxBasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -31,8 +32,9 @@ public class MultiSelectComboBoxBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -40,38 +42,48 @@ public class MultiSelectComboBoxBasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.deselectAll();
-        assertServerInvalid();
-        assertClientInvalid();
-
-        // Try enter custom value
-        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
     }
 
     @Test
-    public void required_customValuesAllowed_assertValidity() {
+    public void required_enterCustomValue_assertValidity() {
+        $("button").id(REQUIRED_BUTTON).click();
+
+        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void required_customValuesAllowed_enterCustomValue_assertValidity() {
         $("button").id(REQUIRED_BUTTON).click();
         $("button").id(ENABLE_CUSTOM_VALUE_BUTTON).click();
 
-        testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-
         testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+
+        testField.deselectAll();
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
     }
 
     @Test
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.deselectAll();
 
         detachAndReattachField();
 
@@ -92,7 +104,8 @@ public class MultiSelectComboBoxBasicValidationIT
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.deselectAll();
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBinderValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBinderValidationIT.java
@@ -25,9 +25,9 @@ public class MultiSelectComboBoxBinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -36,49 +36,60 @@ public class MultiSelectComboBoxBinderValidationIT
 
         // Binder validation fails
         testField.selectByText("bar");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Binder validation passes
         testField.deselectAll();
+        assertValidationCount(1);
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         // Required fails
         testField.deselectAll();
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
-
-        // Try enter custom value, required fails
-        testField.deselectAll();
-        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
-    public void required_customValuesAllowed_changeValue_assertValidity() {
+    public void required_enterCustomValue_assertValidity() {
+        $("input").id(EXPECTED_VALUE_INPUT).sendKeys("foo", Keys.ENTER);
+
+        testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
+    }
+
+    @Test
+    public void required_customValuesAllowed_enterCustomValue_assertValidity() {
         $("button").id(ENABLE_CUSTOM_VALUE_BUTTON).click();
         $("input").id(EXPECTED_VALUE_INPUT).sendKeys("custom", Keys.ENTER);
 
         // Binder validation fails
         testField.sendKeys("invalid", Keys.TAB);
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(UNEXPECTED_VALUE_ERROR_MESSAGE);
 
         // Binder validation passes
         testField.deselectAll();
+        assertValidationCount(1);
         testField.sendKeys("custom", Keys.TAB);
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         // Required fails
         testField.deselectAll();
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -180,8 +180,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
                 e -> getDataCommunicator().notifySelectionChanged());
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -1171,14 +1169,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
 
             setInvalid(isInvalid);
         }
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<TValue> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<>(this, !isInvalid())));
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationPage.java
@@ -10,16 +10,27 @@ import java.util.List;
 public class BasicValidationPage
         extends AbstractValidationPage<RadioButtonGroup<String>> {
     public static final String REQUIRED_BUTTON = "required-button";
+    public static final String SET_INVALID_BUTTON = "set-invalid-button";
 
     public BasicValidationPage() {
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequiredIndicatorVisible(true);
         }));
+
+        add(createButton(SET_INVALID_BUTTON, "Set invalid state", event -> {
+            testField.setInvalid(true);
+        }));
     }
 
     @Override
     protected RadioButtonGroup<String> createTestField() {
-        RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup<>();
+        RadioButtonGroup<String> radioButtonGroup = new RadioButtonGroup<>() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
         radioButtonGroup.setItems(List.of("foo", "bar", "baz"));
         radioButtonGroup.setLabel("Radio Button Group");
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/validation/BinderValidationPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/validation/BinderValidationPage.java
@@ -33,6 +33,9 @@ public class BinderValidationPage
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
     }
 
     @Override

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.openqa.selenium.Keys;
 
 import static com.vaadin.flow.component.radiobutton.tests.validation.BasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.radiobutton.tests.validation.BasicValidationPage.SET_INVALID_BUTTON;
 
 @TestPath("vaadin-radio-button-group/validation/basic")
 public class BasicValidationIT
@@ -22,6 +23,7 @@ public class BasicValidationIT
     @Test
     public void triggerBlur_assertValidity() {
         testField.$(RadioButtonElement.class).last().sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -31,8 +33,9 @@ public class BasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.$(RadioButtonElement.class).last().sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -40,6 +43,7 @@ public class BasicValidationIT
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }
@@ -47,8 +51,7 @@ public class BasicValidationIT
     @Test
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
-        $("button").id(REQUIRED_BUTTON).click();
-        testField.$(RadioButtonElement.class).last().sendKeys(Keys.TAB);
+        $("button").id(SET_INVALID_BUTTON).click();
 
         detachAndReattachField();
 
@@ -67,9 +70,8 @@ public class BasicValidationIT
 
     @Test
     public void clientSideInvalidStateIsNotPropagatedToServer() {
-        // Make the field invalid
-        $("button").id(REQUIRED_BUTTON).click();
-        testField.$(RadioButtonElement.class).last().sendKeys(Keys.TAB);
+        // Make field invalid
+        $("button").id(SET_INVALID_BUTTON).click();
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BinderValidationIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BinderValidationIT.java
@@ -23,14 +23,15 @@ public class BinderValidationIT
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.$(RadioButtonElement.class).last().sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
     public void required_changeValue_assertValidity() {
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
     }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -135,8 +135,6 @@ public class RadioButtonGroup<T>
                 RadioButtonGroup::modelToPresentation);
 
         addValueChangeListener(e -> validate());
-
-        addClientValidatedEventListener(e -> validate());
     }
 
     /**
@@ -733,13 +731,5 @@ public class RadioButtonGroup<T>
 
             setInvalid(isInvalid);
         }
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<T> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<>(this, !isInvalid())));
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/validation/BasicValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/validation/BasicValidationPage.java
@@ -19,7 +19,13 @@ public class BasicValidationPage
 
     @Override
     protected Select<String> createTestField() {
-        Select<String> select = new Select<>();
+        Select<String> select = new Select<>() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
         select.setItems(List.of("foo", "bar", "baz"));
         select.setEmptySelectionAllowed(true);
 

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/validation/BinderValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/validation/BinderValidationPage.java
@@ -33,6 +33,9 @@ public class BinderValidationPage
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)
                 .bind("property");
+        binder.addStatusChangeListener(event -> {
+            incrementServerValidationCounter();
+        });
     }
 
     @Override

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
@@ -20,6 +20,7 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     @Test
     public void triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
+        assertValidationCount(0);
         assertServerValid();
         assertClientValid();
     }
@@ -29,8 +30,9 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
@@ -38,10 +40,12 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
         $("button").id(REQUIRED_BUTTON).click();
 
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.selectByText("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
     }
@@ -50,7 +54,8 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     public void detach_attach_preservesInvalidState() {
         // Make field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.selectByText("");
 
         detachAndReattachField();
 
@@ -71,7 +76,8 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();
-        testField.sendKeys(Keys.TAB);
+        testField.selectByText("foo");
+        testField.selectByText("");
 
         executeScript("arguments[0].invalid = false", testField);
 

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BinderValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BinderValidationIT.java
@@ -21,18 +21,20 @@ public class BinderValidationIT extends AbstractValidationIT<SelectElement> {
     @Test
     public void required_triggerBlur_assertValidity() {
         testField.sendKeys(Keys.TAB);
-        assertServerInvalid();
-        assertClientInvalid();
-        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+        assertValidationCount(0);
+        assertServerValid();
+        assertClientValid();
     }
 
     @Test
     public void required_changeValue_assertValidity() {
         testField.selectByText("foo");
+        assertValidationCount(1);
         assertServerValid();
         assertClientValid();
 
         testField.selectByText("");
+        assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -149,8 +149,6 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
 
         addValueChangeListener(e -> validate());
 
-        addClientValidatedEventListener(e -> validate());
-
         getElement().addPropertyChangeListener("opened", event -> fireEvent(
                 new OpenedChangeEvent(this, event.isUserOriginated())));
 
@@ -1048,14 +1046,6 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
 
             setInvalid(isInvalid);
         }
-    }
-
-    @Override
-    public Registration addValidationStatusChangeListener(
-            ValidationStatusChangeListener<T> listener) {
-        return addClientValidatedEventListener(
-                event -> listener.validationStatusChanged(
-                        new ValidationStatusChangeEvent<>(this, !isInvalid())));
     }
 
     /**


### PR DESCRIPTION
## Description

The PR removes the subscription to the `validated` event from the remaining components.

> **Warning**
> It's a behavior altering change because it removes validation on blur when the value hasn't changed.

Part of #5537 

## Type of change

- [x] Bugfix
