### PR TITLE
fix: override HasStyle methods in MenuBarItem class

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -35,6 +35,9 @@ public class MenuBarTestPage extends Div {
     public static final String MENU_ITEM_FIRST_CLASS_NAME = "menu-item-first-class-name";
     public static final String MENU_ITEM_SECOND_CLASS_NAME = "menu-item-second-class-name";
 
+    public static final String SUB_ITEM_FIRST_CLASS_NAME = "sub-item-first-class-name";
+    public static final String SUB_ITEM_SECOND_CLASS_NAME = "sub-item-second-class-name";
+
     public MenuBarTestPage() {
         MenuBar menuBar = new MenuBar();
         add(menuBar);
@@ -52,6 +55,10 @@ public class MenuBarTestPage extends Div {
                 e -> message.setText("clicked sub item 1"));
         MenuItem subItem2 = item1.getSubMenu()
                 .addItem(new Paragraph("sub item 2"));
+
+        MenuItem subItem3 = item1.getSubMenu()
+                .addItem(new Paragraph("sub item 3"));
+        subItem3.addClassName(SUB_ITEM_FIRST_CLASS_NAME);
 
         subItem2.getSubMenu().addItem(new Paragraph("sub sub item 1"));
         MenuItem checkable = subItem2.getSubMenu().addItem("checkable");
@@ -184,6 +191,48 @@ public class MenuBarTestPage extends Div {
                 });
         addRemoveMultipleClassNames.setId("add-remove-multiple-classes");
 
+        NativeButton toggleSubItemClassNameButton = new NativeButton(
+                "toggle sub item class", e -> {
+                    if (subItem3.hasClassName(SUB_ITEM_FIRST_CLASS_NAME)) {
+                        subItem3.removeClassName(SUB_ITEM_FIRST_CLASS_NAME);
+                    } else {
+                        subItem3.addClassName(SUB_ITEM_FIRST_CLASS_NAME);
+                    }
+                });
+        toggleSubItemClassNameButton.setId("toggle-sub-item-class-name");
+
+        NativeButton removeSubItemClassNameButton = new NativeButton(
+                "remove sub item class", e -> {
+                    subItem3.removeClassName(SUB_ITEM_FIRST_CLASS_NAME);
+                });
+        removeSubItemClassNameButton.setId("remove-sub-item-class-name");
+
+        NativeButton addRemoveMultipleSubItemClassNames = new NativeButton(
+                "toggle multiple sub item classes", e -> {
+                    if (subItem3.hasClassName(SUB_ITEM_FIRST_CLASS_NAME)) {
+                        subItem3.removeClassNames(SUB_ITEM_FIRST_CLASS_NAME,
+                                SUB_ITEM_SECOND_CLASS_NAME);
+                    } else {
+                        subItem3.addClassNames(SUB_ITEM_FIRST_CLASS_NAME,
+                                SUB_ITEM_SECOND_CLASS_NAME);
+                    }
+                });
+        addRemoveMultipleSubItemClassNames
+                .setId("add-remove-multiple-sub-item-classes");
+
+        NativeButton addSecondSubItemClassButton = new NativeButton(
+                "add second sub item class", e -> {
+                    subItem3.addClassName(SUB_ITEM_SECOND_CLASS_NAME);
+                });
+        addSecondSubItemClassButton.setId("add-second-sub-item-class-name");
+
+        NativeButton setUnsetSubItemClassNameButton = new NativeButton(
+                "set/unset sub item class", e -> {
+                    subItem3.setClassName(SUB_ITEM_FIRST_CLASS_NAME,
+                            !subItem3.hasClassName(SUB_ITEM_FIRST_CLASS_NAME));
+                });
+        setUnsetSubItemClassNameButton.setId("set-unset-sub-item-class-name");
+
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableItemButton, toggleItem1VisibilityButton,
@@ -192,6 +241,9 @@ public class MenuBarTestPage extends Div {
                 toggleMenuBarThemeButton, toggleItem1ThemeButton,
                 toggleSubItemThemeButton, toggleClassNameButton,
                 setItemClassNameButton, setUnsetClassNameButton,
-                addRemoveMultipleClassNames);
+                addRemoveMultipleClassNames, toggleSubItemClassNameButton,
+                addSecondSubItemClassButton, removeSubItemClassNameButton,
+                addRemoveMultipleSubItemClassNames,
+                setUnsetSubItemClassNameButton);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -500,6 +500,56 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void subMenuHasClassName_callRemoveClassName_classNameIsRemoved() {
+        verifySubMenuItemClassNames(true,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+
+        click("remove-sub-item-class-name");
+        verifySubMenuItemClassNames(false,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+    }
+
+    @Test
+    public void subMenuItem_toggleMultipleClassNames_classNamesAreToggled() {
+        click("add-second-sub-item-class-name");
+        verifySubMenuItemClassNames(true,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME,
+                MenuBarTestPage.SUB_ITEM_SECOND_CLASS_NAME);
+
+        click("add-remove-multiple-sub-item-classes");
+        verifySubMenuItemClassNames(false,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME,
+                MenuBarTestPage.SUB_ITEM_SECOND_CLASS_NAME);
+
+        click("add-remove-multiple-sub-item-classes");
+        verifySubMenuItemClassNames(true,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME,
+                MenuBarTestPage.SUB_ITEM_SECOND_CLASS_NAME);
+    }
+
+    @Test
+    public void subMenuItem_toggleSingleClassName_classNameIsToggled() {
+        click("toggle-sub-item-class-name");
+        verifySubMenuItemClassNames(false,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+
+        click("toggle-sub-item-class-name");
+        verifySubMenuItemClassNames(true,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+    }
+
+    @Test
+    public void subMenuItem_classNamesAreToggleWithSet_classNamesAreToggled() {
+        click("set-unset-sub-item-class-name");
+        verifySubMenuItemClassNames(false,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+
+        click("set-unset-sub-item-class-name");
+        verifySubMenuItemClassNames(true,
+                MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+    }
+
+    @Test
     public void setMenuItemTheme_toggleVisibility_themeIsPreserved() {
         click("toggle-item-1-theme");
         click("toggle-item-1-visibility");
@@ -633,5 +683,20 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     public void verifyOpened() {
         waitForElementPresent(By.tagName(OVERLAY_TAG));
+    }
+
+    private void verifySubMenuItemClassNames(boolean containsClassNames,
+            String... classNames) {
+        openSubSubMenu();
+        verifyOpened();
+        TestBenchElement subMenuItem = menuBar.getSubMenuItems().get(2);
+        var subMenuItemClassNames = subMenuItem.getAttribute("class");
+        for (String className : classNames) {
+            if (containsClassNames) {
+                Assert.assertTrue(subMenuItemClassNames.contains(className));
+            } else {
+                Assert.assertFalse(subMenuItemClassNames.contains(className));
+            }
+        }
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
@@ -36,4 +36,63 @@ class MenuBarItem extends MenuItem {
         return new MenuBarSubMenu(this, contentReset);
     }
 
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void addClassName(String className) {
+        super.addClassName(className);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void addClassNames(String... classNames) {
+        super.addClassNames(classNames);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void setClassName(String className) {
+        super.setClassName(className);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void setClassName(String className, boolean set) {
+        super.setClassName(className, set);
+        updateClassName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public boolean removeClassName(String className) {
+        var result = super.removeClassName(className);
+        updateClassName();
+        return result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void removeClassNames(String... classNames) {
+        super.removeClassNames(classNames);
+        updateClassName();
+    }
+
+    private void updateClassName() {
+        getElement().executeJs(
+                "window.Vaadin.Flow.menubarConnector.setClassName(this)");
+    }
 }


### PR DESCRIPTION
## Description

Override some methods of the `HasStyle` interface to call the `setClassName` method in the `MenuBar` connector to reflect the class name changes on the `item` object related to the sub-menu item.

This approach is similar to the one done for the `MenuBarRootItem` in which the same methods are overridden for the same purpose. That means **we only support changing class names through the high-level API in `HasStyle`**. Using `getElement().getClassList()` is discouraged.

Differently from the implementation in `MenuBarRootItem`, we don't need to regenerate the items, because the sub-menu item is re-evaluated every time its sub-menu is opened, taking the latest changes to `item` into use.

Fixes #5957

## Type of change

- [X] Bugfix
- [ ] Feature
