### PR TITLE
fix: use executeJS to set flex value in SplitLayout

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -80,6 +80,35 @@ public class SplitterPositionIT extends AbstractComponentIT {
         Assert.assertEquals("100%", width);
     }
 
+    @Test
+    public void setSplitterPositionFromServer_moveOnClient_resetToOriginal() {
+        // Add split layout with 30% splitter position
+        $(NativeButtonElement.class).id("createLayoutJavaApi").click();
+        $(NativeButtonElement.class).id("setSplitPositionJavaApi").click();
+
+        var split = $(SplitLayoutElement.class).id("splitLayoutJavaApi");
+        var primaryComponent = split.getPrimaryComponent();
+
+        var flexBasisInitial = primaryComponent.getCssValue("flex-basis");
+
+        // Move splitter by 150px
+        var splitter = split.getSplitter();
+        Actions resizeAction = new Actions(getDriver());
+        resizeAction.dragAndDropBy(splitter, 150, 0);
+        resizeAction.perform();
+
+        // Check that the splitter position is not 30% anymore
+        var flexBasisAfterDrag = primaryComponent.getCssValue("flex-basis");
+        Assert.assertNotEquals(flexBasisInitial, flexBasisAfterDrag);
+
+        // Reset splitter position to 30%
+        $(NativeButtonElement.class).id("setSplitPositionJavaApi").click();
+
+        // Check that the splitter is at 30%
+        var flexBasisFinal = primaryComponent.getCssValue("flex-basis");
+        Assert.assertEquals(flexBasisInitial, flexBasisFinal);
+    }
+
     private void testSplitterPosition(String testId) {
         testSplitterPosition(testId, splitLayoutElement -> {
         });

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -340,7 +340,8 @@ public class SplitLayout extends Component
         Component innerComponent = primary ? primaryComponent
                 : secondaryComponent;
         if (innerComponent != null) {
-            innerComponent.getElement().getStyle().set(styleName, value);
+            innerComponent.getElement().executeJs("this.style[$0]=$1",
+                    styleName, value);
         } else {
             getElement().executeJs(
                     "var element = this.children[$0]; if (element) { element.style[$1]=$2; }",


### PR DESCRIPTION
## Description

>[!WARNING]
>A cherry-pick from #5798 could not be performed for V24.1 and below because the API used as part of the solution for it, is not available in the earlier versions.

This PR uses an alternative approach that replaces the use of the `getElement().getStyle().set(...)` API to use `getElement().executeJS(...)`, to ensure that the flex value is always sent to the client, to work around the default Flow behavior that avoids sending values from server to the client in case the value in the server didn't change.

Some notes:
- I am unsure whether this approach is better than the one that landed in V24.2+. In V24.2+ the value from the client is sent back from the server after the `dragend` event, but it will send any data from the server when two equal split position values are set in a row. On the other hand, the new approach will not send any data back to the client on `dragend` but will always update the split position, no matter if the split position value hasn't changed.
- Maybe there could be some logic checking whether the new split position is the same as the current and only use the `getElement().executeJS()` API for this case, but I didn't want to make this any more complex, as I think the downside here might be not big for us to worry too much about.

Part of #2124

## Type of change

- [X] Bugfix
