### PR TITLE
fix: remove grid dnd polyfill

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
@@ -145,11 +145,12 @@ public class DragAndDropGridPage extends Div {
         multiSelectButton.setId("multiselect");
         add(multiSelectButton);
 
-        NativeButton removeOnItemClick = new NativeButton("remove on item click", e -> {
-                grid.addItemClickListener(event -> {
+        NativeButton removeOnItemClick = new NativeButton(
+                "remove on item click", e -> {
+                    grid.addItemClickListener(event -> {
                         grid.removeFromParent();
+                    });
                 });
-        });
         removeOnItemClick.setId("remove-on-item-click");
         add(removeOnItemClick);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
@@ -144,6 +144,14 @@ public class DragAndDropGridPage extends Div {
         });
         multiSelectButton.setId("multiselect");
         add(multiSelectButton);
+
+        NativeButton removeOnItemClick = new NativeButton("remove on item click", e -> {
+                grid.addItemClickListener(event -> {
+                        grid.removeFromParent();
+                });
+        });
+        removeOnItemClick.setId("remove-on-item-click");
+        add(removeOnItemClick);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
@@ -209,6 +209,13 @@ public class DragAndDropGridIT extends AbstractComponentIT {
         assertMessages("", "", "");
     }
 
+    @Test
+    public void removeOnItemClick_noError() {
+        click("remove-on-item-click");
+        grid.getCell("0").click();
+        checkLogsForErrors();
+    }
+
     private void assertMessages(String expectedStartMessage,
             String expectedEndMessage, String expectedDropMessage) {
         Assert.assertEquals(expectedStartMessage,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -52,8 +52,6 @@ import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.dnd.DragSource;
-import com.vaadin.flow.component.dnd.DropTarget;
 import com.vaadin.flow.component.grid.GridArrayUpdater.UpdateQueueData;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.grid.dataview.GridDataView;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4234,11 +4234,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see GridDropEvent#getDropLocation()
      */
     public void setDropMode(GridDropMode dropMode) {
-        // We need to add DnD mobile polyfill here by invoking
-        // DndUtil.addMobileDndPolyfillIfNeeded. But, since DndUtil is in a Flow
-        // internal package, DropTarget.create is called to invoke
-        // addMobileDndPolyfillIfNeeded indirectly.
-        DropTarget.create(this).setActive(false);
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
     }
@@ -4264,11 +4259,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            {@code false} if not
      */
     public void setRowsDraggable(boolean rowsDraggable) {
-        // We need to add DnD mobile polyfill here by invoking
-        // DndUtil.addMobileDndPolyfillIfNeeded. But, since DndUtil is in a Flow
-        // internal package, DragSource.create is called to invoke
-        // addMobileDndPolyfillIfNeeded indirectly.
-        DragSource.create(this).setDraggable(false);
         getElement().setProperty("rowsDraggable", rowsDraggable);
     }
 


### PR DESCRIPTION
## Description

Remove DnD mobile polyfill from Grid. The polyfill was initially added to support DnD on mobile Safari which was lacking the feature back then. Safari has had native DnD support since iOS 15 so the polyfill is no longer required.

Additionally, including the polyfill seems to be causing an [error in certain cases](https://github.com/vaadin/flow-components/issues/1434#issuecomment-1790897160), so this is labeled as a bugfix.

## Type of change

Bugfix