### PR TITLE
test: improve data range tests

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -5,27 +5,40 @@ import {
 } from './shared.js';
 import type { FlowGrid } from './shared.js';
 
-const SIZE = 200;
+const ROOT_SIZE = 200;
 const PAGE_SIZE = 50;
 
 describe('grid connector - data range', () => {
   let grid: FlowGrid;
-  let lastRange: [number, number] | null = null;
+  let lastRequestedRange: [number, number] | null;
 
-  function setItemsRange(start: number, count: number) {
-    const items = Array.from({ length: SIZE }, (_, i) => ({ key: `${i}`, name: `Item ${i}` }));
+  function setRootItemsRange(start: number, count: number) {
+    const items = Array.from({ length: ROOT_SIZE }, (_, i) => ({ key: `${i}`, name: `Item-${i}` }));
 
-    if (lastRange) {
-      grid.$connector.clear(lastRange[0], lastRange[1]);
+    if (lastRequestedRange) {
+      grid.$connector.clear(lastRequestedRange[0], lastRequestedRange[1]);
     }
 
+    count = Math.min(count, ROOT_SIZE - start);
     grid.$connector.set(start, items.slice(start, start + count));
     grid.$connector.confirm(-1);
+    lastRequestedRange = [start, count];
+  }
 
-    lastRange = [start, count];
+  function expectRequestedRange(range: [number, number]) {
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql(range);
+  }
+
+  function processRequestedRange() {
+    const range = grid.$server.setRequestedRange.args[0];
+    setRootItemsRange(range[0], range[1]);
+    grid.$server.setRequestedRange.resetHistory();
   }
 
   beforeEach(async () => {
+    lastRequestedRange = null;
+
     grid = fixtureSync(`
       <vaadin-grid>
         <vaadin-grid-column path="name"></vaadin-grid-column>
@@ -36,102 +49,86 @@ describe('grid connector - data range', () => {
     await nextFrame();
 
     grid.pageSize = PAGE_SIZE;
-    grid.$connector.updateSize(SIZE);
+    grid.$connector.updateSize(ROOT_SIZE);
 
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
-
-    setItemsRange(0, PAGE_SIZE);
-    grid.$server.setRequestedRange.resetHistory();
+    expectRequestedRange([0, PAGE_SIZE]);
+    processRequestedRange();
   });
 
-  it('should request correct data range when scrolling to end', async () => {
-    grid.scrollToIndex(SIZE - 1);
+  it('should request correct ranges when scrolling (start -> end -> start)', async () => {
+    grid.scrollToIndex(ROOT_SIZE - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
-  });
+    expectRequestedRange([ROOT_SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
 
-  it('should request correct data range when size decreases after scrolling to end', async () => {
-    const newSize = SIZE / 2;
-    grid.scrollToIndex(SIZE - 1);
-    grid.$connector.updateSize(newSize);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE * 2]);
-  });
-
-  it('should request correct data range when scrolling from end to start', async () => {
-    grid.scrollToIndex(SIZE - 1);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE * 2);
-    grid.$server.setRequestedRange.resetHistory();
+    processRequestedRange();
 
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
+    expectRequestedRange([0, PAGE_SIZE]);
   });
 
-  it('should request correct data ranges when gradually scrolling to end', async () => {
-    for (let i = PAGE_SIZE; i < SIZE; i += PAGE_SIZE) {
-      grid.scrollToIndex(i - 1);
-      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-      expect(grid.$server.setRequestedRange).to.be.calledOnce;
-      expect(grid.$server.setRequestedRange.args[0]).to.eql([i - PAGE_SIZE, PAGE_SIZE * 2]);
-      grid.$server.setRequestedRange.resetHistory();
-    }
-  });
-
-  it('should request correct data ranges when gradually scrolling from end to start', async () => {
-    grid.scrollToIndex(SIZE - 1);
+  it('should request correct range when size decreases after scrolling (start -> end)', async () => {
+    const newSize = ROOT_SIZE / 2;
+    grid.scrollToIndex(ROOT_SIZE - 1);
+    grid.$connector.updateSize(newSize);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
-    grid.$server.setRequestedRange.resetHistory();
-
-    for (let i = SIZE - PAGE_SIZE; i > 0; i -= PAGE_SIZE) {
-      grid.scrollToIndex(i - 1);
-      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-      expect(grid.$server.setRequestedRange).to.be.calledOnce;
-      expect(grid.$server.setRequestedRange.args[0]).to.eql([i - PAGE_SIZE, PAGE_SIZE * 2]);
-      grid.$server.setRequestedRange.resetHistory();
-    }
+    expectRequestedRange([newSize - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  it('should debounce data range requests when scrolling', async () => {
-    grid.scrollToIndex(SIZE / 2);
-    grid.scrollToIndex(SIZE - 1);
+  it('should request correct ranges when scrolling (start -> middle -> end)', async () => {
+    grid.scrollToIndex(ROOT_SIZE / 2);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRequestedRange([ROOT_SIZE / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
+
+    processRequestedRange();
+
+    grid.scrollToIndex(ROOT_SIZE - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([ROOT_SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
-  describe('scrolling to end and immediately back to start', () => {
-    beforeEach(() => {
-      grid.scrollToIndex(SIZE - 1);
-      grid.scrollToIndex(0);
-    });
+  it('should request correct ranges when scrolling (end -> middle -> start)', async () => {
+    grid.scrollToIndex(ROOT_SIZE - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    processRequestedRange();
 
-    it('should request data range first for end and then for start', async () => {
-      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-      expect(grid.$server.setRequestedRange).to.be.calledOnce;
-      expect(grid.$server.setRequestedRange.args[0]).to.eql([SIZE - PAGE_SIZE, PAGE_SIZE]);
+    grid.scrollToIndex(ROOT_SIZE / 2);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([ROOT_SIZE / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
-      grid.$server.setRequestedRange.resetHistory();
+    processRequestedRange();
 
-      setItemsRange(SIZE - PAGE_SIZE, PAGE_SIZE);
-      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-      expect(grid.$server.setRequestedRange).to.be.calledOnce;
-      expect(grid.$server.setRequestedRange.args[0]).to.eql([0, PAGE_SIZE]);
-    });
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([0, PAGE_SIZE]);
+  });
 
-    it('should request correct data range when size decreases after scrolling', async () => {
-      const newSize = SIZE / 2;
-      grid.$connector.updateSize(newSize);
-      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-      expect(grid.$server.setRequestedRange).to.be.calledOnce;
-      expect(grid.$server.setRequestedRange.args[0]).to.eql([newSize - PAGE_SIZE, PAGE_SIZE]);
-    });
+  it('should debounce range requests when scrolling fast', async () => {
+    grid.scrollToIndex(ROOT_SIZE / 2);
+    grid.scrollToIndex(ROOT_SIZE - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([ROOT_SIZE - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
+    grid.scrollToIndex(ROOT_SIZE - 1);
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([ROOT_SIZE - PAGE_SIZE, PAGE_SIZE]);
+
+    processRequestedRange();
+
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([0, PAGE_SIZE]);
+  });
+
+  it('should request correct range when size descreases after scrolling fast (start -> end -> start)', async () => {
+    grid.scrollToIndex(ROOT_SIZE - 1);
+    grid.scrollToIndex(0);
+    const newSize = ROOT_SIZE / 2;
+    grid.$connector.updateSize(newSize);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([newSize - PAGE_SIZE, PAGE_SIZE]);
   });
 });


### PR DESCRIPTION
## Description

Extracted from #5916

The PR simplifies the data range tests by shortening their names, eliminating unnecessary nesting, extracting repetitive code into helpers. Also, it adds `$connector.updateSize` to every range update to better align the tests with the actual server flow.

## Type of change

- [x] Internal
