### PR TITLE
fix: refresh also combobox value json-data when renderer is set

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitRendererPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitRendererPage.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.renderer.LitRenderer;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-multi-select-combo-box/lit-renderer")
+public class MultiSelectComboBoxLitRendererPage extends Div {
+
+    public MultiSelectComboBoxLitRendererPage() {
+        addReadOnlyUseCase();
+    }
+
+    private void addReadOnlyUseCase() {
+        MultiSelectComboBox<Integer> multiSelect = new MultiSelectComboBox<>();
+        multiSelect.setId("read-only-multi-select-combo-box");
+        multiSelect.setItems(
+                IntStream.range(0, 1000).boxed().collect(Collectors.toList()));
+        multiSelect.select(0, 1);
+        multiSelect.setRenderer(createLitRenderer());
+        multiSelect.setReadOnly(true);
+        add(multiSelect);
+    }
+
+    private LitRenderer<Integer> createLitRenderer() {
+        return LitRenderer
+                .<Integer> of(
+                        "<div id=\"item-${index}\">Lit: ${item.name}</div>")
+                .withProperty("name", item -> "Item " + item);
+    }
+
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitRendererIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-multi-select-combo-box/lit-renderer")
+public class MultiSelectComboBoxLitRendererIT extends AbstractComponentIT {
+
+    private MultiSelectComboBoxElement readOnlyComboBox;
+
+    @Before
+    public void init() {
+        open();
+        readOnlyComboBox = $(MultiSelectComboBoxElement.class)
+                .id("read-only-multi-select-combo-box");
+    }
+
+    @Test
+    public void readOnly_shouldRenderSelectedItems() {
+        readOnlyComboBox.openPopup();
+        assertOverlayHasItem("Lit: Item 0");
+        assertOverlayHasItem("Lit: Item 1");
+    }
+
+    private void assertOverlayHasItem(String name) {
+        var items = getMultiSelectComboOverlayItems();
+        Assert.assertTrue(
+                items.stream().anyMatch(text -> text.getText().contains(name)));
+    }
+
+    private List<TestBenchElement> getMultiSelectComboOverlayItems() {
+        TestBenchElement overlay = $("vaadin-multi-select-combo-box-overlay")
+                .first();
+        ElementQuery<TestBenchElement> items = overlay
+                .$("vaadin-multi-select-combo-box-item");
+        return items.all();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java
@@ -81,6 +81,8 @@ class ComboBoxRenderManager<TItem> implements Serializable {
 
         comboBox.getDataController().reset();
         if (comboBox.getValue() != null) {
+            // renderer might added new dataGenerator -> refresh getValue() JSON
+            // data so it also contains the new dataGenerator data
             comboBox.refreshValue();
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java
@@ -15,13 +15,13 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import com.vaadin.flow.data.renderer.Renderer;
-import com.vaadin.flow.shared.Registration;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * Internal class for managing rendering related logic for combo box components
@@ -80,5 +80,8 @@ class ComboBoxRenderManager<TItem> implements Serializable {
         renderingRegistrations.add(rendering.getRegistration());
 
         comboBox.getDataController().reset();
+        if (comboBox.getValue() != null) {
+            comboBox.refreshValue();
+        }
     }
 }


### PR DESCRIPTION
## Description

The `MutliSelectComboBox` (MSCB) overlay seems to be empty because the configured `LitRenderer` misses the data configured by `.withProperty()` methods and is therefore unable to render the item properly. An example of such `LitRenderer` is this:
```
return LitRenderer.<Person> of("<div>Name: ${item.fullName}</div>")
                .withProperty("fullName", Person::getFullName);
```
If the renderer does not have the `fullName` data, it will render only "Name: " in the dropdown.

When the MSCB is in read-only mode, you can still open the dropdown overlay (in contrast to normal ComboBox) to review all the selected items. However, when in `read-only` mode, the backend data provider is **not** invoked to fetch the dropdown data, but rather the `selectedItems` property on the web component is used as a data feed for the `LitRenderer`.

As Serhii pointed out in [his comment](https://github.com/vaadin/flow-components/issues/5270#issuecomment-1822797167), the problem is that the `selectedItems` property doesn't contain keys using `propertyNamespace` expected by `LitRenderer` (so in addition to `label` it should contain `lr_0_fullName` etc) - simply it does not contain the data configured with `.withProperty()` method.

I tracked the issue to a point that the `DataGenerator` which is responsible for generating those data for the `LitRenderer` is not invoked when you set MSCB value using `select()` method. The order of actions is the problem here. Consider the following code:

```
...
multiSelect.setReadOnly(true);
multiSelect.setRenderer(createLitRenderer());
multiSelect.select(people.get(0), people.get(1));
...
```
1. When you set the renderer at line 2, the renderer is registered, but the first render is scheduled only as `BeforeClientResponse` action
2. `.select()` is called on line 3 which ultimately causes a call of `MultiSelectComboBox.refreshValue()` that generates and sets the `selectedItems` on the webcomponent - but it generates only `label` data (using `ItemLabelGenerator`)
3. `BeforeClientResponse` processing happens at last - calling the `render` method of the `LitRenderer` - now finally the data generator which is responsible for generating data for the `LitRenderer` is registered to the combobox ([here](https://github.com/vaadin/flow-components/blob/abe9a5085edb505fcf1d9dea289f6af5533499bb/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxRenderManager.java#L76)).

The problem is that at this point the `selectedItems` value is not regenerated, although the set of `DataGenerator`s has changed.

So, this PR refreshes also the combobox value (selected items) data before a client response after Renderer is "rendered".

I think comparable situation [is here](https://github.com/vaadin/flow-components/blob/e39becb6cc49a96297a9e2a4a5aa039a68754992/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java#L393-L396) - when you set new `ItemLabelGenerator` you also have to do both `dataController.reset()` and ` this.refreshValue();`.

However, I'm not sure if the place where I chose to call `comboBox.refreshValue();` is the correct one... I'm opened to other suggestions.

Fixes #5270 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.