### PR TITLE
fix: sync default header row for selection row

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsPage.java
@@ -26,8 +26,6 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.router.Route;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Route("vaadin-grid-it-demo/header-and-footer-rows")
@@ -78,60 +76,34 @@ public class GridViewHeaderAndFooterRowsPage extends LegacyTestView {
 
         HorizontalLayout buttonsLayout = new HorizontalLayout();
 
-        List<NativeButton> removeHeaderButtons = new ArrayList<>();
-        NativeButton removeAllHeaders = new NativeButton(
-                "Remove all header rows", removeClick -> {
-                    removeHeaderButtons.forEach(
-                            GridViewHeaderAndFooterRowsPage.this::remove);
-                    removeHeaderButtons.clear();
-                    grid.removeAllHeaderRows();
-                });
-        removeAllHeaders.setId("remove-all-header-rows");
+        NativeButton removeAllHeaders = new NativeButton("Remove all headers",
+                removeClick -> grid.removeAllHeaderRows());
+        removeAllHeaders.setId("remove-all-headers");
         buttonsLayout.add(removeAllHeaders);
 
         AtomicInteger prependedHeaderIndex = new AtomicInteger();
         NativeButton prependHeader = new NativeButton("Prepend header",
                 click -> {
-                    int index = prependedHeaderIndex.incrementAndGet();
-                    String title = "Prepended header " + index;
+                    String title = "Prepended header "
+                            + prependedHeaderIndex.incrementAndGet();
                     HeaderRow headerRow = grid.prependHeaderRow();
                     headerRow.getCell(nameColumn).setText(title + " - 0");
                     headerRow.getCell(ageColumn).setText(title + " - 1");
                     headerRow.getCell(streetColumn).setText(title + " - 2");
                     headerRow.getCell(postalCodeColumn).setText(title + " - 3");
-                    NativeButton removePrependedHeader = new NativeButton(
-                            "Remove " + title, removeClick -> {
-                                grid.removeHeaderRow(headerRow);
-                                removeHeaderButtons
-                                        .remove(removeClick.getSource());
-                                buttonsLayout.remove(removeClick.getSource());
-                            });
-                    removePrependedHeader
-                            .setId("remove-prepended-header-" + index);
-                    removeHeaderButtons.add(removePrependedHeader);
-                    buttonsLayout.add(removePrependedHeader);
                 });
         prependHeader.setId("prepend-header");
         buttonsLayout.add(prependHeader);
 
         AtomicInteger appendedHeaderIndex = new AtomicInteger();
         NativeButton appendHeader = new NativeButton("Append header", click -> {
-            int index = appendedHeaderIndex.incrementAndGet();
-            String title = "Appended header " + index;
+            String title = "Appended header "
+                    + appendedHeaderIndex.incrementAndGet();
             HeaderRow headerRow = grid.appendHeaderRow();
             headerRow.getCell(nameColumn).setText(title + " - 0");
             headerRow.getCell(ageColumn).setText(title + " - 1");
             headerRow.getCell(streetColumn).setText(title + " - 2");
             headerRow.getCell(postalCodeColumn).setText(title + " - 3");
-            NativeButton removeAppendedHeader = new NativeButton(
-                    "Remove " + title, removeClick -> {
-                        grid.removeHeaderRow(headerRow);
-                        removeHeaderButtons.remove(removeClick.getSource());
-                        buttonsLayout.remove(removeClick.getSource());
-                    });
-            removeAppendedHeader.setId("remove-appended-header-" + index);
-            removeHeaderButtons.add(removeAppendedHeader);
-            buttonsLayout.add(removeAppendedHeader);
         });
         appendHeader.setId("append-header");
         buttonsLayout.add(appendHeader);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsPage.java
@@ -19,9 +19,16 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.HeaderRow.HeaderCell;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.router.Route;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Route("vaadin-grid-it-demo/header-and-footer-rows")
 public class GridViewHeaderAndFooterRowsPage extends LegacyTestView {
@@ -58,8 +65,79 @@ public class GridViewHeaderAndFooterRowsPage extends LegacyTestView {
         grid.appendFooterRow().getCell(nameColumn)
                 .setText("Total: " + getItems().size() + " people");
         grid.setId("grid-with-header-and-footer-rows");
-        addCard("Header and footer rows", "Adding header and footer rows",
-                grid);
+
+        RadioButtonGroup<Grid.SelectionMode> selectionMode = new RadioButtonGroup<>(
+                "Selection mode");
+        selectionMode.setItems(Grid.SelectionMode.values());
+        selectionMode.setValue(grid.getSelectionMode());
+        selectionMode.addValueChangeListener(
+                event -> grid.setSelectionMode(event.getValue()));
+        selectionMode.setItemLabelGenerator(item -> item.name().charAt(0)
+                + item.name().substring(1).toLowerCase());
+        selectionMode.setId("selection-mode");
+
+        HorizontalLayout buttonsLayout = new HorizontalLayout();
+
+        List<NativeButton> removeHeaderButtons = new ArrayList<>();
+        NativeButton removeAllHeaders = new NativeButton(
+                "Remove all header rows", removeClick -> {
+                    removeHeaderButtons.forEach(
+                            GridViewHeaderAndFooterRowsPage.this::remove);
+                    removeHeaderButtons.clear();
+                    grid.removeAllHeaderRows();
+                });
+        removeAllHeaders.setId("remove-all-header-rows");
+        buttonsLayout.add(removeAllHeaders);
+
+        AtomicInteger prependedHeaderIndex = new AtomicInteger();
+        NativeButton prependHeader = new NativeButton("Prepend header",
+                click -> {
+                    int index = prependedHeaderIndex.incrementAndGet();
+                    String title = "Prepended header " + index;
+                    HeaderRow headerRow = grid.prependHeaderRow();
+                    headerRow.getCell(nameColumn).setText(title + " - 0");
+                    headerRow.getCell(ageColumn).setText(title + " - 1");
+                    headerRow.getCell(streetColumn).setText(title + " - 2");
+                    headerRow.getCell(postalCodeColumn).setText(title + " - 3");
+                    NativeButton removePrependedHeader = new NativeButton(
+                            "Remove " + title, removeClick -> {
+                                grid.removeHeaderRow(headerRow);
+                                removeHeaderButtons
+                                        .remove(removeClick.getSource());
+                                buttonsLayout.remove(removeClick.getSource());
+                            });
+                    removePrependedHeader
+                            .setId("remove-prepended-header-" + index);
+                    removeHeaderButtons.add(removePrependedHeader);
+                    buttonsLayout.add(removePrependedHeader);
+                });
+        prependHeader.setId("prepend-header");
+        buttonsLayout.add(prependHeader);
+
+        AtomicInteger appendedHeaderIndex = new AtomicInteger();
+        NativeButton appendHeader = new NativeButton("Append header", click -> {
+            int index = appendedHeaderIndex.incrementAndGet();
+            String title = "Appended header " + index;
+            HeaderRow headerRow = grid.appendHeaderRow();
+            headerRow.getCell(nameColumn).setText(title + " - 0");
+            headerRow.getCell(ageColumn).setText(title + " - 1");
+            headerRow.getCell(streetColumn).setText(title + " - 2");
+            headerRow.getCell(postalCodeColumn).setText(title + " - 3");
+            NativeButton removeAppendedHeader = new NativeButton(
+                    "Remove " + title, removeClick -> {
+                        grid.removeHeaderRow(headerRow);
+                        removeHeaderButtons.remove(removeClick.getSource());
+                        buttonsLayout.remove(removeClick.getSource());
+                    });
+            removeAppendedHeader.setId("remove-appended-header-" + index);
+            removeHeaderButtons.add(removeAppendedHeader);
+            buttonsLayout.add(removeAppendedHeader);
+        });
+        appendHeader.setId("append-header");
+        buttonsLayout.add(appendHeader);
+
+        addCard("Header and footer rows", "Adding header and footer rows", grid,
+                selectionMode, buttonsLayout);
     }
 
     private void createHeaderAndFooterUsingComponents() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,10 +43,10 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
                 .id("grid-with-header-and-footer-rows");
         scrollToElement(grid);
 
-        assertRendereredHeaderCell(grid.getHeaderCell(0), "Name", true);
-        assertRendereredHeaderCell(grid.getHeaderCell(1), "Age", true);
-        assertRendereredHeaderCell(grid.getHeaderCell(2), "Street", false);
-        assertRendereredHeaderCell(grid.getHeaderCell(3), "Postal Code", false);
+        assertRenderedHeaderCell(grid.getHeaderCell(0), "Name", true);
+        assertRenderedHeaderCell(grid.getHeaderCell(1), "Age", true);
+        assertRenderedHeaderCell(grid.getHeaderCell(2), "Street", false);
+        assertRenderedHeaderCell(grid.getHeaderCell(3), "Postal Code", false);
 
         Assert.assertTrue(
                 "The first column group should have 'Basic Information' header text",
@@ -68,29 +69,57 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
         scrollToElement(grid);
 
         GridTHTDElement headerCell = grid.getHeaderCell(0);
-        assertRendereredHeaderCell(headerCell, "<span>Name</span>", true);
+        assertRenderedHeaderCell(headerCell, "<span>Name</span>", true);
 
         headerCell = grid.getHeaderCell(1);
-        assertRendereredHeaderCell(headerCell, "<span>Age</span>", true);
+        assertRenderedHeaderCell(headerCell, "<span>Age</span>", true);
 
         headerCell = grid.getHeaderCell(2);
-        assertRendereredHeaderCell(headerCell, "<span>Street</span>", false);
+        assertRenderedHeaderCell(headerCell, "<span>Street</span>", false);
 
         headerCell = grid.getHeaderCell(3);
-        assertRendereredHeaderCell(headerCell, "<span>Postal Code</span>",
-                false);
+        assertRenderedHeaderCell(headerCell, "<span>Postal Code</span>", false);
 
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Basic Information' header",
-                hasComponentRendereredHeaderCell(grid, "span",
+                hasComponentRenderedHeaderCell(grid, "span",
                         "Basic Information"));
 
         Assert.assertTrue("There should be a cell with the renderered footer",
-                hasComponentRendereredHeaderCell(grid, "span",
+                hasComponentRenderedHeaderCell(grid, "span",
                         "Total: 500 people"));
     }
 
-    private void assertRendereredHeaderCell(GridTHTDElement headerCell,
+    @Test
+    public void setMultiSelect_appendHeader_selectAllCheckboxOnDefaultHeaderRow() {
+        GridElement grid = setupMultiSelectGrid();
+        $("button").id("append-header").click();
+        Assert.assertTrue(getHeaderCell(grid, 1, 0).getInnerHTML()
+                .contains("selectAllCheckbox"));
+        Assert.assertFalse(getHeaderCell(grid, 2, 0).getInnerHTML()
+                .contains("selectAllCheckbox"));
+    }
+
+    @Test
+    public void setMultiSelect_prependHeader_selectAllCheckboxOnDefaultHeaderRow() {
+        GridElement grid = setupMultiSelectGrid();
+        $("button").id("prepend-header").click();
+        Assert.assertTrue(getHeaderCell(grid, 2, 0).getInnerHTML()
+                .contains("selectAllCheckbox"));
+        Assert.assertFalse(getHeaderCell(grid, 1, 0).getInnerHTML()
+                .contains("selectAllCheckbox"));
+    }
+
+    @Test
+    public void setMultiSelect_removeAllHeaders_appendHeader_selectAllCheckboxOnFirstHeaderRow() {
+        GridElement grid = setupMultiSelectGrid();
+        $("button").id("remove-all-headers").click();
+        $("button").id("append-header").click();
+        Assert.assertTrue(getHeaderCell(grid, 0, 0).getInnerHTML()
+                .contains("selectAllCheckbox"));
+    }
+
+    private void assertRenderedHeaderCell(GridTHTDElement headerCell,
             String text, boolean withSorter) {
 
         String html = headerCell.getInnerHTML();
@@ -102,12 +131,12 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
         Assert.assertTrue(html.contains(text));
     }
 
-    private boolean hasComponentRendereredHeaderCell(WebElement grid,
+    private boolean hasComponentRenderedHeaderCell(WebElement grid,
             String tagName, String text) {
-        return hasComponentRendereredCell(grid, text, tagName);
+        return hasComponentRenderedCell(grid, text, tagName);
     }
 
-    private boolean hasComponentRendereredCell(WebElement grid, String text,
+    private boolean hasComponentRenderedCell(WebElement grid, String text,
             String componentTag) {
         List<WebElement> cells = grid
                 .findElements(By.tagName("vaadin-grid-cell-content"));
@@ -116,5 +145,21 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
                 .map(cell -> cell.findElements(By.tagName(componentTag)))
                 .filter(list -> !list.isEmpty()).map(list -> list.get(0))
                 .anyMatch(cell -> text.equals(cell.getAttribute("innerHTML")));
+    }
+
+    private GridElement setupMultiSelectGrid() {
+        findElement(By.id("selection-mode"))
+                .findElements(By.tagName("vaadin-radio-button")).get(1).click();
+        GridElement grid = $(GridElement.class)
+                .id("grid-with-header-and-footer-rows");
+        scrollToElement(grid);
+        return grid;
+    }
+
+    private GridTHTDElement getHeaderCell(GridElement grid, int headerRowIndex,
+            int columnIndex) {
+        return ((TestBenchElement) executeScript(
+                "return arguments[0].$.header.children[arguments[1]].children[arguments[2]]",
+                grid, headerRowIndex, columnIndex)).wrap(GridTHTDElement.class);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -400,6 +400,10 @@ public abstract class AbstractGridMultiSelectionModel<T>
         return selectionColumn;
     }
 
+    void syncDefaultHeaderRow(int defaultHeaderRowIndex) {
+        selectionColumn.syncDefaultHeaderRow(defaultHeaderRowIndex);
+    }
+
     /**
      * Fetch all items from the given hierarchical data provider.
      *

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2346,7 +2346,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         if (getHeaderRows().size() == 0) {
             return addFirstHeaderRow();
         }
-        HeaderRow newHeaderRow = insertColumnLayer(getLastHeaderLayerIndex() + 1).asHeaderRow();
+        HeaderRow newHeaderRow = insertColumnLayer(
+                getLastHeaderLayerIndex() + 1).asHeaderRow();
         syncSelectionColumnDefaultHeaderRow();
         return newHeaderRow;
     }
@@ -2362,7 +2363,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         if (getHeaderRows().size() == 0) {
             return addFirstHeaderRow();
         }
-        HeaderRow newHeaderRow = insertInmostColumnLayer(true, false).asHeaderRow();
+        HeaderRow newHeaderRow = insertInmostColumnLayer(true, false)
+                .asHeaderRow();
         syncSelectionColumnDefaultHeaderRow();
         return newHeaderRow;
     }
@@ -2406,8 +2408,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     private void syncSelectionColumnDefaultHeaderRow() {
+        // TODO implement and refactor
         if (getSelectionModel() instanceof AbstractGridMultiSelectionModel<T> model) {
-            model.syncDefaultHeaderRow(getHeaderRows().indexOf(defaultHeaderRow));
+            model.syncDefaultHeaderRow(
+                    getHeaderRows().indexOf(defaultHeaderRow));
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2346,7 +2346,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         if (getHeaderRows().size() == 0) {
             return addFirstHeaderRow();
         }
-        return insertColumnLayer(getLastHeaderLayerIndex() + 1).asHeaderRow();
+        HeaderRow newHeaderRow = insertColumnLayer(getLastHeaderLayerIndex() + 1).asHeaderRow();
+        syncSelectionColumnDefaultHeaderRow();
+        return newHeaderRow;
     }
 
     /**
@@ -2360,7 +2362,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         if (getHeaderRows().size() == 0) {
             return addFirstHeaderRow();
         }
-        return insertInmostColumnLayer(true, false).asHeaderRow();
+        HeaderRow newHeaderRow = insertInmostColumnLayer(true, false).asHeaderRow();
+        syncSelectionColumnDefaultHeaderRow();
+        return newHeaderRow;
     }
 
     /**
@@ -2397,6 +2401,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             } else {
                 removeColumnLayer(headerRow.layer);
             }
+            syncSelectionColumnDefaultHeaderRow();
+        }
+    }
+
+    private void syncSelectionColumnDefaultHeaderRow() {
+        if (getSelectionModel() instanceof AbstractGridMultiSelectionModel<T> model) {
+            model.syncDefaultHeaderRow(getHeaderRows().indexOf(defaultHeaderRow));
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2408,7 +2408,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     private void syncSelectionColumnDefaultHeaderRow() {
-        // TODO implement and refactor
         if (getSelectionModel() instanceof AbstractGridMultiSelectionModel<T> model) {
             model.syncDefaultHeaderRow(
                     getHeaderRows().indexOf(defaultHeaderRow));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -127,6 +127,14 @@ public class GridSelectionColumn extends Component {
         return getElement().getProperty("dragSelect", false);
     }
 
+    void syncDefaultHeaderRow(int defaultHeaderRowIndex) {
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, context ->
+                        getElement().callJsFunction(
+                                "_syncDefaultHeaderRow", defaultHeaderRowIndex)
+                ));
+    }
+
     @ClientCallable
     private void selectAll() {
         selectAllCallback.run();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -128,11 +128,11 @@ public class GridSelectionColumn extends Component {
     }
 
     void syncDefaultHeaderRow(int defaultHeaderRowIndex) {
-        getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this, context ->
-                        getElement().callJsFunction(
-                                "_syncDefaultHeaderRow", defaultHeaderRowIndex)
-                ));
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                        context -> getElement().callJsFunction(
+                                "_syncDefaultHeaderRow",
+                                defaultHeaderRowIndex)));
     }
 
     @ClientCallable

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -524,6 +524,7 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                 // Header & footer
                 const tagName = section === 'header' ? 'th' : 'td';
 
+                // The change here is for discussion and should be applied to the web component
                 let isHeaderOrFooterCell;
                 if (section === 'header' && column._customSelectionColumnHeaderHandler) {
                   const headerRowIndex = Array.from(grid.$.header.children).indexOf(row);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -525,15 +525,15 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                 const tagName = section === 'header' ? 'th' : 'td';
 
                 // The change here is for discussion and should be applied to the web component
-                let isHeaderOrFooterCell;
-                if (section === 'header' && column._customSelectionColumnHeaderHandler) {
+                let renderAsHeaderOrFooterCell;
+                if (section === 'header' && column._customSelectionColumnHeaderCellProvider) {
                   const headerRowIndex = Array.from(grid.$.header.children).indexOf(row);
-                  isHeaderOrFooterCell = column._customSelectionColumnHeaderHandler(headerRowIndex);
+                  renderAsHeaderOrFooterCell = column._customSelectionColumnHeaderCellProvider(headerRowIndex);
                 } else {
-                  isHeaderOrFooterCell = isColumnRow || column.localName === 'vaadin-grid-column-group';
+                  renderAsHeaderOrFooterCell = isColumnRow || column.localName === 'vaadin-grid-column-group';
                 }
 
-                if (isHeaderOrFooterCell) {
+                if (renderAsHeaderOrFooterCell) {
                   cell = column[`_${section}Cell`] || grid._createCell(tagName);
                   cell._column = column;
                   row.appendChild(cell);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -53,7 +53,7 @@ export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridCo
    * @protected
    */
   _customSelectionColumnHeaderHandler(headerRowIndex) {
-    if (!this.__defaultHeaderRowIndex) {
+    if (this.__defaultHeaderRowIndex == null) {
       return true;
     }
     return this.__defaultHeaderRowIndex === headerRowIndex;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -52,7 +52,7 @@ export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridCo
   /**
    * @protected
    */
-  _customSelectionColumnHeaderHandler(headerRowIndex) {
+  _customSelectionColumnHeaderCellProvider(headerRowIndex) {
     if (this.__defaultHeaderRowIndex == null) {
       return true;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -42,6 +42,22 @@ export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridCo
     }
   }
 
+  /**
+   * @protected
+   */
+  _syncDefaultHeaderRow(headerCellIndex) {
+    this.__defaultHeaderRowIndex = headerCellIndex;
+  }
+
+  /**
+   * @protected
+   */
+  _customSelectionColumnHeaderHandler(headerRowIndex) {
+    if (!this.__defaultHeaderRowIndex) {
+      return true;
+    }
+    return this.__defaultHeaderRowIndex === headerRowIndex;
+  }
 
   /**
    * Override a method from `GridSelectionColumnBaseMixin` to handle the user


### PR DESCRIPTION
## Description

The selection column in a Grid is not a part of the column layer structure, therefore cannot track the default header. When the index of the default row changes, the sorting indicators are updated, but there is nothing that handles this change for the select all checkbox. This PR introduces a synchronizing mechanism for the Flow selection column. When a header row is appended, prepended, or removed, the default header row index is sent to the client. There is a proposed custom selection column header cell provider, which does not exist by default. When it exists, the decision to set a cell as a header cell while updating the rows is delegated to the custom provider for that column. This way, the checkbox is only rendered in the header cell that corresponds to the default header row.

Note: The proposed custom selection column header cell provider should be in the web component. Currently, for discussion purposes, the relevant code is copied from the web component and modified in the connector.

Fixes #1054

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.