### PR TITLE
refactor: remove extra storage layer for pending requests

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -752,10 +752,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           // The page callbacks for the given item are about to be discarded ->
           // Resolve the callbacks with an empty array to not leave grid in loading state
           const itemContext = dataProviderController.getItemContext(item);
-          const itemSubCache = itemContext?.subCache;
-          if (itemSubCache) {
-            Object.values(itemSubCache.pendingRequests).forEach((callback) => callback([]));
-          }
+          Object.values(itemContext?.subCache?.pendingRequests || {}).forEach((callback) => callback([]));
 
           const itemId = grid.getItemId(item);
           ensureSubCacheQueue = ensureSubCacheQueue.filter((item) => item.itemkey !== itemId);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -778,7 +778,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           const parentItemContext = dataProviderController.getItemContext(parentItem);
           const parentItemSubCache = parentItemContext?.subCache;
           if (parentItemSubCache) {
-            // If grid has outstanding requests for this parent, then resolve them
+            // If grid has pending requests for this parent, then resolve them
             // and let grid update the flat size and re-render.
             const { pendingRequests } = parentItemSubCache;
             Object.entries(pendingRequests).forEach(([page, callback]) => {
@@ -797,7 +797,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               }
             });
 
-            // If size has changed, and there are no outstanding requests, then
+            // If size has changed, and there are no pending requests, then
             // manually update the size of the grid cache and update the effective
             // size, effectively re-rendering the grid. This is necessary when
             // individual items are refreshed on the server, in which case there
@@ -823,7 +823,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
         });
 
         grid.$connector.confirm = tryCatchWrapper(function (id) {
-          // We're done applying changes from this batch, resolve outstanding
+          // We're done applying changes from this batch, resolve pending
           // callbacks
           const { pendingRequests } = dataProviderController.rootCache;
           Object.entries(pendingRequests).forEach(([page, callback]) => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -40,8 +40,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           return grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
         });
 
-        const rootPageCallbacks = {};
-        const treePageCallbacks = {};
         const cache = {};
 
         /* parentRequestDelay - optimizes parent requests by batching several requests
@@ -85,7 +83,8 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
         grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
 
         grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
-          return Object.keys(rootPageCallbacks).length > 0 || (!!rootRequestDebouncer && rootRequestDebouncer.isActive());
+          const { rootCache } = dataProviderController;
+          return Object.keys(rootCache.pendingRequests).length > 0 || (!!rootRequestDebouncer && rootRequestDebouncer.isActive());
         });
 
         grid.$connector.beforeEnsureFlatIndexHierarchy = tryCatchWrapper(function (flatIndex, item) {
@@ -294,9 +293,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
           if (params.parentItem) {
             let parentUniqueKey = grid.getItemId(params.parentItem);
-            if (!treePageCallbacks[parentUniqueKey]) {
-              treePageCallbacks[parentUniqueKey] = {};
-            }
 
             const parentItemContext = dataProviderController.getItemContext(params.parentItem);
             if (cache[parentUniqueKey] && cache[parentUniqueKey][page] && parentItemContext.subCache) {
@@ -305,8 +301,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               // Resolve the callback from cache
               callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
             } else {
-              treePageCallbacks[parentUniqueKey][page] = callback;
-
               grid.$connector.fetchPage(
                 (firstIndex, size) => grid.$connector.beforeParentRequest(firstIndex, size, params.parentItem.key),
                 page,
@@ -329,8 +323,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             if (cache[root] && cache[root][page]) {
               callback(cache[root][page]);
             } else {
-              rootPageCallbacks[page] = callback;
-
               rootRequestDebouncer = Debouncer.debounce(
                 rootRequestDebouncer,
                 timeOut.after(grid._hasData ? rootRequestDelay : 0),
@@ -494,20 +486,18 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             const parentItem = createEmptyItemFromKey(parentKey);
             const parentItemContext = dataProviderController.getItemContext(parentItem);
             if (parentItemContext && parentItemContext.subCache) {
-              const callbacksForParentKey = treePageCallbacks[parentKey];
-              const callback = callbacksForParentKey && callbacksForParentKey[page];
-              _updateGridCache(page, items, callback, parentItemContext.subCache);
+              _updateGridCache(page, items, parentItemContext.subCache);
             }
           } else {
             items = cache[root][page];
-            _updateGridCache(page, items, rootPageCallbacks[page], dataProviderController.rootCache);
+            _updateGridCache(page, items, dataProviderController.rootCache);
           }
           return items;
         };
 
-        const _updateGridCache = function (page, items, callback, levelcache) {
+        const _updateGridCache = function (page, items, levelcache) {
           // Force update unless there's a callback waiting
-          if (!callback) {
+          if (!levelcache.pendingRequests[page]) {
             let rangeStart = page * grid.pageSize;
             let rangeEnd = rangeStart + grid.pageSize;
             if (!items) {
@@ -758,12 +748,15 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
         });
 
         grid.$connector.removeFromQueue = tryCatchWrapper(function (item) {
-          let itemId = grid.getItemId(item);
-          // The treePageCallbacks for the itemId are about to be discarded ->
+          // The page callbacks for the given item are about to be discarded ->
           // Resolve the callbacks with an empty array to not leave grid in loading state
-          Object.values(treePageCallbacks[itemId] || {}).forEach((callback) => callback([]));
+          const itemContext = dataProviderController.getItemContext(item);
+          const itemSubCache = itemContext && itemContext.subCache;
+          if (itemSubCache) {
+            Object.values(itemSubCache.pendingRequests).forEach((callback) => callback([]));
+          }
 
-          delete treePageCallbacks[itemId];
+          const itemId = grid.getItemId(item);
           ensureSubCacheQueue = ensureSubCacheQueue.filter((item) => item.itemkey !== itemId);
           parentRequestQueue = parentRequestQueue.filter((item) => item.parentKey !== itemId);
         });
@@ -780,44 +773,40 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             cache[parentKey][0] = [];
           }
 
-          // If grid has outstanding requests for this parent, then resolve them
-          // and let grid update the flat size and re-render.
-          let outstandingRequests = Object.getOwnPropertyNames(treePageCallbacks[parentKey] || {});
-          for (let i = 0; i < outstandingRequests.length; i++) {
-            let page = outstandingRequests[i];
+          const parentItem = createEmptyItemFromKey(parentKey);
+          const parentItemContext = dataProviderController.getItemContext(parentItem);
+          const parentItemSubCache = parentItemContext && parentItemContext.subCache;
+          if (parentItemSubCache) {
+            // If grid has outstanding requests for this parent, then resolve them
+            // and let grid update the flat size and re-render.
+            const { pendingRequests } = parentItemSubCache;
+            Object.entries(pendingRequests).forEach(([page, callback]) => {
+              let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
 
-            let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
+              if (
+                (cache[parentKey] && cache[parentKey][page]) ||
+                page < lastRequestedRange[0] ||
+                page > lastRequestedRange[1]
+              ) {
+                let items = cache[parentKey][page] || new Array(levelSize);
+                callback(items, levelSize);
+              } else if (callback && levelSize === 0) {
+                // The parent item has 0 child items => resolve the callback with an empty array
+                callback([], levelSize);
+              }
+            });
 
-            const callback = treePageCallbacks[parentKey][page];
-            if (
-              (cache[parentKey] && cache[parentKey][page]) ||
-              page < lastRequestedRange[0] ||
-              page > lastRequestedRange[1]
-            ) {
-              delete treePageCallbacks[parentKey][page];
-              let items = cache[parentKey][page] || new Array(levelSize);
-              callback(items, levelSize);
-            } else if (callback && levelSize === 0) {
-              // The parent item has 0 child items => resolve the callback with an empty array
-              delete treePageCallbacks[parentKey][page];
-              callback([], levelSize);
+            // If size has changed, and there are no outstanding requests, then
+            // manually update the size of the grid cache and update the effective
+            // size, effectively re-rendering the grid. This is necessary when
+            // individual items are refreshed on the server, in which case there
+            // is no loading request from the grid itself. In that case, if
+            // children were added or removed, the grid will not be aware of it
+            // unless we manually update the size.
+            if (hasSizeChanged && Object.keys(pendingRequests).length === 0) {
+              parentItemSubCache.size = levelSize;
+              updateGridFlatSize();
             }
-          }
-
-          // If size has changed, and there are no outstanding requests, then
-          // manually update the size of the grid cache and update the effective
-          // size, effectively re-rendering the grid. This is necessary when
-          // individual items are refreshed on the server, in which case there
-          // is no loading request from the grid itself. In that case, if
-          // children were added or removed, the grid will not be aware of it
-          // unless we manually update the size.
-          if (hasSizeChanged && outstandingRequests.length === 0) {
-            const parentItem = createEmptyItemFromKey(parentKey);
-            const parentItemContext = dataProviderController.getItemContext(parentItem);
-            if (parentItemContext && parentItemContext.subCache) {
-              parentItemContext.subCache.size = levelSize;
-            }
-            updateGridFlatSize();
           }
 
           // Let server know we're done
@@ -835,19 +824,14 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
         grid.$connector.confirm = tryCatchWrapper(function (id) {
           // We're done applying changes from this batch, resolve outstanding
           // callbacks
-          let outstandingRequests = Object.getOwnPropertyNames(rootPageCallbacks);
-          for (let i = 0; i < outstandingRequests.length; i++) {
-            let page = outstandingRequests[i];
-            let lastRequestedRange = lastRequestedRanges[root] || [0, 0];
-
+          const { pendingRequests } = dataProviderController.rootCache;
+          Object.entries(pendingRequests).forEach(([page, callback]) => {
+            const lastRequestedRange = lastRequestedRanges[root] || [0, 0];
             const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
             // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
             const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
             // Resolve if we have data or if we don't expect to get data
-            const callback = rootPageCallbacks[page];
             if ((cache[root] && cache[root][page]) || page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
-              delete rootPageCallbacks[page];
-
               if (cache[root][page]) {
                 // Cached data is available, resolve the callback
                 callback(cache[root][page]);
@@ -860,12 +844,11 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
             } else if (callback && grid.size === 0) {
               // The grid has 0 items => resolve the callback with an empty array
-              delete rootPageCallbacks[page];
               callback([]);
             }
-          }
+          });
 
-          if (Object.keys(rootPageCallbacks).length) {
+          if (Object.keys(pendingRequests).length) {
             // There are still unresolved callbacks waiting for data to the root level,
             // which means that the range grid requested items for was only partially filled.
             //

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -485,8 +485,9 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             items = cache[parentKey][page];
             const parentItem = createEmptyItemFromKey(parentKey);
             const parentItemContext = dataProviderController.getItemContext(parentItem);
-            if (parentItemContext && parentItemContext.subCache) {
-              _updateGridCache(page, items, parentItemContext.subCache);
+            const parentItemSubCache = parentItemContext?.subCache;
+            if (parentItemSubCache) {
+              _updateGridCache(page, items, parentItemSubCache);
             }
           } else {
             items = cache[root][page];
@@ -751,7 +752,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           // The page callbacks for the given item are about to be discarded ->
           // Resolve the callbacks with an empty array to not leave grid in loading state
           const itemContext = dataProviderController.getItemContext(item);
-          const itemSubCache = itemContext && itemContext.subCache;
+          const itemSubCache = itemContext?.subCache;
           if (itemSubCache) {
             Object.values(itemSubCache.pendingRequests).forEach((callback) => callback([]));
           }
@@ -775,7 +776,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
           const parentItem = createEmptyItemFromKey(parentKey);
           const parentItemContext = dataProviderController.getItemContext(parentItem);
-          const parentItemSubCache = parentItemContext && parentItemContext.subCache;
+          const parentItemSubCache = parentItemContext?.subCache;
           if (parentItemSubCache) {
             // If grid has outstanding requests for this parent, then resolve them
             // and let grid update the flat size and re-render.


### PR DESCRIPTION
## Description

The PR refactors the grid connector to access pending requests directly from the web component via DataProviderController. This eliminates the need for an extra storage of page callbacks in the connector.

Part of #5865 

## Type of change

- [x] Refactor
