### PR TITLE
feat: add remove functionality for grid header and footers

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.stream.IntStream;
 
@@ -136,6 +138,62 @@ public class GridHeaderFooterRowPage extends Div {
                 event -> grid2.appendFooterRow().getCells()
                         .forEach(cell -> cell.setText("" + (counter++))));
         button.setId("append-footer-2");
+        add(button);
+
+        button = new NativeButton("Reverse column order", event -> {
+            var cols = new ArrayList<>(grid2.getColumns());
+            Collections.reverse(cols);
+            grid2.setColumnOrder(cols);
+        });
+        button.setId("reverse-column-order");
+        add(button);
+
+        button = new NativeButton("Prepend 2 footers & remove last", event -> {
+            grid2.prependFooterRow();
+            var row = grid2.prependFooterRow();
+            grid2.removeFooterRow(row);
+        });
+        button.setId("prepend-2-footers-remove-last");
+        add(button);
+
+        button = new NativeButton("Prepend 2 footers & remove first", event -> {
+            var row = grid2.prependFooterRow();
+            grid2.prependFooterRow();
+            grid2.removeFooterRow(row);
+        });
+        button.setId("prepend-2-footers-remove-first");
+        add(button);
+
+        button = new NativeButton("Append 2 footers & remove last", event -> {
+            grid2.appendFooterRow();
+            var row = grid2.appendFooterRow();
+            grid2.removeFooterRow(row);
+        });
+        button.setId("append-2-footers-remove-last");
+        add(button);
+
+        button = new NativeButton("Append 2 footers & remove first", event -> {
+            var row = grid2.appendFooterRow();
+            grid2.appendFooterRow();
+            grid2.removeFooterRow(row);
+        });
+        button.setId("append-2-footers-remove-first");
+        add(button);
+
+        button = new NativeButton("Prepend 2 headers & remove last", event -> {
+            grid2.prependHeaderRow();
+            var row = grid2.prependHeaderRow();
+            grid2.removeHeaderRow(row);
+        });
+        button.setId("prepend-2-headers-remove-last");
+        add(button);
+
+        button = new NativeButton("Append 2 headers & remove last", event -> {
+            grid2.appendHeaderRow();
+            var row = grid2.appendHeaderRow();
+            grid2.removeHeaderRow(row);
+        });
+        button.setId("append-2-headers-remove-last");
         add(button);
 
         IntStream.range(0, grid2.getColumns().size() - 1).forEach(i -> {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -124,7 +124,7 @@ public class GridHeaderFooterRowPage extends Div {
         add(grid2);
 
         IntStream.range(0, 4)
-                .forEach(i -> grid2.addColumn(ValueProvider.identity()));
+                .forEach(i -> grid2.addColumn(item -> item + "-" + (i + 1)));
 
         button = new NativeButton("Prepend header",
                 event -> grid2.prependHeaderRow().getCells()
@@ -162,6 +162,16 @@ public class GridHeaderFooterRowPage extends Div {
             b.setId("join-footers-" + i + (i + 1));
             add(b);
         });
+
+        NativeButton removeAllFooterRows = new NativeButton(
+                "removeAllFooterRows", event -> grid2.removeAllFooterRows());
+        removeAllFooterRows.setId("remove-all-footer-rows");
+        add(removeAllFooterRows);
+
+        NativeButton removeAllHeaderRows = new NativeButton(
+                "removeAllHeaderRows", event -> grid2.removeAllHeaderRows());
+        removeAllHeaderRows.setId("remove-all-header-rows");
+        add(removeAllHeaderRows);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -15,9 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.stream.IntStream;
 
@@ -138,62 +136,6 @@ public class GridHeaderFooterRowPage extends Div {
                 event -> grid2.appendFooterRow().getCells()
                         .forEach(cell -> cell.setText("" + (counter++))));
         button.setId("append-footer-2");
-        add(button);
-
-        button = new NativeButton("Reverse column order", event -> {
-            var cols = new ArrayList<>(grid2.getColumns());
-            Collections.reverse(cols);
-            grid2.setColumnOrder(cols);
-        });
-        button.setId("reverse-column-order");
-        add(button);
-
-        button = new NativeButton("Prepend 2 footers & remove last", event -> {
-            grid2.prependFooterRow();
-            var row = grid2.prependFooterRow();
-            grid2.removeFooterRow(row);
-        });
-        button.setId("prepend-2-footers-remove-last");
-        add(button);
-
-        button = new NativeButton("Prepend 2 footers & remove first", event -> {
-            var row = grid2.prependFooterRow();
-            grid2.prependFooterRow();
-            grid2.removeFooterRow(row);
-        });
-        button.setId("prepend-2-footers-remove-first");
-        add(button);
-
-        button = new NativeButton("Append 2 footers & remove last", event -> {
-            grid2.appendFooterRow();
-            var row = grid2.appendFooterRow();
-            grid2.removeFooterRow(row);
-        });
-        button.setId("append-2-footers-remove-last");
-        add(button);
-
-        button = new NativeButton("Append 2 footers & remove first", event -> {
-            var row = grid2.appendFooterRow();
-            grid2.appendFooterRow();
-            grid2.removeFooterRow(row);
-        });
-        button.setId("append-2-footers-remove-first");
-        add(button);
-
-        button = new NativeButton("Prepend 2 headers & remove last", event -> {
-            grid2.prependHeaderRow();
-            var row = grid2.prependHeaderRow();
-            grid2.removeHeaderRow(row);
-        });
-        button.setId("prepend-2-headers-remove-last");
-        add(button);
-
-        button = new NativeButton("Append 2 headers & remove last", event -> {
-            grid2.appendHeaderRow();
-            var row = grid2.appendHeaderRow();
-            grid2.removeHeaderRow(row);
-        });
-        button.setId("append-2-headers-remove-last");
         add(button);
 
         IntStream.range(0, grid2.getColumns().size() - 1).forEach(i -> {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -343,25 +343,129 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         clickButton("prepend-header-2");
         clickButton("remove-all-header-rows");
 
-        assertColumnOrderPreserved();
+        assertColumnOrderPreserved(false);
     }
 
     @Test
-    public void prependMultipleFooters_removeAllFooters_columnOrderPreserved() {
+    public void appendMultipleFooters_removeAllFooters_columnOrderPreserved() {
         grid = $(GridElement.class).id("grid2");
         clickButton("append-footer-2");
         clickButton("append-footer-2");
         clickButton("append-footer-2");
         clickButton("remove-all-footer-rows");
 
-        assertColumnOrderPreserved();
+        assertColumnOrderPreserved(false);
     }
 
-    private void assertColumnOrderPreserved() {
+    @Test
+    public void prependMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("prepend-2-headers-remove-last");
+
+        assertColumnOrderPreserved(false);
+    }
+
+    @Test
+    public void prependMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("prepend-2-footers-remove-first");
+
+        assertColumnOrderPreserved(false);
+    }
+
+    @Test
+    public void prependMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("prepend-2-footers-remove-last");
+
+        assertColumnOrderPreserved(false);
+    }
+
+    @Test
+    public void appendMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("append-2-headers-remove-last");
+
+        assertColumnOrderPreserved(false);
+    }
+
+    @Test
+    public void appendMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("append-2-footers-remove-first");
+
+        assertColumnOrderPreserved(false);
+    }
+
+    @Test
+    public void appendMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("append-2-footers-remove-last");
+
+        assertColumnOrderPreserved(false);
+    }
+
+    @Test
+    public void reverseColumnOrder_appendMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("reverse-column-order");
+        clickButton("append-2-headers-remove-last");
+
+        assertColumnOrderPreserved(true);
+    }
+
+    @Test
+    public void reverseColumnOrder_appendMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("reverse-column-order");
+        clickButton("append-2-footers-remove-first");
+
+        assertColumnOrderPreserved(true);
+    }
+
+    @Test
+    public void reverseColumnOrder_appendMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("reverse-column-order");
+        clickButton("append-2-footers-remove-last");
+
+        assertColumnOrderPreserved(true);
+    }
+
+    @Test
+    public void reverseColumnOrder_prependMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("reverse-column-order");
+        clickButton("prepend-2-headers-remove-last");
+
+        assertColumnOrderPreserved(true);
+    }
+
+    @Test
+    public void reverseColumnOrder_prependMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("reverse-column-order");
+        clickButton("prepend-2-footers-remove-first");
+
+        assertColumnOrderPreserved(true);
+    }
+
+    @Test
+    public void reverseColumnOrder_prependMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("reverse-column-order");
+        clickButton("prepend-2-footers-remove-last");
+
+        assertColumnOrderPreserved(true);
+    }
+
+    private void assertColumnOrderPreserved(boolean reversed) {
         List<GridTHTDElement> cells = grid.getCells(0);
         Assert.assertEquals(4, cells.size());
         for (int i = 0; i < cells.size(); i++) {
-            Assert.assertEquals("Item 1-" + (i + 1), cells.get(i).getText());
+            int index = reversed ? (cells.size() - 1 - i) : i;
+            Assert.assertEquals("Item 1-" + (i + 1),
+                    cells.get(index).getText());
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -332,6 +333,36 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         clickButton("join-headers-01");
         assertHeaderOrder(25, 16, 17, 0, 1, 2, 3);
         assertFooterOrder(8, 9, 10, 11, 19, 18, 24);
+    }
+
+    @Test
+    public void prependMultipleHeaders_removeAllHeaders_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("prepend-header-2");
+        clickButton("prepend-header-2");
+        clickButton("prepend-header-2");
+        clickButton("remove-all-header-rows");
+
+        assertColumnOrderPreserved();
+    }
+
+    @Test
+    public void prependMultipleFooters_removeAllFooters_columnOrderPreserved() {
+        grid = $(GridElement.class).id("grid2");
+        clickButton("append-footer-2");
+        clickButton("append-footer-2");
+        clickButton("append-footer-2");
+        clickButton("remove-all-footer-rows");
+
+        assertColumnOrderPreserved();
+    }
+
+    private void assertColumnOrderPreserved() {
+        List<GridTHTDElement> cells = grid.getCells(0);
+        Assert.assertEquals(4, cells.size());
+        for (int i = 0; i < cells.size(); i++) {
+            Assert.assertEquals("Item 1-" + (i + 1), cells.get(i).getText());
+        }
     }
 
     private void assertHeaderHasGridSorter(int headerIndexFromTop) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -343,129 +343,25 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         clickButton("prepend-header-2");
         clickButton("remove-all-header-rows");
 
-        assertColumnOrderPreserved(false);
+        assertColumnOrderPreserved();
     }
 
     @Test
-    public void appendMultipleFooters_removeAllFooters_columnOrderPreserved() {
+    public void prependMultipleFooters_removeAllFooters_columnOrderPreserved() {
         grid = $(GridElement.class).id("grid2");
         clickButton("append-footer-2");
         clickButton("append-footer-2");
         clickButton("append-footer-2");
         clickButton("remove-all-footer-rows");
 
-        assertColumnOrderPreserved(false);
+        assertColumnOrderPreserved();
     }
 
-    @Test
-    public void prependMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("prepend-2-headers-remove-last");
-
-        assertColumnOrderPreserved(false);
-    }
-
-    @Test
-    public void prependMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("prepend-2-footers-remove-first");
-
-        assertColumnOrderPreserved(false);
-    }
-
-    @Test
-    public void prependMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("prepend-2-footers-remove-last");
-
-        assertColumnOrderPreserved(false);
-    }
-
-    @Test
-    public void appendMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("append-2-headers-remove-last");
-
-        assertColumnOrderPreserved(false);
-    }
-
-    @Test
-    public void appendMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("append-2-footers-remove-first");
-
-        assertColumnOrderPreserved(false);
-    }
-
-    @Test
-    public void appendMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("append-2-footers-remove-last");
-
-        assertColumnOrderPreserved(false);
-    }
-
-    @Test
-    public void reverseColumnOrder_appendMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("reverse-column-order");
-        clickButton("append-2-headers-remove-last");
-
-        assertColumnOrderPreserved(true);
-    }
-
-    @Test
-    public void reverseColumnOrder_appendMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("reverse-column-order");
-        clickButton("append-2-footers-remove-first");
-
-        assertColumnOrderPreserved(true);
-    }
-
-    @Test
-    public void reverseColumnOrder_appendMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("reverse-column-order");
-        clickButton("append-2-footers-remove-last");
-
-        assertColumnOrderPreserved(true);
-    }
-
-    @Test
-    public void reverseColumnOrder_prependMultipleHeadersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("reverse-column-order");
-        clickButton("prepend-2-headers-remove-last");
-
-        assertColumnOrderPreserved(true);
-    }
-
-    @Test
-    public void reverseColumnOrder_prependMultipleFootersAndRemoveFirstInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("reverse-column-order");
-        clickButton("prepend-2-footers-remove-first");
-
-        assertColumnOrderPreserved(true);
-    }
-
-    @Test
-    public void reverseColumnOrder_prependMultipleFootersAndRemoveLastInOneRoundTrip_columnOrderPreserved() {
-        grid = $(GridElement.class).id("grid2");
-        clickButton("reverse-column-order");
-        clickButton("prepend-2-footers-remove-last");
-
-        assertColumnOrderPreserved(true);
-    }
-
-    private void assertColumnOrderPreserved(boolean reversed) {
+    private void assertColumnOrderPreserved() {
         List<GridTHTDElement> cells = grid.getCells(0);
         Assert.assertEquals(4, cells.size());
         for (int i = 0; i < cells.size(); i++) {
-            int index = reversed ? (cells.size() - 1 - i) : i;
-            Assert.assertEquals("Item 1-" + (i + 1),
-                    cells.get(index).getText());
+            Assert.assertEquals("Item 1-" + (i + 1), cells.get(i).getText());
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2377,17 +2377,52 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 throw new NoSuchElementException(
                         "Header to remove cannot be found.");
             }
-            ColumnLayer layerToRemove = headerRow.layer;
-            if (getColumnLayers().get(0).equals(layerToRemove)) {
+            if (getColumnLayers().get(0).equals(headerRow.layer)) {
                 // Switch with next header row
                 HeaderRow nextHeaderRow = headerRows
                         .get(headerRows.indexOf(headerRow) - 1);
-                layerToRemove = nextHeaderRow.layer;
-                headerRow.layer.setHeaderRow(nextHeaderRow);
-                layerToRemove.setHeaderRow(headerRow);
+                switchHeaderRowContent(headerRow, nextHeaderRow);
+                if (nextHeaderRow.equals(defaultHeaderRow)) {
+                    nextHeaderRow.layer.updateSortingIndicators(true);
+                }
             }
-            removeColumnLayer(layerToRemove);
+            removeColumnLayer(headerRow.layer);
         }
+    }
+
+    private void switchHeaderRowContent(HeaderRow headerRow,
+            HeaderRow nextHeaderRow) {
+        List<HeaderRow.HeaderCell> headerRowCells = headerRow.cells;
+        List<HeaderRow.HeaderCell> nextHeaderRowCells = nextHeaderRow.cells;
+
+        // Update cell content
+        for (int i = 0; i < headerRowCells.size(); i++) {
+            HeaderRow.HeaderCell headerRowCell = headerRowCells.get(i);
+            Component headerRowCellComponent = headerRowCell.getComponent();
+            String headerRowCellText = headerRowCell.getText();
+
+            HeaderRow.HeaderCell nextHeaderRowCell = nextHeaderRowCells.get(i);
+            Component nextHeaderRowCellComponent = nextHeaderRowCell
+                    .getComponent();
+            String nextHeaderRowCellText = nextHeaderRowCell.getText();
+
+            if (headerRowCellComponent != null) {
+                nextHeaderRowCell.setComponent(headerRowCellComponent);
+            } else {
+                nextHeaderRowCell.setText(headerRowCellText);
+            }
+
+            if (nextHeaderRowCellComponent != null) {
+                headerRowCell.setComponent(nextHeaderRowCellComponent);
+            } else {
+                headerRowCell.setText(nextHeaderRowCellText);
+            }
+        }
+
+        // Update layer references
+        ColumnLayer headerRowLayer = headerRow.layer;
+        nextHeaderRow.layer.setHeaderRow(headerRow);
+        headerRowLayer.setHeaderRow(nextHeaderRow);
     }
 
     public void removeAllHeaderRows() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2661,11 +2661,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
         layer.getColumns().forEach(column -> {
             Element parent = column.getElement().getParent();
-            int insertIndex = parent.indexOfChild(column.getElement());
-            parent.insertChild(insertIndex,
-                    ((ColumnGroup) column).getChildColumns().stream()
-                            .map(HasElement::getElement)
-                            .toArray(Element[]::new));
+            parent.appendChild(((ColumnGroup) column).getChildColumns().stream()
+                    .map(HasElement::getElement).toArray(Element[]::new));
             column.getElement().removeFromParent();
         });
         columnLayers.remove(layer);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2655,6 +2655,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the layer to remove, not the bottom layer
      */
     protected void removeColumnLayer(ColumnLayer layer) {
+        // This method is inadequately tested. Should be tested thoroughly if
+        // refactored. See:
+        // https://github.com/vaadin/flow-components/pull/5990#discussion_r1474599544
         if (layer.equals(columnLayers.get(0))) {
             throw new IllegalArgumentException(
                     "The bottom column layer cannot be removed");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2661,8 +2661,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
         layer.getColumns().forEach(column -> {
             Element parent = column.getElement().getParent();
-            parent.appendChild(((ColumnGroup) column).getChildColumns().stream()
-                    .map(HasElement::getElement).toArray(Element[]::new));
+            int insertIndex = parent.indexOfChild(column.getElement());
+            parent.insertChild(insertIndex,
+                    ((ColumnGroup) column).getChildColumns().stream()
+                            .map(HasElement::getElement)
+                            .toArray(Element[]::new));
             column.getElement().removeFromParent();
         });
         columnLayers.remove(layer);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2401,7 +2401,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     private void removeNonDefaultHeaderInBottomLayer(HeaderRow headerRow) {
-        // Move content from next footer row and remove that layer
+        // Move content from next header row and remove that layer
         List<HeaderRow> headerRows = getHeaderRows();
         HeaderRow nextHeaderRow = headerRows.get(headerRows.size() - 2);
         ColumnLayer layerToRemove = nextHeaderRow.layer;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2363,6 +2363,19 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         return insertInmostColumnLayer(true, false).asHeaderRow();
     }
 
+    /**
+     * Removes the header row from the grid. Note that the default header row
+     * can be removed only if it is the only header row.
+     *
+     * @see #removeAllHeaderRows()
+     * @param headerRow
+     *            the header row to remove
+     * @throws UnsupportedOperationException
+     *             if default row is being removed while there are other header
+     *             rows
+     * @throws NoSuchElementException
+     *             if the header row cannot be found
+     */
     public void removeHeaderRow(HeaderRow headerRow) {
         Objects.requireNonNull(headerRow);
         List<HeaderRow> headerRows = getHeaderRows();
@@ -2390,6 +2403,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
     }
 
+    /**
+     * Removes all header rows from the grid.
+     *
+     * @see #removeHeaderRow(HeaderRow)
+     */
     public void removeAllHeaderRows() {
         List<HeaderRow> headerRows = getHeaderRows();
         if (headerRows.isEmpty()) {
@@ -2449,6 +2467,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         return insertColumnLayer(getLastFooterLayerIndex() + 1).asFooterRow();
     }
 
+    /**
+     * Removes the footer row from the grid.
+     *
+     * @see #removeAllFooterRows()
+     * @param footerRow
+     *            the footer row to remove
+     * @throws NoSuchElementException
+     *             if the footer row cannot be found
+     */
     public void removeFooterRow(FooterRow footerRow) {
         Objects.requireNonNull(footerRow);
         List<FooterRow> footerRows = getFooterRows();
@@ -2472,6 +2499,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         removeColumnLayer(footerRow.layer);
     }
 
+    /**
+     * Removes all footer rows from the grid.
+     *
+     * @see #removeFooterRow(FooterRow)
+     */
     public void removeAllFooterRows() {
         getFooterRows().forEach(this::removeFooterRow);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2422,6 +2422,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void removeAllHeaderRows() {
         var headerRows = getHeaderRows();
+        if (headerRows.isEmpty()) {
+            return;
+        }
         Collections.reverse(headerRows);
         headerRows.stream()
                 .filter(headerRow -> !headerRow.equals(defaultHeaderRow))

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2420,7 +2420,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see #removeHeaderRow(HeaderRow)
      */
     public void removeAllHeaderRows() {
-        getHeaderRows().stream()
+        var headerRows = getHeaderRows();
+        Collections.reverse(headerRows);
+        headerRows.stream()
                 .filter(headerRow -> !headerRow.equals(defaultHeaderRow))
                 .forEach(this::removeHeaderRow);
         removeDefaultHeaderRow();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2411,6 +2411,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             nextHeaderRow.layer.updateSortingIndicators(true);
         }
         layerToRemove.setHeaderRow(null);
+        clearRowContent(headerRow);
         removeColumnLayer(layerToRemove);
     }
 
@@ -2432,7 +2433,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         defaultHeaderRow.getCells()
                 .forEach(headerCell -> headerCell.setText(null));
         defaultHeaderRow.layer.setHeaderRow(null);
-        defaultHeaderRow.layer = null;
+        clearRowContent(defaultHeaderRow);
         defaultHeaderRow = null;
     }
 
@@ -2506,16 +2507,21 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             footerRow.getCells()
                     .forEach(footerCell -> footerCell.setText(null));
             footerRow.layer.setFooterRow(null);
-            footerRow.layer = null;
+            clearRowContent(footerRow);
             return;
         }
         // Move content from next footer row and remove that layer
         FooterRow nextFooterRow = footerRows
                 .get(footerRows.indexOf(footerRow) + 1);
+        if (nextFooterRow.getCells().size() != footerRow.getCells().size()) {
+            throw new UnsupportedOperationException(
+                    "Top-most footer row cannot have joined cells.");
+        }
         ColumnLayer layerToRemove = nextFooterRow.layer;
         moveRowContent(nextFooterRow, footerRow);
         footerRow.layer.setFooterRow(nextFooterRow);
         layerToRemove.setFooterRow(null);
+        clearRowContent(footerRow);
         removeColumnLayer(layerToRemove);
     }
 
@@ -2526,6 +2532,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void removeAllFooterRows() {
         getFooterRows().forEach(this::removeFooterRow);
+    }
+
+    private void clearRowContent(
+            AbstractRow<? extends AbstractRow.AbstractCell> row) {
+        row.cells.clear();
+        row.layer = null;
     }
 
     private void moveRowContent(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2420,13 +2420,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see #removeHeaderRow(HeaderRow)
      */
     public void removeAllHeaderRows() {
-        List<HeaderRow> headerRows = getHeaderRows();
-        if (headerRows.isEmpty()) {
-            return;
-        }
-        int headerRowCount = headerRows.size();
-        IntStream.range(0, headerRowCount)
-                .mapToObj(index -> headerRows.get(headerRowCount - 1 - index))
+        getHeaderRows().stream()
                 .filter(headerRow -> !headerRow.equals(defaultHeaderRow))
                 .forEach(this::removeHeaderRow);
         removeDefaultHeaderRow();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1110,10 +1110,11 @@ public class HeaderFooterTest {
     }
 
     @Test
-    public void addHeaderRowsAlternatingPrependAndAppend_removeEachRow_rowsRemoved() {
+    public void addHeaderRowsAlternatingPrependAndAppend_removeEachRowExceptDefault_rowsRemoved() {
+        grid.appendHeaderRow();
         List<HeaderRow> headerRows = addMixedHeaderRows(6);
         headerRows.forEach(row -> grid.removeHeaderRow(row));
-        Assert.assertEquals(0, grid.getHeaderRows().size());
+        Assert.assertEquals(1, grid.getHeaderRows().size());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -25,6 +25,7 @@ import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.renderer.LitRenderer;
 
@@ -1107,6 +1108,43 @@ public class HeaderFooterTest {
         grid.prependHeaderRow();
         Assert.assertThrows(UnsupportedOperationException.class,
                 () -> grid.removeHeaderRow(defaultHeaderRow));
+    }
+
+    @Test
+    public void addTextHeaderRow_appendAnotherTextHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
+        int columnCount = grid.getColumns().size();
+        HeaderRow defaultHeaderRow = grid.appendHeaderRow();
+        defaultHeaderRow.getCells().forEach(cell -> cell.setText("DEFAULT"));
+        HeaderRow newHeaderRow = grid.appendHeaderRow();
+        newHeaderRow.getCells().forEach(cell -> cell.setText("NEW"));
+        grid.removeHeaderRow(newHeaderRow);
+        List<HeaderCell> headerCells = grid.getHeaderRows().get(0).getCells();
+        Assert.assertEquals(columnCount, headerCells.size());
+        headerCells.forEach(
+                cell -> Assert.assertEquals("DEFAULT", cell.getText()));
+    }
+
+    @Test
+    public void addComponentHeaderRow_appendAnotherComponentHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
+        int columnCount = grid.getColumns().size();
+        HeaderRow defaultHeaderRow = grid.appendHeaderRow();
+        List<NativeLabel> defaultHeaderRowComponents = IntStream
+                .range(0, columnCount).mapToObj(Integer::toString)
+                .map(NativeLabel::new).toList();
+        for (int i = 0; i < columnCount; i++) {
+            defaultHeaderRow.getCells().get(i)
+                    .setComponent(defaultHeaderRowComponents.get(i));
+        }
+        HeaderRow newHeaderRow = grid.appendHeaderRow();
+        newHeaderRow.getCells()
+                .forEach(cell -> cell.setComponent(new NativeLabel("NEW")));
+        grid.removeHeaderRow(newHeaderRow);
+        List<HeaderCell> headerCells = grid.getHeaderRows().get(0).getCells();
+        Assert.assertEquals(columnCount, headerCells.size());
+        for (int i = 0; i < columnCount; i++) {
+            Assert.assertEquals(defaultHeaderRowComponents.get(i),
+                    headerCells.get(i).getComponent());
+        }
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1307,6 +1307,78 @@ public class HeaderFooterTest {
     }
 
     @Test
+    public void addFooterRow_appendFooterRowWithJoinedCells_removeFirstFooterRow_throwsUnsupportedOperationException() {
+        var first = grid.appendFooterRow();
+        var second = grid.appendFooterRow();
+        var columns = grid.getColumns();
+        second.join(columns.get(0), columns.get(1));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> grid.removeFooterRow(first));
+    }
+
+    @Test
+    public void addHeaderRow_removeHeaderRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        var row = grid.appendHeaderRow();
+        grid.removeHeaderRow(row);
+        assertCannotSetValueOnRemovedRow(row);
+    }
+
+    @Test
+    public void addHeaderRow_prependAnotherHeaderRow_removeSecondHeaderRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        grid.appendHeaderRow();
+        var second = grid.prependHeaderRow();
+        grid.removeHeaderRow(second);
+        assertCannotSetValueOnRemovedRow(second);
+    }
+
+    @Test
+    public void addHeaderRow_appendAnotherHeaderRow_removeSecondHeaderRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        grid.appendHeaderRow();
+        var second = grid.appendHeaderRow();
+        grid.removeHeaderRow(second);
+        assertCannotSetValueOnRemovedRow(second);
+    }
+
+    @Test
+    public void addFooterRow_removeFooterRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        var row = grid.appendFooterRow();
+        grid.removeFooterRow(row);
+        assertCannotSetValueOnRemovedRow(row);
+    }
+
+    @Test
+    public void addFooterRow_prependAnotherFooterRow_removeFirstFooterRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        var first = grid.appendFooterRow();
+        grid.prependFooterRow();
+        grid.removeFooterRow(first);
+        assertCannotSetValueOnRemovedRow(first);
+    }
+
+    @Test
+    public void addFooterRow_prependAnotherFooterRow_removeSecondFooterRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        grid.appendFooterRow();
+        var second = grid.prependFooterRow();
+        grid.removeFooterRow(second);
+        assertCannotSetValueOnRemovedRow(second);
+    }
+
+    @Test
+    public void addFooterRow_appendAnotherFooterRow_removeFirstFooterRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        var first = grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.removeFooterRow(first);
+        assertCannotSetValueOnRemovedRow(first);
+    }
+
+    @Test
+    public void addFooterRow_appendAnotherFooterRow_removeSecondFooterRow_setCellValueForRemovedRow_throwsIllegalArgumentException() {
+        grid.appendFooterRow();
+        var second = grid.appendFooterRow();
+        grid.removeFooterRow(second);
+        assertCannotSetValueOnRemovedRow(second);
+    }
+
+    @Test
     public void setFooterPartName_columnGroupHasFooterPartName() {
         grid.appendFooterRow();
         var footerCell = grid.appendFooterRow().join(firstColumn, secondColumn);
@@ -1475,5 +1547,11 @@ public class HeaderFooterTest {
             row.getCells().get(i).setComponent(rowComponents.get(i));
         }
         return rowComponents;
+    }
+
+    private void assertCannotSetValueOnRemovedRow(
+            AbstractRow<? extends AbstractRow.AbstractCell> row) {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> row.getCell(grid.getColumns().get(0)).setText("TEXT"));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1111,6 +1111,16 @@ public class HeaderFooterTest {
     }
 
     @Test
+    public void addHeaderRow_setSortable_appendAnotherHeaderRow_removeLastHeaderRow_firstHeaderRowIsSortable() {
+        HeaderRow defaultHeaderRow = grid.appendHeaderRow();
+        grid.getColumns().forEach(col -> col.setSortable(true));
+        HeaderRow newHeaderRow = grid.appendHeaderRow();
+        grid.removeHeaderRow(newHeaderRow);
+        defaultHeaderRow.layer.getColumns()
+                .forEach(col -> Assert.assertTrue(col.hasSortingIndicators()));
+    }
+
+    @Test
     public void addTextHeaderRow_appendAnotherTextHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
         String textContent = "DEFAULT";
         HeaderRow defaultHeaderRow = grid.appendHeaderRow();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1112,39 +1112,97 @@ public class HeaderFooterTest {
 
     @Test
     public void addTextHeaderRow_appendAnotherTextHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
-        int columnCount = grid.getColumns().size();
+        String textContent = "DEFAULT";
         HeaderRow defaultHeaderRow = grid.appendHeaderRow();
-        defaultHeaderRow.getCells().forEach(cell -> cell.setText("DEFAULT"));
+        defaultHeaderRow.getCells().forEach(cell -> cell.setText(textContent));
         HeaderRow newHeaderRow = grid.appendHeaderRow();
         newHeaderRow.getCells().forEach(cell -> cell.setText("NEW"));
         grid.removeHeaderRow(newHeaderRow);
-        List<HeaderCell> headerCells = grid.getHeaderRows().get(0).getCells();
-        Assert.assertEquals(columnCount, headerCells.size());
-        headerCells.forEach(
-                cell -> Assert.assertEquals("DEFAULT", cell.getText()));
+        assertRowTextContent(textContent, grid.getHeaderRows().get(0));
     }
 
     @Test
-    public void addComponentHeaderRow_appendAnotherComponentHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
-        int columnCount = grid.getColumns().size();
-        HeaderRow defaultHeaderRow = grid.appendHeaderRow();
-        List<NativeLabel> defaultHeaderRowComponents = IntStream
-                .range(0, columnCount).mapToObj(Integer::toString)
-                .map(NativeLabel::new).toList();
-        for (int i = 0; i < columnCount; i++) {
-            defaultHeaderRow.getCells().get(i)
-                    .setComponent(defaultHeaderRowComponents.get(i));
-        }
+    public void addTextHeaderRow_appendComponentHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
+        String textContent = "DEFAULT";
+        grid.appendHeaderRow().getCells()
+                .forEach(cell -> cell.setText(textContent));
         HeaderRow newHeaderRow = grid.appendHeaderRow();
         newHeaderRow.getCells()
                 .forEach(cell -> cell.setComponent(new NativeLabel("NEW")));
         grid.removeHeaderRow(newHeaderRow);
-        List<HeaderCell> headerCells = grid.getHeaderRows().get(0).getCells();
-        Assert.assertEquals(columnCount, headerCells.size());
-        for (int i = 0; i < columnCount; i++) {
-            Assert.assertEquals(defaultHeaderRowComponents.get(i),
-                    headerCells.get(i).getComponent());
-        }
+        assertRowTextContent(textContent, grid.getHeaderRows().get(0));
+    }
+
+    @Test
+    public void addComponentHeaderRow_appendAnotherComponentHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
+        HeaderRow defaultHeaderRow = grid.appendHeaderRow();
+        List<? extends Component> defaultHeaderRowComponents = setComponentsToRow(
+                defaultHeaderRow);
+        HeaderRow newHeaderRow = grid.appendHeaderRow();
+        newHeaderRow.getCells()
+                .forEach(cell -> cell.setComponent(new NativeLabel("NEW")));
+        grid.removeHeaderRow(newHeaderRow);
+        assertRowComponents(defaultHeaderRowComponents,
+                grid.getHeaderRows().get(0));
+
+    }
+
+    @Test
+    public void addComponentHeaderRow_appendTextHeaderRow_removeAppendedHeaderRow_correctRowIsRemoved() {
+        HeaderRow defaultHeaderRow = grid.appendHeaderRow();
+        List<? extends Component> defaultHeaderRowComponents = setComponentsToRow(
+                defaultHeaderRow);
+        HeaderRow newHeaderRow = grid.appendHeaderRow();
+        newHeaderRow.getCells().forEach(cell -> cell.setText("NEW"));
+        grid.removeHeaderRow(newHeaderRow);
+        assertRowComponents(defaultHeaderRowComponents,
+                grid.getHeaderRows().get(0));
+    }
+
+    @Test
+    public void addTextFooterRow_prependAnotherTextFooterRow_removePrependedFooterRow_correctRowIsRemoved() {
+        String textContent = "DEFAULT";
+        grid.appendFooterRow().getCells()
+                .forEach(cell -> cell.setText(textContent));
+        FooterRow newFooterRow = grid.prependFooterRow();
+        newFooterRow.getCells().forEach(cell -> cell.setText("NEW"));
+        grid.removeFooterRow(newFooterRow);
+        assertRowTextContent(textContent, grid.getFooterRows().get(0));
+    }
+
+    @Test
+    public void addTextFooterRow_prependComponentFooterRow_removePrependedFooterRow_correctRowIsRemoved() {
+        String textContent = "DEFAULT";
+        grid.appendFooterRow().getCells()
+                .forEach(cell -> cell.setText(textContent));
+        FooterRow newFooterRow = grid.prependFooterRow();
+        newFooterRow.getCells()
+                .forEach(cell -> cell.setComponent(new NativeLabel("NEW")));
+        grid.removeFooterRow(newFooterRow);
+        assertRowTextContent(textContent, grid.getFooterRows().get(0));
+    }
+
+    @Test
+    public void addComponentFooterRow_prependAnotherComponentFooterRow_removePrependedFooterRow_correctRowIsRemoved() {
+        FooterRow footerRow = grid.appendFooterRow();
+        List<? extends Component> footerRowComponents = setComponentsToRow(
+                footerRow);
+        FooterRow newFooterRow = grid.prependFooterRow();
+        newFooterRow.getCells()
+                .forEach(cell -> cell.setComponent(new NativeLabel("NEW")));
+        grid.removeFooterRow(newFooterRow);
+        assertRowComponents(footerRowComponents, grid.getFooterRows().get(0));
+    }
+
+    @Test
+    public void addComponentFooterRow_prependTextFooterRow_removePrependedFooterRow_correctRowIsRemoved() {
+        FooterRow footerRow = grid.appendFooterRow();
+        List<? extends Component> footerRowComponents = setComponentsToRow(
+                footerRow);
+        FooterRow newFooterRow = grid.prependFooterRow();
+        newFooterRow.getCells().forEach(cell -> cell.setText("NEW"));
+        grid.removeFooterRow(newFooterRow);
+        assertRowComponents(footerRowComponents, grid.getFooterRows().get(0));
     }
 
     @Test
@@ -1377,5 +1435,35 @@ public class HeaderFooterTest {
                 .mapToObj(index -> index % 2 == 0 ? grid.appendHeaderRow()
                         : grid.prependHeaderRow())
                 .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private void assertRowTextContent(String expectedTextContent,
+            AbstractRow<? extends AbstractRow.AbstractCell> row) {
+        List<? extends AbstractRow.AbstractCell> cells = row.getCells();
+        Assert.assertEquals(grid.getColumns().size(), cells.size());
+        cells.forEach(cell -> Assert.assertEquals(expectedTextContent,
+                cell.getText()));
+    }
+
+    private void assertRowComponents(
+            List<? extends Component> expectedRowComponents,
+            AbstractRow<? extends AbstractRow.AbstractCell> row) {
+        List<? extends AbstractRow.AbstractCell> cells = row.getCells();
+        Assert.assertEquals(grid.getColumns().size(), cells.size());
+        for (int i = 0; i < expectedRowComponents.size(); i++) {
+            Assert.assertEquals(expectedRowComponents.get(i),
+                    cells.get(i).getComponent());
+        }
+    }
+
+    private List<? extends Component> setComponentsToRow(
+            AbstractRow<? extends AbstractRow.AbstractCell> row) {
+        List<NativeLabel> rowComponents = IntStream
+                .range(0, grid.getColumns().size()).mapToObj(Integer::toString)
+                .map(NativeLabel::new).toList();
+        for (int i = 0; i < rowComponents.size(); i++) {
+            row.getCells().get(i).setComponent(rowComponents.get(i));
+        }
+        return rowComponents;
     }
 }


### PR DESCRIPTION
## Description

This PR adds 4 new APIs to Grid:
- `removeHeaderRow(HeaderRow)`
- `removeAllHeaderRows()`
- `removeFooterRow(FooterRow)`
- `removeAllFooterRows()`

Notes:
- The first column layer is never removed. Instead, the content on it is manipulated.
- The default header row can only be removed only when there is no other header row.

Fixes #1538 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
