### PR TITLE
fix: use last parsed date and value to correct century of short year

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatPage.java
@@ -49,6 +49,8 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
     public static final String SERVER_SIDE_VALUE_CHANGE_BUTTON = "SERVER_SIDE_VALUE_CHANGE_BUTTON";
     public static final String CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_DATE_PICKER = "CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_DATE_PICKER";
     public static final String CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_OUTPUT = "CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_OUTPUT";
+    public static final String RENAME_DATE_PICKER = "RENAME_DATE_PICKER";
+    public static final String RENAME_OUTPUT = "RENAME_OUTPUT";
 
     public static final LocalDate may13 = LocalDate.of(2018, Month.MAY, 13);
 
@@ -61,6 +63,7 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
         setupSetFormatAfterLocale();
         setupServerSideValueChange();
         setupCustomReferenceDateAndFormatOptions();
+        setupRename();
     }
 
     public void setupPrimaryFormat() {
@@ -203,6 +206,30 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
         add(datePicker,
                 new Div(setShortFormat, setLongFormat, setMultipleFormats),
                 output);
+    }
+
+    private void setupRename() {
+        LocalDate today = LocalDate.now();
+
+        DatePicker datePicker = new DatePicker(today);
+        datePicker.setId(RENAME_DATE_PICKER);
+        DatePickerI18n i18n = new DatePickerI18n();
+        i18n.setReferenceDate(today.minusYears(100));
+        i18n.setDateFormat("yy-MM-dd");
+        datePicker.setI18n(i18n);
+
+        Span output = new Span();
+        datePicker.addOpenedChangeListener(event -> {
+            LocalDate newValue = datePicker.getValue();
+            if (newValue != null) {
+                output.setText(newValue.format(DateTimeFormatter.ISO_DATE));
+            } else {
+                output.setText("");
+            }
+        });
+        output.setId(RENAME_OUTPUT);
+
+        add(datePicker, output);
     }
 
     private static Span createOutputSpan(DatePicker datePicker) {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatPage.java
@@ -49,8 +49,8 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
     public static final String SERVER_SIDE_VALUE_CHANGE_BUTTON = "SERVER_SIDE_VALUE_CHANGE_BUTTON";
     public static final String CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_DATE_PICKER = "CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_DATE_PICKER";
     public static final String CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_OUTPUT = "CUSTOM_REFERENCE_DATE_AND_FORMAT_OPTIONS_OUTPUT";
-    public static final String RENAME_DATE_PICKER = "RENAME_DATE_PICKER";
-    public static final String RENAME_OUTPUT = "RENAME_OUTPUT";
+    public static final String OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_DATE_PICKER = "OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_DATE_PICKER";
+    public static final String OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT = "OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT";
 
     public static final LocalDate may13 = LocalDate.of(2018, Month.MAY, 13);
 
@@ -63,7 +63,7 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
         setupSetFormatAfterLocale();
         setupServerSideValueChange();
         setupCustomReferenceDateAndFormatOptions();
-        setupRename();
+        setupOldReferenceDateWithShortFormat();
     }
 
     public void setupPrimaryFormat() {
@@ -208,11 +208,11 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
                 output);
     }
 
-    private void setupRename() {
+    private void setupOldReferenceDateWithShortFormat() {
         LocalDate today = LocalDate.now();
 
         DatePicker datePicker = new DatePicker(today);
-        datePicker.setId(RENAME_DATE_PICKER);
+        datePicker.setId(OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_DATE_PICKER);
         DatePickerI18n i18n = new DatePickerI18n();
         i18n.setReferenceDate(today.minusYears(100));
         i18n.setDateFormat("yy-MM-dd");
@@ -227,7 +227,7 @@ public class DatePickerCustomFormatPage extends VerticalLayout {
                 output.setText("");
             }
         });
-        output.setId(RENAME_OUTPUT);
+        output.setId(OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);
 
         add(datePicker, output);
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -142,11 +142,11 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
 
         $("button").id("set-long-format").click();
 
-        submitValue(id, "31-02-27");
-        Assert.assertEquals("1931-02-27", output.getText());
-
         submitValue(id, "2031-02-27");
         Assert.assertEquals("2031-02-27", output.getText());
+
+        submitValue(id, "31-02-27");
+        Assert.assertEquals("1931-02-27", output.getText());
 
         submitValue(id, "29-02-27");
         Assert.assertEquals("2029-02-27", output.getText());
@@ -163,11 +163,11 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
 
         $("button").id("set-multiple-formats").click();
 
-        submitValue(id, "31-02-27");
-        Assert.assertEquals("1931-02-27", output.getText());
-
         submitValue(id, "2031-02-27");
         Assert.assertEquals("2031-02-27", output.getText());
+
+        submitValue(id, "31-02-27");
+        Assert.assertEquals("1931-02-27", output.getText());
 
         submitValue(id, "29-02-27");
         Assert.assertEquals("2029-02-27", output.getText());

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 
 @TestPath("vaadin-date-picker/date-picker-custom-format")
@@ -270,6 +272,23 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
         submitValue(id, "foobar");
 
         Assert.assertEquals("", output.getText());
+    }
+
+    @Test
+    public void renameTest() {
+        String id = DatePickerCustomFormatPage.RENAME_DATE_PICKER;
+        TestBenchElement output = $("span").id(
+                DatePickerCustomFormatPage.RENAME_OUTPUT);
+
+        String todayString = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        Assert.assertEquals(todayString, output.getText());
+
+        $(DatePickerElement.class).id(id).click();
+        waitForElementPresent(By.tagName("vaadin-date-picker-overlay"));
+        $(DatePickerElement.class).id(id).sendKeys(Keys.ESCAPE);
+        waitForElementNotPresent(By.tagName("vaadin-date-picker-overlay"));
+
+        Assert.assertEquals(todayString, output.getText());
     }
 
     private void submitValue(String id, String value) {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -142,11 +142,11 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
 
         $("button").id("set-long-format").click();
 
-        submitValue(id, "2031-02-27");
-        Assert.assertEquals("2031-02-27", output.getText());
-
         submitValue(id, "31-02-27");
         Assert.assertEquals("1931-02-27", output.getText());
+
+        submitValue(id, "2031-02-27");
+        Assert.assertEquals("2031-02-27", output.getText());
 
         submitValue(id, "29-02-27");
         Assert.assertEquals("2029-02-27", output.getText());
@@ -163,11 +163,11 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
 
         $("button").id("set-multiple-formats").click();
 
-        submitValue(id, "2031-02-27");
-        Assert.assertEquals("2031-02-27", output.getText());
-
         submitValue(id, "31-02-27");
         Assert.assertEquals("1931-02-27", output.getText());
+
+        submitValue(id, "2031-02-27");
+        Assert.assertEquals("2031-02-27", output.getText());
 
         submitValue(id, "29-02-27");
         Assert.assertEquals("2029-02-27", output.getText());

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -277,8 +277,8 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
     @Test
     public void pickerWithOldReferenceDateAndShortFormat_yearIsRetainedOnOverlayOpenClose() {
         String id = DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_DATE_PICKER;
-        TestBenchElement output = $("span")
-                .id(DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);
+        TestBenchElement output = $("span").id(
+                DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);
 
         String todayString = LocalDate.now()
                 .format(DateTimeFormatter.ISO_LOCAL_DATE);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -277,10 +277,11 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
     @Test
     public void renameTest() {
         String id = DatePickerCustomFormatPage.RENAME_DATE_PICKER;
-        TestBenchElement output = $("span").id(
-                DatePickerCustomFormatPage.RENAME_OUTPUT);
+        TestBenchElement output = $("span")
+                .id(DatePickerCustomFormatPage.RENAME_OUTPUT);
 
-        String todayString = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        String todayString = LocalDate.now()
+                .format(DateTimeFormatter.ISO_LOCAL_DATE);
         Assert.assertEquals(todayString, output.getText());
 
         $(DatePickerElement.class).id(id).click();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -275,7 +275,7 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
     }
 
     @Test
-    public void pickerWithOldReferenceDateAndShortFormat_yearIsRetainedOnOverlayOpenClose() {
+    public void pickerWithOldReferenceDateAndShortFormat_openAndCloseOverlay_yearIsRetained() {
         String id = DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_DATE_PICKER;
         TestBenchElement output = $("span").id(
                 DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -275,10 +275,10 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
     }
 
     @Test
-    public void renameTest() {
-        String id = DatePickerCustomFormatPage.RENAME_DATE_PICKER;
+    public void pickerWithOldReferenceDateAndShortFormat_yearIsRetainedOnOverlayOpenClose() {
+        String id = DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_DATE_PICKER;
         TestBenchElement output = $("span")
-                .id(DatePickerCustomFormatPage.RENAME_OUTPUT);
+                .id(DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);
 
         String todayString = LocalDate.now()
                 .format(DateTimeFormatter.ISO_LOCAL_DATE);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -79,8 +79,11 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             // The current year check handles the case where a four-digit year is parsed, then formatted
             // as a two-digit year, and then parsed again. In this case we want to keep the century of the
             // originally parsed year, instead of using the century of the reference date.
+            if (!datepicker.value) {
+              return;
+            }
             const currentDate = _parseDate(datepicker.value);
-            if (
+            if (dateFnsIsValid(currentDate) &&
               currentDate.getDate() === date.getDate() &&
               currentDate.getMonth() === date.getMonth() &&
               currentDate.getFullYear() % 100 === date.getFullYear() % 100

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -76,19 +76,16 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           }
 
           function correctFullYear(date) {
-            // The current year check handles the case where a four-digit year is parsed, then formatted
+            // The last parsed date check handles the case where a four-digit year is parsed, then formatted
             // as a two-digit year, and then parsed again. In this case we want to keep the century of the
             // originally parsed year, instead of using the century of the reference date.
-            if (!datepicker.value) {
-              return;
-            }
-            const currentDate = _parseDate(datepicker.value);
-            if (dateFnsIsValid(currentDate) &&
-              currentDate.getDate() === date.getDate() &&
-              currentDate.getMonth() === date.getMonth() &&
-              currentDate.getFullYear() % 100 === date.getFullYear() % 100
+            const dateWithCorrectYear = datepicker.$connector._lastParsedDate || _parseDate(datepicker.value);
+            if (dateFnsIsValid(dateWithCorrectYear) &&
+              dateWithCorrectYear.getDate() === date.getDate() &&
+              dateWithCorrectYear.getMonth() === date.getMonth() &&
+              dateWithCorrectYear.getFullYear() % 100 === date.getFullYear() % 100
             ) {
-              date.setFullYear(currentDate.getFullYear());
+              date.setFullYear(dateWithCorrectYear.getFullYear());
             }
           }
 
@@ -109,6 +106,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
                 const shortYearFormatDate = dateFnsParse(dateString, shortYearFormat, referenceDate);
                 if (dateFnsIsValid(shortYearFormatDate)) {
                   correctFullYear(shortYearFormatDate);
+                  datepicker.$connector._lastParsedDate = shortYearFormatDate;
                   return {
                     day: shortYearFormatDate.getDate(),
                     month: shortYearFormatDate.getMonth(),
@@ -121,6 +119,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
                 if (isShortFormat) {
                   correctFullYear(date);
                 }
+                datepicker.$connector._lastParsedDate = date;
                 return {
                   day: date.getDate(),
                   month: date.getMonth(),
@@ -128,6 +127,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
                 };
               }
             }
+            datepicker.$connector._lastParsedDate = null;
             return false;
           }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -85,7 +85,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
               currentDate.getMonth() === date.getMonth() &&
               currentDate.getFullYear() % 100 === date.getFullYear() % 100
             ) {
-              date.setFullYear(currentDate.getFullYear);
+              date.setFullYear(currentDate.getFullYear());
             }
           }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -75,17 +75,25 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             return false;
           }
 
+          function matchDates(lastParsedDate, date) {
+            return dateFnsIsValid(lastParsedDate) &&
+              lastParsedDate.getDate() === date.getDate() &&
+              lastParsedDate.getMonth() === date.getMonth() &&
+              lastParsedDate.getFullYear() % 100 === date.getFullYear() % 100;
+          }
+
           function correctFullYear(date) {
             // The last parsed date check handles the case where a four-digit year is parsed, then formatted
             // as a two-digit year, and then parsed again. In this case we want to keep the century of the
             // originally parsed year, instead of using the century of the reference date.
-            const dateWithCorrectYear = datepicker.$connector._lastParsedDate || _parseDate(datepicker.value);
-            if (dateFnsIsValid(dateWithCorrectYear) &&
-              dateWithCorrectYear.getDate() === date.getDate() &&
-              dateWithCorrectYear.getMonth() === date.getMonth() &&
-              dateWithCorrectYear.getFullYear() % 100 === date.getFullYear() % 100
-            ) {
-              date.setFullYear(dateWithCorrectYear.getFullYear());
+            const lastParsedDate = datepicker.$connector._lastParsedDate;
+            if (matchDates(lastParsedDate, date)) {
+              date.setFullYear(lastParsedDate.getFullYear());
+              return;
+            }
+            const currentValue = _parseDate(datepicker.value);
+            if (matchDates(currentValue, date)) {
+              date.setFullYear(currentValue.getFullYear());
             }
           }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -76,14 +76,16 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           }
 
           function correctFullYear(date) {
-            // The last parsed year check handles the case where a four-digit year is parsed, then formatted
+            // The current year check handles the case where a four-digit year is parsed, then formatted
             // as a two-digit year, and then parsed again. In this case we want to keep the century of the
             // originally parsed year, instead of using the century of the reference date.
-            let yearValue = date.getFullYear();
+            const currentDate = _parseDate(datepicker.value);
             if (
-              datepicker._selectedDate && datepicker._selectedDate.getFullYear() &&
-              yearValue % 100 === datepicker._selectedDate.getFullYear() % 100) {
-              date.setFullYear(datepicker._selectedDate.getFullYear());
+              currentDate.getDate() === date.getDate() &&
+              currentDate.getMonth() === date.getMonth() &&
+              currentDate.getFullYear() % 100 === date.getFullYear() % 100
+            ) {
+              date.setFullYear(currentDate.getFullYear);
             }
           }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -65,6 +65,28 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             return undefined;
           }
 
+          function isShortYearFormat(format) {
+            if (format.includes('y')) {
+              return !format.includes('yyy');
+            }
+            if (format.includes('Y')) {
+              return !format.includes('YYY');
+            }
+            return false;
+          }
+
+          function correctFullYear(date) {
+            // The last parsed year check handles the case where a four-digit year is parsed, then formatted
+            // as a two-digit year, and then parsed again. In this case we want to keep the century of the
+            // originally parsed year, instead of using the century of the reference date.
+            let yearValue = date.getFullYear();
+            if (
+              datepicker._selectedDate && datepicker._selectedDate.getFullYear() &&
+              yearValue % 100 === datepicker._selectedDate.getFullYear() % 100) {
+              date.setFullYear(datepicker._selectedDate.getFullYear());
+            }
+          }
+
           function formatDate(dateParts) {
             const format = formats[0];
             const date = _parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
@@ -72,32 +94,33 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             return dateFnsFormat(date, format);
           }
 
-          function doParseDate(dateString, format, referenceDate) {
-            const date = dateFnsParse(dateString, format, referenceDate);
-            if (!dateFnsIsValid(date)) {
-              return null;
-            }
-            return {
-              day: date.getDate(),
-              month: date.getMonth(),
-              year: date.getFullYear()
-            };
-          }
-
           function parseDate(dateString) {
             const referenceDate = _getReferenceDate();
             for (let format of formats) {
+              const isShortFormat = isShortYearFormat(format);
               // We first try to match the date with the shorter version.
-              const shortYearFormat = getShortYearFormat(format);
-              if (shortYearFormat) {
-                const parsedDate = doParseDate(dateString, shortYearFormat, referenceDate);
-                if (parsedDate) {
-                  return parsedDate;
+              if (!isShortFormat) {
+                const shortYearFormat = getShortYearFormat(format);
+                const shortYearFormatDate = dateFnsParse(dateString, shortYearFormat, referenceDate);
+                if (dateFnsIsValid(shortYearFormatDate)) {
+                  correctFullYear(shortYearFormatDate);
+                  return {
+                    day: shortYearFormatDate.getDate(),
+                    month: shortYearFormatDate.getMonth(),
+                    year: shortYearFormatDate.getFullYear()
+                  };
                 }
               }
-              const parsedDate = doParseDate(dateString, format, referenceDate);
-              if (parsedDate) {
-                return parsedDate;
+              const date = dateFnsParse(dateString, format, referenceDate);
+              if (dateFnsIsValid(date)) {
+                if (isShortFormat) {
+                  correctFullYear(date);
+                }
+                return {
+                  day: date.getDate(),
+                  month: date.getMonth(),
+                  year: date.getFullYear()
+                };
               }
             }
             return false;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -96,35 +96,36 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             return dateFnsFormat(date, format);
           }
 
+          function doParseDate(dateString, format, referenceDate) {
+            const date = dateFnsParse(dateString, format, referenceDate);
+            if (dateFnsIsValid(date)) {
+              if (isShortYearFormat(format)) {
+                correctFullYear(date);
+              }
+              return {
+                day: date.getDate(),
+                month: date.getMonth(),
+                year: date.getFullYear()
+              };
+            }
+          }
+
           function parseDate(dateString) {
             const referenceDate = _getReferenceDate();
             for (let format of formats) {
               const isShortFormat = isShortYearFormat(format);
               // We first try to match the date with the shorter version.
               if (!isShortFormat) {
-                const shortYearFormat = getShortYearFormat(format);
-                const shortYearFormatDate = dateFnsParse(dateString, shortYearFormat, referenceDate);
-                if (dateFnsIsValid(shortYearFormatDate)) {
-                  correctFullYear(shortYearFormatDate);
-                  datepicker.$connector._lastParsedDate = shortYearFormatDate;
-                  return {
-                    day: shortYearFormatDate.getDate(),
-                    month: shortYearFormatDate.getMonth(),
-                    year: shortYearFormatDate.getFullYear()
-                  };
+                const parsedDate = doParseDate(dateString, getShortYearFormat(format), referenceDate);
+                if (parsedDate) {
+                  datepicker.$connector._lastParsedDate = parsedDate;
+                  return parsedDate;
                 }
               }
-              const date = dateFnsParse(dateString, format, referenceDate);
-              if (dateFnsIsValid(date)) {
-                if (isShortFormat) {
-                  correctFullYear(date);
-                }
-                datepicker.$connector._lastParsedDate = date;
-                return {
-                  day: date.getDate(),
-                  month: date.getMonth(),
-                  year: date.getFullYear()
-                };
+              const parsedDate = doParseDate(dateString, format, referenceDate);
+              if (parsedDate) {
+                datepicker.$connector._lastParsedDate = parsedDate;
+                return parsedDate;
               }
             }
             datepicker.$connector._lastParsedDate = null;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -80,9 +80,13 @@ import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
             // The last parsed date check handles the case where a four-digit year is parsed, then formatted
             // as a two-digit year, and then parsed again. In this case we want to keep the century of the
             // originally parsed year, instead of using the century of the reference date.
+
+            // Do not apply any correction if the previous parse attempt was failed.
             if (datepicker.$connector._lastParseStatus === 'error') {
               return;
             }
+
+            // Update century if the last parsed date is the same except the century.
             if (datepicker.$connector._lastParseStatus === 'successful') {
               if (datepicker.$connector._lastParsedDate.day === date.getDate() &&
                 datepicker.$connector._lastParsedDate.month === date.getMonth() &&
@@ -91,6 +95,8 @@ import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
               }
               return;
             }
+
+            // Update century if this is the first parse after overlay open.
             const currentValue = _parseDate(datepicker.value);
             if (dateFnsIsValid(currentValue) &&
               currentValue.getDate() === date.getDate() &&

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -2,7 +2,6 @@ import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';
 import dateFnsIsValid from 'date-fns/isValid';
 import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
-import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 
 (function () {
   const tryCatchWrapper = function (callback) {


### PR DESCRIPTION
## Description

Date picker does a year correction for short year formats when calculating the full year. This correction does not get applied properly when the selection is done through the overlay. The reason is that there is no previously parsed date. 

This PR:
- Refactors the parsing logic to reduce duplication and increase clarity
- Uses the date picker value to correct the century in the first parse after overlay open
- Uses last parsed date to correct the century if last parse attempt is successful and the dates match except the century
- Does not correct the century if last parse attempt was a failure

Fixes #4636 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.