### PR TITLE
test: fix flaky menubar ITs

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -507,6 +507,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
 
         click("remove-sub-item-class-name");
+        verifyClosed();
         verifySubMenuItemClassNames(false,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
     }
@@ -514,16 +515,19 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void subMenuItem_toggleMultipleClassNames_classNamesAreToggled() {
         click("add-second-sub-item-class-name");
+        verifyClosed();
         verifySubMenuItemClassNames(true,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME,
                 MenuBarTestPage.SUB_ITEM_SECOND_CLASS_NAME);
 
         click("add-remove-multiple-sub-item-classes");
+        verifyClosed();
         verifySubMenuItemClassNames(false,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME,
                 MenuBarTestPage.SUB_ITEM_SECOND_CLASS_NAME);
 
         click("add-remove-multiple-sub-item-classes");
+        verifyClosed();
         verifySubMenuItemClassNames(true,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME,
                 MenuBarTestPage.SUB_ITEM_SECOND_CLASS_NAME);
@@ -532,10 +536,12 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void subMenuItem_toggleSingleClassName_classNameIsToggled() {
         click("toggle-sub-item-class-name");
+        verifyClosed();
         verifySubMenuItemClassNames(false,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
 
         click("toggle-sub-item-class-name");
+        verifyClosed();
         verifySubMenuItemClassNames(true,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
     }
@@ -543,10 +549,12 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void subMenuItem_classNamesAreToggleWithSet_classNamesAreToggled() {
         click("set-unset-sub-item-class-name");
+        verifyClosed();
         verifySubMenuItemClassNames(false,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
 
         click("set-unset-sub-item-class-name");
+        verifyClosed();
         verifySubMenuItemClassNames(true,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
     }


### PR DESCRIPTION
Menu bar ITs added in https://github.com/vaadin/flow-components/pull/6031 fail quite often, seemingly because the menu overlay isn't closed yet before tests attempt to open the menu again:
- https://bender.vaadin.com/buildConfiguration/FlowComponents_Snapshot/506523?buildTab=log&focusLine=25356&logView=flowAware&linesState=644.25355
- https://bender.vaadin.com/buildConfiguration/FlowComponents_Snapshot/506507?buildTab=log&focusLine=25426&logView=flowAware&linesState=645.25424

Waiting for them to be closed after clicking buttons seems to help.
