### PR TITLE
fix: prevent grid from requesting too many sub-level items (#5916) (CP: 23.4)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -114,25 +114,4 @@ describe('grid connector - data range', () => {
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
   });
-
-  it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
-    grid.scrollToIndex(rootSize - 1);
-    grid.scrollToIndex(0);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE]);
-
-    processRequestedRange();
-
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([0, PAGE_SIZE]);
-  });
-
-  it('should request correct range when size descreases after scrolling fast (start -> end -> start)', async () => {
-    grid.scrollToIndex(rootSize - 1);
-    grid.scrollToIndex(0);
-    rootSize /= 2;
-    grid.$connector.updateSize(rootSize);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE]);
-  });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -1,0 +1,138 @@
+import { aTimeout, expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import {
+  init,
+  GRID_CONNECTOR_ROOT_REQUEST_DELAY
+} from './shared.js';
+import type { FlowGrid } from './shared.js';
+
+const PAGE_SIZE = 50;
+
+describe('grid connector - data range', () => {
+  let grid: FlowGrid;
+  let lastRequestedRange: [number, number] | null;
+  let rootSize: number;
+
+  function setRootItemsRange(start: number, count: number) {
+    const items = Array.from({ length: rootSize }, (_, i) => ({ key: `${i}`, name: `Item-${i}` }));
+
+    grid.$connector.updateSize(rootSize);
+
+    if (lastRequestedRange) {
+      grid.$connector.clear(lastRequestedRange[0], lastRequestedRange[1]);
+    }
+
+    count = Math.min(count, rootSize - start);
+    grid.$connector.set(start, items.slice(start, start + count));
+    grid.$connector.confirm(-1);
+    lastRequestedRange = [start, count];
+  }
+
+  function expectRequestedRange(range: [number, number]) {
+    expect(grid.$server.setRequestedRange).to.be.calledOnce;
+    expect(grid.$server.setRequestedRange.args[0]).to.eql(range);
+  }
+
+  function processRequestedRange() {
+    const range = grid.$server.setRequestedRange.args[0];
+    setRootItemsRange(range[0], range[1]);
+    grid.$server.setRequestedRange.resetHistory();
+  }
+
+  beforeEach(async () => {
+    lastRequestedRange = null;
+
+    rootSize = 200;
+
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+    await nextFrame();
+
+    grid.pageSize = PAGE_SIZE;
+    grid.$connector.updateSize(rootSize);
+
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([0, PAGE_SIZE]);
+    processRequestedRange();
+  });
+
+  it('should request correct ranges when scrolling (start -> end -> start)', async () => {
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+
+    processRequestedRange();
+
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([0, PAGE_SIZE]);
+  });
+
+  it('should request correct range when size decreases after scrolling (start -> end)', async () => {
+    grid.scrollToIndex(rootSize - 1);
+    rootSize /= 2;
+    grid.$connector.updateSize(rootSize);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request correct ranges when scrolling (start -> middle -> end)', async () => {
+    grid.scrollToIndex(rootSize / 2);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
+
+    processRequestedRange();
+
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request correct ranges when scrolling (end -> middle -> start)', async () => {
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    processRequestedRange();
+
+    grid.scrollToIndex(rootSize / 2);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
+
+    processRequestedRange();
+
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([0, PAGE_SIZE]);
+  });
+
+  it('should debounce range requests when scrolling fast', async () => {
+    grid.scrollToIndex(rootSize / 2);
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+  });
+
+  it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
+    grid.scrollToIndex(rootSize - 1);
+    grid.scrollToIndex(0);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE]);
+
+    processRequestedRange();
+
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([0, PAGE_SIZE]);
+  });
+
+  it('should request correct range when size descreases after scrolling fast (start -> end -> start)', async () => {
+    grid.scrollToIndex(rootSize - 1);
+    grid.scrollToIndex(0);
+    rootSize /= 2;
+    grid.$connector.updateSize(rootSize);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE]);
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree-data-range.test.ts
@@ -124,23 +124,6 @@ describe('grid connector - tree data range', () => {
     ]);
   });
 
-  it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
-    grid.scrollToIndex(0, childSize - 1);
-    grid.scrollToIndex(0, 0);
-    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
-    expectParentRequestedRanges([
-      { parentKey: rootItems[0].key, firstIndex: childSize - PAGE_SIZE, size: PAGE_SIZE }
-    ]);
-
-    processParentRequestedRanges();
-
-    await nextFrame();
-    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
-    expectParentRequestedRanges([
-      { parentKey: rootItems[0].key, firstIndex: 0, size: PAGE_SIZE }
-    ]);
-  });
-
   it('should debounce range requests when scrolling fast', async () => {
     grid.scrollToIndex(0, childSize / 2);
     grid.scrollToIndex(0, childSize - 1);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree-data-range.test.ts
@@ -1,0 +1,164 @@
+import { aTimeout, expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import {
+  init,
+  setRootItems,
+  expandItems,
+  GRID_CONNECTOR_PARENT_REQUEST_DELAY
+} from './shared.js';
+import type { FlowGrid, Item } from './shared.js';
+
+const PAGE_SIZE = 50;
+
+describe('grid connector - tree data range', () => {
+  let grid: FlowGrid;
+  let lastRequestedRangeMap: Map<string, [number, number]>;
+  let childSize;
+
+  const rootItems = [
+    { key: 'Item-0', name: 'Item-0' },
+    { key: 'Item-1', name: 'Item-1' },
+  ];
+
+  function setChildItemsRange(parentKey: string, start: number, count: number) {
+    const items = Array.from({ length: childSize }, (_, i) => {
+      return { key: `${parentKey}-${i}`, name: `${parentKey}-${i}` };
+    });
+
+    const lastRequestedRange = lastRequestedRangeMap.get(parentKey);
+    if (lastRequestedRange) {
+      grid.$connector.clear(lastRequestedRange[0], lastRequestedRange[1], parentKey);
+    }
+
+    grid.$connector.set(start, items.slice(start, start + count), parentKey);
+    grid.$connector.confirmParent(-1, parentKey, childSize);
+    lastRequestedRangeMap.set(parentKey, [start, count]);
+  }
+
+  function processParentRequestedRanges() {
+    grid.$server.setParentRequestedRanges.args[0][0].forEach(
+      ({ parentKey, firstIndex, size }) => setChildItemsRange(parentKey, firstIndex, size)
+    );
+    grid.$server.setParentRequestedRanges.resetHistory();
+  }
+
+  function expectParentRequestedRanges(ranges: Parameters<typeof grid.$server.setParentRequestedRanges>[0]) {
+    expect(grid.$server.setParentRequestedRanges).to.be.calledOnce;
+    expect(grid.$server.setParentRequestedRanges.args[0][0]).to.eql(ranges);
+  }
+
+  beforeEach(async () => {
+    lastRequestedRangeMap = new Map();
+
+    childSize = 400;
+
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-tree-column path="name"></vaadin-grid-tree-column>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+    await nextFrame();
+
+    setRootItems(grid.$connector, rootItems);
+    expandItems(grid.$connector, [rootItems[0]]);
+
+    await nextFrame();
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: 0, size: PAGE_SIZE }
+    ]);
+    processParentRequestedRanges();
+  });
+
+  it('should request correct range when scrolling (start -> end -> start)', async () => {
+    grid.scrollToIndex(0, childSize - 1);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize - PAGE_SIZE, size: PAGE_SIZE }
+    ]);
+
+    processParentRequestedRanges();
+
+    grid.scrollToIndex(0, 0);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: 0, size: PAGE_SIZE }
+    ]);
+  });
+
+  it('should request correct range when scrolling (start -> middle -> end)', async () => {
+    grid.scrollToIndex(0, childSize / 2);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize / 2 - PAGE_SIZE, size: PAGE_SIZE * 2 }
+    ]);
+
+    processParentRequestedRanges();
+
+    grid.scrollToIndex(0, childSize);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize - PAGE_SIZE, size: PAGE_SIZE }
+    ]);
+  });
+
+  it('should request correct range when scrolling (end -> middle -> start)', async () => {
+    grid.scrollToIndex(0, childSize - 1);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    processParentRequestedRanges();
+
+    grid.scrollToIndex(0, childSize / 2);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize / 2 - PAGE_SIZE, size: PAGE_SIZE * 2 }
+    ]);
+
+    processParentRequestedRanges();
+
+    grid.scrollToIndex(0, 0);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: 0, size: PAGE_SIZE }
+    ]);
+  });
+
+  it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
+    grid.scrollToIndex(0, childSize - 1);
+    grid.scrollToIndex(0, 0);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize - PAGE_SIZE, size: PAGE_SIZE }
+    ]);
+
+    processParentRequestedRanges();
+
+    await nextFrame();
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: 0, size: PAGE_SIZE }
+    ]);
+  });
+
+  it('should debounce range requests when scrolling fast', async () => {
+    grid.scrollToIndex(0, childSize / 2);
+    grid.scrollToIndex(0, childSize - 1);
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize - PAGE_SIZE, size: PAGE_SIZE }
+    ]);
+  });
+
+  it('should batch range requests from different sub-levels when scrolling fast', async () => {
+    grid.$connector.expandItems([rootItems[1]]);
+    await nextFrame();
+    grid.scrollToIndex(1);
+    await nextFrame();
+    await aTimeout(GRID_CONNECTOR_PARENT_REQUEST_DELAY);
+    expectParentRequestedRanges([
+      { parentKey: rootItems[0].key, firstIndex: childSize - PAGE_SIZE, size: PAGE_SIZE },
+      { parentKey: rootItems[1].key, firstIndex: 0, size: PAGE_SIZE }
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

The PR cherry-picks the following fix to `24.2`:

- #5940
- #5916

Fixes #5902 

## Type of change

- [x] Bugfix
