### PR TITLE
fix: use default renderer if no renderer set in editor renderer

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ColumnPathPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ColumnPathPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.grid.ColumnPathRenderer;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.TextField;
@@ -37,6 +38,10 @@ public class ColumnPathPage extends Div {
                 .setHeader("Using template");
         grid.addColumn(Person::getFirstName)
                 .setHeader("Using template because of editor")
+                .setEditorComponent(new TextField());
+        grid.addColumn(
+                new ColumnPathRenderer<>("firstName", Person::getFirstName))
+                .setHeader("Using column path renderer with editor")
                 .setEditorComponent(new TextField());
 
         add(grid);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ColumnPathIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ColumnPathIT.java
@@ -42,6 +42,8 @@ public class ColumnPathIT extends AbstractComponentIT {
         // if the innerHTML contains Person 1
         Assert.assertTrue(grid.getCell(0, 2).getText().contains("Person 1"));
 
+        Assert.assertEquals("Person 1", grid.getCell(0, 3).getText());
+
         List<WebElement> columns = grid
                 .findElements(By.tagName("vaadin-grid-column"));
         Assert.assertNotNull(
@@ -51,8 +53,13 @@ public class ColumnPathIT extends AbstractComponentIT {
         Assert.assertNull("The path property should be undefined for column 1",
                 getPath(columns.get(1)));
 
-        Assert.assertNull("The path property should be undefined for column 2",
+        Assert.assertNotNull(
+                "The path property shouldn't be undefined for column 2",
                 getPath(columns.get(2)));
+
+        Assert.assertNotNull(
+                "The path property shouldn't be undefined for column 3",
+                getPath(columns.get(3)));
     }
 
     private String getPath(WebElement col) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
@@ -178,8 +178,8 @@ public class EditorRenderer<T> extends Renderer<T> implements DataGenerator<T> {
 
                 // If editing, render the editor, otherwise use the original renderer
                 "if (root.__editing) { Vaadin.FlowComponentHost.setChildNodes('" + appId + "', [model.item._" + columnInternalId + "_editor], root); }" +
-                "else if (!originalRender) { this._defaultRenderer(root, container, model); }" +
-                "else { originalRender(root, container, model); }" +
+                "else if (originalRender) { originalRender(root, container, model) }" +
+                "else { this._defaultRenderer(root, container, model) }" +
             "};");
         //@formatter:on
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
@@ -178,15 +178,10 @@ public class EditorRenderer<T> extends Renderer<T> implements DataGenerator<T> {
 
                 // If editing, render the editor, otherwise use the original renderer
                 "if (root.__editing) { Vaadin.FlowComponentHost.setChildNodes('" + appId + "', [model.item._" + columnInternalId + "_editor], root); }" +
-                "else if (!originalRender) { root.textContent = model.item." + getItemFieldName(container) + " }" +
+                "else if (!originalRender) { this._defaultRenderer(root, container, model); }" +
                 "else { originalRender(root, container, model); }" +
             "};");
         //@formatter:on
-    }
-
-    private String getItemFieldName(Element container) {
-        String path = container.getProperty("path");
-        return path == null ? columnInternalId : path;
     }
 
     private void runBeforeClientResponse(Element container,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorRenderer.java
@@ -178,13 +178,15 @@ public class EditorRenderer<T> extends Renderer<T> implements DataGenerator<T> {
 
                 // If editing, render the editor, otherwise use the original renderer
                 "if (root.__editing) { Vaadin.FlowComponentHost.setChildNodes('" + appId + "', [model.item._" + columnInternalId + "_editor], root); }" +
-                "else if (!originalRender) { root.textContent = model.item." + columnInternalId + " }" +
+                "else if (!originalRender) { root.textContent = model.item." + getItemFieldName(container) + " }" +
                 "else { originalRender(root, container, model); }" +
             "};");
         //@formatter:on
+    }
 
-        // clear the path property, since we are using an explicit renderer
-        container.removeProperty("path");
+    private String getItemFieldName(Element container) {
+        String path = container.getProperty("path");
+        return path == null ? columnInternalId : path;
     }
 
     private void runBeforeClientResponse(Element container,


### PR DESCRIPTION
## Description

The `path` property is currently removed when an editor renderer is used. This is unnecessary since the editor renderer uses the original renderer when not in edit mode. 

This PR 
- updates the editor renderer to use the the default renderer if there is no renderer set
- removes the block that removes the `path` property

Fixes #6124 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.