### PR TITLE
docs: add note about fields in LoginOverlay custom form area

### DIFF
--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginOverlay.java
@@ -242,6 +242,11 @@ public class LoginOverlay extends AbstractLogin implements HasStyle {
      * overlay custom form area. This area is displayed only if there's at least
      * one component added with {@link LoginOverlayContent#add(Component...)}.
      *
+     * Fields that are part of custom form area are not automatically submitted
+     * as part of the {@link LoginForm.LoginEvent}, and are not supported when
+     * setting {@code action} as their values will not be part of the login
+     * request.
+     *
      * @since 24.2
      * @return the custom form area object
      */


### PR DESCRIPTION
## Description

Related to #6098

Updated JavaDoc of `getCustomFormArea()` as suggested by https://github.com/vaadin/flow-components/issues/6098#issuecomment-1988556787.

I will also submit a PR to the docs project, as the original issue isn't obvious and deserves a note.

## Type of change

- Documentation