### PR TITLE
refactor: remove deleteObjectContents helper

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -41,7 +41,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           return grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
         });
 
-        const cache = {};
+        let cache = {};
 
         /* parentRequestDelay - optimizes parent requests by batching several requests
          *  into one request. Delay in milliseconds. Disable by setting to 0.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -716,9 +716,9 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
         grid.$connector.reset = tryCatchWrapper(function () {
           grid.size = 0;
-          deleteObjectContents(cache);
-          deleteObjectContents(dataProviderController.rootCache.items);
-          deleteObjectContents(lastRequestedRanges);
+          cache = {};
+          dataProviderController.rootCache.items = [];
+          lastRequestedRanges = {};
           if (ensureSubCacheDebouncer) {
             ensureSubCacheDebouncer.cancel();
           }
@@ -734,8 +734,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
           parentRequestQueue = [];
           updateAllGridRowsInDomBasedOnCache();
         });
-
-        const deleteObjectContents = (obj) => Object.keys(obj).forEach((key) => delete obj[key]);
 
         grid.$connector.updateSize = (newSize) => (grid.size = newSize);
 
@@ -876,7 +874,8 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
               delete cache[parentKey];
             }
           }
-          deleteObjectContents(lastRequestedRanges);
+
+          lastRequestedRanges = {};
 
           dataProviderController.rootCache.removeSubCaches();
 


### PR DESCRIPTION
## Description

The PR removes the `deleteObjectContents` helper from the grid connector.

Part of #5904 

## Type of change

- [x] Refactor
