### PR TITLE
feat: add router-ignore API to SideNavItem

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -394,6 +394,28 @@ public class SideNavItem extends SideNavItemContainer
     }
 
     /**
+     * @return true if this item should be ignored by the Vaadin router and
+     *         behave like a regular anchor.
+     */
+    public boolean isRouterIgnore() {
+        return getElement().getProperty("routerIgnore", false);
+    }
+
+    /**
+     * The routing mechanism in Vaadin by default intercepts all side nav items
+     * with relative URL. This method can be used make the router ignore this
+     * item and this way make it behave like a regular anchor and cause a full
+     * page load.
+     *
+     * @param ignore
+     *            true if this item should not be intercepted by the single-page
+     *            web application routing mechanism in Vaadin.
+     */
+    public void setRouterIgnore(boolean ignore) {
+        getElement().setProperty("routerIgnore", ignore);
+    }
+
+    /**
      * Sets whether the target URL should be opened in a new browser tab.
      * <p>
      * This is a convenience method for setting the target to

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -403,8 +403,8 @@ public class SideNavItem extends SideNavItemContainer
 
     /**
      * The routing mechanism in Vaadin by default intercepts all side nav items
-     * with relative URL. This method can be used make the router ignore this
-     * item and this way make it behave like a regular anchor and cause a full
+     * with a relative URL. This method can be used to make the router ignore
+     * this item. This makes it behave like a regular anchor, causing a full
      * page load.
      *
      * @param ignore

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -621,6 +621,24 @@ public class SideNavItemTest {
     }
 
     @Test
+    public void isRouterIgnore_falseByDefault() {
+        Assert.assertFalse(sideNavItem.isRouterIgnore());
+    }
+
+    @Test
+    public void setRouterIgnore_hasRouterIgnore() {
+        sideNavItem.setRouterIgnore(true);
+        Assert.assertTrue(
+                sideNavItem.getElement().getProperty("routerIgnore", false));
+        Assert.assertTrue(sideNavItem.isRouterIgnore());
+
+        sideNavItem.setRouterIgnore(false);
+        Assert.assertFalse(
+                sideNavItem.getElement().getProperty("routerIgnore", false));
+        Assert.assertFalse(sideNavItem.isRouterIgnore());
+    }
+
+    @Test
     public void setOpenInNewBrowserTab_targetBlankDefinedOnProperty() {
         // call setOpenInNewTab and check that getTarget returns "_blank"
         sideNavItem.setOpenInNewBrowserTab(true);


### PR DESCRIPTION
Adds API to `SideNavItem` that allows to opt out of client-side routing, which makes it work like a regular anchor that causes a full page reload. Related WC PR: https://github.com/vaadin/web-components/pull/7233, requires a new WC release before merging.

Closes https://github.com/vaadin/flow-components/issues/5189