### PR TITLE
fix: prevent context menu on selection column left-click 

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
@@ -12,6 +12,9 @@ import * as Gestures from '@vaadin/component-base/src/gestures.js';
 
     target.$contextMenuTargetConnector = {
       openOnHandler: tryCatchWrapper(function (e) {
+        if (target.preventContextMenu && target.preventContextMenu(e)) {
+          return;
+        }
         e.preventDefault();
         e.stopPropagation();
         this.$contextMenuTargetConnector.openEvent = e;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
@@ -12,6 +12,7 @@ import * as Gestures from '@vaadin/component-base/src/gestures.js';
 
     target.$contextMenuTargetConnector = {
       openOnHandler: tryCatchWrapper(function (e) {
+        // used by Grid to prevent context menu on selection column click
         if (target.preventContextMenu && target.preventContextMenu(e)) {
           return;
         }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
@@ -24,8 +24,8 @@ import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Hr;
-import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.router.Route;
 
@@ -34,10 +34,10 @@ public class ContextMenuGridPage extends Div {
 
     private static final String NO_TARGET_ITEM = "no target item";
 
-    private Label message;
+    private Span message;
 
     public ContextMenuGridPage() {
-        message = new Label("-");
+        message = new Span("-");
         message.setId("message");
         add(message);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
@@ -81,7 +81,11 @@ public class ContextMenuGridPage extends Div {
                 event -> contextMenu.setTarget(null));
         removeContextMenu.setId("remove-context-menu");
 
-        add(grid, toggleOpenOnClick, addSubMenu, removeContextMenu);
+        NativeButton setMultiSelect = new NativeButton("Multi select grid",
+                event -> grid.setSelectionMode(Grid.SelectionMode.MULTI));
+        setMultiSelect.setId("set-multi-select");
+
+        add(grid, toggleOpenOnClick, addSubMenu, removeContextMenu, setMultiSelect);
         grid.setId("grid-with-context-menu");
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
@@ -85,7 +85,8 @@ public class ContextMenuGridPage extends Div {
                 event -> grid.setSelectionMode(Grid.SelectionMode.MULTI));
         setMultiSelect.setId("set-multi-select");
 
-        add(grid, toggleOpenOnClick, addSubMenu, removeContextMenu, setMultiSelect);
+        add(grid, toggleOpenOnClick, addSubMenu, removeContextMenu,
+                setMultiSelect);
         grid.setId("grid-with-context-menu");
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
@@ -98,6 +98,24 @@ public class ContextMenuGridIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setOpenOnClickAndMultiSelect_clickOnRow_itemClickGetsTargetItem() {
+        $("button").id("toggle-open-on-click").click();
+        $("button").id("set-multi-select").click();
+        grid.getCell(14, 1).click();
+        $("vaadin-context-menu-item").first().click();
+        assertMessage("Person 14");
+        verifyClosed();
+    }
+
+    @Test
+    public void setOpenOnClickAndMultiSelect_clickOnSelectionColum_noContextMenuOpen() {
+        $("button").id("toggle-open-on-click").click();
+        $("button").id("set-multi-select").click();
+        grid.getCell(14, 0).click();
+        verifyClosed();
+    }
+
+    @Test
     public void setOpenOnClick_contextClickOnRow_noContextMenuOpen() {
         $("button").id("toggle-open-on-click").click();
         grid.getCell(22, 0).contextClick();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
@@ -239,7 +239,7 @@ public class ContextMenuGridIT extends AbstractComponentIT {
     }
 
     private void assertMessage(String expected) {
-        Assert.assertEquals(expected, $("label").id("message").getText());
+        Assert.assertEquals(expected, $("span").id("message").getText());
     }
 
     private void openSubMenu(TestBenchElement parentItem) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1040,6 +1040,15 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           return { key, columnId };
         });
 
+        grid.preventContextMenu =  tryCatchWrapper(function (event) {
+            const isLeftClick = event.type === 'click';
+            const firstColumnClicked = grid.getEventContext(event).column === grid._getColumns()[0]
+            const isMultiSelectGrid = selectionMode === validSelectionModes[2];
+            const selectionColumnClicked = isMultiSelectGrid && firstColumnClicked;
+
+            return isLeftClick && selectionColumnClicked;
+        });
+
         grid.addEventListener(
           'click',
           tryCatchWrapper((e) => _fireClickEvent(e, 'item-click'))

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1053,7 +1053,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           return { key, columnId };
         });
 
-        grid.preventContextMenu =  tryCatchWrapper(function (event) {
+        grid.preventContextMenu = tryCatchWrapper(function (event) {
             const isLeftClick = event.type === 'click';
             const firstColumnClicked = grid.getEventContext(event).column === grid._getColumns()[0]
             const isMultiSelectGrid = selectionMode === validSelectionModes[2];

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -2,6 +2,7 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
+import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js";
 
 (function () {
   const tryCatchWrapper = function (callback) {
@@ -1055,11 +1056,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 
         grid.preventContextMenu = tryCatchWrapper(function (event) {
             const isLeftClick = event.type === 'click';
-            const firstColumnClicked = grid.getEventContext(event).column === grid._getColumns()[0]
-            const isMultiSelectGrid = selectionMode === validSelectionModes[2];
-            const selectionColumnClicked = isMultiSelectGrid && firstColumnClicked;
+            const { column } = grid.getEventContext(event);
 
-            return isLeftClick && selectionColumnClicked;
+            return isLeftClick && column instanceof GridFlowSelectionColumn;
         });
 
         grid.addEventListener(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -2,7 +2,7 @@ import '@vaadin/grid/vaadin-grid-column.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import { GridSelectionColumnBaseMixin } from '@vaadin/grid/src/vaadin-grid-selection-column-base-mixin.js';
 
-class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
+export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
 
   static get is() {
     return 'vaadin-grid-flow-selection-column';


### PR DESCRIPTION
## Description

You can set the grid context menu to also open on left-click (instead of right-click which is the default) by calling `gridContextMenu.setOpenOnClick(true)`. However, this interferes with checkboxes in the selection column when in multi-selection grid (only the context menu is opened, but the selection checkbox is not checked -> therefore, no row can be selected)

I described the reasons why this has been working in V24.1 and why it's not working now in [this comment](https://github.com/vaadin/flow-components/issues/5833#issuecomment-1867933676). The comment also presents the context for the solution (and also some worse solutions that I tried).

This PR introduces a way how to prevent calling `e.preventDefault()` inside `contextMenuTargetConnector.js -> openOnHandler` that is responsible for the selection checkbox not being checked. I've introduced a new function that can be defined on the context menu target, that (if implemented) can prevent any context menu processing code. This function is then implemented by the `gridConnector`, where the code specific to the multi-selection grid can be put.

Note that the described issue is specific **only to Flow** usage of the Grid and ContextMenu - [see this comment](https://github.com/vaadin/flow-components/issues/5833#issuecomment-1871127437) related to web component usage

Fixes #5833

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.
