### PR TITLE
feat: support reverse button collapsing order in menu-bar

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -365,6 +365,30 @@ public class MenuBar extends Component
     }
 
     /**
+     * Sets reverse collapse order for the menu bar.
+     *
+     * @param reverseCollapseOrder
+     *            If {@code true}, the buttons will be collapsed into the
+     *            overflow menu starting from the "start" end of the bar instead
+     *            of the "end".
+     */
+    public void setReverseCollapseOrder(boolean reverseCollapseOrder) {
+        getElement().setProperty("reverseCollapse", reverseCollapseOrder);
+    }
+
+    /**
+     * Gets whether the menu bar uses reverse collapse order.
+     *
+     * @return {@code true} if the buttons will be collapsed into the overflow
+     *         menu starting from the "start" end of the bar instead of the
+     *         "end".
+     *
+     */
+    public boolean isReverseCollapseOrder() {
+        return getElement().getProperty("reverseCollapse", false);
+    }
+
+    /**
      * Gets the internationalization object previously set for this component.
      * <p>
      * Note: updating the object content that is gotten from this method will

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTest.java
@@ -93,6 +93,21 @@ public class MenuBarTest {
                         .isAssignableFrom(new MenuBar().getClass()));
     }
 
+    @Test
+    public void isReverseCollapseOrder() {
+        Assert.assertFalse(menuBar.isReverseCollapseOrder());
+        Assert.assertFalse(
+                menuBar.getElement().getProperty("reverseCollapse", false));
+    }
+
+    @Test
+    public void setReverseCollapseOrder_isReverseCollapseOrder() {
+        menuBar.setReverseCollapseOrder(true);
+        Assert.assertTrue(menuBar.isReverseCollapseOrder());
+        Assert.assertTrue(
+                menuBar.getElement().getProperty("reverseCollapse", false));
+    }
+
     private void assertChildrenAndItems(MenuItem... expected) {
         Object[] menuItems = menuBar.getChildren().toArray();
         Assert.assertArrayEquals(expected, menuItems);


### PR DESCRIPTION
## Description

Support reverse button collapsing order in menu-bar

https://github.com/vaadin/platform/assets/1222264/5a5f469f-d69f-4808-95c5-72ac2df0bc5a

Part of https://github.com/vaadin/platform/issues/5018

Related https://github.com/vaadin/web-components/pull/7124

## Type of change

Feature