### PR TITLE
refactor: drop obsolete workaround from connector (#6096) (CP: 23.3)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -92,26 +92,6 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
             }
             return level;
           });
-          
-          const recalculateColumnWidthsOriginal = Grid.prototype._recalculateColumnWidths;
-          Grid.prototype._recalculateColumnWidths = function(cols) {
-            // Flush until row count stabilizes
-            // Temporary fix for https://github.com/vaadin/flow-components/issues/5595
-            let previousRowCount;
-            while (previousRowCount !== this.$.items.childElementCount) {
-              previousRowCount = this.$.items.childElementCount;
-              
-              // Flush the virtualizer
-              this.__virtualizer.flush();
-              if (ensureSubCacheDebouncer) {
-                // Flush pending ensureSubCache calls
-                ensureSubCacheDebouncer.flush();
-              }
-            }
-
-            recalculateColumnWidthsOriginal.call(this, cols);
-          };
-
         }
 
         const rootPageCallbacks = {};


### PR DESCRIPTION
## Description

A cherry-pick of https://github.com/vaadin/flow-components/pull/6096 to 23.3.

## Type of change

- [x] Refactor
