### PR TITLE
fix: regex to get the version for computing [skip ci]

### DIFF
--- a/scripts/generateChangeLog.js
+++ b/scripts/generateChangeLog.js
@@ -52,7 +52,7 @@ async function getPlatformVersions(branch) {
 
 function computeVersion() {
   if (to == 'HEAD') {
-    const r = /^(.*)\b(\d+)\b$/.exec(from);
+    const r = /^(.*?)(\d+)$/.exec(from);
     if (r) {
       version = r[1] + (parseInt(r[2]) + 1);
     }

--- a/scripts/generateChangeLog.js
+++ b/scripts/generateChangeLog.js
@@ -52,7 +52,7 @@ async function getPlatformVersions(branch) {
 
 function computeVersion() {
   if (to == 'HEAD') {
-    const r = /^(.*)(\d+)$/.exec(from);
+    const r = /^(.*)\b(\d+)\b$/.exec(from);
     if (r) {
       version = r[1] + (parseInt(r[2]) + 1);
     }


### PR DESCRIPTION
previous regex only get the last number from version string. 

for example "23.3.29", it will only return 9 then do plus one, which results in 23.3.210.

