### PR TITLE
fix: refresh value on data communicator reset

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxSelectedItemsOnTopPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxSelectedItemsOnTopPage.java
@@ -3,8 +3,11 @@ package com.vaadin.flow.component.combobox.test;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -30,7 +33,29 @@ public class MultiSelectComboBoxSelectedItemsOnTopPage extends Div {
                 });
         unsetSelectedOnTop.setId("unset-selected-on-top");
 
+        NativeButton setComponentRenderer = new NativeButton(
+                "Set component renderer", e -> comboBox.setRenderer(
+                        new ComponentRenderer<>(i -> new Span(i))));
+        setComponentRenderer.setId("set-component-renderer");
+
+        NativeButton useCustomValueSetListener = new NativeButton(
+                "Use custom value set listener", click -> {
+                    comboBox.setItems(query -> comboBox.getValue().stream()
+                            .skip(query.getOffset()).limit(query.getLimit()));
+                    comboBox.addCustomValueSetListener(event -> {
+                        String value = event.getDetail();
+                        if (value != null) {
+                            List<String> accounts = new ArrayList<>(
+                                    comboBox.getValue());
+                            accounts.add(value);
+                            comboBox.setValue(accounts);
+                        }
+                    });
+                });
+        useCustomValueSetListener.setId("use-custom-value-set-listener");
+
         add(comboBox);
-        add(new Div(setSelectedOnTop, unsetSelectedOnTop));
+        add(new Div(setSelectedOnTop, unsetSelectedOnTop, setComponentRenderer,
+                useCustomValueSetListener));
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxSelectedItemsOnTopIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxSelectedItemsOnTopIT.java
@@ -8,6 +8,7 @@ import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.Keys;
 
 @TestPath("vaadin-multi-select-combo-box/selected-items-on-top")
 public class MultiSelectComboBoxSelectedItemsOnTopIT
@@ -15,6 +16,8 @@ public class MultiSelectComboBoxSelectedItemsOnTopIT
     private MultiSelectComboBoxElement comboBox;
     private TestBenchElement setSelectedOnTop;
     private TestBenchElement unsetSelectedOnTop;
+    private TestBenchElement setComponentRenderer;
+    private TestBenchElement useCustomValueSetListener;
 
     @Before
     public void init() {
@@ -22,6 +25,9 @@ public class MultiSelectComboBoxSelectedItemsOnTopIT
         comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
         setSelectedOnTop = $("button").id("set-selected-on-top");
         unsetSelectedOnTop = $("button").id("unset-selected-on-top");
+        setComponentRenderer = $("button").id("set-component-renderer");
+        useCustomValueSetListener = $("button")
+                .id("use-custom-value-set-listener");
     }
 
     @Test
@@ -34,10 +40,7 @@ public class MultiSelectComboBoxSelectedItemsOnTopIT
         comboBox.openPopup();
         comboBox.waitForLoadingFinished();
 
-        TestBenchElement overlay = $("vaadin-multi-select-combo-box-overlay")
-                .first();
-        ElementQuery<TestBenchElement> items = overlay
-                .$("vaadin-multi-select-combo-box-item");
+        ElementQuery<TestBenchElement> items = getItems();
 
         TestBenchElement item1 = items.get(0);
         TestBenchElement item2 = items.get(1);
@@ -59,10 +62,7 @@ public class MultiSelectComboBoxSelectedItemsOnTopIT
         comboBox.openPopup();
         comboBox.waitForLoadingFinished();
 
-        TestBenchElement overlay = $("vaadin-multi-select-combo-box-overlay")
-                .first();
-        ElementQuery<TestBenchElement> items = overlay
-                .$("vaadin-multi-select-combo-box-item");
+        ElementQuery<TestBenchElement> items = getItems();
 
         TestBenchElement item1 = items.get(0);
         TestBenchElement item2 = items.get(1);
@@ -91,10 +91,7 @@ public class MultiSelectComboBoxSelectedItemsOnTopIT
         comboBox.openPopup();
         comboBox.waitForLoadingFinished();
 
-        TestBenchElement overlay = $("vaadin-multi-select-combo-box-overlay")
-                .first();
-        ElementQuery<TestBenchElement> items = overlay
-                .$("vaadin-multi-select-combo-box-item");
+        ElementQuery<TestBenchElement> items = getItems();
 
         TestBenchElement item1 = items.get(0);
         TestBenchElement item2 = items.get(1);
@@ -104,5 +101,45 @@ public class MultiSelectComboBoxSelectedItemsOnTopIT
 
         Assert.assertFalse(item1.hasAttribute("selected"));
         Assert.assertTrue(item2.hasAttribute("selected"));
+    }
+
+    @Test
+    public void componentRendererAndCustomValues_selectedItemsOnTop_addAndSelectItems_deselectFirst_itemsCorrect() {
+        setComponentRenderer.click();
+        useCustomValueSetListener.click();
+        setSelectedOnTop.click();
+
+        addCustomItem("foo");
+        addCustomItem("bar");
+
+        comboBox.deselectByText("foo");
+
+        comboBox.closePopup();
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+
+        ElementQuery<TestBenchElement> items = getItems();
+
+        TestBenchElement item1 = items.get(0);
+        TestBenchElement item2 = items.get(1);
+
+        Assert.assertEquals("bar", item1.getText());
+        Assert.assertEquals("foo", item2.getText());
+
+        Assert.assertTrue(item1.hasAttribute("selected"));
+        Assert.assertFalse(item2.hasAttribute("selected"));
+    }
+
+    private ElementQuery<TestBenchElement> getItems() {
+        TestBenchElement overlay = $("vaadin-multi-select-combo-box-overlay")
+                .first();
+        return overlay.$("vaadin-multi-select-combo-box-item");
+    }
+
+    private void addCustomItem(String item) {
+        comboBox.sendKeys(item);
+        comboBox.waitForLoadingFinished();
+        comboBox.sendKeys(Keys.ENTER);
+        comboBox.waitForLoadingFinished();
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataCommunicator.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataCommunicator.java
@@ -84,8 +84,6 @@ public class ComboBoxDataCommunicator<TItem> extends DataCommunicator<TItem> {
         }
     }
 
-    private final ComboBoxBase<?, TItem, ?> comboBox;
-
     public ComboBoxDataCommunicator(ComboBoxBase<?, TItem, ?> comboBox,
             DataGenerator<TItem> dataGenerator, ArrayUpdater arrayUpdater,
             SerializableConsumer<JsonArray> dataUpdater, StateNode stateNode,
@@ -93,20 +91,7 @@ public class ComboBoxDataCommunicator<TItem> extends DataCommunicator<TItem> {
         super(dataGenerator, arrayUpdater, dataUpdater, stateNode,
                 fetchEnabled);
 
-        this.comboBox = comboBox;
         setKeyMapper(new SelectionPreservingKeyMapper<>(comboBox));
-    }
-
-    @Override
-    public void reset() {
-        super.reset();
-        // The data is destroyed and rebuilt on data communicator reset. When
-        // component renderers are used, this means that the nodeIds for the
-        // items should also be updated. However, the "selectedItems" property
-        // is manually set in "refreshValue()". Therefore, the selected items
-        // can contain obsolete nodeIds. For this reason, this value refresh is
-        // necessary.
-        comboBox.refreshValue();
     }
 
     public void notifySelectionChanged() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataCommunicator.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataCommunicator.java
@@ -84,6 +84,8 @@ public class ComboBoxDataCommunicator<TItem> extends DataCommunicator<TItem> {
         }
     }
 
+    private final ComboBoxBase<?, TItem, ?> comboBox;
+
     public ComboBoxDataCommunicator(ComboBoxBase<?, TItem, ?> comboBox,
             DataGenerator<TItem> dataGenerator, ArrayUpdater arrayUpdater,
             SerializableConsumer<JsonArray> dataUpdater, StateNode stateNode,
@@ -91,7 +93,20 @@ public class ComboBoxDataCommunicator<TItem> extends DataCommunicator<TItem> {
         super(dataGenerator, arrayUpdater, dataUpdater, stateNode,
                 fetchEnabled);
 
+        this.comboBox = comboBox;
         setKeyMapper(new SelectionPreservingKeyMapper<>(comboBox));
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        // The data is destroyed and rebuilt on data communicator reset. When
+        // component renderers are used, this means that the nodeIds for the
+        // items should also be updated. However, the "selectedItems" property
+        // is manually set in "refreshValue()". Therefore, the selected items
+        // can contain obsolete nodeIds. For this reason, this value refresh is
+        // necessary.
+        comboBox.refreshValue();
     }
 
     public void notifySelectionChanged() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -523,7 +523,24 @@ class ComboBoxDataController<TItem>
                     dataGenerator, arrayUpdater,
                     data -> comboBox.getElement()
                             .callJsFunction("$connector.updateData", data),
-                    comboBox.getElement().getNode(), enableFetch);
+                    comboBox.getElement().getNode(), enableFetch) {
+
+                @Override
+                public void reset() {
+                    super.reset();
+                    if (comboBox instanceof MultiSelectComboBox) {
+                        // The data is destroyed and rebuilt on data
+                        // communicator reset. When component renderers are
+                        // used, this means that the nodeIds for the items
+                        // should also be updated. However, the "selectedItems"
+                        // property is manually set in "refreshValue()".
+                        // Therefore, the selected items can contain obsolete
+                        // nodeIds. For this reason, this value refresh is
+                        // necessary.
+                        comboBox.refreshValue();
+                    }
+                }
+            };
             dataCommunicator.setPageSize(comboBox.getPageSize());
         } else {
             // Enable/disable items fetch from data provider depending on the


### PR DESCRIPTION
## Description

The data is destroyed and rebuilt on data communicator reset. When component renderers are used, this means that the nodeIds for the items should also be updated. However, the `selectedItems` property is manually set in `refreshValue()`. Therefore, the selected items can contain obsolete nodeIds. 

This PR adds a `refreshValue()` call on every data communicator reset to make sure that the nodeIds of selected items to remain in sync.

Fixes #5985 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.