### PR TITLE
fix: handle empty node id in component renderer

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComponentRendererPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComponentRendererPage.java
@@ -17,8 +17,8 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.html.Div;
@@ -26,7 +26,6 @@ import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.provider.ListDataProvider;
-import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.router.Route;
@@ -38,7 +37,7 @@ public class ComponentRendererPage extends Div {
         itemsAfterRenderer();
         dataProviderBeforeRenderer();
         dataProviderAfterRenderer();
-        throttledDataProvider();
+        multiplePagesOfItems();
     }
 
     private ComponentRenderer<VerticalLayout, ComboBoxDemoPage.Song> renderer = new ComponentRenderer<>(
@@ -109,32 +108,20 @@ public class ComponentRendererPage extends Div {
         add(comboBox);
     }
 
-    private void throttledDataProvider() {
+    private void multiplePagesOfItems() {
         ComboBox<ComboBoxDemoPage.Song> comboBox = new ComboBox<>();
         comboBox.setRenderer(
                 new ComponentRenderer<>(item -> new Span(item.getName())));
 
-        comboBox.setItems(ComponentRendererPage::getThrottledItems,
-                query -> Math.toIntExact(getThrottledItems(query).count()));
-
-        comboBox.getStyle().set(ElementConstants.STYLE_WIDTH, "250px");
-        comboBox.setId("throttled-data-provider");
-        add(comboBox);
-    }
-
-    private static Stream<ComboBoxDemoPage.Song> getThrottledItems(
-            Query<ComboBoxDemoPage.Song, String> query) {
-        if (query.getOffset() == 0) {
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return IntStream.range(0, 1000)
+        List<ComboBoxDemoPage.Song> longListOfSongs = IntStream.range(0, 1000)
                 .mapToObj(i -> new ComboBoxDemoPage.Song("Song " + i,
                         "Artist " + i, "Album " + i))
-                .skip(query.getOffset()).limit(query.getLimit());
+                .collect(Collectors.toList());
+        comboBox.setItems(longListOfSongs);
+
+        comboBox.getStyle().set(ElementConstants.STYLE_WIDTH, "250px");
+        comboBox.setId("multiple-pages-of-items");
+        add(comboBox);
     }
 
     private List<ComboBoxDemoPage.Song> createListOfSongs() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
@@ -68,28 +68,24 @@ public class ComponentRendererIT extends AbstractComboBoxIT {
     }
 
     @Test
-    public void throttledDataProvider_scrollDown_close_noItemsWhenReopened()
-            throws InterruptedException {
+    public void multiplePagesOfItems_scrollDown_close_noItemsWhenReopened() {
         ComboBoxElement comboBox = $(ComboBoxElement.class)
-                .id("throttled-data-provider");
+                .id("multiple-pages-of-items");
 
         comboBox.openPopup();
         waitUntilTextInContent("Song");
 
-        int pageSize = 50;
-        int pageCount = 12;
-        for (int i = 0; i < pageCount * pageSize; i += pageSize) {
+        for (int i = 0; i < 600; i += 50) {
             scrollToItem(comboBox, i);
         }
 
         comboBox.closePopup();
 
-        String text = (String) executeScript("arguments[0].open();"
+        String firstItemText = (String) executeScript("arguments[0].open();"
                 + "const item = document.querySelector('vaadin-combo-box-item');"
                 + "const spanInItem = item.querySelector('span');"
                 + "return spanInItem ? spanInItem.innerText : '';", comboBox);
-
-        Assert.assertEquals("", text);
+        Assert.assertEquals("", firstItemText);
     }
 
     private void testItems(TestBenchElement comboBox) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
@@ -15,27 +15,26 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.component.orderedlayout.testbench.VerticalLayoutElement;
-import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("vaadin-combo-box/component-renderer")
-public class ComponentRendererIT extends AbstractComponentIT {
+public class ComponentRendererIT extends AbstractComboBoxIT {
+
+    @Before
+    public void init() {
+        open();
+    }
 
     @Test
     public void captionsForItemsExistWhenFirstAddingItems() {
-        open();
-
         ComboBoxElement comboBox = $(ComboBoxElement.class)
                 .id("before-renderer");
 
@@ -45,8 +44,6 @@ public class ComponentRendererIT extends AbstractComponentIT {
 
     @Test
     public void captionsForItemsExistWhenFirstAddingRenderer() {
-        open();
-
         ComboBoxElement comboBox = $(ComboBoxElement.class)
                 .id("after-renderer");
 
@@ -55,8 +52,6 @@ public class ComponentRendererIT extends AbstractComponentIT {
 
     @Test
     public void captionsForItemsExistWhenFirstSettingDataProvider() {
-        open();
-
         ComboBoxElement comboBox = $(ComboBoxElement.class)
                 .id("dp-before-renderer");
 
@@ -66,12 +61,35 @@ public class ComponentRendererIT extends AbstractComponentIT {
 
     @Test
     public void captionsForItemsExistWhenFirstAddingRenderer_thenDataProvider() {
-        open();
-
         ComboBoxElement comboBox = $(ComboBoxElement.class)
                 .id("dp-after-renderer");
 
         testItems(comboBox);
+    }
+
+    @Test
+    public void throttledDataProvider_scrollDown_close_noItemsWhenReopened()
+            throws InterruptedException {
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id("throttled-data-provider");
+
+        comboBox.openPopup();
+        waitUntilTextInContent("Song");
+
+        int pageSize = 50;
+        int pageCount = 12;
+        for (int i = 0; i < pageCount * pageSize; i += pageSize) {
+            scrollToItem(comboBox, i);
+        }
+
+        comboBox.closePopup();
+
+        String text = (String) executeScript("arguments[0].open();"
+                + "const item = document.querySelector('vaadin-combo-box-item');"
+                + "const spanInItem = item.querySelector('span');"
+                + "return spanInItem ? spanInItem.innerText : '';", comboBox);
+
+        Assert.assertEquals("", text);
     }
 
     private void testItems(TestBenchElement comboBox) {
@@ -87,16 +105,4 @@ public class ComponentRendererIT extends AbstractComponentIT {
                 "Component renderer not run as we have no VerticalLayout.",
                 item.$(VerticalLayoutElement.class).exists()));
     }
-
-    private List<?> getItems(WebElement combo) {
-        List<?> items = (List<?>) getCommandExecutor()
-                .executeScript("return arguments[0].items;", combo);
-        return items;
-    }
-
-    private Object getItem(List<?> items, int index) {
-        Map<?, ?> map = (Map<?, ?>) items.get(index);
-        return map.get("label");
-    }
-
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
@@ -82,7 +82,8 @@ public class ComponentRendererIT extends AbstractComboBoxIT {
         comboBox.closePopup();
 
         String firstItemText = (String) executeScript("arguments[0].open();"
-                + "return document.querySelector('vaadin-combo-box-item')?.textContent;", comboBox);
+                + "return document.querySelector('vaadin-combo-box-item')?.textContent;",
+                comboBox);
         Assert.assertEquals("", firstItemText);
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
@@ -82,9 +82,7 @@ public class ComponentRendererIT extends AbstractComboBoxIT {
         comboBox.closePopup();
 
         String firstItemText = (String) executeScript("arguments[0].open();"
-                + "const item = document.querySelector('vaadin-combo-box-item');"
-                + "const spanInItem = item.querySelector('span');"
-                + "return spanInItem ? spanInItem.innerText : '';", comboBox);
+                + "return document.querySelector('vaadin-combo-box-item')?.textContent;", comboBox);
         Assert.assertEquals("", firstItemText);
     }
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -108,7 +108,9 @@ class FlowComponentRenderer extends PolymerElement {
       return;
     }
     if (this.nodeid == null) {
-      this.remove(this.firstChild);
+      if (this.firstChild) {
+        this.removeChild(this.firstChild);
+      }
       return;
     }
     const renderedComponent = this._getRenderedComponent();

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js
@@ -104,7 +104,11 @@ class FlowComponentRenderer extends PolymerElement {
   }
 
   _attachRenderedComponentIfAble() {
-    if (!this.nodeid || !this.appid) {
+    if (this.appid == null) {
+      return;
+    }
+    if (this.nodeid == null) {
+      this.remove(this.firstChild);
       return;
     }
     const renderedComponent = this._getRenderedComponent();


### PR DESCRIPTION
## Description

This PR handles the empty nodeid case for Flow component renderer. This is already [handled](https://github.com/vaadin/flow-components/blob/8cebb28a0f8ecb55dc3e79c78da42b4831bcbb42/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-directive.js#L34-L35) in the newer Flow component directive. With the new change, if a null/undefined node ID is received and there is a rendered child, it is removed.

Note: The test will succeed without the change in v24. The reason is that the Flow component renderer has already been refactored out of the renderer.

Note 2: There is no test added to the renderer package since I could not come up with a good test. This test is added to test at least the use-case provided in the related issue for this change.

Fixes #5830

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.