### PR TITLE
feat: implement proper readonly state in CheckboxGroup

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -127,9 +127,9 @@ public class CheckboxGroupIT extends AbstractComponentIT {
         List<CheckboxElement> checkboxes = group.getCheckboxes();
 
         Assert.assertEquals(Boolean.TRUE.toString(),
-                checkboxes.get(1).getAttribute("disabled"));
+                checkboxes.get(1).getAttribute("readonly"));
         Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getAttribute("disabled"));
+                group.getAttribute("readonly"));
 
         scrollToElement(group);
         getCommandExecutor().executeScript("window.scrollBy(0,50);");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -105,8 +105,6 @@ public class CheckboxGroup<T>
     private final AtomicReference<DataProvider<T, ?>> dataProvider = new AtomicReference<>(
             DataProvider.ofItems());
 
-    private boolean isReadOnly;
-
     private SerializablePredicate<T> itemEnabledProvider = item -> isEnabled();
 
     private ItemLabelGenerator<T> itemLabelGenerator = String::valueOf;
@@ -461,26 +459,21 @@ public class CheckboxGroup<T>
 
     @Override
     public void onEnabledStateChanged(boolean enabled) {
-        if (isReadOnly()) {
-            setDisabled(true);
-        } else {
-            setDisabled(!enabled);
-        }
+        setDisabled(!enabled);
         getCheckboxItems().forEach(this::updateEnabled);
     }
 
     @Override
     public void setReadOnly(boolean readOnly) {
-        isReadOnly = readOnly;
+        getElement().setProperty("readonly", readOnly);
         if (isEnabled()) {
-            setDisabled(readOnly);
             refreshCheckboxes();
         }
     }
 
     @Override
     public boolean isReadOnly() {
-        return isReadOnly;
+        return getElement().getProperty("readonly", false);
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -466,9 +466,6 @@ public class CheckboxGroup<T>
     @Override
     public void setReadOnly(boolean readOnly) {
         getElement().setProperty("readonly", readOnly);
-        if (isEnabled()) {
-            refreshCheckboxes();
-        }
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -463,16 +463,6 @@ public class CheckboxGroup<T>
         getCheckboxItems().forEach(this::updateEnabled);
     }
 
-    @Override
-    public void setReadOnly(boolean readOnly) {
-        getElement().setProperty("readonly", readOnly);
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return getElement().getProperty("readonly", false);
-    }
-
     /**
      * Returns the item enabled predicate.
      *

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -113,18 +113,6 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void setReadOnlyEnabledCheckboxGroup_groupIsNotDisabled() {
-        CheckboxGroup<String> group = new CheckboxGroup<>();
-        group.setReadOnly(true);
-        group.setEnabled(true);
-
-        Assert.assertTrue(group.isReadOnly());
-        Assert.assertTrue(group.isEnabled());
-        Assert.assertEquals(Boolean.FALSE.toString(),
-                group.getElement().getProperty("disabled"));
-    }
-
-    @Test
     public void unsetReadOnlyEnabledCheckboxGroup_groupIsEnabled() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setEnabled(false);

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -78,19 +78,14 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void setReadOnlyCheckboxGroup_groupIsReadOnlyAndDisabled() {
+    public void setReadOnlyCheckboxGroup_groupIsReadOnly() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setItems("foo", "bar");
         group.setReadOnly(true);
         Assert.assertTrue(group.isReadOnly());
 
         Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getElement().getProperty("disabled"));
-
-        long disabledChildCount = group.getChildren().filter(
-                child -> child.getElement().getProperty("disabled", false))
-                .count();
-        Assert.assertEquals(group.getChildren().count(), disabledChildCount);
+                group.getElement().getProperty("readonly"));
     }
 
     @Test
@@ -118,18 +113,12 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void setReadOnlyEnabledCheckboxGroup_groupIsDisabledAndNotReadonly() {
+    public void setReadOnlyEnabledCheckboxGroup_groupIsNotDisabled() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setReadOnly(true);
         group.setEnabled(true);
 
         Assert.assertTrue(group.isReadOnly());
-        Assert.assertTrue(group.isEnabled());
-        Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getElement().getProperty("disabled"));
-
-        group.setReadOnly(false);
-
         Assert.assertTrue(group.isEnabled());
         Assert.assertEquals(Boolean.FALSE.toString(),
                 group.getElement().getProperty("disabled"));


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/5178

Depends on https://github.com/vaadin/web-components/pull/7199

Updated `CheckboxGroup.setReadonly(true)` to use `readonly` property on the web component instead of disabling.

## Type of change

- Feature