### PR TITLE
fix: allow short formats, add date-picker connector WTR tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ error-screenshots
 **/frontend/index.html
 **/frontend/*.tsx
 dev-bundle
+prod.bundle

--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -53,7 +53,7 @@ function runTests() {
       });
 
       // Install dependencies required to run the web-test-runner tests
-      execSync(`npm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon --save-dev`, {
+      execSync(`pnpm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon --save-dev`, {
         cwd: itFolder,
         stdio: 'inherit'
       });

--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -53,7 +53,7 @@ function runTests() {
       });
 
       // Install dependencies required to run the web-test-runner tests
-      execSync(`pnpm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon --save-dev`, {
+      execSync(`npm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon --save-dev`, {
         cwd: itFolder,
         stdio: 'inherit'
       });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -16,7 +16,7 @@ describe('date-picker connector', () => {
     expect(datePicker.$connector).to.equal(connector);
   });
 
-  const DATE = new Date(2024, 0, 1);
+  const DATE = new Date(Date.UTC(2023, 11, 1));
   const DATE_OBJ = extractDateParts(DATE);
 
   [
@@ -36,19 +36,30 @@ describe('date-picker connector', () => {
     'dd'
   ].forEach((format) => {
     describe(`${format} format`, () => {
-      let date;
+      let dateStr;
+      let dateObj = { ...DATE_OBJ };
 
       beforeEach(() => {
-        date = dateFnsFormat(DATE, format);
+        dateStr = dateFnsFormat(DATE, format);
         datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
+
+        // No year specified assumes current year.
+        if (!format.includes('y') && !format.includes('Y')) {
+          dateObj.year = new Date().getFullYear();
+        }
+
+        // Days only format assumes current month.
+        if (format === 'dd') {
+          dateObj.month = new Date().getMonth();
+        }
       });
 
       it(`should format date using ${format} format`, () => {
-        expect(datePicker.i18n.formatDate(DATE_OBJ)).to.equal(date);
+        expect(datePicker.i18n.formatDate(dateObj)).to.equal(dateStr);
       });
 
       it(`should parse date using ${format} format`, () => {
-        expect(datePicker.i18n.parseDate(date)).to.eql(DATE_OBJ);
+        expect(datePicker.i18n.parseDate(dateStr)).to.eql(dateObj);
       });
     });
   });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -16,7 +16,7 @@ describe('date-picker connector', () => {
     expect(datePicker.$connector).to.equal(connector);
   });
 
-  const DATE = new Date();
+  const DATE = new Date(2024, 0, 1);
   const DATE_OBJ = extractDateParts(DATE);
 
   [

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixtureSync } from '@open-wc/testing';
+import dateFnsFormat from 'date-fns/format';
 import { init, extractDateParts, datepickerConnector, type FlowDatePicker } from './shared.js';
 
 describe('date-picker connector', () => {
@@ -18,41 +19,37 @@ describe('date-picker connector', () => {
   const DATE = new Date();
   const DATE_OBJ = extractDateParts(DATE);
 
-  const D = DATE_OBJ.day;
-  const DD = `${D}`.length == 1 ? `0${D}` : `${D}`;
-
-  const M = DATE_OBJ.month + 1;
-  const MM = `${M}`.length == 1 ? `0${M}` : `${M}`;
-
-  const YYYY = DATE_OBJ.year;
-  const YY = `${YYYY}`.slice(2);
-
   [
     // Day, month, year
-    ['dd.MM.yyyy', `${DD}.${MM}.${YYYY}`],
-    ['ddMMyyyy', `${DD}${MM}${YYYY}`],
-    ['yyyy-MM-dd', `${YYYY}-${MM}-${DD}`],
-    ['MM/dd/yyyy', `${MM}/${DD}/${YYYY}`],
-    ['ddMMyy', `${DD}${MM}${YY}`],
+    'dd.MM.yyyy',
+    'ddMMyyyy',
+    'yyyy-MM-dd',
+    'MM/dd/yyyy',
+    'ddMMyy',
     // Day and month only
-    ['dd.MM', `${DD}.${MM}`],
-    ['ddMM', `${DD}${MM}`],
-    ['dd-MM', `${DD}-${MM}`],
-    ['MM/dd', `${MM}/${DD}`],
-    ['M/dd', `${M}/${DD}`],
+    'dd.MM',
+    'ddMM',
+    'dd-MM',
+    'MM/dd',
+    'M/dd',
     // Day only
-    ['dd', `${DD}`]
-  ].forEach(([format, date]) => {
-    it(`should format date using ${format} format`, () => {
-      datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
+    'dd'
+  ].forEach((format) => {
+    describe(`${format} format`, () => {
+      let date;
 
-      expect(datePicker.i18n.formatDate(DATE_OBJ)).to.equal(date);
-    });
+      beforeEach(() => {
+        date = dateFnsFormat(DATE, format);
+        datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
+      });
 
-    it(`should parse date using ${format} format`, () => {
-      datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
+      it(`should format date using ${format} format`, () => {
+        expect(datePicker.i18n.formatDate(DATE_OBJ)).to.equal(date);
+      });
 
-      expect(datePicker.i18n.parseDate(date)).to.eql(DATE_OBJ);
+      it(`should parse date using ${format} format`, () => {
+        expect(datePicker.i18n.parseDate(date)).to.eql(DATE_OBJ);
+      });
     });
   });
 });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -1,0 +1,44 @@
+import { expect, fixtureSync } from '@open-wc/testing';
+import { init, datepickerConnector, type DatePickerDate, type FlowDatePicker } from './shared.js';
+
+describe('date-picker connector', () => {
+  let datePicker: FlowDatePicker;
+
+  beforeEach(() => {
+    datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+    init(datePicker);
+  });
+
+  it('should not reinitialize the connector', () => {
+    const connector = datePicker.$connector;
+    datepickerConnector.initLazy(datePicker);
+    expect(datePicker.$connector).to.equal(connector);
+  });
+
+  // Use current year to not hardcode it
+  const YEAR = new Date().getFullYear();
+
+  [
+    // Day, month, year
+    ['dd.MM.yyyy', `31.01.${YEAR}`],
+    ['ddMMyyyy', `3101${YEAR}`],
+    ['yyyy-MM-dd', `${YEAR}-01-31`],
+    ['MM/dd/yyyy', `01/31/${YEAR}`],
+    ['ddMMyy', `3101${YEAR - 2000}`],
+    // Day and month only
+    ['dd.MM', '31.01'],
+    ['ddMM', '3101'],
+    ['dd-MM', '31-01'],
+    ['MM/dd', '01/31'],
+    ['M/dd', '1/31'],
+  ].forEach(([format, date]) => {
+    it(`should parse date using ${format} format`, () => {
+      datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
+
+      const { day, month, year } = datePicker.i18n.parseDate(date) as DatePickerDate;
+      expect(day).to.be.equal(31);
+      expect(month).to.be.equal(0);
+      expect(year).to.be.equal(YEAR);
+    });
+  });
+});

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -1,5 +1,5 @@
 import { expect, fixtureSync } from '@open-wc/testing';
-import { init, datepickerConnector, type FlowDatePicker } from './shared.js';
+import { init, extractDateParts, datepickerConnector, type FlowDatePicker } from './shared.js';
 
 describe('date-picker connector', () => {
   let datePicker: FlowDatePicker;
@@ -16,19 +16,16 @@ describe('date-picker connector', () => {
   });
 
   const DATE = new Date();
+  const DATE_OBJ = extractDateParts(DATE);
 
-  const D = DATE.getDate();
+  const D = DATE_OBJ.day;
   const DD = `${D}`.length == 1 ? `0${D}` : `${D}`;
 
-  const MONTH = DATE.getMonth();
-
-  const M = MONTH + 1;
+  const M = DATE_OBJ.month + 1;
   const MM = `${M}`.length == 1 ? `0${M}` : `${M}`;
 
-  const YYYY = DATE.getFullYear();
+  const YYYY = DATE_OBJ.year;
   const YY = `${YYYY}`.slice(2);
-
-  const DATE_OBJ = { day: D, month: MONTH, year: YYYY };
 
   [
     // Day, month, year

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -15,17 +15,20 @@ describe('date-picker connector', () => {
     expect(datePicker.$connector).to.equal(connector);
   });
 
-  // Use current year to not hardcode it
-  const YYYY = new Date().getFullYear();
-  const YY = YYYY - 2000;
+  const DATE = new Date();
 
-  // Get 0 based month to not hardcode it
-  const MONTH = new Date().getMonth();
+  const D = DATE.getDate();
+  const DD = `${D}`.length == 1 ? `0${D}` : `${D}`;
+
+  const MONTH = DATE.getMonth();
 
   const M = MONTH + 1;
   const MM = `${M}`.length == 1 ? `0${M}` : `${M}`;
 
-  const DD = 15;
+  const YYYY = DATE.getFullYear();
+  const YY = `${YYYY}`.slice(2);
+
+  const DATE_OBJ = { day: D, month: MONTH, year: YYYY };
 
   [
     // Day, month, year
@@ -43,13 +46,16 @@ describe('date-picker connector', () => {
     // Day only
     ['dd', `${DD}`]
   ].forEach(([format, date]) => {
+    it(`should format date using ${format} format`, () => {
+      datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
+
+      expect(datePicker.i18n.formatDate(DATE_OBJ)).to.equal(date);
+    });
+
     it(`should parse date using ${format} format`, () => {
       datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
 
-      const { day, month, year } = datePicker.i18n.parseDate(date) as DatePickerDate;
-      expect(day).to.be.equal(DD);
-      expect(month).to.be.equal(MONTH);
-      expect(year).to.be.equal(YYYY);
+      expect(datePicker.i18n.parseDate(date)).to.eql(DATE_OBJ);
     });
   });
 });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -1,5 +1,5 @@
 import { expect, fixtureSync } from '@open-wc/testing';
-import { init, datepickerConnector, type DatePickerDate, type FlowDatePicker } from './shared.js';
+import { init, datepickerConnector, type FlowDatePicker } from './shared.js';
 
 describe('date-picker connector', () => {
   let datePicker: FlowDatePicker;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -16,29 +16,40 @@ describe('date-picker connector', () => {
   });
 
   // Use current year to not hardcode it
-  const YEAR = new Date().getFullYear();
+  const YYYY = new Date().getFullYear();
+  const YY = YYYY - 2000;
+
+  // Get 0 based month to not hardcode it
+  const MONTH = new Date().getMonth();
+
+  const M = MONTH + 1;
+  const MM = `${M}`.length == 1 ? `0${M}` : `${M}`;
+
+  const DD = 15;
 
   [
     // Day, month, year
-    ['dd.MM.yyyy', `31.01.${YEAR}`],
-    ['ddMMyyyy', `3101${YEAR}`],
-    ['yyyy-MM-dd', `${YEAR}-01-31`],
-    ['MM/dd/yyyy', `01/31/${YEAR}`],
-    ['ddMMyy', `3101${YEAR - 2000}`],
+    ['dd.MM.yyyy', `${DD}.${MM}.${YYYY}`],
+    ['ddMMyyyy', `${DD}${MM}${YYYY}`],
+    ['yyyy-MM-dd', `${YYYY}-${MM}-${DD}`],
+    ['MM/dd/yyyy', `${MM}/${DD}/${YYYY}`],
+    ['ddMMyy', `${DD}${MM}${YY}`],
     // Day and month only
-    ['dd.MM', '31.01'],
-    ['ddMM', '3101'],
-    ['dd-MM', '31-01'],
-    ['MM/dd', '01/31'],
-    ['M/dd', '1/31'],
+    ['dd.MM', `${DD}.${MM}`],
+    ['ddMM', `${DD}${MM}`],
+    ['dd-MM', `${DD}-${MM}`],
+    ['MM/dd', `${MM}/${DD}`],
+    ['M/dd', `${M}/${DD}`],
+    // Day only
+    ['dd', `${DD}`]
   ].forEach(([format, date]) => {
     it(`should parse date using ${format} format`, () => {
       datePicker.$connector.updateI18n('en-US', { dateFormats: [format] });
 
       const { day, month, year } = datePicker.i18n.parseDate(date) as DatePickerDate;
-      expect(day).to.be.equal(31);
-      expect(month).to.be.equal(0);
-      expect(year).to.be.equal(YEAR);
+      expect(day).to.be.equal(DD);
+      expect(month).to.be.equal(MONTH);
+      expect(year).to.be.equal(YYYY);
     });
   });
 });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/env-setup.ts
@@ -1,0 +1,10 @@
+window.Vaadin ||= {};
+const Flow = {
+  tryCatchWrapper: function (originalFunction) {
+    return function () {
+      return originalFunction.apply(this, arguments);
+    };
+  }
+};
+// @ts-expect-error
+window.Vaadin.Flow = Flow;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
@@ -1,20 +1,16 @@
 import './env-setup.js';
 import '@vaadin/date-picker/vaadin-date-picker.js';
 import '../frontend/generated/jar-resources/datepickerConnector.js';
-import type { DatePicker, DatePickerDate } from '@vaadin/date-picker';
+import type { DatePicker } from '@vaadin/date-picker';
 import type {} from '@web/test-runner-mocha';
 
-export type { DatePickerDate } from '@vaadin/date-picker';
-
-export type DatePickerI18n = {
+export type FlowDatePickerI18n = {
   dateFormats: string[];
-  firstDayOfWeek?: number;
-  referenceDate?: DatePickerDate;
-}
+};
 
 export type DatePickerConnector = {
   initLazy: (datePicker: DatePicker) => void;
-  updateI18n: (locale: string, i18n: DatePickerI18n) => void;
+  updateI18n: (locale: string, i18n: FlowDatePickerI18n) => void;
 };
 
 export type FlowDatePicker = DatePicker & {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
@@ -1,0 +1,36 @@
+import './env-setup.js';
+import '@vaadin/date-picker/vaadin-date-picker.js';
+import '../frontend/generated/jar-resources/datepickerConnector.js';
+import type { DatePicker, DatePickerDate } from '@vaadin/date-picker';
+import type {} from '@web/test-runner-mocha';
+
+export type { DatePickerDate } from '@vaadin/date-picker';
+
+export type DatePickerI18n = {
+  dateFormats: string[];
+  firstDayOfWeek?: number;
+  referenceDate?: DatePickerDate;
+}
+
+export type DatePickerConnector = {
+  initLazy: (datePicker: DatePicker) => void;
+  updateI18n: (locale: string, i18n: DatePickerI18n) => void;
+};
+
+export type FlowDatePicker = DatePicker & {
+  $connector: DatePickerConnector;
+};
+
+type Vaadin = {
+  Flow: {
+    datepickerConnector: DatePickerConnector;
+  };
+};
+
+const Vaadin = window.Vaadin as Vaadin;
+
+export const datepickerConnector = Vaadin.Flow.datepickerConnector;
+
+export function init(datePicker: FlowDatePicker): void {
+  datepickerConnector.initLazy(datePicker);
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
@@ -2,6 +2,7 @@ import './env-setup.js';
 import '@vaadin/date-picker/vaadin-date-picker.js';
 import '../frontend/generated/jar-resources/datepickerConnector.js';
 import type { DatePicker } from '@vaadin/date-picker';
+export { extractDateParts } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 import type {} from '@web/test-runner-mocha';
 
 export type FlowDatePickerI18n = {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
@@ -1,0 +1,11 @@
+import { esbuildPlugin } from "@web/dev-server-esbuild";
+
+export default {
+  plugins: [esbuildPlugin({ ts: true })],
+  testFramework: {
+    config: {
+      ui: 'bdd',
+      timeout: '10000',
+    },
+  },
+};

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -71,6 +71,10 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             if (!format.includes('y') && !format.includes('Y')) {
               return true;
             }
+            // Format with days only is also considered short.
+            if (!format.includes('m') && !format.includes('M')) {
+              return true;
+            }
             if (format.includes('y')) {
               return !format.includes('yyy');
             }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -66,6 +66,11 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           }
 
           function isShortYearFormat(format) {
+            // Format is considered short if it includes year
+            // as "yy" or "YY", or no year specified at all.
+            if (!format.includes('y') && !format.includes('Y')) {
+              return true;
+            }
             if (format.includes('y')) {
               return !format.includes('yyy');
             }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -66,22 +66,8 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           }
 
           function isShortYearFormat(format) {
-            // Format is considered short if it includes year
-            // as "yy" or "YY", or no year specified at all.
-            if (!format.includes('y') && !format.includes('Y')) {
-              return true;
-            }
-            // Format with days only is also considered short.
-            if (!format.includes('m') && !format.includes('M')) {
-              return true;
-            }
-            if (format.includes('y')) {
-              return !format.includes('yyy');
-            }
-            if (format.includes('Y')) {
-              return !format.includes('YYY');
-            }
-            return false;
+            // Format is long if it includes a four-digit year.
+            return !format.includes('yyyy') && !format.includes('YYYY');
           }
 
           function correctFullYear(date) {


### PR DESCRIPTION
## Description

Fixes #6065

This PR adds `web-test-runner` tests to the `datepickerConnector`, especially `parseDate` and `formatDate`.

The logic is as follows:

- The date format is now considered short unless it contains a four-digit year: `yyyy` or `YYYY`
- When using `ddMM` format (and any other format without year set), current year is assumed. 
- With `dd` format, both current month and year are assumed (see `beforeEach` in unit tests)

## Type of change

- Bugfix