### PR TITLE
test: move treegrid test page to the correct package

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/SelectComponentColumnAfterExpandPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/SelectComponentColumnAfterExpandPage.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.grid.it;
+package com.vaadin.flow.component.treegrid.it;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/SelectComponentColumnAfterExpandIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/SelectComponentColumnAfterExpandIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
-import com.vaadin.flow.component.grid.it.SelectComponentColumnAfterExpandPage;
 import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
## Description

This PR moves a TreeGrid IT page from Grid test package to the TreeGrid test package.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Test

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.