### PR TITLE
fix: wraps client setEditModeRenderer call in a runWhenAttached callback

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/GridProDetachAttachPage.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/GridProDetachAttachPage.java
@@ -62,7 +62,14 @@ public class GridProDetachAttachPage extends Div {
                 });
         addColumnButton.setId("add-column");
 
-        add(grid, attachDetachButton, addColumnButton);
+        NativeButton attachAndDetachButton = new NativeButton(
+                "Attach and Detach", event -> {
+                    add(grid);
+                    remove(grid);
+                });
+        attachAndDetachButton.setId("attach-and-detach");
+
+        add(grid, attachDetachButton, addColumnButton, attachAndDetachButton);
     }
 
     public class SamplePerson {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/GridProDetachAttachIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/GridProDetachAttachIT.java
@@ -57,6 +57,13 @@ public class GridProDetachAttachIT extends AbstractComponentIT {
         assertCellEnterEditModeOnDoubleClick(grid, 0, 1, "vaadin-text-field");
     }
 
+    @Test
+    public void attachAndDetach_noClientErrors() {
+        toggleAttachedButton.click();
+        $("button").id("attach-and-detach").click();
+        checkLogsForErrors();
+    }
+
     private void assertCellEnterEditModeOnDoubleClick(GridProElement grid,
             Integer rowIndex, Integer colIndex, String editorTag) {
         GridTHTDElement cell = grid.getCell(rowIndex, colIndex);

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/EditColumnConfigurator.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/EditColumnConfigurator.java
@@ -37,6 +37,8 @@ public class EditColumnConfigurator<T> implements Serializable {
     private final EditColumn<T> column;
     private Registration attachRegistration;
 
+    private boolean editModeRendererRequested = false;
+
     /**
      * Creates a new configurator for the given column.
      *
@@ -150,21 +152,37 @@ public class EditColumnConfigurator<T> implements Serializable {
             attachRegistration.remove();
             attachRegistration = null;
         }
+        // Need to call on attach to make sure that the edit mode renderer is
+        // set in case the GridPro is detached and attached again
         attachRegistration = column.getElement()
                 .addAttachListener(e -> setEditModeRenderer(component));
 
-        column.getElement().getNode()
-                .runWhenAttached(ui -> ui.beforeClientResponse(column,
-                        context -> setEditModeRenderer(component)));
+        // Calling setEditModeRenderer here in case the GridPro is already
+        // attached and the column is added later
+        // This is needed because in this case the attach listener is not called
+        setEditModeRenderer(component);
+
         return configureColumn(valueProvider, (item, ignore) -> itemUpdater
                 .accept(item, component.getValue()), EditorType.CUSTOM,
                 component);
     }
 
     private <V> void setEditModeRenderer(HasValueAndElement<?, V> component) {
-        UI.getCurrent().getPage().executeJs(
-                "window.Vaadin.Flow.gridProConnector.setEditModeRenderer($0, $1)",
-                column.getElement(), component.getElement());
+        if (editModeRendererRequested) {
+            return;
+        }
+        editModeRendererRequested = true;
+        column.getElement().getNode().runWhenAttached(ui -> {
+            ui.beforeClientResponse(column, context -> {
+                if (!editModeRendererRequested) {
+                    return;
+                }
+                ui.getPage().executeJs(
+                        "window.Vaadin.Flow.gridProConnector.setEditModeRenderer($0, $1)",
+                        column.getElement(), component.getElement());
+                editModeRendererRequested = false;
+            });
+        });
     }
 
     /**

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -26,6 +26,9 @@
     },
     setEditModeRenderer: (column, component) =>
       tryCatchWrapper(function (column, component) {
+        if (!column || !component) {
+            return;
+        }
         column.editModeRenderer = tryCatchWrapper(function editModeRenderer(root, _, rowData) {
           if (!isEditedRow(this._grid, rowData)) {
             this._grid._stopEdit();

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -26,9 +26,6 @@
     },
     setEditModeRenderer: (column, component) =>
       tryCatchWrapper(function (column, component) {
-        if (!column || !component) {
-            return;
-        }
         column.editModeRenderer = tryCatchWrapper(function editModeRenderer(root, _, rowData) {
           if (!isEditedRow(this._grid, rowData)) {
             this._grid._stopEdit();


### PR DESCRIPTION
## Description

Wrapps the `setEditModeRenderer` method in a `runWhenAttached` callback. 

Both calls to `setEditModeRenderer` private method in the `EditColumnConfigurator` class due to two factors:
- the attach listener is only called when the whole GridPro is attached to the client, because the listener is not called when the column is created to an already attached GridPro
- because of the previous issue, there's still the need to keep a call to `setEditModeRenderer` inside the `custom` set it when the column is added afterward

To avoid the issue of two calls for the same column/component on the initialization, I implemented the same flags used in the `AbstractColumn` class for the `scheduleHeaderRendering`/`scheduleFooterRendering` methods.
Fixes #5925

## Type of change

- [X] Bugfix
- [ ] Feature
