### PR TITLE
fix: add polyfill to trigger context-menu on long press

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionWidget.java
@@ -217,7 +217,6 @@ public class SelectionWidget extends Composite {
                                 onPaintEvent(event);
                             }
                         }
-                        event.preventDefault();
                         event.stopPropagation();
                     }
                 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetEventListener.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetEventListener.java
@@ -36,12 +36,11 @@ public class SheetEventListener implements EventListener {
     }
 
     protected void listenToEventsOnPane(Element sheetElement) {
-        Event.sinkEvents(sheetElement,
-                Event.ONSCROLL | Event.ONMOUSEDOWN | Event.ONMOUSEMOVE
-                        | Event.ONMOUSEOVER | Event.ONMOUSEOUT | Event.ONMOUSEUP
-                        | Event.TOUCHEVENTS | Event.ONLOSECAPTURE
-                        | Event.ONCLICK | Event.ONDBLCLICK | Event.ONKEYPRESS
-                        | Event.ONKEYDOWN | Event.FOCUSEVENTS);
+        Event.sinkEvents(sheetElement, Event.ONSCROLL | Event.ONMOUSEDOWN
+                | Event.ONMOUSEMOVE | Event.ONMOUSEOVER | Event.ONMOUSEOUT
+                | Event.ONMOUSEUP | Event.TOUCHEVENTS | Event.ONLOSECAPTURE
+                | Event.ONCLICK | Event.ONDBLCLICK | Event.ONKEYPRESS
+                | Event.ONKEYDOWN | Event.FOCUSEVENTS | Event.ONCONTEXTMENU);
         Event.setEventListener(sheetElement, this);
     }
 
@@ -85,12 +84,8 @@ public class SheetEventListener implements EventListener {
                     widget.onSheetMouseDown(event);
                 }
                 break;
-            case Event.ONMOUSEUP:
-                if (event.getButton() == NativeEvent.BUTTON_RIGHT) {
-                    // Context menu is displayed on mouse up to prevent
-                    // contextmenu event on VContextMenu
-                    widget.onSheetMouseDown(event);
-                }
+            case Event.ONCONTEXTMENU:
+                widget.onSheetMouseDown(event);
                 break;
             case Event.ONDBLCLICK:
                 onSheetDoubleClick(event);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -1151,8 +1151,7 @@ public class SheetWidget extends Panel {
 
         if (isEventInCustomEditorCell(event) || touchedOnSelectedCell) {
             // allow sheet context menu on top of custom editors
-            if (event.getButton() == NativeEvent.BUTTON_RIGHT
-                    || event.getType() == BrowserEvents.CONTEXTMENU) {
+            if (BrowserEvents.CONTEXTMENU.equals(event.getType())) {
                 actionHandler.onCellRightClick(event, selectedCellCol,
                         selectedCellRow);
             } else if (selectingCells) { // this is probably unnecessary
@@ -1196,8 +1195,7 @@ public class SheetWidget extends Panel {
 
             event.stopPropagation();
             event.preventDefault();
-            if (event.getButton() == NativeEvent.BUTTON_RIGHT
-                    || event.getType() == BrowserEvents.CONTEXTMENU) {
+            if (BrowserEvents.CONTEXTMENU.equals(event.getType())) {
                 Event.releaseCapture(sheet);
                 actionHandler.onCellRightClick(event, targetCol, targetRow);
             } else {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -28,6 +28,7 @@ import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
@@ -1141,7 +1142,8 @@ public class SheetWidget extends Panel {
 
         if (isEventInCustomEditorCell(event)) {
             // allow sheet context menu on top of custom editors
-            if (event.getButton() == NativeEvent.BUTTON_RIGHT) {
+            if (event.getButton() == NativeEvent.BUTTON_RIGHT
+                    || event.getType() == BrowserEvents.CONTEXTMENU) {
                 actionHandler.onCellRightClick(event, selectedCellCol,
                         selectedCellRow);
             } else if (selectingCells) { // this is probably unnecessary
@@ -1185,7 +1187,8 @@ public class SheetWidget extends Panel {
 
             event.stopPropagation();
             event.preventDefault();
-            if (event.getButton() == NativeEvent.BUTTON_RIGHT) {
+            if (event.getButton() == NativeEvent.BUTTON_RIGHT
+                    || event.getType() == BrowserEvents.CONTEXTMENU) {
                 Event.releaseCapture(sheet);
                 actionHandler.onCellRightClick(event, targetCol, targetRow);
             } else {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetContextMenuPolyfill.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetContextMenuPolyfill.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.spreadsheet.client;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.BrowserEvents;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.EventTarget;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Touch;
+import com.google.gwt.event.dom.client.TouchCancelEvent;
+import com.google.gwt.event.dom.client.TouchCancelHandler;
+import com.google.gwt.event.dom.client.TouchEndEvent;
+import com.google.gwt.event.dom.client.TouchEndHandler;
+import com.google.gwt.event.dom.client.TouchMoveEvent;
+import com.google.gwt.event.dom.client.TouchMoveHandler;
+import com.google.gwt.event.dom.client.TouchStartEvent;
+import com.google.gwt.event.dom.client.TouchStartHandler;
+import com.google.gwt.user.client.Timer;
+
+/**
+ * Handles the context menu event.
+ * <p>
+ * This class is a polyfill for the context menu event on touch devices. It
+ * implements touch event handlers to trigger a context menu event after a long
+ * press.
+ * </p>
+ * <p>
+ * On touch start, a timer is started. If the user releases the touch before the
+ * timer expires, the timer is cancelled. If the user moves the touch before the
+ * timer expires, the timer is cancelled. If the timer expires, a context menu
+ * event is triggered.
+ * </p>
+ *
+ */
+final class SpreadsheetContextMenuPolyfill implements TouchStartHandler,
+        TouchCancelHandler, TouchEndHandler, TouchMoveHandler {
+    final SpreadsheetWidget spreadsheetWidget;
+    /* default */ Timer timer;
+
+    /**
+     * @param widget
+     */
+    public SpreadsheetContextMenuPolyfill(SpreadsheetWidget widget) {
+        this.spreadsheetWidget = widget;
+    }
+
+    /**
+     * @see TouchCancelHandler#onTouchCancel(TouchCancelEvent)
+     */
+    @Override
+    public void onTouchCancel(TouchCancelEvent event) {
+        if (timer != null) {
+            timer.cancel();
+        }
+    }
+
+    /**
+     * @see TouchEndHandler#onTouchEnd(TouchEndEvent)
+     */
+    @Override
+    public void onTouchEnd(TouchEndEvent event) {
+        if (timer != null) {
+            timer.cancel();
+        }
+    }
+
+    /**
+     * @see TouchMoveHandler#onTouchMove(TouchMoveEvent)
+     */
+    @Override
+    public void onTouchMove(TouchMoveEvent event) {
+        if (timer != null) {
+            timer.cancel();
+        }
+    }
+
+    /**
+     * @see TouchStartHandler#onTouchStart(TouchStartEvent)
+     */
+    @Override
+    public void onTouchStart(TouchStartEvent event) {
+        NativeEvent nativeEvent = event.getNativeEvent();
+        Element target = nativeEvent.getEventTarget().cast();
+
+        if (target == null) {
+            target = spreadsheetWidget.getSheetWidget().getElement();
+        }
+
+        final Element finalTarget = target;
+
+        JsArray<Touch> targetTouches = nativeEvent.getTargetTouches();
+        Touch touch = null;
+        if (targetTouches != null && targetTouches.length() > 0) {
+            touch = targetTouches.get(0);
+        }
+
+        final int screenX = touch != null ? touch.getScreenX()
+                : nativeEvent.getScreenX();
+        final int screenY = touch == null ? nativeEvent.getScreenY()
+                : touch.getScreenY();
+        final int clientX = touch != null ? touch.getClientX()
+                : nativeEvent.getClientX();
+        final int clientY = touch != null ? touch.getClientY()
+                : nativeEvent.getClientY();
+        final EventTarget relatedEventTarget = touch != null ? touch.getTarget()
+                : nativeEvent.getEventTarget();
+        final Element relatedTarget = relatedEventTarget != null
+                ? Element.as(relatedEventTarget)
+                : null;
+
+        timer = new Timer() {
+            @Override
+            public void run() {
+                NativeEvent contextMenuEvent = Document.get().createMouseEvent(
+                        BrowserEvents.CONTEXTMENU, true, true, 0, screenX,
+                        screenY, clientX, clientY, false, false, false, false,
+                        NativeEvent.BUTTON_RIGHT, relatedTarget);
+                finalTarget.dispatchEvent(contextMenuEvent);
+            }
+        };
+
+        timer.schedule(750);
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetContextMenuPolyfill.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetContextMenuPolyfill.java
@@ -42,14 +42,14 @@ import com.google.gwt.user.client.Timer;
  */
 final class SpreadsheetContextMenuPolyfill implements TouchStartHandler,
         TouchCancelHandler, TouchEndHandler, TouchMoveHandler {
-    final SpreadsheetWidget spreadsheetWidget;
-    /* default */ Timer timer;
+    private final SheetWidget sheetWidget;
+    /* default */ private Timer timer;
 
     /**
      * @param widget
      */
-    public SpreadsheetContextMenuPolyfill(SpreadsheetWidget widget) {
-        this.spreadsheetWidget = widget;
+    public SpreadsheetContextMenuPolyfill(SheetWidget widget) {
+        this.sheetWidget = widget;
     }
 
     /**
@@ -91,7 +91,7 @@ final class SpreadsheetContextMenuPolyfill implements TouchStartHandler,
         Element target = nativeEvent.getEventTarget().cast();
 
         if (target == null) {
-            target = spreadsheetWidget.getSheetWidget().getElement();
+            target = sheetWidget.getElement();
         }
 
         final Element finalTarget = target;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -8,6 +8,15 @@
  */
 package com.vaadin.addon.spreadsheet.client;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Document;
@@ -30,15 +39,6 @@ import com.vaadin.client.ServerConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.communication.RpcProxy;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 public class SpreadsheetWidget extends Composite implements SheetHandler,
         FormulaBarHandler, SheetTabSheetHandler, Focusable {
@@ -2078,5 +2078,4 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
     public void setHost(Element host, Node renderRoot) {
         sheetWidget.setHost(host, renderRoot);
     }
-
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -8,23 +8,19 @@
  */
 package com.vaadin.addon.spreadsheet.client;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Node;
+import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.TouchCancelEvent;
+import com.google.gwt.event.dom.client.TouchEndEvent;
 import com.google.gwt.event.dom.client.TouchEvent;
+import com.google.gwt.event.dom.client.TouchMoveEvent;
+import com.google.gwt.event.dom.client.TouchStartEvent;
 import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
@@ -34,11 +30,21 @@ import com.vaadin.addon.spreadsheet.client.MergedRegionUtil.MergedRegionContaine
 import com.vaadin.addon.spreadsheet.client.SheetTabSheet.SheetTabSheetHandler;
 import com.vaadin.addon.spreadsheet.client.SpreadsheetConnector.CommsTrigger;
 import com.vaadin.addon.spreadsheet.shared.GroupingData;
+import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.Focusable;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.communication.RpcProxy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 public class SpreadsheetWidget extends Composite implements SheetHandler,
         FormulaBarHandler, SheetTabSheetHandler, Focusable {
@@ -220,6 +226,24 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
 
             }
         });
+
+        if (isTouchMode() && !BrowserInfo.get().isAndroid()) {
+            final var longPressHandler = new SpreadsheetContextMenuPolyfill(
+                    this);
+            sheetWidget.addDomHandler(longPressHandler,
+                    TouchStartEvent.getType());
+            sheetWidget.addDomHandler(longPressHandler,
+                    TouchEndEvent.getType());
+            sheetWidget.addDomHandler(longPressHandler,
+                    TouchMoveEvent.getType());
+            sheetWidget.addDomHandler(longPressHandler,
+                    TouchCancelEvent.getType());
+
+            sheetWidget.addDomHandler(
+                    event -> sheetWidget
+                            .onSheetMouseDown((Event) event.getNativeEvent()),
+                    ContextMenuEvent.getType());
+        }
     }
 
     @Override
@@ -2078,4 +2102,5 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
     public void setHost(Element host, Node renderRoot) {
         sheetWidget.setHost(host, renderRoot);
     }
+
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -14,13 +14,8 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Node;
-import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.dom.client.TouchCancelEvent;
-import com.google.gwt.event.dom.client.TouchEndEvent;
 import com.google.gwt.event.dom.client.TouchEvent;
-import com.google.gwt.event.dom.client.TouchMoveEvent;
-import com.google.gwt.event.dom.client.TouchStartEvent;
 import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
@@ -30,7 +25,6 @@ import com.vaadin.addon.spreadsheet.client.MergedRegionUtil.MergedRegionContaine
 import com.vaadin.addon.spreadsheet.client.SheetTabSheet.SheetTabSheetHandler;
 import com.vaadin.addon.spreadsheet.client.SpreadsheetConnector.CommsTrigger;
 import com.vaadin.addon.spreadsheet.shared.GroupingData;
-import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.Focusable;
 import com.vaadin.client.ServerConnector;
 import com.vaadin.client.Util;
@@ -226,24 +220,6 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
 
             }
         });
-
-        if (isTouchMode() && !BrowserInfo.get().isAndroid()) {
-            final var longPressHandler = new SpreadsheetContextMenuPolyfill(
-                    this);
-            sheetWidget.addDomHandler(longPressHandler,
-                    TouchStartEvent.getType());
-            sheetWidget.addDomHandler(longPressHandler,
-                    TouchEndEvent.getType());
-            sheetWidget.addDomHandler(longPressHandler,
-                    TouchMoveEvent.getType());
-            sheetWidget.addDomHandler(longPressHandler,
-                    TouchCancelEvent.getType());
-
-            sheetWidget.addDomHandler(
-                    event -> sheetWidget
-                            .onSheetMouseDown((Event) event.getNativeEvent()),
-                    ContextMenuEvent.getType());
-        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Add a polyfill to trigger context-menu events for long presses in iOS devices.

The polyfill is heavily based on this one provided by @WoozyG in [his comment on the issue he reported](https://github.com/vaadin/flow-components/issues/5787#issuecomment-1832744531).

The polyfill only triggers the context-menu event when the user presses down for more than 750 milliseconds. The event is handled by the same method that handles the click button, except that it now checks for the type of the event for the cases where the right click should be handled.

Below a demonstration of the feature working on a iPhone:

https://github.com/vaadin/flow-components/assets/262432/45bbbc94-706b-417c-a81d-7b994f6fee8c

Not sure yet how to add tests for this behavior.

Fixes #5787

## Type of change

- [X] Bugfix
- [ ] Feature
