### PR TITLE
feat: add file name to progress and file rejected listeners

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
@@ -61,11 +61,16 @@ public class UploadView extends Div {
             eventsOutput.add("-succeeded");
         });
         upload.addAllFinishedListener(event -> eventsOutput.add("-finished"));
-        upload.addFileRejectedListener(event -> eventsOutput.add("-rejected"));
+        upload.addFileRejectedListener(event -> {
+            eventsOutput.add("-rejected");
+            output.add("REJECTED:" + event.getFileName());
+        });
         upload.addFileRemovedListener(event -> {
             eventsOutput.add("-removed");
             output.add("REMOVED:" + event.getFileName());
         });
+        upload.addProgressListener(
+                event -> output.add("PROGRESS:" + event.getFileName()));
 
         NativeButton clearFileListBtn = new NativeButton("Clear file list",
                 e -> upload.clearFileList());

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -57,10 +57,10 @@ public class UploadIT extends AbstractUploadIT {
 
         String content = uploadOutput.getText();
 
-        String expectedContent = tempFile.getName() + getTempFileContents();
-
-        Assert.assertEquals("Upload content does not match expected",
-                expectedContent, content);
+        Assert.assertTrue("Upload content does not contain file details",
+                content.contains(tempFile.getName() + getTempFileContents()));
+        Assert.assertTrue("Progress update event was not fired properly",
+                content.contains("PROGRESS:" + tempFile.getName()));
     }
 
     @Test
@@ -110,8 +110,14 @@ public class UploadIT extends AbstractUploadIT {
 
         getUpload().upload(invalidFile);
 
+        WebElement eventsOutput = getDriver()
+                .findElement(By.id("test-events-output"));
         Assert.assertEquals("Invalid file was not rejected", "-rejected",
                 eventsOutput.getText());
+
+        WebElement uploadOutput = getDriver().findElement(By.id("test-output"));
+        Assert.assertTrue("Rejected file name was incorrect", uploadOutput
+                .getText().contains("REJECTED:" + invalidFile.getName()));
     }
 
     @Test

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
@@ -25,7 +25,9 @@ import com.vaadin.flow.component.ComponentEvent;
  */
 public class FileRejectedEvent extends ComponentEvent<Upload> {
 
-    private String errorMessage;
+    private final String fileName;
+
+    private final String errorMessage;
 
     /**
      * Creates a new event using the given source and indicator whether the
@@ -35,10 +37,14 @@ public class FileRejectedEvent extends ComponentEvent<Upload> {
      *            the source component
      * @param errorMessage
      *            the error message
+     * @param fileName
+     *            the rejected file name
      */
-    public FileRejectedEvent(Upload source, String errorMessage) {
+    public FileRejectedEvent(Upload source, String errorMessage,
+            String fileName) {
         super(source, true);
         this.errorMessage = errorMessage;
+        this.fileName = fileName;
     }
 
     /**
@@ -48,5 +54,14 @@ public class FileRejectedEvent extends ComponentEvent<Upload> {
      */
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    /**
+     * Get the file name.
+     *
+     * @return file name
+     */
+    public String getFileName() {
+        return fileName;
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
@@ -87,7 +87,7 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
     }
 
     /**
-     * Get file name.
+     * Get the file name.
      *
      * @return file name
      */

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
@@ -35,6 +35,11 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
     private final long contentLength;
 
     /**
+     * Name of file currently being uploaded
+     */
+    private final String fileName;
+
+    /**
      * Event constructor method to construct a new progress event.
      *
      * @param source
@@ -43,12 +48,15 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
      *            bytes transferred
      * @param contentLength
      *            total size of file currently being uploaded, -1 if unknown
+     * @param fileName
+     *            name of file currently being uploaded
      */
     public ProgressUpdateEvent(Upload source, long readBytes,
-            long contentLength) {
+            long contentLength, String fileName) {
         super(source, false);
         this.readBytes = readBytes;
         this.contentLength = contentLength;
+        this.fileName = fileName;
     }
 
     /**
@@ -76,5 +84,14 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
      */
     public long getContentLength() {
         return contentLength;
+    }
+
+    /**
+     * Get file name.
+     *
+     * @return file name
+     */
+    public String getFileName() {
+        return fileName;
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -105,6 +105,7 @@ public class Upload extends Component implements HasSize, HasStyle {
     public Upload() {
         final String eventDetailError = "event.detail.error";
         final String eventDetailFileName = "event.detail.file.name";
+
         getElement().addEventListener("file-reject", event -> {
             String detailError = event.getEventData()
                     .getString(eventDetailError);
@@ -113,7 +114,6 @@ public class Upload extends Component implements HasSize, HasStyle {
             fireEvent(new FileRejectedEvent(this, detailError, detailFileName));
         }).addEventData(eventDetailError).addEventData(eventDetailFileName);
 
-        final String eventDetailFileName = "event.detail.file.name";
         getElement().addEventListener("file-remove", event -> {
             String detailFileName = event.getEventData()
                     .getString(eventDetailFileName);

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -104,11 +104,14 @@ public class Upload extends Component implements HasSize, HasStyle {
      */
     public Upload() {
         final String eventDetailError = "event.detail.error";
+        final String eventDetailFileName = "event.detail.file.name";
         getElement().addEventListener("file-reject", event -> {
             String detailError = event.getEventData()
                     .getString(eventDetailError);
-            fireEvent(new FileRejectedEvent(this, detailError));
-        }).addEventData(eventDetailError);
+            String detailFileName = event.getEventData()
+                    .getString(eventDetailFileName);
+            fireEvent(new FileRejectedEvent(this, detailError, detailFileName));
+        }).addEventData(eventDetailError).addEventData(eventDetailFileName);
 
         final String eventDetailFileName = "event.detail.file.name";
         getElement().addEventListener("file-remove", event -> {
@@ -489,9 +492,13 @@ public class Upload extends Component implements HasSize, HasStyle {
      *            bytes received so far
      * @param contentLength
      *            actual size of the file being uploaded, if known
+     * @param contentLength
+     *            name of the file being uploaded
      */
-    protected void fireUpdateProgress(long totalBytes, long contentLength) {
-        fireEvent(new ProgressUpdateEvent(this, totalBytes, contentLength));
+    protected void fireUpdateProgress(long totalBytes, long contentLength,
+            String fileName) {
+        fireEvent(new ProgressUpdateEvent(this, totalBytes, contentLength,
+                fileName));
     }
 
     /**
@@ -744,7 +751,7 @@ public class Upload extends Component implements HasSize, HasStyle {
         @Override
         public void onProgress(StreamVariable.StreamingProgressEvent event) {
             upload.fireUpdateProgress(event.getBytesReceived(),
-                    event.getContentLength());
+                    event.getContentLength(), event.getFileName());
         }
 
         @Override


### PR DESCRIPTION
## Description

This PR 
- adds file name support to progress update listeners and file rejected listeners
- updates tests in order to check for the file names in events

The file name can be accessed via `FileRejectedEvent.getFileName()` and `ProgressUpdateEvent.getFileName()`.

**!!! IMPORTANT !!! - Should be merged to the new minor branch.**

Fixes #1328 
Fixes #3087

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
