### PR TITLE
feat: implement file remove listener for upload (24.4)

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
@@ -62,7 +62,10 @@ public class UploadView extends Div {
         });
         upload.addAllFinishedListener(event -> eventsOutput.add("-finished"));
         upload.addFileRejectedListener(event -> eventsOutput.add("-rejected"));
-        upload.addFileRemovedListener(event -> eventsOutput.add("-removed"));
+        upload.addFileRemovedListener(event -> {
+            eventsOutput.add("-removed");
+            output.add("REMOVED:" + event.getFileName());
+        });
 
         NativeButton clearFileListBtn = new NativeButton("Clear file list",
                 e -> upload.clearFileList());

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.component.upload.tests;
 import java.io.IOException;
 
 import com.vaadin.flow.component.html.NativeButton;
+import elemental.json.JsonArray;
 import org.apache.commons.io.IOUtils;
 
 import com.vaadin.flow.component.Component;
@@ -43,7 +44,7 @@ public class UploadView extends Div {
     private void createSimpleUpload() {
         Div output = new Div();
         Div eventsOutput = new Div();
-        Div fileList = new Div();
+        Div fileCount = new Div();
 
         MultiFileMemoryBuffer buffer = new MultiFileMemoryBuffer();
         Upload upload = new Upload(buffer);
@@ -61,24 +62,30 @@ public class UploadView extends Div {
         });
         upload.addAllFinishedListener(event -> eventsOutput.add("-finished"));
         upload.addFileRejectedListener(event -> eventsOutput.add("-rejected"));
+        upload.addFileRemovedListener(event -> eventsOutput.add("-removed"));
 
         NativeButton clearFileListBtn = new NativeButton("Clear file list",
                 e -> upload.clearFileList());
 
-        NativeButton printFileListBtn = new NativeButton("Print file list",
-                e -> fileList
-                        .setText(upload.getElement().getProperty("files")));
+        NativeButton printFileCountBtn = new NativeButton("Print file count",
+                e -> {
+                    upload.getElement().executeJs("return this.files")
+                            .then(jsonValue -> {
+                                fileCount.setText(String.valueOf(
+                                        ((JsonArray) jsonValue).length()));
+                            });
+                });
 
         upload.setMaxFileSize(500 * 1024);
         upload.setId("test-upload");
         clearFileListBtn.setId("clear-file-list");
-        printFileListBtn.setId("print-file-list");
-        fileList.setId("file-list");
+        printFileCountBtn.setId("print-file-count");
+        fileCount.setId("file-count");
         output.setId("test-output");
         eventsOutput.setId("test-events-output");
 
         addCard("Simple in memory receiver", upload, output, eventsOutput,
-                fileList, clearFileListBtn, printFileListBtn);
+                fileCount, clearFileListBtn, printFileCountBtn);
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -67,16 +67,16 @@ public class UploadIT extends AbstractUploadIT {
         getUpload().upload(tempFile);
         getUpload().upload(tempFile);
 
-        $("button").id("print-file-list").click();
+        $("button").id("print-file-count").click();
 
-        Assert.assertNotEquals("File list should contain files", "[]",
-                $("div").id("file-list").getText());
+        Assert.assertEquals("File list should contain 3 files", 3,
+                getFileCount());
 
         $("button").id("clear-file-list").click();
-        $("button").id("print-file-list").click();
+        $("button").id("print-file-count").click();
 
-        Assert.assertEquals("File list should not contain files", "[]",
-                $("div").id("file-list").getText());
+        Assert.assertEquals("File list should not contain files", 0,
+                getFileCount());
     }
 
     @Test
@@ -120,6 +120,30 @@ public class UploadIT extends AbstractUploadIT {
     }
 
     @Test
+    public void uploadFile_removeFile_fileIsRemoved() throws Exception {
+        File tempFile = createTempFile("txt");
+
+        getUpload().upload(tempFile);
+
+        $("button").id("print-file-count").click();
+
+        Assert.assertEquals("File list should contain one file", 1,
+                getFileCount());
+
+        getUpload().removeFile(0);
+
+        $("button").id("print-file-count").click();
+
+        Assert.assertEquals("File list should not contain files", 0,
+                getFileCount());
+
+        WebElement eventsOutput = getDriver()
+                .findElement(By.id("test-events-output"));
+        Assert.assertEquals("File was not properly removed",
+                "-succeeded-finished-removed", eventsOutput.getText());
+    }
+
+    @Test
     public void uploadFileAndNoErrorThrown() throws Exception {
         File tempFile = createTempFile("txt");
         getUpload().upload(tempFile);
@@ -133,6 +157,10 @@ public class UploadIT extends AbstractUploadIT {
         List<LogEntry> logList2 = getLogEntries(Level.SEVERE);
         assertThat("There should have no severe message in the console",
                 logList2.size(), CoreMatchers.is(0));
+    }
+
+    private int getFileCount() {
+        return Integer.parseInt($("div").id("file-count").getText());
     }
 
     private UploadElement getUpload() {

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -38,18 +38,22 @@ import static org.junit.Assert.assertThat;
 @TestPath("vaadin-upload")
 public class UploadIT extends AbstractUploadIT {
 
+    private WebElement uploadOutput;
+
+    private WebElement eventsOutput;
+
     @Before
     public void init() {
         open();
         waitUntil(driver -> getUpload().isDisplayed());
+        uploadOutput = getDriver().findElement(By.id("test-output"));
+        eventsOutput = getDriver().findElement(By.id("test-events-output"));
     }
 
     @Test
     public void testUploadAnyFile() throws Exception {
         File tempFile = createTempFile("txt");
         getUpload().upload(tempFile);
-
-        WebElement uploadOutput = getDriver().findElement(By.id("test-output"));
 
         String content = uploadOutput.getText();
 
@@ -85,9 +89,6 @@ public class UploadIT extends AbstractUploadIT {
 
         getUpload().uploadMultiple(List.of(tempFile, tempFile, tempFile), 10);
 
-        WebElement eventsOutput = getDriver()
-                .findElement(By.id("test-events-output"));
-
         Assert.assertEquals("Upload event order does not match expected",
                 "-succeeded-succeeded-succeeded-finished",
                 eventsOutput.getText());
@@ -99,9 +100,6 @@ public class UploadIT extends AbstractUploadIT {
 
         getUpload().upload(tempFile);
 
-        WebElement eventsOutput = getDriver()
-                .findElement(By.id("test-events-output"));
-
         Assert.assertEquals("Upload event order does not match expected",
                 "-succeeded-finished", eventsOutput.getText());
     }
@@ -111,9 +109,6 @@ public class UploadIT extends AbstractUploadIT {
         File invalidFile = createTempFile("pdf");
 
         getUpload().upload(invalidFile);
-
-        WebElement eventsOutput = getDriver()
-                .findElement(By.id("test-events-output"));
 
         Assert.assertEquals("Invalid file was not rejected", "-rejected",
                 eventsOutput.getText());
@@ -137,10 +132,11 @@ public class UploadIT extends AbstractUploadIT {
         Assert.assertEquals("File list should not contain files", 0,
                 getFileCount());
 
-        WebElement eventsOutput = getDriver()
-                .findElement(By.id("test-events-output"));
         Assert.assertEquals("File was not properly removed",
                 "-succeeded-finished-removed", eventsOutput.getText());
+
+        Assert.assertTrue("Removed file name was incorrect", uploadOutput
+                .getText().contains("REMOVED:" + tempFile.getName()));
     }
 
     @Test

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRemovedEvent.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRemovedEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload;
+
+import com.vaadin.flow.component.ComponentEvent;
+
+/**
+ * Sent when a file selected for upload is removed.
+ *
+ * @author Vaadin Ltd.
+ */
+public class FileRemovedEvent extends ComponentEvent<Upload> {
+
+    private final String fileName;
+
+    /**
+     * Creates a new event using the given source and the removed file name.
+     *
+     * @param source
+     *            the source component
+     * @param fileName
+     *            the removed file name
+     */
+    public FileRemovedEvent(Upload source, String fileName) {
+        super(source, true);
+        this.fileName = fileName;
+    }
+
+    /**
+     * Get the removed file name.
+     *
+     * @return the removed file name
+     */
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -569,8 +569,7 @@ public class Upload extends Component implements HasSize, HasStyle {
     }
 
     /**
-     * Adds a listener for {@code file-remove} events fired when a file is
-     * removed.
+     * Adds a listener for events fired when a file is removed.
      *
      * @param listener
      *            the listener

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -22,14 +22,11 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
@@ -40,7 +37,6 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.dom.DomEventListener;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.server.NoInputStreamException;
@@ -113,6 +109,13 @@ public class Upload extends Component implements HasSize, HasStyle {
                     .getString(eventDetailError);
             fireEvent(new FileRejectedEvent(this, detailError));
         }).addEventData(eventDetailError);
+
+        final String eventDetailFileName = "event.detail.file.name";
+        getElement().addEventListener("file-remove", event -> {
+            String detailFileName = event.getEventData()
+                    .getString(eventDetailFileName);
+            fireEvent(new FileRemovedEvent(this, detailFileName));
+        }).addEventData(eventDetailFileName);
 
         // If client aborts upload mark upload as interrupted on server also
         getElement().addEventListener("upload-abort",
@@ -563,6 +566,19 @@ public class Upload extends Component implements HasSize, HasStyle {
     public Registration addFileRejectedListener(
             ComponentEventListener<FileRejectedEvent> listener) {
         return addListener(FileRejectedEvent.class, listener);
+    }
+
+    /**
+     * Adds a listener for {@code file-remove} events fired when a file is
+     * removed.
+     *
+     * @param listener
+     *            the listener
+     * @return a {@link Registration} for removing the event listener
+     */
+    public Registration addFileRemovedListener(
+            ComponentEventListener<FileRemovedEvent> listener) {
+        return addListener(FileRemovedEvent.class, listener);
     }
 
     /**

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.openqa.selenium.WebDriver.Timeouts;
-import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chromium.ChromiumDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.WebDriver;
@@ -129,6 +128,19 @@ public class UploadElement extends TestBenchElement {
     }
 
     /**
+     * Removes the file with the given index. Does nothing if there is no file
+     * with the given index.
+     *
+     * @param index
+     *            the index of the file to remove
+     */
+    public void removeFile(int index) {
+        executeScript(
+                "arguments[0]._removeFile(arguments[0].files[arguments[1]])",
+                this, index);
+    }
+
+    /**
      * Wait for the given number of seconds for all uploads to finish.
      *
      * @param maxSeconds
@@ -146,12 +158,6 @@ public class UploadElement extends TestBenchElement {
                 + "}, 500);";
         getCommandExecutor().getDriver().executeAsyncScript(script, this);
 
-    }
-
-    private void removeFile(int i) {
-        executeScript(
-                "arguments[0]._removeFile(arguments[0].files[arguments[1]])",
-                this, i);
     }
 
     private void startUpload() {


### PR DESCRIPTION
## Description

Based on the [suggested API](https://github.com/vaadin/flow-components/issues/1342#issuecomment-1827745328), this PR:
- Introduces `addFileRemoveListener` for `Upload`
- Introduces `FileRemovedEvent`
- Fixes the `testClearFileList` test which was a false positive
- Adds a test for the new API
- Makes the `TestBench` API `removeFile` public

**!!! IMPORTANT !!! - Should be merged to the new minor branch.**

Fixes #1342

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.