### PR TITLE
fix: use a custom Tab id if available

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -47,6 +47,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <scope>test</scope>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
@@ -35,6 +36,7 @@ import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -139,16 +141,27 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
             tabToContent.get(tab).removeFromParent();
         }
 
-        // On the client, content is associated with a tab by id
-        var id = "tabsheet-tab-" + UUID.randomUUID().toString();
-        tab.setId(id);
-        content.getElement().setAttribute("tab", id);
+        linkTabToContent(tab, content);
 
         tabToContent.put(tab, content.getElement());
 
         updateContent();
 
         return tab;
+    }
+
+    private void linkTabToContent(Tab tab, Component content) {
+        runBeforeClientResponse(ui -> {
+            // On the client, content is associated with a tab by id
+            var tabId = tab.getId().orElse("tabsheet-tab-" + UUID.randomUUID());
+            tab.setId(tabId);
+            content.getElement().setAttribute("tab", tabId);
+        });
+    }
+
+    private void runBeforeClientResponse(SerializableConsumer<UI> command) {
+        getElement().getNode().runWhenAttached(ui -> ui
+                .beforeClientResponse(this, context -> command.accept(ui)));
     }
 
     /**


### PR DESCRIPTION
## Description

The `TabSheet` component uses `Tab` id attribute to link the associated `content` element with it. When a `Tab` is selected, the element with `tab='tab-id-xxxxxx'` attribute is searched and displayed in the `TabSheet` content pane.

When using `TabSheet` as a web-component, it's the responsibility of the developer to make sure that the `id` of the `vaadin-tab` matches with the `tab` attribute of it's content. See [example here](https://vaadin.com/docs/latest/components/tabs#tab-sheet). However, when used from Flow, the developer does not have to set the `Tab` id at all -> it'll be generated for him.

The problem was when the developer _wanted_ to set a custom `Tab` id. You could call the `Tab.setId()`, but this did not change the `tab` attribute on the content element -> the `Tab` and `content` got disconnected and the whole `TabSheet` functionality stopped working.

This PR introduces two things:
1. The `TabSheet` code does not generate a random `Tab` id if there is already custom Id set on the `Tab`
2. It defers linking the `Tab` with `content` to `beforeClientResponse` so the developer can also set the id after the `Tab` have been added to the `TabSheet`

Note that this fixes only a situation when you call `Tab.setId()` during `TabSheet` "initialization phase" - meaning before the created `TabSheet` is sent to the client for the first time. If you, for example, change the `Tab` id in some Button click handler, then the `TabSheet` will still stop working - because you'd disconnect the `Tab` with the `content`.

After some consideration, I've chosen not to include code fixing this case in this PR. If you change id of the `Tab`, some other things will stop working too: for example the `aria-labelledby` attribute of the `content` element. So more things will have to be changed to fix this properly. On the other hand, how often somebody changes id attribute of an element after it's attached to the DOM?

Fixes #5825

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.