### PR TITLE
Revert "test: check tree grid expand with small page size (#5176)"

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollToPage.java
@@ -49,11 +49,6 @@ public class TreeGridScrollToPage extends Div {
         });
         scrollToIndex.setId("scroll-to-index");
 
-        NativeButton changePageSize = new NativeButton("Change page size (2)",
-                e -> grid.setPageSize(2));
-        changePageSize.setId("change-page-size");
-
-        add(grid, expandAll, scrollToStart, scrollToEnd, scrollToIndex,
-                changePageSize);
+        add(grid, expandAll, scrollToStart, scrollToEnd, scrollToIndex);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollToIT.java
@@ -67,15 +67,6 @@ public class TreeGridScrollToIT extends AbstractComponentIT {
     }
 
     @Test
-    public void smallPageSize_expandAll_correctLastVisibleItem() {
-        $("button").id("change-page-size").click();
-        expandAllButton.click();
-
-        int lastVisibleRow = grid.getLastVisibleRowIndex();
-        Assert.assertEquals("Son 0/0/7", getCellContent(lastVisibleRow));
-    }
-
-    @Test
     public void scrollToEnd_correctLastVisibleItem() {
         scrollToEndButton.click();
 


### PR DESCRIPTION
## Description

The PR reverts the test that was intended to prevent the #5045 regression. The regression is still present which means the test isn't working correctly.

Part of https://github.com/vaadin/flow-components/issues/5904

## Type of change

- [x] Revert
