### PR TITLE
fix: do not defer updating client-side sorter directions

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
@@ -185,4 +185,22 @@ public class DetachReattachIT extends AbstractComponentIT {
 
         checkLogsForErrors();
     }
+
+    @Test
+    public void sort_detachAndAttach_sortDirectionPreserved() {
+        open();
+
+        GridElement grid = $(GridElement.class).first();
+        var sorter = grid.getHeaderCell(0).$("vaadin-grid-sorter").first();
+        sorter.click();
+        var direction = sorter.getProperty("direction");
+        Assert.assertNotNull(direction);
+
+        $("button").id("detach-and-reattach-button").click();
+        $("button").id("detach-and-reattach-button").click();
+
+        grid = $(GridElement.class).first();
+        sorter = grid.getHeaderCell(0).$("vaadin-grid-sorter").first();
+        Assert.assertEquals(direction, sorter.getProperty("direction"));
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3826,7 +3826,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         if (getElement().getNode().isAttached()) {
-            callJsFunctionBeforeClientResponse("$connector.setSorterDirections",
+            getElement().executeJs(
+                    "if (this.$connector) { this.$connector.setSorterDirections($0) }",
                     directions);
         }
     }


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/vaadin/flow-components/pull/5788

Similarly to https://github.com/vaadin/flow-components/pull/6028, `beforeClientResponse` mustn't be used for updating the client-side sorter directions.

Fixes https://github.com/vaadin/flow-components/issues/5994

## Type of change

Bugfix