### PR TITLE
fix: reset fetch range when requested page is out of visible range

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -89,4 +89,27 @@ describe('grid connector - data range', () => {
       grid.$server.setRequestedRange.resetHistory();
     }
   });
+
+  it('should debounce data range requests when scrolling', async () => {
+    grid.scrollToIndex(SIZE / 2);
+    grid.scrollToIndex(SIZE - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request data range twice when scrolling to end and immediately back to start', async () => {
+    grid.scrollToIndex(SIZE - 1);
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
+
+    grid.$server.setRequestedRange.resetHistory();
+
+    setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
+  });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -46,14 +46,14 @@ describe('grid connector - data range', () => {
     grid.$server.setRequestedRange.resetHistory();
   });
 
-  it('should request data range after scrolling to end', async () => {
+  it('should request correct data range after scrolling to end', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expect(grid.$server.setRequestedRange).to.be.calledOnce;
     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  it('should request data range after scrolling to end and back to start', async () => {
+  it('should request correct data range after scrolling from end to start', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE * 2);
@@ -65,7 +65,16 @@ describe('grid connector - data range', () => {
     expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
   });
 
-  it('should request data range while gradually scrolling from start to end', async () => {
+  it('should request correct data range after size decreases after scrolling to end', async () => {
+    const newSize = SIZE / 2;
+    grid.scrollToIndex(SIZE - 1);
+    grid.$connector.updateSize(newSize);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request correct data ranges when gradually scrolling to end', async () => {
     for (let i = PAGE_SIZE; i < SIZE; i += PAGE_SIZE) {
       grid.scrollToIndex(i - 1);
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -75,7 +84,7 @@ describe('grid connector - data range', () => {
     }
   });
 
-  it('should request data range while gradually scrolling from end to start', async () => {
+  it('should request correct data ranges when gradually scrolling from end to start', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
@@ -98,18 +107,31 @@ describe('grid connector - data range', () => {
     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  it('should request data range twice when scrolling to end and immediately back to start', async () => {
-    grid.scrollToIndex(SIZE - 1);
-    grid.scrollToIndex(0);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
+  // describe('scrolling to end and immediately back to start', () => {
+  //   beforeEach(() => {
+  //     grid.scrollToIndex(SIZE - 1);
+  //     grid.scrollToIndex(0);
+  //   });
 
-    grid.$server.setRequestedRange.resetHistory();
+  //   it('should request data range first for end and then start', async () => {
+  //     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+  //     expect(grid.$server.setRequestedRange).to.be.calledOnce;
+  //     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
 
-    setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
-  });
+  //     grid.$server.setRequestedRange.resetHistory();
+
+  //     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
+  //     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+  //     expect(grid.$server.setRequestedRange).to.be.calledOnce;
+  //     expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
+  //   });
+
+  //   it('should request correct data range after size decreases after scrolling', async () => {
+  //     const newSize = SIZE / 2;
+  //     grid.$connector.updateSize(newSize);
+  //     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+  //     expect(grid.$server.setRequestedRange).to.be.calledOnce;
+  //     expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE]);
+  //   });
+  // });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -46,14 +46,14 @@ describe('grid connector - data range', () => {
     grid.$server.setRequestedRange.resetHistory();
   });
 
-  it('should request correct data range after scrolling to end', async () => {
+  it('should request data range after scrolling to end', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expect(grid.$server.setRequestedRange).to.be.calledOnce;
     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  it('should request correct data range after scrolling from end to start', async () => {
+  it('should request data range after scrolling to end and back to start', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE * 2);
@@ -65,16 +65,7 @@ describe('grid connector - data range', () => {
     expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
   });
 
-  it('should request correct data range after size decreases after scrolling to end', async () => {
-    const newSize = SIZE / 2;
-    grid.scrollToIndex(SIZE - 1);
-    grid.$connector.updateSize(newSize);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE * 2]);
-  });
-
-  it('should request correct data ranges when gradually scrolling to end', async () => {
+  it('should request data range while gradually scrolling from start to end', async () => {
     for (let i = PAGE_SIZE; i < SIZE; i += PAGE_SIZE) {
       grid.scrollToIndex(i - 1);
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -84,7 +75,7 @@ describe('grid connector - data range', () => {
     }
   });
 
-  it('should request correct data ranges when gradually scrolling from end to start', async () => {
+  it('should request data range while gradually scrolling from end to start', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
@@ -107,31 +98,18 @@ describe('grid connector - data range', () => {
     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  // describe('scrolling to end and immediately back to start', () => {
-  //   beforeEach(() => {
-  //     grid.scrollToIndex(SIZE - 1);
-  //     grid.scrollToIndex(0);
-  //   });
+  it('should request data range twice when scrolling to end and immediately back to start', async () => {
+    grid.scrollToIndex(SIZE - 1);
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
 
-  //   it('should request data range first for end and then start', async () => {
-  //     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-  //     expect(grid.$server.setRequestedRange).to.be.calledOnce;
-  //     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
+    grid.$server.setRequestedRange.resetHistory();
 
-  //     grid.$server.setRequestedRange.resetHistory();
-
-  //     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
-  //     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-  //     expect(grid.$server.setRequestedRange).to.be.calledOnce;
-  //     expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
-  //   });
-
-  //   it('should request correct data range after size decreases after scrolling', async () => {
-  //     const newSize = SIZE / 2;
-  //     grid.$connector.updateSize(newSize);
-  //     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-  //     expect(grid.$server.setRequestedRange).to.be.calledOnce;
-  //     expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE]);
-  //   });
-  // });
+    setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
+  });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -244,7 +244,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           // Adjust the requested page to be within the valid range in case
           // the grid size has changed while fetchPage was debounced.
           if (parentKey === root) {
-            page = Math.min(page, Math.floor(grid.size / grid.pageSize));
+            page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
           }
 
           // Determine what to fetch based on scroll position and not only

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -240,27 +240,40 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           });
         });
 
-        grid.$connector.fetchPage = tryCatchWrapper(function (fetch, page, parentKey) {
-          // Adjust the requested page to be within the valid range in case
-          // the grid size has changed while fetchPage was debounced.
-          if (parentKey === root) {
-            page = Math.min(page, Math.floor(grid.size / grid.pageSize));
-          }
+        grid.$connector.cancelRootRequests = tryCatchWrapper(function (predicate) {
+          const { pendingRequests } = dataProviderController.rootCache;
+          Object.entries(pendingRequests)
+            .filter(([page, _callback]) => !predicate || predicate(+page))
+            .forEach(([_page, callback]) => callback([]));
+        });
 
+        grid.$connector.cancelRootRequestsOutOfRange = tryCatchWrapper(function () {
+          const lastRequestedRange = lastRequestedRanges[root];
+          // const lastPage = Math.floor((grid.size - 1) / grid.pageSize);
+
+          if (lastRequestedRange) {
+            grid.$connector.cancelRootRequests((page) => {
+              return page < lastRequestedRange[0] || page > lastRequestedRange[1];
+            });
+          }
+        });
+
+        grid.$connector.fetchVisibleRange = tryCatchWrapper(function (fetch, parentKey) {
           // Determine what to fetch based on scroll position and not only
           // what grid asked for
-          const visibleRows = grid._getRenderedRows();
-          let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
-          let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
 
           // The buffer size could be multiplied by some constant defined by the user,
           // if he needs to reduce the number of items sent to the Grid to improve performance
           // or to increase it to make Grid smoother when scrolling
+          const visibleRows = grid._getRenderedRows();
+          let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
+          let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
           let buffer = end - start;
+
           let firstNeededIndex = Math.max(0, start - buffer);
           let lastNeededIndex = Math.min(end + buffer, grid._flatSize);
 
-          let pageRange = [null, null];
+          let pageRange = [];
           for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
             const { cache, index } = dataProviderController.getFlatIndexContext(idx);
             // Try to match level by going up in hierarchy. The page range should include
@@ -271,26 +284,17 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             // items from the current level cache. This can lead to an infinite loop when using
             // scrollToIndex feature.
             const sameLevelPage = grid.$connector._getSameLevelPage(parentKey, cache, index);
-            if (sameLevelPage === null) {
-              continue;
+            if (sameLevelPage !== null) {
+              pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
+              pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
             }
-            pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
-            pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
           }
 
-          // When the viewport doesn't contain the requested page or it doesn't contain any items from
-          // the requested level at all, it means that the scroll position has changed while fetchPage
-          // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
-          // then immediately back to the top. In this case, the request for the last page will be left
-          // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
-          // to make sure all hanging requests are resolved. After that, the grid requests the first page
-          // or whatever in the viewport again.
-          if (pageRange.some((p) => p === null) || page < pageRange[0] || page > pageRange[1]) {
-            pageRange = [page, page];
-          }
+          pageRange[0] ??= 0;
+          pageRange[1] ??= 0;
 
           let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
-          if (lastRequestedRange[0] != pageRange[0] || lastRequestedRange[1] != pageRange[1]) {
+          if (lastRequestedRange[0] !== pageRange[0] || lastRequestedRange[1] !== pageRange[1]) {
             lastRequestedRanges[parentKey] = pageRange;
             let pageCount = pageRange[1] - pageRange[0] + 1;
             fetch(pageRange[0] * grid.pageSize, pageCount * grid.pageSize);
@@ -314,9 +318,8 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               // Resolve the callback from cache
               callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
             } else {
-              grid.$connector.fetchPage(
-                (firstIndex, size) => grid.$connector.beforeParentRequest(firstIndex, size, params.parentItem.key),
-                page,
+              grid.$connector.fetchVisibleRange(
+                (firstIndex, size) => grid.$connector.beforeParentRequest(firstIndex, size, parentUniqueKey),
                 parentUniqueKey
               );
             }
@@ -340,11 +343,12 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                 rootRequestDebouncer,
                 timeOut.after(grid._hasData ? rootRequestDelay : 0),
                 () => {
-                  grid.$connector.fetchPage(
+                  grid.$connector.fetchVisibleRange(
                     (firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size),
-                    page,
                     root
                   );
+
+                  grid.$connector.cancelRootRequestsOutOfRange();
                 }
               );
             }
@@ -845,7 +849,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               // No cached data, resolve the callback with an empty array
               callback(new Array(grid.pageSize));
               // Request grid for content update
-              grid.requestContentUpdate();
+              // grid.requestContentUpdate();
             } else if (callback && grid.size === 0) {
               // The grid has 0 items => resolve the callback with an empty array
               callback([]);


### PR DESCRIPTION
## Description

The PR updates the grid connector's `fetchPage` method to reset the fetch range instead of extending it to avoid server exceptions about too large range when the requested page is outside the visible range.

The requested page can end up outside the visible range when the user, for example, scrolls the grid to the end and then back to the start within 150 ms (= root request debouncer timeout). Since the first page is already loaded, there will be only a request for the last page scheduled in the debouncer. The fetch range needs to be reset to ensure the resolution of that "last page" request, as well as any other requests that happen to be hanging, by the `confirm` method. After that, the grid will request the first page or whatever in the viewport again. The obvious drawback is that there will be two round-trips and can be a short blink if the server is slow. However, I propose this as a workaround for the time being. The combo-box seems to work similarly. 

I also considered canceling such requests to avoid blinks 58383b7027ae4239f4905ac4751e984dbc82c615, but that caused some ITs using small page sizes to fail and I couldn't get to the reason in a reasonable amount of time.

Fixes #5865 

## Type of change

- [x] Bugfix
