### PR TITLE
fix: process the last registered grid edit request

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
@@ -53,8 +53,8 @@ public class GridEditorPage extends Div {
         grid.addItemDoubleClickListener(
                 event -> grid.getEditor().editItem(event.getItem()));
 
-        NativeButton subsequentEditRequests = new NativeButton("Subsequent edits",
-                event -> {
+        NativeButton subsequentEditRequests = new NativeButton(
+                "Subsequent edits", event -> {
                     editor.editItem(items.get(0));
                     editor.editItem(items.get(1));
                 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.editor.Editor;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/editor")
+public class GridEditorPage extends Div {
+
+    public GridEditorPage() {
+        Grid<Person> grid = new Grid<>();
+
+        final List<Person> items = createGridData();
+
+        ListDataProvider<Person> dataProvider = new ListDataProvider<>(items);
+        grid.setItems(dataProvider);
+
+        Grid.Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
+                .setHeader("Name");
+
+        Binder<Person> binder = new Binder<>(Person.class);
+        Editor<Person> editor = grid.getEditor();
+        editor.setBinder(binder);
+
+        TextField field = new TextField();
+        binder.bind(field, "firstName");
+        nameColumn.setEditorComponent(field);
+        editor.addOpenListener(event -> field.focus());
+        grid.addItemDoubleClickListener(
+                event -> grid.getEditor().editItem(event.getItem()));
+
+        NativeButton subsequentEditRequests = new NativeButton("Subsequent edits",
+                event -> {
+                    editor.editItem(items.get(0));
+                    editor.editItem(items.get(1));
+                });
+        subsequentEditRequests.setId("subsequent-edit-requests");
+
+        add(grid, subsequentEditRequests);
+    }
+
+    private List<Person> createGridData() {
+        List<Person> items = new ArrayList<>();
+        items.add(new Person("foo", 10));
+        items.add(new Person("bar", 11));
+        items.add(new Person("yxz", 12));
+        return items;
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
@@ -25,33 +25,23 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.binder.Binder;
-import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-grid/editor")
 public class GridEditorPage extends Div {
 
+    private final Binder<Person> binder = new Binder<>(Person.class);
+
     public GridEditorPage() {
         Grid<Person> grid = new Grid<>();
 
         final List<Person> items = createGridData();
+        grid.setItems(items);
 
-        ListDataProvider<Person> dataProvider = new ListDataProvider<>(items);
-        grid.setItems(dataProvider);
-
-        Grid.Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
-                .setHeader("Name");
-
-        Binder<Person> binder = new Binder<>(Person.class);
         Editor<Person> editor = grid.getEditor();
         editor.setBinder(binder);
 
-        TextField field = new TextField();
-        binder.bind(field, "firstName");
-        nameColumn.setEditorComponent(field);
-        editor.addOpenListener(event -> field.focus());
-        grid.addItemDoubleClickListener(
-                event -> grid.getEditor().editItem(event.getItem()));
+        createColumnWithEditor(grid);
 
         NativeButton subsequentEditRequests = new NativeButton(
                 "Subsequent edits", event -> {
@@ -61,6 +51,15 @@ public class GridEditorPage extends Div {
         subsequentEditRequests.setId("subsequent-edit-requests");
 
         add(grid, subsequentEditRequests);
+    }
+
+    private void createColumnWithEditor(Grid<Person> grid) {
+        Grid.Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
+                .setHeader("Name");
+
+        TextField field = new TextField();
+        binder.bind(field, "firstName");
+        nameColumn.setEditorComponent(field);
     }
 
     private List<Person> createGridData() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/editor")
+public class GridEditorIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.tagName("vaadin-grid"));
+        grid = $(GridElement.class).first();
+
+        waitUntil(driver -> grid.getRowCount() > 0);
+    }
+
+    @Test
+    public void subsequentEditRowRequested_correctRowEdited() {
+        findElement(By.id("subsequent-edit-requests")).click();
+
+        assertEditorOpenedOnRow(1);
+    }
+
+    private void assertEditorOpenedOnRow(int rowIndex) {
+        final GridTHTDElement nameCell = getNameCellForRow(rowIndex);
+        final ElementQuery<TestBenchElement> editor = nameCell.$("vaadin-text-field");
+        Assert.assertTrue(editor.exists());
+    }
+
+    private GridTHTDElement getNameCellForRow(int rowIndex) {
+        GridTRElement row = grid.getRow(rowIndex);
+        return row.getCell(grid.getColumn("Name"));
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
@@ -51,7 +51,8 @@ public class GridEditorIT extends AbstractComponentIT {
 
     private void assertEditorOpenedOnRow(int rowIndex) {
         final GridTHTDElement nameCell = getNameCellForRow(rowIndex);
-        final ElementQuery<TestBenchElement> editor = nameCell.$("vaadin-text-field");
+        final ElementQuery<TestBenchElement> editor = nameCell
+                .$("vaadin-text-field");
         Assert.assertTrue(editor.exists());
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
@@ -135,8 +135,8 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
             if (this.editItemRequestRegistration != null) {
                 editItemRequestRegistration.remove();
             }
-            this.editItemRequestRegistration = ui.beforeClientResponse(getGrid(),
-                    context -> {
+            this.editItemRequestRegistration = ui
+                    .beforeClientResponse(getGrid(), context -> {
                         requestEditItem(it);
                         this.editItemRequestRegistration = null;
                     });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid.editor;
 
-import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.internal.ExecutionContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,6 +30,7 @@ import com.vaadin.flow.component.grid.ItemClickEvent;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.PropertySet;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.JsonObject;
@@ -52,7 +51,7 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
     private static final String EDITING = "_editing";
 
     private final Map<Class<?>, List<?>> listeners = new HashMap<>();
-    private SerializableConsumer<ExecutionContext> editItemRequest;
+    private StateTree.ExecutionRegistration editItemRequestRegistration;
     private Binder<T> binder;
     private T edited;
     private boolean isBuffered;
@@ -132,15 +131,16 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
         Objects.requireNonNull(item, "Editor can't edit null");
 
         final T it = item;
-        if (editItemRequest == null) {
-            editItemRequest = context -> {
-                requestEditItem(it);
-                editItemRequest = null;
-            };
-            getGrid().getElement().getNode().runWhenAttached(
-                    ui -> ui.getInternals().getStateTree().beforeClientResponse(
-                            getGrid().getElement().getNode(), editItemRequest));
-        }
+        getGrid().getElement().getNode().runWhenAttached(ui -> {
+            if (this.editItemRequestRegistration != null) {
+                editItemRequestRegistration.remove();
+            }
+            this.editItemRequestRegistration = ui.beforeClientResponse(getGrid(),
+                    context -> {
+                        requestEditItem(it);
+                        this.editItemRequestRegistration = null;
+                    });
+        });
     }
 
     private void requestEditItem(T item) {


### PR DESCRIPTION
## Description

Calling `Grid.getEditor().editItem(item)` multiple times in a single server request results in only the first call being processed and the rest of the calls being ignored. i.e. in the following code:

```
editor.editItem(itemA)
editor.editItem(itemB)
```

The `itemA` is edited in the browser, while you would expect that `itemB` is edited.

This PR changes the implementation of the `Editor.editItem` method, so only the last `editItem` call is processed. 
Inspiration for the implementation taken from [DatePicker](https://github.com/vaadin/flow-components/blob/dcdf56173c8dff47c4a4c48630a65fbfe2e253ba/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java#L448)

Fixes #5740 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.
