### PR TITLE
fix: add mobile polyfill without creating drop target

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
@@ -144,6 +144,16 @@ public class DragAndDropGridPage extends Div {
         });
         multiSelectButton.setId("multiselect");
         add(multiSelectButton);
+
+        NativeButton addNavigationClickListener = new NativeButton(
+                "Add navigation click listener", e -> {
+                    grid.addItemClickListener(event -> {
+                        grid.getUI().ifPresent(
+                                ui -> ui.navigate(GridEmptyPage.class));
+                    });
+                });
+        addNavigationClickListener.setId("add-navigation-click-listener");
+        add(addNavigationClickListener);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
@@ -209,6 +209,13 @@ public class DragAndDropGridIT extends AbstractComponentIT {
         assertMessages("", "", "");
     }
 
+    @Test
+    public void addNavigationClickListener_navigate_noErrorsLogged() {
+        click("add-navigation-click-listener");
+        grid.getCell(0, 0).click();
+        checkLogsForErrors();
+    }
+
     private void assertMessages(String expectedStartMessage,
             String expectedEndMessage, String expectedDropMessage) {
         Assert.assertEquals(expectedStartMessage,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -53,7 +53,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dnd.DragSource;
-import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.component.grid.GridArrayUpdater.UpdateQueueData;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.grid.dataview.GridDataView;
@@ -4217,11 +4217,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see GridDropEvent#getDropLocation()
      */
     public void setDropMode(GridDropMode dropMode) {
-        // We need to add DnD mobile polyfill here by invoking
-        // DndUtil.addMobileDndPolyfillIfNeeded. But, since DndUtil is in a Flow
-        // internal package, DropTarget.create is called to invoke
-        // addMobileDndPolyfillIfNeeded indirectly.
-        DropTarget.create(this).setActive(false);
+        DndUtil.addMobileDndPolyfillIfNeeded(this);
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
     }


### PR DESCRIPTION
## Description

Currently clicking on an item in a grid results in Javascript errors if drag and drop is enabled and the click results in navigation to a different view. It's caused by the Grid creating a drop target when enabling drag and drop, which is only necessary to install a mobile DND polyfill for iOS. The drop target is deactivated right after creating it.

The issue can be fixed by not creating a drop target and instead installing the polyfill directly using the respective `DndUtil` class. The code comment mentions that using this class should be avoided since it's marked as internal, but I think it's less of an issue now. It's unlikely that this class or the method will be removed in v23, and even if its modified we'll catch the issue in platform validation and can adapt. In v24 the mobile polyfill has been removed entirely already.

Fixes https://github.com/vaadin/flow-components/issues/6066

## Type of change

- Bugfix
