### PR TITLE
fix: don't escape text in Notification#setText

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -282,8 +282,7 @@ public class Notification extends Component implements HasComponents, HasStyle,
      */
     public void setText(String text) {
         removeAll();
-        this.getElement().setProperty("text",
-                text != null ? HtmlUtils.escape(text) : null);
+        this.getElement().setProperty("text", text);
         this.getElement().callJsFunction("requestContentUpdate");
     }
 


### PR DESCRIPTION
fix: don't escape text in Notification#setText

`Notification.show("Java > JavaScript");` currently displays `Java &gt; JavaScript` on the screen.

This bug causes any symbol that HTML escapes (`" ' & < >`) to display incorrectly (e.g. as `&gt;`).
This can be fixed by directly running `this.getElement().setProperty("text", text);` in Notification#setText.

This change will fix the functionality of Notification#setText with special characters.

Fixes #5790 