### PR TITLE
fix: do not call itemEnabledProvider for null values (#6119) (CP: 24.3)

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -303,7 +303,12 @@ public class RadioButtonGroup<T>
     @Override
     protected boolean hasValidValue() {
         String selectedKey = getElement().getProperty("value");
-        return itemEnabledProvider.test(keyMapper.get(selectedKey));
+        T item = keyMapper.get(selectedKey);
+        // The item enabled provider should not be invoked for null values.
+        if (item == null) {
+            return true;
+        }
+        return itemEnabledProvider.test(item);
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -23,19 +23,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AbstractField;
-import com.vaadin.flow.component.HasAriaLabel;
-import com.vaadin.flow.component.shared.InputField;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import org.mockito.Mockito;
-
+import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -44,6 +39,14 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.mockito.Mockito;
+
 import com.vaadin.tests.DataProviderListenersTest;
 
 public class RadioButtonGroupTest {
@@ -443,6 +446,19 @@ public class RadioButtonGroupTest {
         group.setItems("enabled", "disabled", null);
         group.setValue(null);
         Assert.assertEquals(group.getValue(), null);
+    }
+
+    @Test
+    public void setItemEnabledProvider_nullValue_doesNotThrow() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setItems("Foo", "Bar", "Baz");
+        group.setValue("Foo");
+        group.setItemEnabledProvider(it -> it.equals("Foo"));
+
+        group.getElement().setProperty("value", null);
+
+        ComponentUtil.fireEvent(group,
+                new ComponentValueChangeEvent<>(group, group, "Foo", true));
     }
 
     @Test


### PR DESCRIPTION
## Description

Manual cherry-pick of #6119 to `24.3` branch.

## Type of change

- Cherry-pick