### PR TITLE
fix: do not defer updating client-side selection mode

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -83,6 +83,13 @@ public class DetachReattachPage extends Div {
                 });
         selectAndDetachButton.setId("select-and-detach-button");
 
+        NativeButton selectMultipleItems = new NativeButton(
+                "Select multiple items", e -> {
+                    grid.select("A");
+                    grid.select("B");
+                });
+        selectMultipleItems.setId("select-multiple-items-button");
+
         NativeButton setPageSizeAndDetachButton = new NativeButton(
                 "Set page size and detach", e -> {
                     grid.setPageSize(40);
@@ -111,6 +118,11 @@ public class DetachReattachPage extends Div {
                 e -> grid.setSelectionMode(Grid.SelectionMode.NONE));
         btnSelectionModeNone.setId("selection-mode-none-button");
 
+        NativeButton btnSelectionModeMulti = new NativeButton(
+                "Change to selection multi",
+                e -> grid.setSelectionMode(Grid.SelectionMode.MULTI));
+        btnSelectionModeMulti.setId("selection-mode-multi-button");
+
         NativeButton btnHideGrid = new NativeButton("Hide grid",
                 e -> grid.setVisible(false));
         btnHideGrid.setId("hide-grid-button");
@@ -128,9 +140,9 @@ public class DetachReattachPage extends Div {
 
         add(btnAttach, btnDetach, btnDisallowDeselect, addItemDetailsButton,
                 toggleDetailsVisibleOnClick, resetSortingButton,
-                selectAndDetachButton, setPageSizeAndDetachButton,
-                setSelectionModeAndDetachButton, sortAndDetachButton,
-                btnHideGrid, btnSelectionModeNone, btnDetachAndReattach,
-                btnShowGrid, grid);
+                selectAndDetachButton, selectMultipleItems,
+                setPageSizeAndDetachButton, setSelectionModeAndDetachButton,
+                sortAndDetachButton, btnHideGrid, btnSelectionModeNone,
+                btnSelectionModeMulti, btnDetachAndReattach, btnShowGrid, grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
@@ -185,4 +185,18 @@ public class DetachReattachIT extends AbstractComponentIT {
 
         checkLogsForErrors();
     }
+
+    @Test
+    public void detach_selectMultiple_reattach() {
+        open();
+
+        $("button").id("selection-mode-multi-button").click();
+        $("button").id("detach-button").click();
+        $("button").id("select-multiple-items-button").click();
+        $("button").id("attach-button").click();
+
+        GridElement grid = $(GridElement.class).first();
+        Assert.assertTrue(grid.getRow(0).isSelected());
+        Assert.assertTrue(grid.getRow(1).isSelected());
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2979,7 +2979,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     protected void updateSelectionModeOnClient() {
-        callJsFunctionBeforeClientResponse("$connector.setSelectionMode",
+        getElement().executeJs(
+                "if (this.$connector) { this.$connector.setSelectionMode($0) }",
                 selectionMode.name());
     }
 


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/vaadin/flow-components/pull/5788

The `updateSelectionModeOnClient()` js call should not use `beforeClientResponse` because that might lead to the selection mode getting updated _after_ applying selections.

Fixes https://github.com/vaadin/flow-components/issues/5996
Fixes https://github.com/vaadin/flow-components/issues/5986

## Type of change

Bugfix