### PR TITLE
fix: enable invisible button after disable on click

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -50,6 +50,7 @@ public class ButtonView extends Div {
         createDisabledButton();
         createButtonWithDisableOnClick();
         createButtonWithDisableOnClickThatEnablesInSameRoundtrip();
+        createButtonWithDisableOnClickThatIsHidden();
         addVariantsFeature();
         createButtonsWithShortcuts();
 
@@ -260,6 +261,22 @@ public class ButtonView extends Div {
         button.setId("disable-on-click-re-enable-button");
         addCard("Button disabled on click and re-enabled in same roundtrip",
                 button);
+    }
+
+    private void createButtonWithDisableOnClickThatIsHidden() {
+        Button button = new Button("Disabled on click and hidden", event -> {
+            event.getSource().setVisible(false);
+        });
+        button.setDisableOnClick(true);
+        button.setId("disable-on-click-hidden-button");
+
+        Button enableButton = new Button("Enable hidden button", event -> {
+            button.setVisible(true);
+            button.setEnabled(true);
+        });
+        enableButton.setId("enable-hidden-button");
+
+        addCard("Button disabled on click and hidden", button, enableButton);
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -270,10 +270,11 @@ public class ButtonView extends Div {
         button.setDisableOnClick(true);
         button.setId("disable-on-click-hidden-button");
 
-        Button enableButton = new Button("Enable hidden button and show", event -> {
-            button.setEnabled(true);
-            button.setVisible(true);
-        });
+        Button enableButton = new Button("Enable hidden button and show",
+                event -> {
+                    button.setEnabled(true);
+                    button.setVisible(true);
+                });
         enableButton.setId("enable-hidden-button");
 
         addCard("Button disabled on click and hidden", button, enableButton);

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -49,6 +49,7 @@ public class ButtonView extends Div {
         createButtonsWithTabIndex();
         createDisabledButton();
         createButtonWithDisableOnClick();
+        createButtonWithDisableOnClickThatEnablesInSameRoundtrip();
         addVariantsFeature();
         createButtonsWithShortcuts();
 
@@ -248,6 +249,17 @@ public class ButtonView extends Div {
         disableOnClickButton.setId("disable-on-click-button");
         temporarilyDisabledButton.setId("temporarily-disabled-button");
         enable.setId("enable-button");
+    }
+
+    private void createButtonWithDisableOnClickThatEnablesInSameRoundtrip() {
+        Button button = new Button(
+                "Disabled on click and re-enabled in same roundtrip", event -> {
+                    event.getSource().setEnabled(true);
+                });
+        button.setDisableOnClick(true);
+        button.setId("disable-on-click-re-enable-button");
+        addCard("Button disabled on click and re-enabled in same roundtrip",
+                button);
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -271,8 +271,8 @@ public class ButtonView extends Div {
         button.setId("disable-on-click-hidden-button");
 
         Button enableButton = new Button("Enable hidden button", event -> {
-            button.setVisible(true);
             button.setEnabled(true);
+            button.setVisible(true);
         });
         enableButton.setId("enable-hidden-button");
 

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -264,13 +264,13 @@ public class ButtonView extends Div {
     }
 
     private void createButtonWithDisableOnClickThatIsHidden() {
-        Button button = new Button("Disabled on click and hidden", event -> {
+        Button button = new Button("Disabled on click and hide", event -> {
             event.getSource().setVisible(false);
         });
         button.setDisableOnClick(true);
         button.setId("disable-on-click-hidden-button");
 
-        Button enableButton = new Button("Enable hidden button", event -> {
+        Button enableButton = new Button("Enable hidden button and show", event -> {
             button.setEnabled(true);
             button.setVisible(true);
         });

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -277,6 +277,20 @@ public class ButtonIT extends AbstractComponentIT {
     }
 
     @Test
+    public void disableOnClick_enableInSameRoundtrip_clientSideButtonIsEnabled() {
+        WebElement button = layout
+                .findElement(By.id("disable-on-click-re-enable-button"));
+        for (int i = 0; i < 3; i++) {
+            Boolean disabled = (Boolean) executeScript(
+                    "arguments[0].click(); return arguments[0].disabled",
+                    button);
+            Assert.assertTrue(disabled);
+
+            waitUntil(ExpectedConditions.elementToBeClickable(button));
+        }
+    }
+
+    @Test
     public void buttonShortcuts_shortcutsWork() {
         WebElement button = findElement(By.id("shortcuts-enter-button"));
 

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -291,6 +291,23 @@ public class ButtonIT extends AbstractComponentIT {
     }
 
     @Test
+    public void disableOnClick_hideWhenDisabled_showWhenEnabled_clientSideButtonIsEnabled() {
+        WebElement button = layout
+                .findElement(By.id("disable-on-click-hidden-button"));
+        for (int i = 0; i < 3; i++) {
+            button.click();
+
+            waitUntil(ExpectedConditions.invisibilityOf(button));
+            waitUntil(ExpectedConditions
+                    .not(ExpectedConditions.elementToBeClickable(button)));
+
+            layout.findElement(By.id("enable-hidden-button")).click();
+            waitUntil(ExpectedConditions.visibilityOf(button));
+            waitUntil(ExpectedConditions.elementToBeClickable(button));
+        }
+    }
+
+    @Test
     public void buttonShortcuts_shortcutsWork() {
         WebElement button = findElement(By.id("shortcuts-enter-button"));
 

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -36,12 +36,8 @@ import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
-import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.shared.Registration;
 
-import java.io.Serializable;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -70,10 +70,10 @@ public class Button extends Component
     private PendingJavaScriptResult initDisableOnClick;
 
     // Register immediately as first listener
-    private Registration disableListener = addClickListener(
+    private final Registration disableListener = addClickListener(
             buttonClickEvent -> {
                 if (disableOnClick) {
-                    doDisableOnClick();
+                    setEnabled(false);
                 }
             });
 
@@ -374,6 +374,17 @@ public class Button extends Component
         }
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        Focusable.super.setEnabled(enabled);
+        // Force updating the disabled state on the client
+        // When using disable on click, the client side will immediately
+        // run JS to disable the button. If the button is then disabled and
+        // re-enabled during the same round trip, Flow will not detect any
+        // changes and the client side button would not be enabled again.
+        getElement().executeJs("this.disabled = $0", !enabled);
+    }
+
     private void updateIconSlot() {
         iconComponent.getElement().setAttribute("slot",
                 iconAfterText ? "suffix" : "prefix");
@@ -435,37 +446,6 @@ public class Button extends Component
             getThemeNames().add("icon");
         } else {
             getThemeNames().remove("icon");
-        }
-    }
-
-    /*
-     * https://github.com/vaadin/vaadin-button-flow/issues/115 because of the
-     * latency compensation, we need to hack the "diffstate" for the server side
-     * state, so that the disabled value can be reverted during the same
-     * roundtrip.
-     */
-    private void doDisableOnClick() {
-        ElementAttributeMap elementAttributeMap = getElement().getNode()
-                .getFeature(ElementAttributeMap.class);
-        elementAttributeMap.set("disabled", "true");
-        Map<NodeFeature, Serializable> changes = getElement().getNode()
-                .getChangeTracker(elementAttributeMap, () -> null);
-        // Remove the change, if it was applied. It should have been
-        // applied unless something else has done the exact same thing already
-        // (which is almost impossible, but ...)
-        if (changes != null) {
-            changes.remove("disabled");
-            setEnabled(false);
-            getUI().ifPresent(
-                    ui -> ui.beforeClientResponse(this, executionContext -> {
-                        // in case the disabled status was reverted,
-                        // the client might not update the value in
-                        // case it was that already
-                        if (isEnabled()) {
-                            executionContext.getUI().getPage().executeJs(
-                                    "$0.disabled = false;", getElement());
-                        }
-                    }));
         }
     }
 

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -314,12 +314,6 @@ public class ButtonTest {
         Assert.assertFalse(
                 "Button should have been disabled when event has been fired",
                 buttonIsEnabled.get());
-
-        StateNode node = button.getElement().getNode();
-        HashMap<String, Serializable> changeTracker = node.getChangeTracker(
-                node.getFeature(ElementAttributeMap.class), () -> null);
-        Assert.assertEquals("Disabled attribute should be set to true", "true",
-                changeTracker.get("disabled"));
     }
 
     @Test


### PR DESCRIPTION
When using disable on click, `Button` has a workaround for the case where the button is enabled again in the same roundtrip that it was disabled. Basically the client-side component disables itself right after the click, the server-side component disables itself, and then the application code enables the button again in the same roundtrip. In that case Flow doesn't detect any changes to the disabled state and wouldn't enable the client-side component again. This is the original issue that caused the workaround to be introduced: https://github.com/vaadin/vaadin-button-flow/issues/115.

The existing workaround does some tampering with state nodes that doesn't seem to work if the component is invisible, probably because Flow ignores updates to invisible components. This change replaces the workaround with a different solution that forces the client-side `disabled` property to be updated using JS whenever `setEnabled` is called. That seems to work in both cases.

Fixes #5924