### PR TITLE
refactor: simplify grid connector with optional chaining

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-no-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-no-connector.test.ts
@@ -3,7 +3,7 @@ import { getBodyCellText, init } from './shared.js';
 import type { Grid } from '@vaadin/grid';
 
 /**
- * These tests target a <vaadin-grid> which is added on a page with gridConnector.js loaded
+ * These tests target a <vaadin-grid> which is added on a page with gridConnector.ts loaded
  * but the grid itself doesn't have a connector. An example of such a scenario is a
  * Flow view built with LitTemplate.
  */

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -1,6 +1,6 @@
 import './env-setup.js';
 import '@vaadin/grid/all-imports.js';
-import '../frontend/generated/jar-resources/gridConnector.js';
+import '../frontend/generated/jar-resources/gridConnector.ts';
 import '../frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
 // For some reason vaadin-grid-flow-selection-column doesn't import vaadin-checkbox
 import '@vaadin/checkbox';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -213,7 +213,7 @@ import org.slf4j.LoggerFactory;
 @JsModule("@vaadin/grid/src/vaadin-grid-sorter.js")
 @JsModule("@vaadin/checkbox/src/vaadin-checkbox.js")
 @JsModule("./flow-component-renderer.js")
-@JsModule("./gridConnector.js")
+@JsModule("./gridConnector.ts")
 @JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 public class Grid<T> extends Component implements HasStyle, HasSize,
         Focusable<Grid<T>>, SortNotifier<Grid<T>, GridSortOrder<T>>, HasTheme,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -76,15 +76,15 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
         grid.$connector = {};
 
-        grid.$connector.hasCacheForParentKey = tryCatchWrapper((parentKey) => cache[parentKey] !== undefined && cache[parentKey].size !== undefined);
+        grid.$connector.hasCacheForParentKey = tryCatchWrapper((parentKey) => cache[parentKey]?.size !== undefined);
 
         grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(() => ensureSubCacheQueue.length > 0);
 
         grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
 
         grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
-          const { rootCache } = dataProviderController;
-          return Object.keys(rootCache.pendingRequests).length > 0 || (!!rootRequestDebouncer && rootRequestDebouncer.isActive());
+          const { pendingRequests } = dataProviderController.rootCache;
+          return Object.keys(pendingRequests).length > 0 || !!rootRequestDebouncer?.isActive();
         });
 
         grid.$connector.beforeEnsureFlatIndexHierarchy = tryCatchWrapper(function (flatIndex, item) {
@@ -139,7 +139,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             const itemToDeselect = items.shift();
             for (let i = 0; i < updatedSelectedItems.length; i++) {
               const selectedItem = updatedSelectedItems[i];
-              if (itemToDeselect && itemToDeselect.key === selectedItem.key) {
+              if (itemToDeselect?.key === selectedItem.key) {
                 updatedSelectedItems.splice(i, 1);
                 break;
               }
@@ -295,7 +295,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             let parentUniqueKey = grid.getItemId(params.parentItem);
 
             const parentItemContext = dataProviderController.getItemContext(params.parentItem);
-            if (cache[parentUniqueKey] && cache[parentUniqueKey][page] && parentItemContext.subCache) {
+            if (cache[parentUniqueKey]?.[page] && parentItemContext.subCache) {
               // Ensure grid isn't in loading state when the callback executes
               ensureSubCacheQueue = [];
               // Resolve the callback from cache
@@ -320,7 +320,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               return;
             }
 
-            if (cache[root] && cache[root][page]) {
+            if (cache[root]?.[page]) {
               callback(cache[root][page]);
             } else {
               rootRequestDebouncer = Debouncer.debounce(
@@ -392,22 +392,18 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           if (!row.hidden) {
             // make sure that component renderers are updated
             Array.from(row.children).forEach((cell) => {
-              if (cell._content && cell._content.__templateInstance && cell._content.__templateInstance.children) {
-                Array.from(cell._content.__templateInstance.children).forEach((content) => {
-                  if (content._attachRenderedComponentIfAble) {
-                    content._attachRenderedComponentIfAble();
-                  }
-                  // In hierarchy column of tree grid, the component renderer is inside its content,
-                  // this updates it renderer from innerContent
-                  if (content.children) {
-                    Array.from(content.children).forEach((innerContent) => {
-                      if (innerContent._attachRenderedComponentIfAble) {
-                        innerContent._attachRenderedComponentIfAble();
-                      }
-                    });
+              Array.from(cell?._content?.__templateInstance?.children || []).forEach((content) => {
+                if (content._attachRenderedComponentIfAble) {
+                  content._attachRenderedComponentIfAble();
+                }
+                // In hierarchy column of tree grid, the component renderer is inside its content,
+                // this updates it renderer from innerContent
+                Array.from(content?.children || []).forEach((innerContent) => {
+                  if (innerContent._attachRenderedComponentIfAble) {
+                    innerContent._attachRenderedComponentIfAble();
                   }
                 });
-              }
+              });
             });
           }
           // since no row can be selected when selection mode is NONE
@@ -829,17 +825,14 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
             const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
             // Resolve if we have data or if we don't expect to get data
-            if ((cache[root] && cache[root][page]) || page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
-              if (cache[root][page]) {
-                // Cached data is available, resolve the callback
-                callback(cache[root][page]);
-              } else {
-                // No cached data, resolve the callback with an empty array
-                callback(new Array(grid.pageSize));
-                // Request grid for content update
-                grid.requestContentUpdate();
-              }
-
+            if (cache[root]?.[page]) {
+              // Cached data is available, resolve the callback
+              callback(cache[root][page]);
+            } else if (page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
+              // No cached data, resolve the callback with an empty array
+              callback(new Array(grid.pageSize));
+              // Request grid for content update
+              grid.requestContentUpdate();
             } else if (callback && grid.size === 0) {
               // The grid has 0 items => resolve the callback with an empty array
               callback([]);
@@ -1020,8 +1013,8 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           // when using open on click we just use the click event itself
           const sourceEvent = event.detail.sourceEvent || event;
           const eventContext = grid.getEventContext(sourceEvent);
-          const key = (eventContext.item && eventContext.item.key) || '';
-          const columnId = (eventContext.column && eventContext.column.id) || '';
+          const key = eventContext.item?.key || '';
+          const columnId = eventContext.column?.id || '';
           return { key, columnId };
         });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut, animationFrame } from '@polymer/polymer/lib/utils/async.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';


### PR DESCRIPTION
## Description

The PR simplifies the grid connector's code with the optional chaining operator. It also converts the grid connector into a TypeScript file to ensure optional chaining is properly transformed in apps that still use webpack.

## Type of change

- [x] Refactor
