### PR TITLE
fix: re-render components on attach

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -53,8 +53,12 @@ public class DetachReattachPage extends Div {
         NativeButton addItemDetailsButton = new NativeButton("Add item details",
                 e -> {
                     grid.setSelectionMode(Grid.SelectionMode.NONE);
-                    grid.setItemDetailsRenderer(new ComponentRenderer<>(
-                            item -> new Span("Item details")));
+                    grid.setItemDetailsRenderer(
+                            new ComponentRenderer<>(item -> {
+                                var span = new Span("Item details");
+                                span.setClassName("item-details");
+                                return span;
+                            }));
                 });
         addItemDetailsButton.setId("add-item-details-button");
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -30,7 +30,9 @@ public class DetachReattachPage extends Div {
     public DetachReattachPage() {
         Grid<String> grid = new Grid<String>();
         grid.setItems("A", "B", "C");
-        grid.addColumn(x -> x).setHeader("Col").setSortable(true);
+        grid.addColumn(x -> x).setHeader("Text column").setSortable(true);
+        grid.addComponentColumn(x -> new Span("Component " + x))
+                .setHeader("Component column").setSortable(true);
 
         grid.setSelectionMode(Grid.SelectionMode.SINGLE);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
@@ -68,12 +68,12 @@ public class DetachReattachIT extends AbstractComponentIT {
         grid.getCell(1, 0).click();
 
         Assert.assertTrue("Item details are visible on cell click by default.",
-                grid.findElement(By.tagName("span")).isDisplayed());
+                grid.findElement(By.className("item-details")).isDisplayed());
 
         grid.getCell(1, 0).click();
 
         Assert.assertEquals("Item details are hidden on subsequent cell click.",
-                0, grid.findElements(By.tagName("span")).size());
+                0, grid.findElements(By.className("item-details")).size());
 
         // Do not show details on click
         $("button").id("toggle-details-visible-click-button").click();
@@ -81,7 +81,7 @@ public class DetachReattachIT extends AbstractComponentIT {
         grid.getCell(1, 0).click();
         Assert.assertEquals(
                 "Item details are hidden with setDetailsVisibleOnClick(false).",
-                0, grid.findElements(By.tagName("span")).size());
+                0, grid.findElements(By.className("item-details")).size());
 
         // Detach and re-attach
         $("button").id("detach-button").click();
@@ -93,7 +93,7 @@ public class DetachReattachIT extends AbstractComponentIT {
         grid.getCell(1, 0).click();
         Assert.assertEquals(
                 "Item details are still hidden after detach and re-attach.", 0,
-                grid.findElements(By.tagName("span")).size());
+                grid.findElements(By.className("item-details")).size());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
@@ -97,6 +97,17 @@ public class DetachReattachIT extends AbstractComponentIT {
     }
 
     @Test
+    public void detachAndReattach_componentRenderersRestored() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+        Assert.assertEquals("Component A", grid.getCell(0, 1).getText());
+
+        $("button").id("detach-and-reattach-button").click();
+        grid = $(GridElement.class).first();
+        Assert.assertEquals("Component A", grid.getCell(0, 1).getText());
+    }
+
+    @Test
     public void detachAndReattach_resetSorting_noErrorIsThrown() {
         open();
         GridElement grid = $(GridElement.class).first();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1677,10 +1677,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         updateMultiSortPriority(defaultMultiSortPriority);
 
         initSelectionPreservationHandler();
-
-        addAttachListener(e -> {
-            dataCommunicator.reset();
-        });
     }
 
     private void generateUniqueKeyData(T item, JsonObject jsonObject) {
@@ -3567,12 +3563,16 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
         updateClientSideSorterIndicators(sortOrder);
         updateSelectionModeOnClient();
         if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }
+        // When the component is detached and reattached in the same roundtrip,
+        // data communicator will clear all data generators, which will also
+        // remove all components rendered by component renderers. Thus reset the
+        // data communicator to re-render components.
+        dataCommunicator.reset();
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1677,6 +1677,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         updateMultiSortPriority(defaultMultiSortPriority);
 
         initSelectionPreservationHandler();
+
+        addAttachListener(e -> {
+            dataCommunicator.reset();
+        });
     }
 
     private void generateUniqueKeyData(T item, JsonObject jsonObject) {


### PR DESCRIPTION
When a grid component is detached, its data communicator will clear all data generators, which also removes all components rendered by component renderers. If the grid is then reattached in the same roundtrip, the components are not rendered again, causing them to disappear on the client-side.

This fixes the issue by resetting the data communicator on attach, which forces items to be regenerated, thus triggering a new render of the component renderers. This causes additional roundtrips in the detach / reattach scenario, but doesn't change how the component behaves when detaching / attaching in separate roundtrips, or when attaching the component for the first time.

Fixes #5732