### PR TITLE
fix: call updateSelectionModeOnClient on attach

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinSession;
 
 @Route(value = "vaadin-grid/detach-reattach-page")
 public class DetachReattachPage extends Div {
@@ -37,6 +38,26 @@ public class DetachReattachPage extends Div {
 
         NativeButton btnDetach = new NativeButton("Detach", e -> remove(grid));
         btnDetach.setId("detach-button");
+
+        NativeButton btnSelectionModeNone = new NativeButton(
+                "Change to selection none",
+                e -> grid.setSelectionMode(Grid.SelectionMode.NONE));
+        btnSelectionModeNone.setId("selection-mode-none-button");
+
+        NativeButton btnHideGrid = new NativeButton("Hide grid",
+                e -> grid.setVisible(false));
+        btnHideGrid.setId("hide-grid-button");
+
+        NativeButton btnShowGrid = new NativeButton("Show grid",
+                e -> grid.setVisible(true));
+        btnShowGrid.setId("show-grid-button");
+
+        NativeButton btnDetachAndReattach = new NativeButton(
+                "Detach and reattach", e -> {
+                    remove(grid);
+                    add(grid);
+                });
+        btnDetachAndReattach.setId("detach-and-reattach-button");
 
         NativeButton btnDisallowDeselect = new NativeButton("Disallow deselect",
                 e -> {
@@ -68,7 +89,17 @@ public class DetachReattachPage extends Div {
                 });
         resetSortingButton.setId("reset-sorting-button");
 
+        Span errorMessage = new Span();
+        errorMessage.setId("error-message");
+
+        // Set error handler to show errors in the UI
+        VaadinSession.getCurrent().setErrorHandler(event -> {
+            errorMessage.setText("Error: " + event.getThrowable().getMessage());
+        });
+
         add(btnAttach, btnDetach, btnDisallowDeselect, addItemDetailsButton,
-                toggleDetailsVisibleOnClick, resetSortingButton, grid);
+                toggleDetailsVisibleOnClick, resetSortingButton, btnHideGrid,
+                btnSelectionModeNone, btnDetachAndReattach, btnShowGrid, grid,
+                errorMessage);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
@@ -114,4 +114,22 @@ public class DetachReattachIT extends AbstractComponentIT {
         // after re-attaching the grid when sorting is reset
         checkLogsForErrors();
     }
+
+    @Test
+    public void hideGridAndChangeMode_detachAndReattach_noErrorIsThrown() {
+        open();
+
+        $("button").id("hide-grid-button").click();
+        $("button").id("selection-mode-none-button").click();
+        $("button").id("detach-and-reattach-button").click();
+        $("button").id("show-grid-button").click();
+
+        GridElement grid = $(GridElement.class).first();
+        // Click on the first cell on the first row
+        grid.getCell(0, 0).click();
+
+        // Check that the error-message span is empty
+        Assert.assertEquals("Error message is empty.", "",
+                $("span").id("error-message").getText());
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3455,6 +3455,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         updateClientSideSorterIndicators(sortOrder);
+        updateSelectionModeOnClient();
         if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }


### PR DESCRIPTION
- fix: call updateSelectionModeOnClient on attach
- test: add test checking no server log error is thrown

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description

Add a call to `updateSelectionModeOnClient` on the `onAttach` method to ensure that the
selection mode is correctly set in case a Grid is first attached not visible and detached
and reattached again in the same roundtrip.

The cause of this issue is that Flow does not send JS commands to the client when the component
is not visible. If the component is then detached, Flow clears any pending JS command, which makes
the selection mode to be not synched between server and client.

Fixes #5645

## Type of change

- [x] Bugfix
