### PR TITLE
fix: prevent sorters change when updating multiple headers (#6125) (CP: 24.3)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
@@ -43,8 +44,14 @@ public class SortingPage extends Div {
         btRm.setId("btn-detach");
         NativeButton btattach = new NativeButton("attach", evt -> add(grid));
         btattach.setId("btn-attach");
-        add(btRm, btattach, grid);
 
+        AtomicInteger sortCount = new AtomicInteger(0);
+        Div count = new Div("Sort count: " + sortCount);
+        count.setId("sort-listener-count");
+        grid.addSortListener(event -> count
+                .setText("Sort count: " + sortCount.incrementAndGet()));
+
+        add(btRm, btattach, grid, count);
     }
 
     private void createInitiallyHiddenGrid() {
@@ -91,6 +98,14 @@ public class SortingPage extends Div {
                 });
         button.setId(sortBtnId);
 
+        NativeButton sortByTwoColumns = new NativeButton("Sort by two columns",
+                e -> {
+                    List<GridSortOrder<Person>> sortByAgeThenName = new GridSortOrderBuilder<Person>()
+                            .thenAsc(ageColumn).thenDesc(nameColumn).build();
+                    grid.sort(sortByAgeThenName);
+                });
+        sortByTwoColumns.setId("sort-by-two-columns");
+
         NativeButton reOrder = new NativeButton("Re-order", e -> {
             grid.setColumnOrder(ageColumn, nameColumn);
         });
@@ -108,12 +123,19 @@ public class SortingPage extends Div {
                 });
         changeHeaderTextComponent.setId("change-header-text-component");
 
+        NativeButton changeTwoColumnHeaders = new NativeButton(
+                "Change two column headers", e -> {
+                    nameColumn.setHeader("Name (changed)");
+                    ageColumn.setHeader("Age (changed)");
+                });
+        changeTwoColumnHeaders.setId("change-two-column-headers");
+
         NativeButton clearButton = new NativeButton("Clear items",
                 e -> grid.setItems(new ArrayList<Person>()));
         clearButton.setId("clear-items");
 
-        add(button, reOrder, changeHeaderText, changeHeaderTextComponent,
-                clearButton);
+        add(button, sortByTwoColumns, reOrder, changeHeaderText,
+                changeHeaderTextComponent, changeTwoColumnHeaders, clearButton);
 
         return grid;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -105,6 +105,24 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInitialSortOrder_sortByTwoColumns_sortCountIncreases() {
+        findElement(By.id("sort-by-age")).click();
+        WebElement count = findElement(By.id("sort-listener-count"));
+        Assert.assertEquals(count.getText(), "Sort count: 1");
+        findElement(By.id("sort-by-two-columns")).click();
+        Assert.assertEquals(count.getText(), "Sort count: 2");
+    }
+
+    @Test
+    public void setInitialSortOrder_updateTwoColumnHeaders_sortCountDoesNotIncrease() {
+        findElement(By.id("sort-by-age")).click();
+        WebElement count = findElement(By.id("sort-listener-count"));
+        Assert.assertEquals(count.getText(), "Sort count: 1");
+        findElement(By.id("change-two-column-headers")).click();
+        Assert.assertEquals(count.getText(), "Sort count: 1");
+    }
+
+    @Test
     public void emptyGrid_sort_noClientErrors() {
         findElement(By.id("clear-items")).click();
         grid.findElements(By.tagName("vaadin-grid-sorter")).get(0).click();


### PR DESCRIPTION
## Description

Manual cherry-pick of #6125 to `24.3` branch.

## Type of change

- Cherry-pick