### PR TITLE
chore: replace links to Discord with Vaadin Forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-question.yml
+++ b/.github/ISSUE_TEMPLATE/support-question.yml
@@ -1,12 +1,9 @@
 name: 🤗 Support Question
-description: If you have a question 💬, please check out our Discord or StackOverflow!
+description: If you have a question 💬, please check out Vaadin Forum!
 body:
   - type: markdown
     attributes:
-      value: "We primarily use GitHub as an issue tracker. For support questions, please check out these resources below. Thank you!"
-  - type: markdown
-    attributes:
-      value: "* StackOverflow: https://stackoverflow.com/questions/tagged/vaadin using the tag `vaadin`\n* Discord: If it's just a quick question you can ask it on our Discord channel: https://discord.com/invite/MYFq5RTbBn\n* Also have a look at our website for more information on how to get support: https://vaadin.com/support"
+      value: "We primarily use GitHub as an issue tracker. For support questions, please check out https://vaadin.com/forum/. Thank you!"
   - type: input
     id: ignore
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to Vaadin Flow Components
 
-*There are many ways to participate to the Vaadin Flow Components project. You can ask questions and participate to discussion in [Discord](https://discord.com/channels/732335336448852018/774366844684468284), [forum](https://vaadin.com/forum), [fill bug reports](https://github.com/vaadin/flow/issues) and enhancement suggestions and contribute code. These instructions are for contributing code to Flow project itself.*
+*There are many ways to contribute to the Vaadin Flow Components project. You can ask questions and participate in discussions in the [Vaadin Forum](https://vaadin.com/forum/), [create issues](https://github.com/vaadin/flow-components/issues/new/choose) to file bug reports and enhancement suggestions, or contribute code.*
 
-The contributing docs have moved to: https://vaadin.com/docs/latest/guide/contributing/overview
+The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/pr


### PR DESCRIPTION
## Description

The Vaadin Discord server is now discontinued and the [Forum](https://vaadin.com/forum/) should be used instead.

## Type of change

- Internal change