### PR TITLE
fix: set focus-target attribute on the select all checkbox (14.10)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -45,6 +45,9 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         Assert.assertNull(
                 "in-memory grid selectAllCheckbox should be visible by default",
                 selectAllCheckbox.getAttribute("hidden"));
+        Assert.assertNotNull(
+                "selectAllCheckbox should have focus-target attribute",
+                selectAllCheckbox.getAttribute("focus-target"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
@@ -15,8 +15,9 @@
         hidden$="[[selectAllHidden]]"
         on-click="_onSelectAllClick"
         checked="[[selectAll]]"
-        indeterminate="[[indeterminate]]">
-      </vaadin-checkbox>
+        indeterminate="[[indeterminate]]"
+        focus-target
+      ></vaadin-checkbox>
     </template>
     <template id="defaultBodyTemplate">
       <vaadin-checkbox

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -12,8 +12,15 @@ import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js
           font-size: var(--lumo-font-size-m);
         }
       </style>
-      <vaadin-checkbox id="selectAllCheckbox" aria-label="Select All" hidden\$="[[selectAllHidden]]" on-click="_onSelectAllClick" checked="[[selectAll]]" indeterminate="[[indeterminate]]">
-      </vaadin-checkbox>
+      <vaadin-checkbox
+        id="selectAllCheckbox"
+        aria-label="Select All"
+        hidden$="[[selectAllHidden]]"
+        on-click="_onSelectAllClick"
+        checked="[[selectAll]]"
+        indeterminate="[[indeterminate]]"
+        focus-target
+      ></vaadin-checkbox>
     </template>
     <template id="defaultBodyTemplate">
       <vaadin-checkbox aria-label="Select Row" checked="[[selected]]" on-click="_onSelectClick">


### PR DESCRIPTION
## Description

Same as #5672 but for `14.10` branch.

## Type of change

- Bugfix