### PR TITLE
fix: enforce current year if date format does not contain year

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/date-picker-connector.test.ts
@@ -1,5 +1,6 @@
 import { expect, fixtureSync } from '@open-wc/testing';
 import dateFnsFormat from 'date-fns/format';
+import { DatePickerDate } from '@vaadin/date-picker';
 import { init, extractDateParts, datepickerConnector, type FlowDatePicker } from './shared.js';
 
 describe('date-picker connector', () => {
@@ -60,6 +61,27 @@ describe('date-picker connector', () => {
 
       it(`should parse date using ${format} format`, () => {
         expect(datePicker.i18n.parseDate(dateStr)).to.eql(dateObj);
+      });
+    });
+  });
+
+  describe('reference date', () => {
+    const DATE = '10-01-14';
+
+    [
+      { referenceDate: '1940-01-01', year: 1914 },
+      { referenceDate: '1990-01-01', year: 2014 }
+    ].forEach(({ referenceDate, year }) => {
+      it(`should use ${referenceDate} reference date with short year format`, () => {
+        datePicker.$connector.updateI18n('en-US', { dateFormats: ['dd-MM-yy'], referenceDate });
+        const result = datePicker.i18n.parseDate(DATE) as DatePickerDate;
+        expect(result.year).to.equal(year);
+      });
+
+      it(`should not use ${referenceDate} reference date with format without years`, () => {
+        datePicker.$connector.updateI18n('en-US', { dateFormats: ['dd-MM'], referenceDate });
+        const result = datePicker.i18n.parseDate(DATE.slice(0, 5)) as DatePickerDate;
+        expect(result.year).to.equal(new Date().getFullYear());
       });
     });
   });

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/shared.ts
@@ -7,6 +7,7 @@ import type {} from '@web/test-runner-mocha';
 
 export type FlowDatePickerI18n = {
   dateFormats: string[];
+  referenceDate?: string;
 };
 
 export type DatePickerConnector = {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -65,6 +65,10 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
             return undefined;
           }
 
+          function isFormatWithoutYears(format) {
+            return !format.includes('y') && !format.includes('Y');
+          }
+
           function isShortYearFormat(format) {
             // Format is long if it includes a four-digit year.
             return !format.includes('yyyy') && !format.includes('YYYY');
@@ -82,9 +86,11 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
 
             // Update century if the last parsed date is the same except the century.
             if (datepicker.$connector._lastParseStatus === 'successful') {
-              if (datepicker.$connector._lastParsedDate.day === date.getDate() &&
+              if (
+                datepicker.$connector._lastParsedDate.day === date.getDate() &&
                 datepicker.$connector._lastParsedDate.month === date.getMonth() &&
-                datepicker.$connector._lastParsedDate.year % 100 === date.getFullYear() % 100) {
+                datepicker.$connector._lastParsedDate.year % 100 === date.getFullYear() % 100
+              ) {
                 date.setFullYear(datepicker.$connector._lastParsedDate.year);
               }
               return;
@@ -92,10 +98,12 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
 
             // Update century if this is the first parse after overlay open.
             const currentValue = _parseDate(datepicker.value);
-            if (dateFnsIsValid(currentValue) &&
+            if (
+              dateFnsIsValid(currentValue) &&
               currentValue.getDate() === date.getDate() &&
               currentValue.getMonth() === date.getMonth() &&
-              currentValue.getFullYear() % 100 === date.getFullYear() % 100) {
+              currentValue.getFullYear() % 100 === date.getFullYear() % 100
+            ) {
               date.setFullYear(currentValue.getFullYear());
             }
           }
@@ -108,7 +116,9 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           }
 
           function doParseDate(dateString, format, referenceDate) {
-            const date = dateFnsParse(dateString, format, referenceDate);
+            // When format does not contain a year, then current year should be used.
+            const refDate = isFormatWithoutYears(format) ? new Date() : referenceDate;
+            const date = dateFnsParse(dateString, format, refDate);
             if (dateFnsIsValid(date)) {
               if (isShortYearFormat(format)) {
                 correctFullYear(date);
@@ -169,7 +179,7 @@ import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/s
           datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
         });
 
-        datepicker.addEventListener('opened-changed', () => datepicker.$connector._lastParseStatus = undefined);
+        datepicker.addEventListener('opened-changed', () => (datepicker.$connector._lastParseStatus = undefined));
       })(datepicker)
   };
 })();


### PR DESCRIPTION
## Description

Fixes #6099

Follow-up to #6088 which was an incomplete fix.

This change enforces the behavior as described in the issue:

> When year is not included at all, it should always be this year.
> Only when 2-digit year is included should it use the reference date.

As `date-fns` parse function requires a reference date, the current date is used in case format like `ddMM` is passed.

## Type of change

- Bugfix