### PR TITLE
fix: avoid duplicate requests to the server when sorting

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -1,0 +1,111 @@
+import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import { init, getBodyCellContent, setRootItems } from './shared.js';
+import type { FlowGrid, Item } from './shared.js';
+import sinon from 'sinon';
+import { GridColumn } from '@vaadin/grid';
+import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
+
+describe('grid connector - sorting', () => {
+  let grid: FlowGrid;
+  let columns: GridColumn<Item>[];
+  let sorters: GridSorter[];
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+        <vaadin-grid-column path="age"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    columns = [...grid.querySelectorAll('vaadin-grid-column')] as GridColumn<Item>[];
+
+    grid.$connector.setHeaderRenderer(columns[0], { content: 'Name', showSorter: true, sorterPath: 'name' });
+    grid.$connector.setHeaderRenderer(columns[1], { content: 'Age', showSorter: true, sorterPath: 'age' });
+
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'Andrew', age: 25 },
+      { key: '1', name: 'Bob', age: 30 }
+    ]);
+    await nextFrame();
+
+    sorters = [...grid.querySelectorAll('vaadin-grid-sorter')] as GridSorter[];
+  });
+
+  it('should not make requests to server by default', () => {
+    expect(grid.$server.sortersChanged).to.not.be.called;
+  });
+
+  describe('single column sorting', () => {
+    it('should notify server on sorter click', () => {
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
+
+      grid.$server.sortersChanged.resetHistory();
+
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'desc' }]);
+
+      grid.$server.sortersChanged.resetHistory();
+
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: null }]);
+    });
+
+    it('should notify server when switching sorters', () => {
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
+
+      grid.$server.sortersChanged.resetHistory();
+
+      sorters[1].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'age', direction: 'asc' }]);
+    });
+  });
+
+  describe('multiple column sorting', () => {
+    beforeEach(() => {
+      grid.multiSort = true;
+    });
+
+    it('should notify server on sorter click', () => {
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
+
+      grid.$server.sortersChanged.resetHistory();
+
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'desc' }]);
+
+      grid.$server.sortersChanged.resetHistory();
+
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([]);
+    });
+
+    it('should notify server when joining sorters', () => {
+      sorters[0].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
+
+      grid.$server.sortersChanged.resetHistory();
+
+      sorters[1].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([
+        { path: 'age', direction: 'asc' },
+        { path: 'name', direction: 'asc' }
+      ]);
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -1,7 +1,6 @@
 import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
-import { init, getBodyCellContent, setRootItems } from './shared.js';
+import { init, setRootItems } from './shared.js';
 import type { FlowGrid, Item } from './shared.js';
-import sinon from 'sinon';
 import { GridColumn } from '@vaadin/grid';
 import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
 
@@ -20,7 +19,7 @@ describe('grid connector - sorting', () => {
 
     init(grid);
 
-    columns = [...grid.querySelectorAll('vaadin-grid-column')] as GridColumn<Item>[];
+    columns = [...grid.querySelectorAll<GridColumn<Item>>('vaadin-grid-column')];
 
     grid.$connector.setHeaderRenderer(columns[0], { content: 'Name', showSorter: true, sorterPath: 'name' });
     grid.$connector.setHeaderRenderer(columns[1], { content: 'Price', showSorter: true, sorterPath: 'price' });
@@ -31,7 +30,7 @@ describe('grid connector - sorting', () => {
     ]);
     await nextFrame();
 
-    sorters = [...grid.querySelectorAll('vaadin-grid-sorter')] as GridSorter[];
+    sorters = [...grid.querySelectorAll<GridSorter>('vaadin-grid-sorter')];
   });
 
   it('should not make requests to server by default', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -93,19 +93,40 @@ describe('grid connector - sorting', () => {
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([]);
     });
 
-    it('should notify server when joining sorters', () => {
-      sorters[0].click();
-      expect(grid.$server.sortersChanged).to.be.calledOnce;
-      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
+    describe('multi-sort-priority=append', () => {
+      beforeEach(() => {
+        grid.multiSortPriority = 'append';
+      });
 
-      grid.$server.sortersChanged.resetHistory();
+      it('should notify server when joining sorters', () => {
+        sorters[0].click();
+        grid.$server.sortersChanged.resetHistory();
 
-      sorters[1].click();
-      expect(grid.$server.sortersChanged).to.be.calledOnce;
-      expect(grid.$server.sortersChanged.args[0][0]).to.eql([
-        { path: 'age', direction: 'asc' },
-        { path: 'name', direction: 'asc' }
-      ]);
+        sorters[1].click();
+        expect(grid.$server.sortersChanged).to.be.calledOnce;
+        expect(grid.$server.sortersChanged.args[0][0]).to.eql([
+          { path: 'name', direction: 'asc' },
+          { path: 'age', direction: 'asc' }
+        ]);
+      });
+    });
+
+    describe('multi-sort-priority=prepend', () => {
+      beforeEach(() => {
+        grid.multiSortPriority = 'prepend';
+      });
+
+      it('should notify server when joining sorters', () => {
+        sorters[0].click();
+        grid.$server.sortersChanged.resetHistory();
+
+        sorters[1].click();
+        expect(grid.$server.sortersChanged).to.be.calledOnce;
+        expect(grid.$server.sortersChanged.args[0][0]).to.eql([
+          { path: 'age', direction: 'asc' },
+          { path: 'name', direction: 'asc' },
+        ]);
+      });
     });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -14,7 +14,7 @@ describe('grid connector - sorting', () => {
     grid = fixtureSync(`
       <vaadin-grid>
         <vaadin-grid-column path="name"></vaadin-grid-column>
-        <vaadin-grid-column path="age"></vaadin-grid-column>
+        <vaadin-grid-column path="price"></vaadin-grid-column>
       </vaadin-grid>
     `);
 
@@ -23,11 +23,11 @@ describe('grid connector - sorting', () => {
     columns = [...grid.querySelectorAll('vaadin-grid-column')] as GridColumn<Item>[];
 
     grid.$connector.setHeaderRenderer(columns[0], { content: 'Name', showSorter: true, sorterPath: 'name' });
-    grid.$connector.setHeaderRenderer(columns[1], { content: 'Age', showSorter: true, sorterPath: 'age' });
+    grid.$connector.setHeaderRenderer(columns[1], { content: 'Price', showSorter: true, sorterPath: 'price' });
 
     setRootItems(grid.$connector, [
-      { key: '0', name: 'Andrew', age: 25 },
-      { key: '1', name: 'Bob', age: 30 }
+      { key: '0', name: 'Macbook', price: 2500 },
+      { key: '1', name: 'iPad', price: 1000 }
     ]);
     await nextFrame();
 
@@ -66,7 +66,7 @@ describe('grid connector - sorting', () => {
 
       sorters[1].click();
       expect(grid.$server.sortersChanged).to.be.calledOnce;
-      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'age', direction: 'asc' }]);
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'price', direction: 'asc' }]);
     });
   });
 
@@ -106,7 +106,7 @@ describe('grid connector - sorting', () => {
         expect(grid.$server.sortersChanged).to.be.calledOnce;
         expect(grid.$server.sortersChanged.args[0][0]).to.eql([
           { path: 'name', direction: 'asc' },
-          { path: 'age', direction: 'asc' }
+          { path: 'price', direction: 'asc' }
         ]);
       });
     });
@@ -123,7 +123,7 @@ describe('grid connector - sorting', () => {
         sorters[1].click();
         expect(grid.$server.sortersChanged).to.be.calledOnce;
         expect(grid.$server.sortersChanged.args[0][0]).to.eql([
-          { path: 'age', direction: 'asc' },
+          { path: 'price', direction: 'asc' },
           { path: 'name', direction: 'asc' },
         ]);
       });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -44,7 +44,7 @@ export type GridServer = {
 export type Item = {
   key: string;
   name?: string;
-  age?: number,
+  price?: number,
   selected?: boolean;
   detailsOpened?: boolean;
   style?: Record<string, string>;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -23,6 +23,8 @@ export type GridConnector = {
   doSelection: (items: Item[] | [null], userOriginated: boolean) => void;
   doDeselection: (items: Item[], userOriginated: boolean) => void;
   clear: (index: number, length: number, parentKey?: string) => void;
+  setSorterDirections: (sorters: { path: string, direction: string }[]) => void;
+  setHeaderRenderer: (column: GridColumn, options: { content: Node | string, showSorter: boolean, sorterPath?: string }) => void;
 };
 
 export type GridServer = {
@@ -36,11 +38,13 @@ export type GridServer = {
   setRequestedRange: ((firstIndex: number, size: number) => void) & sinon.SinonSpy;
   setParentRequestedRanges: ((ranges: { firstIndex: number; size: number; parentKey: string }[]) => void) &
     sinon.SinonSpy;
+  sortersChanged: ((sorters: { path: string, direction: string }[]) => void) & sinon.SinonSpy;
 };
 
 export type Item = {
   key: string;
   name?: string;
+  age?: number,
   selected?: boolean;
   detailsOpened?: boolean;
   style?: Record<string, string>;
@@ -87,7 +91,8 @@ export function init(grid: FlowGrid): void {
     deselectAll: sinon.spy(),
     setDetailsVisible: sinon.spy(),
     setRequestedRange: sinon.spy(),
-    setParentRequestedRanges: sinon.spy()
+    setParentRequestedRanges: sinon.spy(),
+    sortersChanged: sinon.spy()
   };
 
   gridConnector.initLazy(grid);


### PR DESCRIPTION
## Description

The PR refactors the grid connector to avoid duplicate requests to the server when sorting. The number of duplicate requests has increased after #4774, but the issue has been present even before. The cause is the grid connector that listened to the `_previousSorters` property to notify the server when the sort model changes. This property changes twice on every `__applySorters()` call because `mapSorters()` always generates a new array when called. Also, the grid can call `__applySorters()` multiple times within a round-trip even when the sort model hasn't changed.

Finding from #5513.

## Type of change

- [x] Bugfix
