### PR TITLE
chore: fix vite configs to work with React

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/vite.config.ts
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/vite.config.ts
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/vite.config.ts
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/vite.config.ts
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/vite.config.ts
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/vite.config.ts
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/vite.config.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/vite.config.ts
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/vite.config.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/vite.config.ts
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/vite.config.ts
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/vite.config.ts
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/vite.config.ts
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/vite.config.ts
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/vite.config.ts
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/vite.config.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/vite.config.ts
@@ -10,15 +10,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/vite.config.ts
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/vite.config.ts
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/vite.config.ts
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/vite.config.ts
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/vite.config.ts
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/vite.config.ts
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/vite.config.ts
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/vite.config.ts
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/vite.config.ts
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/vite.config.ts
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/vite.config.ts
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/vite.config.ts
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/vite.config.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/vite.config.ts
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/vite.config.ts
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/vite.config.ts
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/vite.config.ts
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/vite.config.ts
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/vite.config.ts
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/vite.config.ts
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/vite.config.ts
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/vite.config.ts
@@ -8,15 +8,9 @@ const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
 
-  // Disable the Vite deps pre-bundling in the app to prevent Vite
-  // from caching connectors’ source code in the file system
-  optimizeDeps: {
-    disabled: true
-  },
-
   // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to 
-  // the absolute path of your web-components repo's node_modules 
+  // To use this un-comment the lines below and change the path to
+  // the absolute path of your web-components repo's node_modules
   // folder
   // DO NOT COMMIT THESE CHANGES!
   /*


### PR DESCRIPTION
Remove disabling dependency optimization from `vite.config.ts` in IT modules to make them work with the newly added React support in Flow. Contrary to the comment, the configuration doesn't seem to be necessary anymore to get live reload of changes to connector files, or a linked local web components repo.