### PR TITLE
fix: do not call itemEnabledProvider for null values

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -308,7 +308,12 @@ public class RadioButtonGroup<T>
     @Override
     protected boolean hasValidValue() {
         String selectedKey = getElement().getProperty("value");
-        return itemEnabledProvider.test(keyMapper.get(selectedKey));
+        T item = keyMapper.get(selectedKey);
+        // The item enabled provider should not be invoked for null values.
+        if (item == null) {
+            return true;
+        }
+        return itemEnabledProvider.test(item);
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -23,20 +23,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AbstractField;
-import com.vaadin.flow.component.HasAriaLabel;
-import com.vaadin.flow.component.shared.InputField;
-import com.vaadin.flow.component.shared.SelectionPreservationMode;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import org.mockito.Mockito;
-
+import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.InputField;
+import com.vaadin.flow.component.shared.SelectionPreservationMode;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -45,6 +40,14 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.mockito.Mockito;
+
 import com.vaadin.tests.DataProviderListenersTest;
 
 public class RadioButtonGroupTest {
@@ -444,6 +447,19 @@ public class RadioButtonGroupTest {
         group.setItems("enabled", "disabled", null);
         group.setValue(null);
         Assert.assertEquals(group.getValue(), null);
+    }
+
+    @Test
+    public void setItemEnabledProvider_nullValue_doesNotThrow() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setItems("Foo", "Bar", "Baz");
+        group.setValue("Foo");
+        group.setItemEnabledProvider(it -> it.equals("Foo"));
+
+        group.getElement().setProperty("value", null);
+
+        ComponentUtil.fireEvent(group,
+                new ComponentValueChangeEvent<>(group, group, "Foo", true));
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #6040

Note: the original issue happens without `setValue()` but I was unable to create a proper unit test reproducing this scenario. 
The `hasValidValue()` is called by Flow on [property change event](https://github.com/vaadin/flow/blob/fb9661ff515c1a728f50dea382fd029836bbe1c0/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java#L350-L351) so I used `setProperty()` + `fireEvent` to test the fix.

## Type of change

- Bugfix