### PR TITLE
feat: allow using live directive in LitRenderer

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
@@ -50,6 +50,14 @@ public class LitRendererPage extends Div {
         setSimpleLitRendererButton.setId("setSimpleLitRendererButton");
         add(setSimpleLitRendererButton);
 
+        NativeButton setCheckboxRenderer = new NativeButton("Set LitRenderer with checkbox", e -> {
+            component.setRenderer(LitRenderer.<String> of(
+                    "<input type='checkbox' .checked='${live(item.checked)}'>")
+                .withProperty("checked", "2"::equals));
+        });
+        setCheckboxRenderer.setId("setCheckboxRenderer");
+        add(setCheckboxRenderer);
+
         NativeButton removeRendererButton = new NativeButton("Remove renderer",
                 e -> component.setRenderer(null));
         removeRendererButton.setId("removeRendererButton");
@@ -86,14 +94,6 @@ public class LitRendererPage extends Div {
                 });
         toggleAttachedButton.setId("toggleAttachedButton");
         add(toggleAttachedButton);
-
-        NativeButton setCheckboxRenderer = new NativeButton("Set renderer with checkbox", e -> {
-            component.setRenderer(LitRenderer.<String> of(
-                    "<input type='checkbox' .checked='${live(item.checked)}'>")
-                    .withProperty("checked", "2"::equals));
-        });
-        setCheckboxRenderer.setId("setCheckboxRenderer");
-        add(setCheckboxRenderer);
     }
 
     private void setLitRenderer(LitRendererTestComponent component) {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
@@ -87,6 +87,13 @@ public class LitRendererPage extends Div {
         toggleAttachedButton.setId("toggleAttachedButton");
         add(toggleAttachedButton);
 
+        NativeButton setCheckboxRenderer = new NativeButton("Set renderer with checkbox", e -> {
+            component.setRenderer(LitRenderer.<String> of(
+                    "<input type='checkbox' .checked='${live(item.checked)}'>")
+                    .withProperty("checked", "2"::equals));
+        });
+        setCheckboxRenderer.setId("setCheckboxRenderer");
+        add(setCheckboxRenderer);
     }
 
     private void setLitRenderer(LitRendererTestComponent component) {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererPage.java
@@ -50,11 +50,12 @@ public class LitRendererPage extends Div {
         setSimpleLitRendererButton.setId("setSimpleLitRendererButton");
         add(setSimpleLitRendererButton);
 
-        NativeButton setCheckboxRenderer = new NativeButton("Set LitRenderer with checkbox", e -> {
-            component.setRenderer(LitRenderer.<String> of(
-                    "<input type='checkbox' .checked='${live(item.checked)}'>")
-                .withProperty("checked", "2"::equals));
-        });
+        NativeButton setCheckboxRenderer = new NativeButton(
+                "Set LitRenderer with checkbox", e -> {
+                    component.setRenderer(LitRenderer.<String> of(
+                            "<input type='checkbox' .checked='${live(item.checked)}'>")
+                            .withProperty("checked", "2"::equals));
+                });
         setCheckboxRenderer.setId("setCheckboxRenderer");
         add(setCheckboxRenderer);
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/LitRendererIT.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/LitRendererIT.java
@@ -129,6 +129,16 @@ public class LitRendererIT extends AbstractComponentIT {
         Assert.assertEquals("Details: 0 (details)", details.getText());
     }
 
+    @Test
+    public void shouldBeAbleToUseLiveDirective() {
+        clickElementWithJs("setCheckboxRenderer");
+        WebElement checkbox = findElement(By.cssSelector("#item-0 input"));
+        checkbox.click();
+        clickElementWithJs("longRefreshButton");
+        checkbox = findElement(By.cssSelector("#item-0 input"));
+        Assert.assertFalse(checkbox.isSelected());
+    }
+
     private String getFirstClientCallableLogMessage() {
         return getLogEntries(Level.WARNING).stream()
                 // Discard all but event messages

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/lit-renderer.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/lit-renderer.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable max-params */
 import { html, render } from 'lit';
+import { live } from 'lit/directives/live.js';
 
 type RenderRoot = HTMLElement & { __litRenderer?: Renderer; _$litPart$?: any };
 
@@ -39,7 +40,7 @@ _window.Vaadin.setLitRenderer = (
   const renderFunction = Function(`
     "use strict";
 
-    const [render, html, returnChannel] = arguments;
+    const [render, html, live, returnChannel] = arguments;
 
     return (root, model, itemKey) => {
       const { item, index } = model;
@@ -57,7 +58,7 @@ _window.Vaadin.setLitRenderer = (
 
       render(html\`${templateExpression}\`, root)
     }
-  `)(render, html, returnChannel);
+  `)(render, html, live, returnChannel);
 
   const renderer: Renderer = (root, _, model) => {
     const { item } = model;


### PR DESCRIPTION
## Description

Inject the `live` directive into the closure where the render is executed.

It's beneficial for cases where components can have their state changed by users to reset their value when the render is called.
