### PR TITLE
refactor: simplify $connector.fetchPage method

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -1,0 +1,78 @@
+import { aTimeout, expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import {
+  init,
+  GRID_CONNECTOR_ROOT_REQUEST_DELAY
+} from './shared.js';
+import type { FlowGrid } from './shared.js';
+
+describe('grid connector - data range', () => {
+  let grid: FlowGrid;
+  let size = 500;
+
+  let lastRange: [number, number] | null = null;
+
+  function setItemsRange(start: number, count: number) {
+    const items = Array.from({ length: size }, (_, i) => ({ key: `${i}`, name: `Item ${i}` }));
+
+    if (lastRange) {
+      grid.$connector.clear(lastRange[0], lastRange[1]);
+    }
+
+    grid.$connector.set(start, items.slice(start, start + count));
+    grid.$connector.confirm(-1);
+
+    lastRange = [start, count];
+  }
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+    await nextFrame();
+
+    grid.$connector.updateSize(size);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+  });
+
+  it('should request initial data range', () => {
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([0, 50]);
+  });
+
+  describe('initial data range is loaded', () => {
+    beforeEach(async () => {
+      setItemsRange(0, 50);
+      grid.$server.setRequestedRange.resetHistory();
+    });
+
+    it('should request data range after scrolling to middle', async () => {
+      grid.scrollToIndex(250);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
+      expect(grid.$server.setRequestedRange.args[0]).to.eql([200, 100]);
+    });
+
+    it('should request data range after scrolling to end', async () => {
+      grid.scrollToIndex(size - 1);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
+      expect(grid.$server.setRequestedRange.args[0]).to.eql([450, 100]);
+    });
+
+    it('should request data range after scrolling to end and back to start', async () => {
+      grid.scrollToIndex(size - 1);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      setItemsRange(450, 100);
+      grid.$server.setRequestedRange.resetHistory();
+
+      grid.scrollToIndex(0);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
+      expect(grid.$server.setRequestedRange.args[0]).to.eql([0, 50]);
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -276,13 +276,9 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
           let firstPage = Math.max(0, firstNeededPage);
           let lastPage =
             parentKey !== root ? lastNeededPage : Math.min(lastNeededPage, Math.floor(grid.size / grid.pageSize));
-          let lastRequestedRange = lastRequestedRanges[parentKey];
-          if (!lastRequestedRange) {
-            lastRequestedRange = [-1, -1];
-          }
+          let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
           if (lastRequestedRange[0] != firstPage || lastRequestedRange[1] != lastPage) {
-            lastRequestedRange = [firstPage, lastPage];
-            lastRequestedRanges[parentKey] = lastRequestedRange;
+            lastRequestedRanges[parentKey] = [firstPage, lastPage];
             let count = lastPage - firstPage + 1;
             fetch(firstPage * grid.pageSize, count * grid.pageSize);
           }


### PR DESCRIPTION
## Description

The PR slightly simplifies the grid connector's `fetchPage` method to improve its readability. It also adds basic tests to cover that method.

Part of #5865 

## Type of change

- [x] Refactor
