### PR TITLE
chore: refactor the formlayout test after #5592

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutIT.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutIT.java
@@ -91,10 +91,10 @@ public class FormLayoutIT extends AbstractComponentIT {
                         .equals(info.getText()));
 
         // Fill form: there shouldn't be an error
-        setValue("binder-first-name", "foo");
-        setValue("binder-last-name", "bar");
-        setValue("binder-phone", "123-456-789");
-        setValue("binder-email", "example@foo.bar");
+        $("vaadin-text-field").id("binder-first-name").sendKeys("foo");
+        $("vaadin-text-field").id("binder-last-name").sendKeys("bar");
+        $("vaadin-text-field").id("binder-phone").sendKeys("123-456-789");
+        $("vaadin-text-field").id("binder-email").sendKeys("example@foo.bar");
         setValue("binder-birth-date", "2003-01-02");
         setChecked("binder-do-not-call", true);
         forceClick(save);
@@ -108,7 +108,8 @@ public class FormLayoutIT extends AbstractComponentIT {
         Assert.assertTrue(info.getText().contains(", born on 2003-01-02"));
 
         // Make email address incorrect
-        setValue("binder-email", "abc");
+        setValue("binder-email", "");
+        $("vaadin-text-field").id("binder-email").sendKeys("abc");
         forceClick(save);
 
         waitUntil(driver -> info.getText().startsWith("There are errors"));


### PR DESCRIPTION
>The failing test directly manipulates the text fields’ client-side value property to simulate filling in values. It needs to be rewritten so that it uses the TestBench setValue method instead (this method additionally dispatches an input and change event).