### PR TITLE
feat: add scrolltoitem support for grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -50,6 +50,19 @@ public class GridScrollToPage extends Div {
                 });
         addRowAndScrollToIndex.setId("add-row-and-scroll-to-index");
 
+        NativeButton scrollToItem500 = new NativeButton("Scroll to item 500",
+                e -> grid.scrollToItem(items.get(500)));
+        scrollToItem500.setId("scroll-to-item-500");
+
+        NativeButton addRowAndScrollToItem = new NativeButton(
+                "Add row and scroll to item", e -> {
+                    String itemToAdd = String.valueOf(items.size());
+                    items.add(itemToAdd);
+                    grid.getDataProvider().refreshAll();
+                    grid.scrollToItem(itemToAdd);
+                });
+        addRowAndScrollToItem.setId("add-row-and-scroll-to-item");
+
         NativeButton setSmallPageSize = new NativeButton(
                 "Set small page size (5)", e -> {
                     grid.setPageSize(5);
@@ -57,7 +70,7 @@ public class GridScrollToPage extends Div {
         setSmallPageSize.setId("set-small-page-size");
 
         add(grid, scrollToStart, scrollToEnd, scrollToRow500,
-                addRowsAndScrollToEnd, addRowAndScrollToIndex,
-                setSmallPageSize);
+                addRowsAndScrollToEnd, addRowAndScrollToIndex, scrollToItem500,
+                addRowAndScrollToItem, setSmallPageSize);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
@@ -90,6 +90,26 @@ public class GridScrollToIT extends AbstractComponentIT {
     }
 
     @Test
+    public void grid_scrollToItem500() {
+        $("button").id("scroll-to-item-500").click();
+
+        checkLogsForErrors();
+        Assert.assertEquals(500, grid.getFirstVisibleRowIndex());
+        Assert.assertEquals("500",
+                grid.getCell(grid.getFirstVisibleRowIndex(), 0).getText());
+    }
+
+    @Test
+    public void grid_addItem_scrollToItem() {
+        $("button").id("add-row-and-scroll-to-item").click();
+
+        checkLogsForErrors();
+        Assert.assertEquals(1001, grid.getLastVisibleRowIndex());
+        Assert.assertEquals("1001",
+                grid.getCell(grid.getLastVisibleRowIndex(), 0).getText());
+    }
+
+    @Test
     public void grid_addItem_scrollToIndex_twice() {
         $("button").id("add-row-and-scroll-to-index").click();
         // Wait until finished loading

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -74,6 +74,7 @@ import com.vaadin.flow.data.binder.PropertySet;
 import com.vaadin.flow.data.binder.Setter;
 import com.vaadin.flow.data.event.SortEvent;
 import com.vaadin.flow.data.event.SortEvent.SortNotifier;
+import com.vaadin.flow.data.provider.AbstractDataView;
 import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
@@ -92,6 +93,7 @@ import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasLazyDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.InMemoryDataProvider;
+import com.vaadin.flow.data.provider.ItemIndexProvider;
 import com.vaadin.flow.data.provider.KeyMapper;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
@@ -4661,6 +4663,31 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         // Scroll to the requested index
         getElement().callJsFunction("scrollToIndex", rowIndex);
+    }
+
+    /**
+     * Scrolls to the row presenting the given item.
+     * <p>
+     * Note that the item index provider should be explicitly set using
+     * {@link GridLazyDataView#setItemIndexProvider(ItemIndexProvider)} for lazy
+     * loading data providers.
+     *
+     * @param item
+     *            the item to scroll to, not {@code null}.
+     * @throws NullPointerException
+     *             if the {@code item} parameter is {@code null}.
+     * @throws NoSuchElementException
+     *             if the {@code item} cannot be found.
+     */
+    public void scrollToItem(T item) {
+        Objects.requireNonNull(item, "Item to scroll to cannot be null.");
+        AbstractDataView<T> dataView = getDataProvider().isInMemory()
+                ? getListDataView()
+                : getLazyDataView();
+        int itemIndex = dataView.getItemIndex(item)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Item to scroll to cannot be found: " + item));
+        scrollToIndex(itemIndex);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4670,7 +4670,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <p>
      * Note that the item index provider should be explicitly set using
      * {@link GridLazyDataView#setItemIndexProvider(ItemIndexProvider)} for lazy
-     * loading data providers.
+     * loading data providers. Otherwise, an
+     * {@link UnsupportedOperationException} will be thrown.
      *
      * @param item
      *            the item to scroll to, not {@code null}.
@@ -4678,6 +4679,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *             if the {@code item} parameter is {@code null}.
      * @throws NoSuchElementException
      *             if the {@code item} cannot be found.
+     * @throws UnsupportedOperationException
+     *             if {@link ItemIndexProvider} is missing for grid with a lazy
+     *             loading data provider.
      */
     public void scrollToItem(T item) {
         Objects.requireNonNull(item, "Item to scroll to cannot be null.");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -1095,4 +1095,23 @@ public class TreeGrid<T> extends Grid<T>
                 ctx -> getElement().executeJs(
                         "this.scrollToIndex(...Array(10).fill(Infinity))")));
     }
+
+    /**
+     * TreeGrid does not support scrolling to a given item. Use
+     * {@link #scrollToIndex(int...)} instead.
+     * <p>
+     * This method is inherited from Grid and has been marked as deprecated to
+     * indicate that it is not supported. This method will throw an
+     * {@link UnsupportedOperationException}.
+     *
+     * @param item
+     *            the item to scroll to
+     * @deprecated
+     */
+    @Deprecated
+    @Override
+    public void scrollToItem(T item) {
+        throw new UnsupportedOperationException(
+                "scrollToItem method is not supported in TreeGrid");
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -72,7 +72,7 @@ public class GridScrollTest {
     }
 
     @Test
-    public void listDataProvider_scrollToItem() {
+    public void listDataProvider_scrollToItem_loadsCorrectRange() {
         List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
                 .toList();
 
@@ -83,7 +83,18 @@ public class GridScrollTest {
     }
 
     @Test
-    public void lazyDataProvider_scrollToItem() {
+    public void lazyDataProvider_noItemIndexProvider_scrollToItem_throwsUnsupportedOperationException() {
+        List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
+                .toList();
+
+        grid.setItems(
+                q -> items.stream().skip(q.getOffset()).limit(q.getLimit()));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> grid.scrollToItem(items.get(500)));
+    }
+
+    @Test
+    public void lazyDataProvider_withItemIndexProvider_scrollToItem_loadsCorrectRange() {
         List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
                 .toList();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import com.vaadin.flow.internal.Range;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.IntStream;
 
 public class GridScrollTest {
@@ -92,6 +93,17 @@ public class GridScrollTest {
 
         grid.scrollToItem(items.get(500));
         Assert.assertEquals("500-550", getRequestedRange(grid));
+    }
+
+    @Test
+    public void scrollToNonExistingItem_noSuchElementExceptionThrown() {
+        List<String> items = IntStream.range(0, 10).mapToObj(String::valueOf)
+                .toList();
+
+        grid.setItems(items);
+
+        Assert.assertThrows(NoSuchElementException.class,
+                () -> grid.scrollToItem("Not present"));
     }
 
     private String getRequestedRange(Grid<String> grid) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -20,6 +20,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import com.vaadin.flow.internal.Range;
+import java.util.List;
+import java.util.stream.IntStream;
 
 public class GridScrollTest {
 
@@ -66,6 +68,30 @@ public class GridScrollTest {
         grid.setPageSize(5);
         grid.scrollToIndex(499);
         Assert.assertEquals("495-540", getRequestedRange(grid));
+    }
+
+    @Test
+    public void listDataProvider_scrollToItem() {
+        List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
+                .toList();
+
+        grid.setItems(items);
+
+        grid.scrollToItem(items.get(500));
+        Assert.assertEquals("500-550", getRequestedRange(grid));
+    }
+
+    @Test
+    public void lazyDataProvider_scrollToItem() {
+        List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
+                .toList();
+
+        grid.setItems(
+                q -> items.stream().skip(q.getOffset()).limit(q.getLimit()))
+                .setItemIndexProvider((item, query) -> items.indexOf(item));
+
+        grid.scrollToItem(items.get(500));
+        Assert.assertEquals("500-550", getRequestedRange(grid));
     }
 
     private String getRequestedRange(Grid<String> grid) {


### PR DESCRIPTION
## Description

This PR adds `scrollToItem` support to Grid, which takes an item as a parameter instead of an index. Note that this feature is not supported for TreeGrid.

Based on another [PR](https://github.com/vaadin/flow-components/pull/5628). The PR was updated based on the new [getItemIndex](https://github.com/vaadin/flow/pull/18306) API in Flow.

Fixes https://github.com/vaadin/web-components/issues/1951

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
