### PR TITLE
fix: apply sort directions in the correct order

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -1,5 +1,5 @@
 import { aTimeout, expect, fixtureSync, nextFrame } from '@open-wc/testing';
-import { getBodyCellContent, getHeaderCellContent, init, setRootItems } from './shared.js';
+import { getHeaderCellContent, init, setRootItems } from './shared.js';
 import type { FlowGrid, Item } from './shared.js';
 import { GridColumn } from '@vaadin/grid';
 import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -1,5 +1,5 @@
-import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
-import { init, setRootItems } from './shared.js';
+import { aTimeout, expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import { getBodyCellContent, getHeaderCellContent, init, setRootItems } from './shared.js';
 import type { FlowGrid, Item } from './shared.js';
 import { GridColumn } from '@vaadin/grid';
 import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
@@ -7,7 +7,7 @@ import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
 describe('grid connector - sorting', () => {
   let grid: FlowGrid;
   let columns: GridColumn<Item>[];
-  let sorters: GridSorter[];
+  let sorters: Array<GridSorter & { _order?: number | null }>;
 
   beforeEach(async () => {
     grid = fixtureSync(`
@@ -30,15 +30,15 @@ describe('grid connector - sorting', () => {
     ]);
     await nextFrame();
 
-    sorters = [...grid.querySelectorAll<GridSorter>('vaadin-grid-sorter')];
+    sorters = columns.map((column) => getHeaderCellContent(column).querySelector<GridSorter>('vaadin-grid-sorter')!);
   });
 
-  it('should not make requests to server by default', () => {
+  it('should not make sort requests by default', () => {
     expect(grid.$server.sortersChanged).to.not.be.called;
   });
 
   describe('single column sorting', () => {
-    it('should notify server on sorter click', () => {
+    it('should make a sort request on sorter click', () => {
       sorters[0].click();
       expect(grid.$server.sortersChanged).to.be.calledOnce;
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
@@ -56,7 +56,7 @@ describe('grid connector - sorting', () => {
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: null }]);
     });
 
-    it('should notify server when switching sorters', () => {
+    it('should make a sort request when switching sorters', () => {
       sorters[0].click();
       expect(grid.$server.sortersChanged).to.be.calledOnce;
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
@@ -67,6 +67,54 @@ describe('grid connector - sorting', () => {
       expect(grid.$server.sortersChanged).to.be.calledOnce;
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'price', direction: 'asc' }]);
     });
+
+    describe('setSorterDirections', () => {
+      it('should prevent sort requests while setting directions', async () => {
+        grid.$connector.setSorterDirections([{ column: 'name', direction: 'asc' }]);
+        await aTimeout(0);
+        expect(grid.$server.sortersChanged).to.be.not.called;
+      });
+
+      it('should not prevent sort requests after directions are set', async () => {
+        grid.$connector.setSorterDirections([{ column: 'name', direction: 'asc' }]);
+        await aTimeout(0);
+        sorters[0].click();
+        expect(grid.$server.sortersChanged).to.be.calledOnce;
+      });
+
+      it('should update direction on sorters', async () => {
+        grid.$connector.setSorterDirections([{ column: 'name', direction: 'asc' }]);
+        await aTimeout(0);
+        expect(sorters[0].direction).to.equal('asc');
+        expect(sorters[1].direction).to.be.null;
+
+        grid.$connector.setSorterDirections([{ column: 'name', direction: 'desc' }]);
+        await aTimeout(0);
+        expect(sorters[0].direction).to.equal('desc');
+        expect(sorters[1].direction).to.be.null;
+
+        grid.$connector.setSorterDirections([{ column: 'price', direction: 'asc' }]);
+        await aTimeout(0);
+        expect(sorters[0].direction).to.be.null;
+        expect(sorters[1].direction).to.equal('asc');
+
+        grid.$connector.setSorterDirections([]);
+        await aTimeout(0);
+        expect(sorters[0].direction).to.be.null;
+        expect(sorters[1].direction).to.be.null;
+      });
+
+      it('should update direction on hidden sorters', async () => {
+        grid.$connector.setSorterDirections([{ column: 'name', direction: 'asc' }]);
+        await aTimeout(0);
+        columns[0].hidden = true;
+        await nextFrame();
+
+        grid.$connector.setSorterDirections([]);
+        await aTimeout(0);
+        expect(sorters[0].direction).to.be.null;
+      });
+    });
   });
 
   describe('multiple column sorting', () => {
@@ -74,7 +122,7 @@ describe('grid connector - sorting', () => {
       grid.multiSort = true;
     });
 
-    it('should notify server on sorter click', () => {
+    it('should make a sort request on sorter click', () => {
       sorters[0].click();
       expect(grid.$server.sortersChanged).to.be.calledOnce;
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([{ path: 'name', direction: 'asc' }]);
@@ -92,39 +140,100 @@ describe('grid connector - sorting', () => {
       expect(grid.$server.sortersChanged.args[0][0]).to.eql([]);
     });
 
-    describe('multi-sort-priority=append', () => {
-      beforeEach(() => {
-        grid.multiSortPriority = 'append';
-      });
+    it('should make a sort request when joining sorters with multiSortPriority=append', () => {
+      grid.multiSortPriority = 'append';
+      sorters[0].click();
+      grid.$server.sortersChanged.resetHistory();
 
-      it('should notify server when joining sorters', () => {
-        sorters[0].click();
-        grid.$server.sortersChanged.resetHistory();
-
-        sorters[1].click();
-        expect(grid.$server.sortersChanged).to.be.calledOnce;
-        expect(grid.$server.sortersChanged.args[0][0]).to.eql([
-          { path: 'name', direction: 'asc' },
-          { path: 'price', direction: 'asc' }
-        ]);
-      });
+      sorters[1].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([
+        { path: 'name', direction: 'asc' },
+        { path: 'price', direction: 'asc' }
+      ]);
     });
 
-    describe('multi-sort-priority=prepend', () => {
-      beforeEach(() => {
-        grid.multiSortPriority = 'prepend';
-      });
+    it('should make a sort request when joining sorters with multiSortPriority=prepend', () => {
+      grid.multiSortPriority = 'prepend';
+      sorters[0].click();
+      grid.$server.sortersChanged.resetHistory();
 
-      it('should notify server when joining sorters', () => {
-        sorters[0].click();
-        grid.$server.sortersChanged.resetHistory();
+      sorters[1].click();
+      expect(grid.$server.sortersChanged).to.be.calledOnce;
+      expect(grid.$server.sortersChanged.args[0][0]).to.eql([
+        { path: 'price', direction: 'asc' },
+        { path: 'name', direction: 'asc' }
+      ]);
+    });
 
-        sorters[1].click();
-        expect(grid.$server.sortersChanged).to.be.calledOnce;
-        expect(grid.$server.sortersChanged.args[0][0]).to.eql([
-          { path: 'price', direction: 'asc' },
-          { path: 'name', direction: 'asc' },
-        ]);
+    describe('setSorterDirections', () => {
+      (['append', 'prepend'] as const).forEach((multiSortPriority) => {
+        describe(`multiSortPriority=${multiSortPriority}`, () => {
+          beforeEach(() => {
+            grid.multiSortPriority = multiSortPriority;
+          });
+
+          it('should update direction on sorters', async () => {
+            grid.$connector.setSorterDirections([{ column: 'name', direction: 'asc' }]);
+            await aTimeout(0);
+            expect(sorters[0].direction).to.equal('asc');
+            expect(sorters[1].direction).to.be.null;
+
+            grid.$connector.setSorterDirections([
+              { column: 'name', direction: 'asc' },
+              { column: 'price', direction: 'asc' }
+            ]);
+            await aTimeout(0);
+            expect(sorters[0].direction).to.equal('asc');
+            expect(sorters[1].direction).to.equal('asc');
+
+            grid.$connector.setSorterDirections([
+              { column: 'price', direction: 'desc' },
+              { column: 'name', direction: 'desc' }
+            ]);
+            await aTimeout(0);
+            expect(sorters[0].direction).to.equal('desc');
+            expect(sorters[1].direction).to.equal('desc');
+
+            grid.$connector.setSorterDirections([{ column: 'price', direction: 'desc' }]);
+            await aTimeout(0);
+            expect(sorters[0].direction).to.be.null;
+            expect(sorters[1].direction).to.equal('desc');
+
+            grid.$connector.setSorterDirections([]);
+            await aTimeout(0);
+            expect(sorters[0].direction).to.be.null;
+            expect(sorters[1].direction).to.be.null;
+          });
+
+          it('should update sorters order', async () => {
+            grid.$connector.setSorterDirections([{ column: 'name', direction: 'asc' }]);
+            await aTimeout(0);
+            expect(sorters[0]._order).to.be.null;
+            expect(sorters[1]._order).to.be.null;
+
+            grid.$connector.setSorterDirections([
+              { column: 'name', direction: 'asc' },
+              { column: 'price', direction: 'asc' }
+            ]);
+            await aTimeout(0);
+            expect(sorters[0]._order).to.equal(0);
+            expect(sorters[1]._order).to.equal(1);
+
+            grid.$connector.setSorterDirections([
+              { column: 'price', direction: 'desc' },
+              { column: 'name', direction: 'desc' }
+            ]);
+            await aTimeout(0);
+            expect(sorters[0]._order).to.equal(1);
+            expect(sorters[1]._order).to.equal(0);
+
+            grid.$connector.setSorterDirections([{ column: 'price', direction: 'desc' }]);
+            await aTimeout(0);
+            expect(sorters[0]._order).to.be.null;
+            expect(sorters[1]._order).to.be.null;
+          });
+        });
       });
     });
   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -23,7 +23,7 @@ export type GridConnector = {
   doSelection: (items: Item[] | [null], userOriginated: boolean) => void;
   doDeselection: (items: Item[], userOriginated: boolean) => void;
   clear: (index: number, length: number, parentKey?: string) => void;
-  setSorterDirections: (sorters: { path: string, direction: string }[]) => void;
+  setSorterDirections: (sorters: { column: string, direction: string }[]) => void;
   setHeaderRenderer: (column: GridColumn, options: { content: Node | string, showSorter: boolean, sorterPath?: string }) => void;
 };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -371,9 +371,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
                 });
 
                 sorters.forEach((sorter) => {
-                  if (!directions.filter((d) => d.column === sorter.getAttribute('path'))[0]) {
-                    sorter.direction = null;
-                  }
+                  sorter.direction = null;
                 });
 
                 // Apply directions in correct order, depending on configured multi-sort priority.
@@ -385,7 +383,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
                 }
                 directions.forEach(({ column, direction }) => {
                   sorters.forEach((sorter) => {
-                    if (sorter.getAttribute('path') === column && sorter.direction !== direction) {
+                    if (sorter.getAttribute('path') === column) {
                       sorter.direction = direction;
                     }
                   });


### PR DESCRIPTION
## Description

The PR fixes a bug in the grid connector where sort directions could be applied in an order that didn't match the order in which they were built on the server. This happened because the grid connector only reset the direction of sorters that were missing from the new set of directions, whereas it should've reset the direction for _all_ sorters before applying new directions.

The example scenario:

```js
$connector.setSorterDirections([
  { column: 'name', direction: 'asc' }, 
  { column: 'price', direction: 'asc' }
]);

// The sorters' order: (1) name (2) price – OK

$connector.setSorterDirections([
  { column: 'price', direction: 'asc' }, 
  { column: 'name', direction: 'asc' }
]);

// The sorters' order: (1) name (2) price – WRONG, expected the other way around
```

Finding from https://github.com/vaadin/flow-components/issues/5513

## Type of change

- [x] Bugfix
