### PR TITLE
refactor: avoid an extra render on grid connector confirm parent

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree.test.ts
@@ -75,7 +75,7 @@ describe('grid connector - tree', () => {
     await nextFrame();
 
     // This number may come down from further optimization
-    expect(spy.callCount).to.equal(3);
+    expect(spy.callCount).to.equal(2);
   });
 
   it('should not compute column auto-width prematurely', async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -799,14 +799,6 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
 
           // Let server know we're done
           grid.$server.confirmParentUpdate(id, parentKey);
-
-          if (!grid.loading) {
-            grid.__confirmParentUpdateDebouncer = Debouncer.debounce(
-              grid.__confirmParentUpdateDebouncer,
-              animationFrame,
-              () => grid.__updateVisibleRows()
-            );
-          }
         });
 
         grid.$connector.confirm = tryCatchWrapper(function (id) {


### PR DESCRIPTION
## Description

The PR restores https://github.com/vaadin/flow-components/pull/4894 which was reverted some time ago due to being misidentified as the cause of this [regression](https://github.com/vaadin/flow-components/issues/5045).

Part of https://github.com/vaadin/flow-components/issues/5904

## Type of change

- [x] Refactor
