### PR TITLE
fix: call to setSplitterPoisition on splitter-dragend event

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -102,6 +102,31 @@ public class SplitterPositionIT extends AbstractComponentIT {
         Assert.assertTrue(splitPosition < 81);
     }
 
+    @Test
+    public void setSplitterPositionFromServer_moveOnClient_resetToOriginal() {
+        // Add split layout with 30% splitter position
+        $(NativeButtonElement.class).id("createLayoutJavaApi").click();
+        $(NativeButtonElement.class).id("setSplitPositionJavaApi").click();
+
+        var split = $(SplitLayoutElement.class).id("splitLayoutJavaApi");
+        var primaryComponent = split.getPrimaryComponent();
+
+        var flexBasisInitial = primaryComponent.getCssValue("flex-basis");
+
+        // Move splitter by 150px
+        var splitter = split.getSplitter();
+        Actions resizeAction = new Actions(getDriver());
+        resizeAction.dragAndDropBy(splitter, 150, 0);
+        resizeAction.perform();
+
+        // Reset splitter position to 30%
+        $(NativeButtonElement.class).id("setSplitPositionJavaApi").click();
+
+        // Check that the splitter is at 30%
+        var flexBasisFinal = primaryComponent.getCssValue("flex-basis");
+        Assert.assertEquals(flexBasisInitial, flexBasisFinal);
+    }
+
     private void testSplitterPosition(String testId) {
         testSplitterPosition(testId, splitLayoutElement -> {
         });

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -119,6 +119,10 @@ public class SplitterPositionIT extends AbstractComponentIT {
         resizeAction.dragAndDropBy(splitter, 150, 0);
         resizeAction.perform();
 
+        // Check that the splitter position is not 30% anymore
+        var flexBasisAfterDrag = primaryComponent.getCssValue("flex-basis");
+        Assert.assertNotEquals(flexBasisInitial, flexBasisAfterDrag);
+
         // Reset splitter position to 30%
         $(NativeButtonElement.class).id("setSplitPositionJavaApi").click();
 

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -80,13 +80,11 @@ public class SplitLayout extends Component
         setOrientation(orientation);
         addAttachListener(
                 e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
-        addSplitterDragendListener(
-                e -> {
-                 var splitterPosition = calcNewSplitterPosition(
-                        e.primaryComponentFlexBasis,
-                        e.secondaryComponentFlexBasis);
-                 setSplitterPosition(splitterPosition);
-                });
+        addSplitterDragendListener(e -> {
+            var splitterPosition = calcNewSplitterPosition(
+                    e.primaryComponentFlexBasis, e.secondaryComponentFlexBasis);
+            setSplitterPosition(splitterPosition);
+        });
 
     }
 

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -81,9 +81,13 @@ public class SplitLayout extends Component
         addAttachListener(
                 e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
         addSplitterDragendListener(
-                e -> this.splitterPosition = calcNewSplitterPosition(
+                e -> {
+                 var splitterPosition = calcNewSplitterPosition(
                         e.primaryComponentFlexBasis,
-                        e.secondaryComponentFlexBasis));
+                        e.secondaryComponentFlexBasis);
+                 setSplitterPosition(splitterPosition);
+                });
+
     }
 
     /**


### PR DESCRIPTION
## Description

Add a call to `setSplitterPosition` on the default `splitter-dragend` listener to force synching the value from the client-side to the server-side. Previously, although we saved the split position in the server when the user changes it in the client, we can't reset it to the previous value from the server because Flow still thinks that the split position hasn't been changed.

This effectively will send a command to the client on every split change, but as it's part of the same roundtrip that the event is triggered, it won't cause any extra communication.

Fixes #2124

## Type of change

- [X] Bugfix
- [ ] Feature
