### PR TITLE
fix: reset controller on attach to re-render components

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -28,7 +28,6 @@ public class DetachReattachPage extends Div {
 
     public DetachReattachPage() {
         ComboBox<String> comboBox = new ComboBox<>();
-        comboBox.setRenderer(new ComponentRenderer<>(s -> new NativeLabel(s)));
         comboBox.setItems("foo", "bar");
 
         NativeButton detach = new NativeButton("detach", e -> remove(comboBox));
@@ -53,6 +52,11 @@ public class DetachReattachPage extends Div {
                 e -> comboBox.setValue("foo"));
         setValue.setId("set-value");
 
+        NativeButton setComponentRenderer = new NativeButton(
+                "set component renderer", e -> comboBox.setRenderer(
+                        new ComponentRenderer<>(s -> new NativeLabel(s))));
+        setComponentRenderer.setId("set-component-renderer");
+
         Div valueChanges = new Div();
         valueChanges.setId("value-changes");
         comboBox.addValueChangeListener(e -> {
@@ -60,6 +64,6 @@ public class DetachReattachPage extends Div {
         });
 
         add(comboBox, detach, attach, attachDetach, detachAttach, setValue,
-                valueChanges);
+                setComponentRenderer, valueChanges);
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -18,7 +18,9 @@ package com.vaadin.flow.component.combobox.test;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-combo-box/detach-reattach")
@@ -26,6 +28,7 @@ public class DetachReattachPage extends Div {
 
     public DetachReattachPage() {
         ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setRenderer(new ComponentRenderer<>(s -> new NativeLabel(s)));
         comboBox.setItems("foo", "bar");
 
         NativeButton detach = new NativeButton("detach", e -> remove(comboBox));
@@ -40,6 +43,12 @@ public class DetachReattachPage extends Div {
         });
         attachDetach.setId("attach-detach");
 
+        NativeButton detachAttach = new NativeButton("detach-attach", e -> {
+            remove(comboBox);
+            add(comboBox);
+        });
+        detachAttach.setId("detach-attach");
+
         NativeButton setValue = new NativeButton("set value foo",
                 e -> comboBox.setValue("foo"));
         setValue.setId("set-value");
@@ -50,6 +59,7 @@ public class DetachReattachPage extends Div {
             valueChanges.add(new Paragraph(e.getValue()));
         });
 
-        add(comboBox, detach, attach, attachDetach, setValue, valueChanges);
+        add(comboBox, detach, attach, attachDetach, detachAttach, setValue,
+                valueChanges);
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -23,6 +23,8 @@ import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
+import java.util.List;
+
 @TestPath("vaadin-combo-box/detach-reattach")
 public class DetachReattachIT extends AbstractComboBoxIT {
 
@@ -81,6 +83,22 @@ public class DetachReattachIT extends AbstractComboBoxIT {
 
         combo = $(ComboBoxElement.class).first();
         Assert.assertEquals("foo", combo.getInputElementValue());
+    }
+
+    @Test
+    public void detachAndReattach_componentRenderersRestored() {
+        combo.openPopup();
+        combo.closePopup();
+
+        clickButton("detach-attach");
+
+        combo = $(ComboBoxElement.class).waitForFirst();
+        combo.openPopup();
+        TestBenchElement overlay = $("vaadin-combo-box-overlay").waitForFirst();
+        List<TestBenchElement> items = overlay.$("vaadin-combo-box-item").all();
+
+        Assert.assertEquals(2, items.size());
+        items.forEach(item -> Assert.assertTrue(item.$("label").exists()));
     }
 
     private void assertValueChanges(String... expected) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -86,7 +86,9 @@ public class DetachReattachIT extends AbstractComboBoxIT {
     }
 
     @Test
-    public void detachAndReattach_componentRenderersRestored() {
+    public void withComponentRenderer_renderComponentsInitially_detachAndReattach_componentRenderersRestored() {
+        clickButton("set-component-renderer");
+
         combo.openPopup();
         combo.closePopup();
 
@@ -94,10 +96,9 @@ public class DetachReattachIT extends AbstractComboBoxIT {
 
         combo = $(ComboBoxElement.class).waitForFirst();
         combo.openPopup();
+
         TestBenchElement overlay = $("vaadin-combo-box-overlay").waitForFirst();
         List<TestBenchElement> items = overlay.$("vaadin-combo-box-item").all();
-
-        Assert.assertEquals(2, items.size());
         items.forEach(item -> Assert.assertTrue(item.$("label").exists()));
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -218,6 +218,8 @@ class ComboBoxDataController<TItem>
 
         clearFilterOnCloseRegistration = comboBox.getElement()
                 .addPropertyChangeListener("opened", this::clearFilterOnClose);
+
+        reset();
     }
 
     /**


### PR DESCRIPTION
## Description

When a ComboBox with a component renderer is detached and attached in the same roundtrip, the data is destroyed but never rendered again. This PR adds a reset call on attach in the data controller to fix this issue.

Based on the approach in a [fix](https://github.com/vaadin/flow-components/pull/5989) for a similar Grid [issue](https://github.com/vaadin/flow-components/issues/5732).

Fixes #5100 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.