### PR TITLE
fix: make Tooltip.forComponent return existing tooltip handle

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -117,7 +117,12 @@ public class Tooltip implements Serializable {
      * @return the tooltip handle
      */
     public static Tooltip forComponent(Component component) {
-        return forElement(component.getElement());
+        var tooltip = getForElement(component.getElement());
+        if (tooltip == null) {
+            tooltip = forElement(component.getElement());
+            ComponentUtil.setData(component, TOOLTIP_DATA_KEY, tooltip);
+        }
+        return tooltip;
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -110,7 +110,7 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * Creates a tooltip to the given {@code Component}.
+     * Creates a tooltip to the given {@code Component} if one hasn't already been created.
      *
      * @param component
      *            the component to attach the tooltip to

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -143,6 +143,13 @@ public class TooltipTest {
     }
 
     @Test
+    public void tooltipForCompopnentTwice_sameReference() {
+        var tooltip = Tooltip.forComponent(component);
+        var tooltip2 = Tooltip.forComponent(component);
+        Assert.assertSame(tooltip, tooltip2);
+    }
+
+    @Test
     public void createTooltip_fluentAPI() {
         ui.add(component);
 


### PR DESCRIPTION
## Description

This change will make `Tooltip.forComponent(component)` return an existing Tooltip handle in case one was already created before.

Fixes https://github.com/vaadin/flow-components/issues/4736

## Type of change

Bugfix