### PR TITLE
fix: remove previous component on slot in add to primary/secondary

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -165,14 +165,8 @@ public class SplitLayout extends Component
      * @see #setOrientation(Orientation)
      */
     public void addToPrimary(Component... components) {
-        if (components.length == 1) {
-            primaryComponent = components[0];
-        } else {
-            Div container = new Div();
-            container.add(components);
-            primaryComponent = container;
-        }
-        setComponents();
+        primaryComponent = getComponentOrWrap(components);
+        setComponent(primaryComponent, "primary");
     }
 
     /**
@@ -195,14 +189,8 @@ public class SplitLayout extends Component
      * @see #setOrientation(Orientation)
      */
     public void addToSecondary(Component... components) {
-        if (components.length == 1) {
-            secondaryComponent = components[0];
-        } else {
-            Div container = new Div();
-            container.add(components);
-            secondaryComponent = container;
-        }
-        setComponents();
+        secondaryComponent = getComponentOrWrap(components);
+        setComponent(secondaryComponent, "secondary");
     }
 
     /**
@@ -294,15 +282,27 @@ public class SplitLayout extends Component
         setInnerComponentStyle(styleName, value, false);
     }
 
-    private void setComponent(Component component, String slot) {
-        Component child = component == null ? new Div() : component;
-        SlotUtils.addToSlot(this, slot, child);
+    /**
+     * Returns the component if the given components array contains only one
+     * or a wrapper div with the given components if the array contains more.
+     *
+     * @param components the components to wrap
+     * @return the component or a wrapper div
+     */
+    private Component getComponentOrWrap(Component... components) {
+        if (components.length == 1) {
+            return components[0];
+        } else {
+            Div container = new Div();
+            container.add(components);
+            return container;
+        }
     }
 
-    private void setComponents() {
-        removeAll();
-        setComponent(primaryComponent, "primary");
-        setComponent(secondaryComponent, "secondary");
+    private void setComponent(Component component, String slot) {
+        Component child = component == null ? new Div() : component;
+        SlotUtils.clearSlot(this, slot);
+        SlotUtils.addToSlot(this, slot, child);
     }
 
     /**
@@ -323,15 +323,6 @@ public class SplitLayout extends Component
                         + component + ") is not a child of this component");
             }
         }
-    }
-
-    /**
-     * Removes the primary and the secondary components.
-     */
-    public void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
-        getElement().removeAllChildren();
     }
 
     @DomEvent("splitter-dragend")

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -283,10 +283,11 @@ public class SplitLayout extends Component
     }
 
     /**
-     * Returns the component if the given components array contains only one
-     * or a wrapper div with the given components if the array contains more.
+     * Returns the component if the given components array contains only one or
+     * a wrapper div with the given components if the array contains more.
      *
-     * @param components the components to wrap
+     * @param components
+     *            the components to wrap
      * @return the component or a wrapper div
      */
     private Component getComponentOrWrap(Component... components) {
@@ -323,6 +324,15 @@ public class SplitLayout extends Component
                         + component + ") is not a child of this component");
             }
         }
+    }
+
+    /**
+     * Removes the primary and the secondary components.
+     */
+    public void removeAll() {
+        getElement().getChildren()
+                .forEach(child -> child.removeAttribute("slot"));
+        getElement().removeAllChildren();
     }
 
     @DomEvent("splitter-dragend")

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -291,19 +291,12 @@ public class SplitLayout extends Component
      * @return the component or a wrapper div
      */
     private Component getComponentOrWrap(Component... components) {
-        if (components.length == 1) {
-            return components[0];
-        } else {
-            Div container = new Div();
-            container.add(components);
-            return container;
-        }
+        return components.length == 1 ? components[0] : new Div(components);
     }
 
     private void setComponent(Component component, String slot) {
         Component child = component == null ? new Div() : component;
-        SlotUtils.clearSlot(this, slot);
-        SlotUtils.addToSlot(this, slot, child);
+        SlotUtils.setSlot(this, slot, child);
     }
 
     /**

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -57,7 +57,8 @@ public class SplitLayoutUnitTest {
 
         var primaryComponent = new Div();
         var detachCounter = new AtomicInteger();
-        primaryComponent.addDetachListener(event -> detachCounter.incrementAndGet());
+        primaryComponent
+                .addDetachListener(event -> detachCounter.incrementAndGet());
 
         splitLayout.addToPrimary(primaryComponent);
         splitLayout.addToSecondary(new Div());
@@ -72,7 +73,8 @@ public class SplitLayoutUnitTest {
 
         var secondaryComponent = new Div();
         var detachCounter = new AtomicInteger();
-        secondaryComponent.addDetachListener(event -> detachCounter.incrementAndGet());
+        secondaryComponent
+                .addDetachListener(event -> detachCounter.incrementAndGet());
 
         splitLayout.addToSecondary(secondaryComponent);
         splitLayout.addToPrimary(new Div());

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.splitlayout.tests;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import org.junit.Assert;
 import org.junit.Test;
@@ -9,6 +10,8 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout.SplitterDragendEvent;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SplitLayoutUnitTest {
 
@@ -44,6 +47,36 @@ public class SplitLayoutUnitTest {
                 secondaryComponent.getElement().getTag());
         Assert.assertEquals("Wrong number of children", 2,
                 secondaryComponent.getChildren().count());
+    }
+
+    @Test
+    public void splitLayoutWithPrimaryComponent_secondComponentAdded_primaryIsNotDetached() {
+        var ui = new UI();
+        var splitLayout = new SplitLayout();
+        ui.add(splitLayout);
+
+        var primaryComponent = new Div();
+        var detachCounter = new AtomicInteger();
+        primaryComponent.addDetachListener(event -> detachCounter.incrementAndGet());
+
+        splitLayout.addToPrimary(primaryComponent);
+        splitLayout.addToSecondary(new Div());
+        Assert.assertEquals(0, detachCounter.get());
+    }
+
+    @Test
+    public void splitLayoutWithSecondaryComponent_primaryComponentAdded_secondaryIsNotDetached() {
+        var ui = new UI();
+        var splitLayout = new SplitLayout();
+        ui.add(splitLayout);
+
+        var secondaryComponent = new Div();
+        var detachCounter = new AtomicInteger();
+        secondaryComponent.addDetachListener(event -> detachCounter.incrementAndGet());
+
+        splitLayout.addToSecondary(secondaryComponent);
+        splitLayout.addToPrimary(new Div());
+        Assert.assertEquals(0, detachCounter.get());
     }
 
     @Test


### PR DESCRIPTION
## Description

Change the SplitLayout behavior to remove only the previous component in the same slot when a new component is added to the primary or secondary slots.

SplitLayout currently removes all children first before adding the components to their slots. This might be unexpected when adding a component to the secondary slot leads to detaching the primary component.

Fixes #3586

## Type of change

- [x] Bugfix
- [ ] Feature
