### PR TITLE
feature: add SubMenu.addSeparator(). Fixes #1461

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.contextmenu;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.function.SerializableRunnable;
 
 /**
@@ -55,5 +56,12 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
         return new MenuManager<>(getParentMenuItem().getContextMenu(),
                 contentReset, MenuItem::new, MenuItem.class,
                 getParentMenuItem());
+    }
+
+    /**
+     * Adds a separator between items.
+     */
+    public void addSeparator() {
+        add(new Hr());
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.html.Hr;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +71,16 @@ public class SubMenuTest {
     public void addItem_getChildren_returnsMenuItem() {
         MenuItem foo = subMenu.addItem("foo");
         verifyChildren(subMenu, foo);
+    }
+
+    @Test
+    public void addSeparatorAddsHr() {
+        MenuItem foo = subMenu.addItem("foo");
+        subMenu.addSeparator();
+        Hr separator = (Hr) subMenu.getChildren().skip(1).findFirst()
+                .orElse(null);
+        MenuItem bar = subMenu.addItem("foo");
+        verifyChildren(subMenu, foo, separator, bar);
     }
 
     @Test


### PR DESCRIPTION
## Description

Add SubMenu.addSeparator(). This adds convenience API, both for new users and for Vaadin 8 users migrating to Vaadin 24.

Fixes #1461

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
