### PR TITLE
feat: disable editing for individual cells

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderPage.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderPage.java
@@ -12,9 +12,14 @@ public class CellEditableProviderPage extends Div {
         grid.setItems(new Transaction("Transaction 1", 100, true),
                 new Transaction("Transaction 2", 200, false));
         grid.addEditColumn(Transaction::getName).text(Transaction::setName);
-        var amount = grid.addEditColumn(Transaction::getAmount)
+        // Disable editing of amount and approved if transaction is approved
+        grid.addEditColumn(Transaction::getAmount)
+                .withCellEditableProvider(
+                        transaction -> !transaction.isApproved())
                 .text((item, value) -> item.setAmount(Integer.parseInt(value)));
-        var approved = grid.addEditColumn(Transaction::isApproved)
+        grid.addEditColumn(Transaction::isApproved)
+                .withCellEditableProvider(
+                        transaction -> !transaction.isApproved())
                 .checkbox(Transaction::setApproved);
         add(grid);
 
@@ -26,30 +31,6 @@ public class CellEditableProviderPage extends Div {
         });
         updateData.setId("update-data");
         add(updateData);
-
-        NativeButton setProvider = new NativeButton(
-                "Set cell editable provider", e -> {
-                    // Disable editing of amount and approved if transaction is
-                    // approved
-                    ((GridPro.EditColumn<Transaction>) amount)
-                            .setCellEditableProvider(
-                                    transaction -> !transaction.isApproved());
-                    ((GridPro.EditColumn<Transaction>) approved)
-                            .setCellEditableProvider(
-                                    transaction -> !transaction.isApproved());
-                });
-        setProvider.setId("set-provider");
-        add(setProvider);
-
-        NativeButton clearProvider = new NativeButton(
-                "Clear cell editable provider", e -> {
-                    ((GridPro.EditColumn<Transaction>) amount)
-                            .setCellEditableProvider(null);
-                    ((GridPro.EditColumn<Transaction>) approved)
-                            .setCellEditableProvider(null);
-                });
-        clearProvider.setId("clear-provider");
-        add(clearProvider);
 
         NativeButton detach = new NativeButton("Detach", e -> {
             remove(grid);

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderPage.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderPage.java
@@ -1,0 +1,102 @@
+package com.vaadin.flow.component.gridpro.tests;
+
+import com.vaadin.flow.component.gridpro.GridPro;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid-pro/cell-editable-provider")
+public class CellEditableProviderPage extends Div {
+    public CellEditableProviderPage() {
+        GridPro<Transaction> grid = new GridPro<>();
+        grid.setItems(new Transaction("Transaction 1", 100, true),
+                new Transaction("Transaction 2", 200, false));
+        grid.addEditColumn(Transaction::getName).text(Transaction::setName);
+        var amount = grid.addEditColumn(Transaction::getAmount)
+                .text((item, value) -> item.setAmount(Integer.parseInt(value)));
+        var approved = grid.addEditColumn(Transaction::isApproved)
+                .checkbox(Transaction::setApproved);
+        add(grid);
+
+        NativeButton updateData = new NativeButton("Update data", e -> {
+            grid.getListDataView().getItems().forEach(transaction -> {
+                transaction.setApproved(!transaction.isApproved());
+            });
+            grid.getDataProvider().refreshAll();
+        });
+        updateData.setId("update-data");
+        add(updateData);
+
+        NativeButton setProvider = new NativeButton(
+                "Set cell editable provider", e -> {
+                    // Disable editing of amount and approved if transaction is
+                    // approved
+                    ((GridPro.EditColumn<Transaction>) amount)
+                            .setCellEditableProvider(
+                                    transaction -> !transaction.isApproved());
+                    ((GridPro.EditColumn<Transaction>) approved)
+                            .setCellEditableProvider(
+                                    transaction -> !transaction.isApproved());
+                });
+        setProvider.setId("set-provider");
+        add(setProvider);
+
+        NativeButton clearProvider = new NativeButton(
+                "Clear cell editable provider", e -> {
+                    ((GridPro.EditColumn<Transaction>) amount)
+                            .setCellEditableProvider(null);
+                    ((GridPro.EditColumn<Transaction>) approved)
+                            .setCellEditableProvider(null);
+                });
+        clearProvider.setId("clear-provider");
+        add(clearProvider);
+
+        NativeButton detach = new NativeButton("Detach", e -> {
+            remove(grid);
+        });
+        detach.setId("detach");
+        add(detach);
+
+        NativeButton attach = new NativeButton("Attach", e -> {
+            add(grid);
+        });
+        attach.setId("attach");
+        add(attach);
+    }
+
+    public static class Transaction {
+        private String name;
+        private int amount;
+        private boolean approved;
+
+        public Transaction(String name, int amount, boolean approved) {
+            this.name = name;
+            this.amount = amount;
+            this.approved = approved;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAmount() {
+            return amount;
+        }
+
+        public void setAmount(int amount) {
+            this.amount = amount;
+        }
+
+        public boolean isApproved() {
+            return approved;
+        }
+
+        public void setApproved(boolean approved) {
+            this.approved = approved;
+        }
+    }
+}

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderIT.java
@@ -20,20 +20,7 @@ public class CellEditableProviderIT extends AbstractComponentIT {
     }
 
     @Test
-    public void noProvider_allCellsEditable() {
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", true);
-
-        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", true);
-    }
-
-    @Test
-    public void setProvider_individualCellsEditable() {
-        $("button").id("set-provider").click();
-
+    public void individualCellsEditable() {
         assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
         assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
         assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
@@ -44,13 +31,7 @@ public class CellEditableProviderIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setProvider_updateData_editableCellsUpdated() {
-        $("button").id("set-provider").click();
-
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
-
+    public void updateData_editableCellsUpdated() {
         // Reverse the approved state of all transactions
         $("button").id("update-data").click();
 
@@ -64,32 +45,7 @@ public class CellEditableProviderIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setProvider_clearProvider_allCellsEditable() {
-        $("button").id("set-provider").click();
-
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
-
-        $("button").id("clear-provider").click();
-
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", true);
-
-        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", true);
-    }
-
-    @Test
-    public void setProvider_detach_attach_individualCellsEditable() {
-        $("button").id("set-provider").click();
-
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
-
+    public void detach_attach_individualCellsEditable() {
         $("button").id("detach").click();
         $("button").id("attach").click();
         grid = $(GridProElement.class).waitForFirst();
@@ -100,25 +56,7 @@ public class CellEditableProviderIT extends AbstractComponentIT {
     }
 
     @Test
-    public void detach_setProvider_attach_editableCellsUpdated() {
-        $("button").id("detach").click();
-        $("button").id("set-provider").click();
-        $("button").id("attach").click();
-        grid = $(GridProElement.class).waitForFirst();
-
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
-    }
-
-    @Test
-    public void setProvider_detach_updateData_attach_editableCellsUpdated() {
-        $("button").id("set-provider").click();
-
-        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
-        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
-        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
-
+    public void detach_updateData_attach_editableCellsUpdated() {
         $("button").id("detach").click();
         $("button").id("update-data").click();
         $("button").id("attach").click();

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/CellEditableProviderIT.java
@@ -1,0 +1,150 @@
+package com.vaadin.flow.component.gridpro.tests;
+
+import com.vaadin.flow.component.gridpro.testbench.GridProElement;
+import com.vaadin.flow.component.gridpro.testbench.GridTHTDElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+@TestPath("vaadin-grid-pro/cell-editable-provider")
+public class CellEditableProviderIT extends AbstractComponentIT {
+    private GridProElement grid;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridProElement.class).waitForFirst();
+    }
+
+    @Test
+    public void noProvider_allCellsEditable() {
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", true);
+
+        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", true);
+    }
+
+    @Test
+    public void setProvider_individualCellsEditable() {
+        $("button").id("set-provider").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+
+        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", true);
+    }
+
+    @Test
+    public void setProvider_updateData_editableCellsUpdated() {
+        $("button").id("set-provider").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+
+        // Reverse the approved state of all transactions
+        $("button").id("update-data").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", true);
+
+        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", false);
+    }
+
+    @Test
+    public void setProvider_clearProvider_allCellsEditable() {
+        $("button").id("set-provider").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+
+        $("button").id("clear-provider").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", true);
+
+        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", true);
+    }
+
+    @Test
+    public void setProvider_detach_attach_individualCellsEditable() {
+        $("button").id("set-provider").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+
+        $("button").id("detach").click();
+        $("button").id("attach").click();
+        grid = $(GridProElement.class).waitForFirst();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+    }
+
+    @Test
+    public void detach_setProvider_attach_editableCellsUpdated() {
+        $("button").id("detach").click();
+        $("button").id("set-provider").click();
+        $("button").id("attach").click();
+        grid = $(GridProElement.class).waitForFirst();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+    }
+
+    @Test
+    public void setProvider_detach_updateData_attach_editableCellsUpdated() {
+        $("button").id("set-provider").click();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", false);
+
+        $("button").id("detach").click();
+        $("button").id("update-data").click();
+        $("button").id("attach").click();
+        grid = $(GridProElement.class).waitForFirst();
+
+        assertCellEditable(0, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 1, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(0, 2, "vaadin-grid-pro-edit-checkbox", true);
+
+        assertCellEditable(1, 0, "vaadin-grid-pro-edit-text-field", true);
+        assertCellEditable(1, 1, "vaadin-grid-pro-edit-text-field", false);
+        assertCellEditable(1, 2, "vaadin-grid-pro-edit-checkbox", false);
+    }
+
+    private void assertCellEditable(Integer rowIndex, Integer colIndex,
+            String editorTag, boolean editable) {
+        GridTHTDElement cell = grid.getCell(rowIndex, colIndex);
+
+        // Not in edit mode initially
+        Assert.assertFalse(cell.innerHTMLContains(editorTag));
+
+        // Entering edit mode with enter
+        cell.sendKeys(Keys.ENTER);
+        Assert.assertEquals(editable, cell.innerHTMLContains(editorTag));
+
+        // Exiting edit mode with escape
+        cell.sendKeys(Keys.ESCAPE);
+    }
+}

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/EditColumnConfigurator.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/EditColumnConfigurator.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.gridpro.GridPro.EditColumn;
 import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.shared.Registration;
 
@@ -314,6 +315,22 @@ public class EditColumnConfigurator<T> implements Serializable {
      */
     public EditColumnConfigurator<T> withManualRefresh() {
         column.setManualRefresh(true);
+        return this;
+    }
+
+    /**
+     * Configures a predicate that determines whether individual cells in this
+     * column are editable. The predicate is called for each rendered item of
+     * the grid and should return a boolean indicating whether the cell is
+     * editable or not. By default, the provider is null, which means that all
+     * cells in the column are editable.
+     *
+     * @param cellEditableProvider
+     *            the cell editable provider
+     */
+    public EditColumnConfigurator<T> withCellEditableProvider(
+            SerializablePredicate<T> cellEditableProvider) {
+        column.setCellEditableProvider(cellEditableProvider);
         return this;
     }
 }

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -721,8 +721,20 @@ public class GridPro<E> extends Grid<E> {
      */
     public Registration addItemPropertyChangedListener(
             ComponentEventListener<ItemPropertyChangedEvent<E>> listener) {
+        // Wrap the listener to filter out events for cells that are not
+        // editable
+        ComponentEventListener<ItemPropertyChangedEvent<E>> wrapper = event -> {
+            EditColumn<E> column = (EditColumn<E>) this.idToColumnMap
+                    .get(event.getPath());
+
+            if (column.cellEditableProvider == null
+                    || column.cellEditableProvider.test(event.getItem())) {
+                listener.onComponentEvent(event);
+            }
+        };
+
         return ComponentUtil.addListener(this, ItemPropertyChangedEvent.class,
-                (ComponentEventListener) listener);
+                (ComponentEventListener) wrapper);
     }
 
     /**

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -307,33 +307,6 @@ public class GridPro<E> extends Grid<E> {
             this.valueProvider = valueProvider;
         }
 
-        /**
-         * The current predicate for determining whether individual cells in
-         * this column are editable, or null if none is set.
-         *
-         * @return the cell editable provider
-         */
-        public SerializablePredicate<T> getCellEditableProvider() {
-            return cellEditableProvider;
-        }
-
-        /**
-         * Sets a predicate that determines whether individual cells in this
-         * column are editable. The predicate is called for each rendered item
-         * of the grid and should return a boolean indicating whether the cell
-         * is editable or not. By default, the provider is null, which means
-         * that all cells in the column are editable. Setting the provider back
-         * to null makes all cells editable again.
-         *
-         * @param cellEditableProvider
-         *            the cell editable provider
-         */
-        public void setCellEditableProvider(
-                SerializablePredicate<T> cellEditableProvider) {
-            this.cellEditableProvider = cellEditableProvider;
-            getGrid().getDataCommunicator().reset();
-        }
-
         boolean isManualRefresh() {
             return manualRefresh;
         }
@@ -342,7 +315,12 @@ public class GridPro<E> extends Grid<E> {
             this.manualRefresh = manualRefresh;
         }
 
-        // Expose protected method
+        void setCellEditableProvider(
+                SerializablePredicate<T> cellEditableProvider) {
+            this.cellEditableProvider = cellEditableProvider;
+        }
+
+        // Expose protected method from Column to GridPro
         @Override
         protected String getInternalId() {
             return super.getInternalId();

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -62,6 +62,14 @@
             root.innerHTML = `<${tagName}></${tagName}>`;
           }
         });
+      })(column),
+    initCellEditableProvider: (column) =>
+      tryCatchWrapper(function(column) {
+        column.isCellEditable = function(model) {
+          // If there is no cell editable data, assume the cell is editable
+          const isEditable = model.item.cellEditable && model.item.cellEditable[column._flowId];
+          return isEditable === undefined || isEditable;
+        };
       })(column)
   };
 })();

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.gridpro;
 
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.KeyMapper;
@@ -109,5 +110,47 @@ public class GridProTest {
                         "col1"));
         Mockito.verify(mock, Mockito.never()).accept(Mockito.isNull(),
                 Mockito.anyString());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void itemPropertyChangedListener_onlyCalledWhenCellIsEditable() {
+        ComponentEventListener listener = Mockito
+                .mock(ComponentEventListener.class);
+        grid.addItemPropertyChangedListener(listener);
+
+        ItemUpdater<Person, String> itemUpdater = Mockito
+                .mock(ItemUpdater.class);
+        GridPro.EditColumn<Person> column = (GridPro.EditColumn<Person>) grid
+                .addEditColumn(Person::getName).text(itemUpdater);
+        JsonObject item = new JreJsonFactory()
+                .parse("{\"key\": \"1\", \"col1\":\"foo\"}");
+        GridPro.ItemPropertyChangedEvent<Person> event = new GridPro.ItemPropertyChangedEvent<>(
+                grid, true, item, "col1");
+
+        // No editable provider - should fire event
+        ComponentUtil.fireEvent(grid, event);
+        Mockito.verify(listener, Mockito.times(1))
+                .onComponentEvent(Mockito.any());
+        Mockito.verify(itemUpdater, Mockito.times(1)).accept(Mockito.any(),
+                Mockito.any());
+
+        // Cell is not editable - should not fire event
+        column.setCellEditableProvider(person -> false);
+        Mockito.reset(listener, itemUpdater);
+        ComponentUtil.fireEvent(grid, event);
+        Mockito.verify(listener, Mockito.never())
+                .onComponentEvent(Mockito.any());
+        Mockito.verify(itemUpdater, Mockito.never()).accept(Mockito.any(),
+                Mockito.any());
+
+        // Cell is editable - should fire event
+        column.setCellEditableProvider(person -> true);
+        Mockito.reset(listener, itemUpdater);
+        ComponentUtil.fireEvent(grid, event);
+        Mockito.verify(listener, Mockito.times(1))
+                .onComponentEvent(Mockito.any());
+        Mockito.verify(itemUpdater, Mockito.times(1)).accept(Mockito.any(),
+                Mockito.any());
     }
 }


### PR DESCRIPTION
Adds an API for configuring a predicate that determines whether individual cells in columns are editable or not.

Depends on: https://github.com/vaadin/web-components/pull/7269
Part of: https://github.com/vaadin/flow-components/issues/4524
AC: https://github.com/vaadin/platform/issues/5177