### PR TITLE
fix: use flowComponentDirective in setChildNodes

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogContentView.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogContentView.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dialog.tests;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Page created for testing purposes. Not suitable for demos.
+ *
+ * @author Vaadin Ltd
+ */
+@Route("vaadin-dialog/content")
+public class DialogContentView extends HorizontalLayout {
+
+    private Dialog dialog = new Dialog();
+
+    public DialogContentView() {
+        var closeButton = new Button("Close dialog", e -> {
+            dialog.close();
+        });
+        closeButton.setId("close-button");
+
+        var addContentButton = new Button("Add content", e -> {
+            dialog.add(closeButton);
+        });
+        addContentButton.setId("add-content-button");
+
+        var openButton = new Button("Open dialog", e -> {
+            dialog.open();
+        });
+        openButton.setId("open-button");
+
+        // It's crucial that the dialog itself is added to the UI for this test
+        add(dialog, addContentButton, openButton);
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogContentIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogContentIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dialog.tests;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-dialog/content")
+public class DialogContentIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void addContentAndOpenTwice_contentPresent() {
+        // Add dialog content (the close button) and open the dialog
+        clickElementWithJs("add-content-button");
+        clickElementWithJs("open-button");
+        waitForElementPresent(
+                By.cssSelector("vaadin-dialog-overlay #close-button"));
+
+        // Close the dialog
+        clickElementWithJs("open-button");
+
+        // Add the same content again and open the dialog
+        clickElementWithJs("add-content-button");
+        clickElementWithJs("open-button");
+        // Expect the content to be present inside the dialog overlay
+        waitForElementPresent(
+                By.cssSelector("vaadin-dialog-overlay #close-button"));
+    }
+}

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -7,16 +7,6 @@ import { flowComponentDirective } from './flow-component-directive.js';
 import { render, html as litHtml } from 'lit';
 
 /**
- * Returns the requested node from the Flow client.
- * @param {string} appid
- * @param {number} nodeid
- * @returns {Element | null} The element if found, null otherwise.
- */
-function getNodeInternal(appid, nodeid) {
-  return window.Vaadin.Flow.clients[appid].getByNodeId(nodeid);
-}
-
-/**
  * Returns the requested node in a form suitable for Lit template interpolation.
  * @param {string} appid
  * @param {number} nodeid
@@ -34,7 +24,7 @@ function getNode(appid, nodeid) {
  * @param {Element} root
  */
 function setChildNodes(appid, nodeIds, root) {
-  render(litHtml`${nodeIds.map(id => getNodeInternal(appid, id))}`, root);
+  render(litHtml`${nodeIds.map(id => flowComponentDirective(appid, id))}`, root);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5719

Make `setChildNodes` in `flow-component-renderer.js` use the `flowComponentDirective`.

The current implementation relies on Lit defaults which assume a previously rendered node to still be inside the render container even in the case where it has been manually "hijacked" to another container by some external logic (in this case FlowClient, after calling `dialog.add(content)` again for the same content).

The `flowComponentDirective` is intended specifically for rendering Flow components obtained by node id and has [logic](https://github.com/vaadin/flow-components/blob/13b89ea0674f02872ceb93862fe8bca794d8fa3f/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js#L45) that checks if the desired node is physically attached to the render container or not. If the node has been moved to another container, `flowComponentDirective` would move it back.

## Type of change

Bugfix