### PR TITLE
fix: reset fetch range when requested page is out of visible range (#5897) (CP: 24.3)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -46,14 +46,23 @@ describe('grid connector - data range', () => {
     grid.$server.setRequestedRange.resetHistory();
   });
 
-  it('should request data range after scrolling to end', async () => {
+  it('should request correct data range when scrolling to end', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expect(grid.$server.setRequestedRange).to.be.calledOnce;
     expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  it('should request data range after scrolling to end and back to start', async () => {
+  it('should request correct data range when size decreases after scrolling to end', async () => {
+    const newSize = SIZE / 2;
+    grid.scrollToIndex(SIZE - 1);
+    grid.$connector.updateSize(newSize);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request correct data range when scrolling from end to start', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE * 2);
@@ -65,7 +74,7 @@ describe('grid connector - data range', () => {
     expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
   });
 
-  it('should request data range while gradually scrolling from start to end', async () => {
+  it('should request correct data ranges when gradually scrolling to end', async () => {
     for (let i = PAGE_SIZE; i < SIZE; i += PAGE_SIZE) {
       grid.scrollToIndex(i - 1);
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -75,7 +84,7 @@ describe('grid connector - data range', () => {
     }
   });
 
-  it('should request data range while gradually scrolling from end to start', async () => {
+  it('should request correct data ranges when gradually scrolling from end to start', async () => {
     grid.scrollToIndex(SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
@@ -88,5 +97,41 @@ describe('grid connector - data range', () => {
       expect(grid.$server.setRequestedRange.args[0]).to.eql([i - PAGE_SIZE, PAGE_SIZE * 2]);
       grid.$server.setRequestedRange.resetHistory();
     }
+  });
+
+  it('should debounce data range requests when scrolling', async () => {
+    grid.scrollToIndex(SIZE / 2);
+    grid.scrollToIndex(SIZE - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  describe('scrolling to end and immediately back to start', () => {
+    beforeEach(() => {
+      grid.scrollToIndex(SIZE - 1);
+      grid.scrollToIndex(0);
+    });
+
+    it('should request data range first for end and then for start', async () => {
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
+      expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
+
+      grid.$server.setRequestedRange.resetHistory();
+
+      setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
+      expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
+    });
+
+    it('should request correct data range when size decreases after scrolling', async () => {
+      const newSize = SIZE / 2;
+      grid.$connector.updateSize(newSize);
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setRequestedRange).to.be.calledOnce;
+      expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE]);
+    });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -242,22 +242,26 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
         });
 
         grid.$connector.fetchPage = tryCatchWrapper(function (fetch, page, parentKey) {
+          // Adjust the requested page to be within the valid range in case
+          // the grid size has changed while fetchPage was debounced.
+          if (parentKey === root) {
+            page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
+          }
+
           // Determine what to fetch based on scroll position and not only
           // what grid asked for
+          const visibleRows = grid._getRenderedRows();
+          let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
+          let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
 
           // The buffer size could be multiplied by some constant defined by the user,
           // if he needs to reduce the number of items sent to the Grid to improve performance
           // or to increase it to make Grid smoother when scrolling
-          const visibleRows = grid._getRenderedRows();
-          let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
-          let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
           let buffer = end - start;
-
           let firstNeededIndex = Math.max(0, start - buffer);
           let lastNeededIndex = Math.min(end + buffer, grid._flatSize);
 
-          let firstNeededPage = page;
-          let lastNeededPage = page;
+          let pageRange = [null, null];
           for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
             const { cache, index } = dataProviderController.getFlatIndexContext(idx);
             // Try to match level by going up in hierarchy. The page range should include
@@ -271,18 +275,26 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             if (sameLevelPage === null) {
               continue;
             }
-            firstNeededPage = Math.min(firstNeededPage, sameLevelPage);
-            lastNeededPage = Math.max(lastNeededPage, sameLevelPage);
+            pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
+            pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
           }
 
-          let firstPage = Math.max(0, firstNeededPage);
-          let lastPage =
-            parentKey !== root ? lastNeededPage : Math.min(lastNeededPage, Math.floor(grid.size / grid.pageSize));
+          // When the viewport doesn't contain the requested page or it doesn't contain any items from
+          // the requested level at all, it means that the scroll position has changed while fetchPage
+          // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
+          // then immediately back to the top. In this case, the request for the last page will be left
+          // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
+          // to make sure all hanging requests are resolved. After that, the grid requests the first page
+          // or whatever in the viewport again.
+          if (pageRange.some((p) => p === null) || page < pageRange[0] || page > pageRange[1]) {
+            pageRange = [page, page];
+          }
+
           let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
-          if (lastRequestedRange[0] != firstPage || lastRequestedRange[1] != lastPage) {
-            lastRequestedRanges[parentKey] = [firstPage, lastPage];
-            let count = lastPage - firstPage + 1;
-            fetch(firstPage * grid.pageSize, count * grid.pageSize);
+          if (lastRequestedRange[0] != pageRange[0] || lastRequestedRange[1] != pageRange[1]) {
+            lastRequestedRanges[parentKey] = pageRange;
+            let pageCount = pageRange[1] - pageRange[0] + 1;
+            fetch(pageRange[0] * grid.pageSize, pageCount * grid.pageSize);
           }
         });
 


### PR DESCRIPTION
## Description

A cherry-pick of the following fix to `24.3`:

- https://github.com/vaadin/flow-components/pull/5897

Fixes https://github.com/vaadin/flow-components/issues/5865

## Type of change

- [x] Bugfix
