### PR TITLE
fix: use parent node in directive to control retry timeout

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
@@ -76,20 +76,6 @@ describe('flow-component-renderer', () => {
     expect(container.firstElementChild).to.equal(element);
   });
 
-  it('should try to retrieve a node only once', async () => {
-    const { getByNodeId } = window.Vaadin.Flow.clients.ROOT;
-    const component = fixtureSync<TestComponent>(`<test-component></test-component>`);
-    component.nodeId = 0;
-
-    getByNodeId.resetHistory();
-
-    await nextFrame();
-    await nextFrame();
-    await nextFrame();
-
-    expect(getByNodeId).to.have.been.calledTwice;
-  });
-
   it('should remove old node', async () => {
     const container = fixtureSync<HTMLDivElement>(`<div></div>`);
     const element = document.createElement('div');

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/test/flow-component-renderer.test.ts
@@ -76,6 +76,20 @@ describe('flow-component-renderer', () => {
     expect(container.firstElementChild).to.equal(element);
   });
 
+  it('should try to retrieve a node only once', async () => {
+    const { getByNodeId } = window.Vaadin.Flow.clients.ROOT;
+    const component = fixtureSync<TestComponent>(`<test-component></test-component>`);
+    component.nodeId = 0;
+
+    getByNodeId.resetHistory();
+
+    await nextFrame();
+    await nextFrame();
+    await nextFrame();
+
+    expect(getByNodeId).to.have.been.calledTwice;
+  });
+
   it('should remove old node', async () => {
     const container = fixtureSync<HTMLDivElement>(`<div></div>`);
     const element = document.createElement('div');

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -17,16 +17,17 @@ class FlowComponentDirective extends AsyncDirective {
 
   updateContent(part, appid, nodeid) {
     const { parentNode, startNode } = part;
+    this.__parentNode = parentNode;
 
     const hasNewNodeId = nodeid !== undefined && nodeid !== null;
     const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
-    clearTimeout(this.__nodeRetryTimeout);
+    clearTimeout(this.__parentNode.__nodeRetryTimeout);
 
     if (hasNewNodeId && !newNode) {
       // If the node is not found, try again later.
-      this.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
+      this.__parentNode.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -51,7 +52,7 @@ class FlowComponentDirective extends AsyncDirective {
   }
 
   disconnected() {
-    clearTimeout(this.__nodeRetryTimeout);
+    clearTimeout(this.__parentNode.__nodeRetryTimeout);
   }
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -22,14 +22,11 @@ class FlowComponentDirective extends AsyncDirective {
     const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
+    clearTimeout(this.__nodeRetryTimeout);
+
     if (hasNewNodeId && !newNode) {
-      // If the node is not found, try again later once.
-      if (this.__onRetry) {
-        this.__onRetry = undefined;
-        return;
-      }
-      this.__onRetry = true;
-      queueMicrotask(() => this.updateContent(part, appid, nodeid));
+      // If the node is not found, try again later.
+      this.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -54,7 +51,7 @@ class FlowComponentDirective extends AsyncDirective {
   }
 
   disconnected() {
-    this.__onRetry = undefined;
+    clearTimeout(this.__nodeRetryTimeout);
   }
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -22,14 +22,14 @@ class FlowComponentDirective extends AsyncDirective {
     const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
+    this.__isRetry = !!this.__nodeRetryTimeout;
+    clearTimeout(this.__nodeRetryTimeout);
+
     if (hasNewNodeId && !newNode) {
       // If the node is not found, try again later once.
-      if (this.__onRetry) {
-        this.__onRetry = undefined;
-        return;
+      if (!this.__isRetry) {
+        this.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
       }
-      this.__onRetry = true;
-      queueMicrotask(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -54,7 +54,7 @@ class FlowComponentDirective extends AsyncDirective {
   }
 
   disconnected() {
-    this.__onRetry = undefined;
+    clearTimeout(this.__nodeRetryTimeout);
   }
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -23,13 +23,8 @@ class FlowComponentDirective extends AsyncDirective {
     const oldNode = this.getOldNode(part);
 
     if (hasNewNodeId && !newNode) {
-      // If the node is not found, try again later once.
-      if (this.__onRetry) {
-        this.__onRetry = undefined;
-        return;
-      }
-      this.__onRetry = true;
-      queueMicrotask(() => this.updateContent(part, appid, nodeid));
+      // If the node is not found, try again later twice.
+      this.__handleRetry(part, appid, nodeid);
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -55,6 +50,28 @@ class FlowComponentDirective extends AsyncDirective {
 
   disconnected() {
     this.__onRetry = undefined;
+  }
+
+  __handleRetry(part, appid, nodeid) {
+    // Retry limit achieved
+    if (this.__onRetry === 2) {
+      this.__onRetry = undefined;
+      return;
+    }
+    const doRetry = () => queueMicrotask(() => this.updateContent(part, appid, nodeid));
+    // On second retry
+    if (this.__onRetry === 1) {
+      this.__onRetry = 2;
+      function retry() {
+        doRetry();
+        this.removeEventListener('animationend', retry);
+      }
+      this.addEventListener('animationend', retry);
+      return;
+    }
+    // On first retry
+    this.__onRetry = 1;
+    doRetry();
   }
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -22,11 +22,14 @@ class FlowComponentDirective extends AsyncDirective {
     const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
-    clearTimeout(this.__nodeRetryTimeout);
-
     if (hasNewNodeId && !newNode) {
-      // If the node is not found, try again later.
-      this.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
+      // If the node is not found, try again later once.
+      if (this.__onRetry) {
+        this.__onRetry = undefined;
+        return;
+      }
+      this.__onRetry = true;
+      queueMicrotask(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -51,7 +54,7 @@ class FlowComponentDirective extends AsyncDirective {
   }
 
   disconnected() {
-    clearTimeout(this.__nodeRetryTimeout);
+    this.__onRetry = undefined;
   }
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -64,9 +64,9 @@ class FlowComponentDirective extends AsyncDirective {
       this.__onRetry = 2;
       function retry() {
         doRetry();
-        this.removeEventListener('animationend', retry);
+        window.removeEventListener('animationend', retry);
       }
-      this.addEventListener('animationend', retry);
+      window.addEventListener('animationend', retry);
       return;
     }
     // On first retry

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -22,14 +22,14 @@ class FlowComponentDirective extends AsyncDirective {
     const newNode = hasNewNodeId ? this.getNewNode(appid, nodeid) : null;
     const oldNode = this.getOldNode(part);
 
-    this.__isRetry = !!this.__nodeRetryTimeout;
-    clearTimeout(this.__nodeRetryTimeout);
-
     if (hasNewNodeId && !newNode) {
       // If the node is not found, try again later once.
-      if (!this.__isRetry) {
-        this.__nodeRetryTimeout = setTimeout(() => this.updateContent(part, appid, nodeid));
+      if (this.__onRetry) {
+        this.__onRetry = undefined;
+        return;
       }
+      this.__onRetry = true;
+      queueMicrotask(() => this.updateContent(part, appid, nodeid));
     } else if (oldNode === newNode) {
       return;
     } else if (oldNode && newNode) {
@@ -54,7 +54,7 @@ class FlowComponentDirective extends AsyncDirective {
   }
 
   disconnected() {
-    clearTimeout(this.__nodeRetryTimeout);
+    this.__onRetry = undefined;
   }
 }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js
@@ -64,9 +64,9 @@ class FlowComponentDirective extends AsyncDirective {
       this.__onRetry = 2;
       function retry() {
         doRetry();
-        window.removeEventListener('animationend', retry);
+        this.removeEventListener('animationend', retry);
       }
-      window.addEventListener('animationend', retry);
+      this.addEventListener('animationend', retry);
       return;
     }
     // On first retry


### PR DESCRIPTION
## Description

It is possible that a node cannot be retrieved when it is requested. In this case, the directive continuously tries to retrieve the node. If this is the case for multiple updates in the same round-trip for the same item, the node retrieval can lead to an infinite loop. Usually, the newer update overwrites the previous one in the same directive, which clears the retry timeout. But it is possible that there is a new directive, and the first retry loop is not overwritten by the new one since it operates on another directive. This leads to the old directive never being cleaned, and this loop ramps up quickly to render the browser tab unusable.

This PR uses the parent node of the directive to control the retry timeout. The parent node is the same for any directive for an item. This prevents the update loop and the stale directive can be cleaned up.

Fixes #5775 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.