### PR TITLE
test: fix date picker custom format IT

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -280,15 +280,13 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
         TestBenchElement output = $("span").id(
                 DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);
 
-        String todayString = LocalDate.now()
-                .format(DateTimeFormatter.ISO_LOCAL_DATE);
-        Assert.assertEquals(todayString, output.getText());
-
         $(DatePickerElement.class).id(id).click();
         waitForElementPresent(By.tagName("vaadin-date-picker-overlay"));
         $(DatePickerElement.class).id(id).sendKeys(Keys.ESCAPE);
         waitForElementNotPresent(By.tagName("vaadin-date-picker-overlay"));
 
+        String todayString = LocalDate.now()
+                .format(DateTimeFormatter.ISO_LOCAL_DATE);
         Assert.assertEquals(todayString, output.getText());
     }
 


### PR DESCRIPTION
This test has been failing multiple times in [snapshot validation](https://bender.vaadin.com/buildConfiguration/FlowComponents_Snapshot/491905?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true) for `main` and also fails for me locally. The first assertion checks whether the output span contains a certain date, however the output span is only populated when the date picker opens or closes:
https://github.com/vaadin/flow-components/blob/52f392be4e08c6392b41ee796b6e76b6bca25474/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatPage.java#L221-L230

The test never opens the date picker before the assertion, so it seems that previously the component fired the opened changed event by just adding it to the page, but now it doesn't do that anymore. To fix it I removed the first assertion as it doesn't seem relevant for the test.