### PR TITLE
chore: ignore Vaadin-generated tsx files under frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ error-screenshots
 
 **/frontend/generated
 **/frontend/index.html
+**/frontend/*.tsx
 dev-bundle


### PR DESCRIPTION
## Description

Ignore the Vaadin-generated tsx-files: `frontend/routes.tsx`, `frontend/App.tsx`

## Type of change

Chore