### PR TITLE
fix: prevent sorters change when updating multiple headers

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
@@ -43,8 +44,14 @@ public class SortingPage extends Div {
         btRm.setId("btn-detach");
         NativeButton btattach = new NativeButton("attach", evt -> add(grid));
         btattach.setId("btn-attach");
-        add(btRm, btattach, grid);
 
+        AtomicInteger sortCount = new AtomicInteger(0);
+        Div count = new Div("Sort count: " + sortCount);
+        count.setId("sort-listener-count");
+        grid.addSortListener(event -> count
+                .setText("Sort count: " + sortCount.incrementAndGet()));
+
+        add(btRm, btattach, grid, count);
     }
 
     private void createInitiallyHiddenGrid() {
@@ -108,12 +115,19 @@ public class SortingPage extends Div {
                 });
         changeHeaderTextComponent.setId("change-header-text-component");
 
+        NativeButton changeTwoColumnHeaders = new NativeButton(
+                "Change two column headers", e -> {
+                    nameColumn.setHeader("Name (changed)");
+                    ageColumn.setHeader("Age (changed)");
+                });
+        changeTwoColumnHeaders.setId("change-two-column-headers");
+
         NativeButton clearButton = new NativeButton("Clear items",
                 e -> grid.setItems(new ArrayList<Person>()));
         clearButton.setId("clear-items");
 
         add(button, reOrder, changeHeaderText, changeHeaderTextComponent,
-                clearButton);
+                changeTwoColumnHeaders, clearButton);
 
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -98,6 +98,14 @@ public class SortingPage extends Div {
                 });
         button.setId(sortBtnId);
 
+        NativeButton sortByTwoColumns = new NativeButton("Sort by two columns",
+                e -> {
+                    List<GridSortOrder<Person>> sortByAgeThenName = new GridSortOrderBuilder<Person>()
+                            .thenAsc(ageColumn).thenDesc(nameColumn).build();
+                    grid.sort(sortByAgeThenName);
+                });
+        sortByTwoColumns.setId("sort-by-two-columns");
+
         NativeButton reOrder = new NativeButton("Re-order", e -> {
             grid.setColumnOrder(ageColumn, nameColumn);
         });
@@ -126,8 +134,8 @@ public class SortingPage extends Div {
                 e -> grid.setItems(new ArrayList<Person>()));
         clearButton.setId("clear-items");
 
-        add(button, reOrder, changeHeaderText, changeHeaderTextComponent,
-                changeTwoColumnHeaders, clearButton);
+        add(button, sortByTwoColumns, reOrder, changeHeaderText,
+                changeHeaderTextComponent, changeTwoColumnHeaders, clearButton);
 
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -105,12 +105,36 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setInitialSortOrder_updateTwoColumnHeaders_sortCountDoesNotGrow() {
+    public void setInitialSortOrder_sortByTwoColumns_sortCountIncreases() {
+        findElement(By.id("sort-by-age")).click();
+        WebElement count = findElement(By.id("sort-listener-count"));
+        Assert.assertEquals(count.getText(), "Sort count: 1");
+        findElement(By.id("sort-by-two-columns")).click();
+        Assert.assertEquals(count.getText(), "Sort count: 2");
+    }
+
+    @Test
+    public void setInitialSortOrder_updateTwoColumnHeaders_sortCountDoesNotIncrease() {
         findElement(By.id("sort-by-age")).click();
         WebElement count = findElement(By.id("sort-listener-count"));
         Assert.assertEquals(count.getText(), "Sort count: 1");
         findElement(By.id("change-two-column-headers")).click();
         Assert.assertEquals(count.getText(), "Sort count: 1");
+    }
+
+    @Test
+    public void setInitialSortOrder_sortByTwoColumns_sortIndicatorsUpdated() {
+        findElement(By.id("sort-by-age")).click();
+        findElement(By.id("sort-by-two-columns")).click();
+        assertTwoSorters("Name", "Age");
+    }
+
+    @Test
+    public void sortByTwoColumns_updateTwoColumnHeaders_sortIndicatorsRemain() {
+        findElement(By.id("sort-by-two-columns")).click();
+        assertTwoSorters("Name", "Age");
+        findElement(By.id("change-two-column-headers")).click();
+        assertTwoSorters("Name (changed)", "Age (changed)");
     }
 
     @Test
@@ -192,4 +216,19 @@ public class SortingIT extends AbstractComponentIT {
         Assert.assertTrue(sorter.getText().startsWith(expectedColumnHeader));
     }
 
+    private void assertTwoSorters(String firstHeader, String secondHeader) {
+        List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter")
+                .hasAttribute("direction").all();
+        Assert.assertEquals("Two columns should be sorted.", 2, sorters.size());
+
+        TestBenchElement sorter1 = sorters.get(0);
+        Assert.assertEquals("Expected descending sort order.", "desc",
+                sorter1.getAttribute("direction"));
+        Assert.assertTrue(sorter1.getText().startsWith(firstHeader));
+
+        TestBenchElement sorter2 = sorters.get(1);
+        Assert.assertEquals("Expected ascending sort order.", "asc",
+                sorter2.getAttribute("direction"));
+        Assert.assertTrue(sorter2.getText().startsWith(secondHeader));
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -105,6 +105,15 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInitialSortOrder_updateTwoColumnHeaders_sortCountDoesNotGrow() {
+        findElement(By.id("sort-by-age")).click();
+        WebElement count = findElement(By.id("sort-listener-count"));
+        Assert.assertEquals(count.getText(), "Sort count: 1");
+        findElement(By.id("change-two-column-headers")).click();
+        Assert.assertEquals(count.getText(), "Sort count: 1");
+    }
+
+    @Test
     public void emptyGrid_sort_noClientErrors() {
         findElement(By.id("clear-items")).click();
         grid.findElements(By.tagName("vaadin-grid-sorter")).get(0).click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -123,21 +123,6 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setInitialSortOrder_sortByTwoColumns_sortIndicatorsUpdated() {
-        findElement(By.id("sort-by-age")).click();
-        findElement(By.id("sort-by-two-columns")).click();
-        assertTwoSorters("Name", "Age");
-    }
-
-    @Test
-    public void sortByTwoColumns_updateTwoColumnHeaders_sortIndicatorsRemain() {
-        findElement(By.id("sort-by-two-columns")).click();
-        assertTwoSorters("Name", "Age");
-        findElement(By.id("change-two-column-headers")).click();
-        assertTwoSorters("Name (changed)", "Age (changed)");
-    }
-
-    @Test
     public void emptyGrid_sort_noClientErrors() {
         findElement(By.id("clear-items")).click();
         grid.findElements(By.tagName("vaadin-grid-sorter")).get(0).click();
@@ -216,19 +201,4 @@ public class SortingIT extends AbstractComponentIT {
         Assert.assertTrue(sorter.getText().startsWith(expectedColumnHeader));
     }
 
-    private void assertTwoSorters(String firstHeader, String secondHeader) {
-        List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter")
-                .hasAttribute("direction").all();
-        Assert.assertEquals("Two columns should be sorted.", 2, sorters.size());
-
-        TestBenchElement sorter1 = sorters.get(0);
-        Assert.assertEquals("Expected descending sort order.", "desc",
-                sorter1.getAttribute("direction"));
-        Assert.assertTrue(sorter1.getText().startsWith(firstHeader));
-
-        TestBenchElement sorter2 = sorters.get(1);
-        Assert.assertEquals("Expected ascending sort order.", "asc",
-                sorter2.getAttribute("direction"));
-        Assert.assertTrue(sorter2.getText().startsWith(secondHeader));
-    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -375,8 +375,11 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                   }
                 });
 
+                // Only reset direction for sorters that no longer apply.
                 sorters.forEach((sorter) => {
-                  sorter.direction = null;
+                  if (!directions.some(({ column }) => column === sorter.getAttribute('path'))) {
+                    sorter.direction = null;
+                  }
                 });
 
                 // Apply directions in correct order, depending on configured multi-sort priority.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -375,12 +375,15 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                   }
                 });
 
-                // Only reset direction for sorters that no longer apply.
-                sorters.forEach((sorter) => {
-                  if (!directions.some(({ column }) => column === sorter.getAttribute('path'))) {
+                // When changing header components, this method can be invoked multiple times with
+                // the same directions. In this case, we should avoid re-setting sorters state.
+                if (JSON.stringify(this._previousDirections) !== JSON.stringify(directions)) {
+                  sorters.forEach((sorter) => {
                     sorter.direction = null;
-                  }
-                });
+                  });
+                }
+
+                this._previousDirections = [...directions];
 
                 // Apply directions in correct order, depending on configured multi-sort priority.
                 // For the default "prepend" mode, directions need to be applied in reverse, in

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -375,9 +375,11 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                   }
                 });
 
-                // When changing header components, this method can be invoked multiple times with
+                const directionsStr = JSON.stringify(directions);
+                // 1) When calling `grid.sort(null)`, directions array is empty - reset all sorters.
+                // 2) When changing header components, this method can be called multiple times with
                 // the same directions. In this case, we should avoid re-setting sorters state.
-                if (JSON.stringify(this._previousDirections) !== JSON.stringify(directions)) {
+                if (directionsStr === '[]' || directionsStr !== JSON.stringify(this._previousDirections)) {
                   sorters.forEach((sorter) => {
                     sorter.direction = null;
                   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -375,17 +375,9 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
                   }
                 });
 
-                const directionsStr = JSON.stringify(directions);
-                // 1) When calling `grid.sort(null)`, directions array is empty - reset all sorters.
-                // 2) When changing header components, this method can be called multiple times with
-                // the same directions. In this case, we should avoid re-setting sorters state.
-                if (directionsStr === '[]' || directionsStr !== JSON.stringify(this._previousDirections)) {
-                  sorters.forEach((sorter) => {
-                    sorter.direction = null;
-                  });
-                }
-
-                this._previousDirections = [...directions];
+                sorters.forEach((sorter) => {
+                  sorter.direction = null;
+                });
 
                 // Apply directions in correct order, depending on configured multi-sort priority.
                 // For the default "prepend" mode, directions need to be applied in reverse, in


### PR DESCRIPTION
## Description

Fixes #6122

When calling `setHeader()` on the column, Grid updates sorter indicators (as implemented in #1841). Currently it is done by re-setting `direction` to `null` in the connector and then setting directions in the right order.

The logic was changed to reset `direction` for all sorters in #5822, which introduced the regression: when calling `setHeader()` for more than one column in one request, it caused grid to incorrectly apply sorters change.

Updated the connector to add a check for this case, and added new ITs to verify that sort listeners are not invoked.

## Type of change

- Bugfix