### PR TITLE
refactor: remove incorrect workaround from grid connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -300,9 +300,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
             const parentItemContext = dataProviderController.getItemContext(params.parentItem);
             if (cache[parentUniqueKey] && cache[parentUniqueKey][page] && parentItemContext.subCache) {
-              // workaround: sometimes grid-element gives page index that overflows
-              page = Math.min(page, Math.floor(cache[parentUniqueKey].size / grid.pageSize));
-
               // Ensure grid isn't in loading state when the callback executes
               ensureSubCacheQueue = [];
               // Resolve the callback from cache
@@ -317,9 +314,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               );
             }
           } else {
-            // workaround: sometimes grid-element gives page index that overflows
-            page = Math.min(page, Math.floor(grid.size / grid.pageSize));
-
             // size is controlled by the server (data communicator), so if the
             // size is zero, we know that there is no data to fetch.
             // This also prevents an empty grid getting stuck in a loading state.


### PR DESCRIPTION
## Description

The PR removes an old workaround from the grid connector because it no longer works correctly. The workaround traces back to https://github.com/vaadin/vaadin-grid-flow/pull/241 where the tree grid was merged with the regular grid. Back then, the grid could apparently request pages beyond the grid size.

## Type of change

- [x] Refactor
