### PR TITLE
feat: add target API to SideNavItem

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -357,6 +357,66 @@ public class SideNavItem extends SideNavItemContainer
         }
     }
 
+    /**
+     * Gets the target of this item.
+     *
+     * @return the target of this item
+     */
+    public String getTarget() {
+        return getElement().getProperty("target");
+    }
+
+    /**
+     * Where to display the linked URL, as the name for a browsing context.
+     * <p>
+     * The following keywords have special meanings for where to load the URL:
+     * <ul>
+     * <li><code>_self</code>: the current browsing context. (Default)</li>
+     * <li><code>_blank</code>: usually a new tab, but users can configure
+     * browsers to open a new window instead.</li>
+     * <li><code>_parent</code>: the parent browsing context of the current one.
+     * If no parent, behaves as <code>_self</code>.</li>
+     * <li><code>_top</code>: the topmost browsing context (the "highest"
+     * context that’s an ancestor of the current one). If no ancestors, behaves
+     * as <code>_self</code>.</li>
+     * </ul>
+     * </p>
+     *
+     * @param target
+     *            the target of this item
+     */
+    public void setTarget(String target) {
+        if (target == null) {
+            getElement().removeProperty("target");
+        } else {
+            getElement().setProperty("target", target);
+        }
+    }
+
+    /**
+     * Sets whether the target URL should be opened in a new browser tab.
+     * <p>
+     * This is a convenience method for setting the target to
+     * <code>_blank</code>. See {@link #setTarget(String)} for more information.
+     * </p>
+     *
+     * @param openInNewBrowserTab true if the target URL should be opened in a
+     *                            new browser tab, false otherwise
+     */
+    public void setOpenInNewBrowserTab(boolean openInNewBrowserTab) {
+        setTarget(openInNewBrowserTab ? "_blank" : null);
+    }
+
+    /**
+     * Gets whether the target URL should be opened in a new browser tab.
+     *
+     * @return true if the target URL should be opened in a new browser tab,
+     *         false otherwise
+     */
+    public boolean isOpenInNewBrowserTab() {
+        return "_blank".equals(getTarget());
+    }
+
     private Set<String> getPathAliasesFromView(Class<? extends Component> view,
             RouteParameters routeParameters) {
         RouteAlias[] routeAliases = view.getAnnotationsByType(RouteAlias.class);

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -400,8 +400,9 @@ public class SideNavItem extends SideNavItemContainer
      * <code>_blank</code>. See {@link #setTarget(String)} for more information.
      * </p>
      *
-     * @param openInNewBrowserTab true if the target URL should be opened in a
-     *                            new browser tab, false otherwise
+     * @param openInNewBrowserTab
+     *            true if the target URL should be opened in a new browser tab,
+     *            false otherwise
      */
     public void setOpenInNewBrowserTab(boolean openInNewBrowserTab) {
         setTarget(openInNewBrowserTab ? "_blank" : null);

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -604,6 +604,39 @@ public class SideNavItemTest {
         }, TestRouteWithAliases.class);
     }
 
+    @Test
+    public void setTarget_hasTarget() {
+        sideNavItem.setTarget("_blank");
+        Assert.assertEquals("_blank",
+                sideNavItem.getElement().getProperty("target"));
+        Assert.assertEquals("_blank", sideNavItem.getTarget());
+    }
+
+    @Test
+    public void targetDefined_setToNull_noTarget() {
+        sideNavItem.setTarget("_blank");
+        sideNavItem.setTarget(null);
+        Assert.assertFalse(sideNavItem.getElement().hasProperty("target"));
+        Assert.assertNull(sideNavItem.getTarget());
+    }
+
+    @Test
+    public void setOpenInNewBrowserTab_targetBlankDefinedOnProperty() {
+        // call setOpenInNewTab and check that getTarget returns "_blank"
+        sideNavItem.setOpenInNewBrowserTab(true);
+        Assert.assertEquals("_blank",
+                sideNavItem.getElement().getProperty("target"));
+        Assert.assertTrue(sideNavItem.isOpenInNewBrowserTab());
+    }
+
+    @Test
+    public void openInNewBrowserTabDefined_setOpenInNewBrowserTabToFalse() {
+        sideNavItem.setOpenInNewBrowserTab(true);
+        sideNavItem.setOpenInNewBrowserTab(false);
+        Assert.assertFalse(sideNavItem.getElement().hasProperty("target"));
+        Assert.assertFalse(sideNavItem.isOpenInNewBrowserTab());
+    }
+
     private boolean sideNavItemHasLabelElement() {
         return sideNavItem.getElement().getChildren()
                 .anyMatch(this::isLabelElement);


### PR DESCRIPTION
## Description

Add two new API for setting/getting the `target` property of a `SideNavItem`, whose value is used to set the `target` attribute in the internal anchor element inside the web-component:
- `setTarget(String)`/`getTarget()` - which receives any string as argument
- `setOpenInNewBrowserTab(boolean)`/`isOpenInNewBrowserTab()`- a convenience method that internally calls `setTarget` with `_blank` as value when called with `true`.

Depends on vaadin/web-components#7088
Fixes #5091
AC https://github.com/vaadin/platform/issues/4850

## Type of change

- [ ] Bugfix
- [X] Feature
