### PR TITLE
fix: ensure time parts in parsed time object are numeric

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerPage.java
@@ -36,6 +36,7 @@ public class TimePickerPage extends Div {
         createTimePickerWithStepSetting();
         createTimePickerWithMinAndMaxSetting();
         createTimePickerFromRenderer();
+        createTimePickerWithSmallMs();
         createHelperText();
         createHelperComponent();
     }
@@ -123,6 +124,15 @@ public class TimePickerPage extends Div {
                     return timePicker;
                 });
         renderer.render(getElement(), null);
+    }
+
+    private void createTimePickerWithSmallMs() {
+        TimePicker timePicker = new TimePicker();
+        timePicker.setValue(LocalTime.of(0, 0, 0, 50000000));
+        timePicker.setStep(Duration.ofMillis(1));
+        timePicker.setId("picker-with-small-ms");
+        timePicker.setLabel("TimePicker with small ms");
+        add(timePicker);
     }
 
     private void createHelperText() {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
@@ -143,6 +143,14 @@ public class TimePickerIT extends AbstractComponentIT {
         Assert.assertNull(picker.getHelperComponent());
     }
 
+    @Test
+    public void timePickerWithSmallMs_msNotRoundedDownToZero() {
+        TimePickerElement picker = $(TimePickerElement.class)
+                .id("picker-with-small-ms");
+
+        validatePickerValue(picker, "00:00:00.050");
+    }
+
     private void selectStep(String step) {
         NativeSelectElement select = $(NativeSelectElement.class)
                 .id("step-picker");

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -32,10 +32,10 @@ import { TimePicker } from '@vaadin/time-picker';
     // The web component returns an object with string values
     // while the connector expects number values.
     return {
-      hours: parseInt(timeObject.hours),
-      minutes: parseInt(timeObject.minutes),
-      seconds: parseInt(timeObject.seconds),
-      milliseconds: parseInt(timeObject.milliseconds)
+      hours: parseInt(timeObject.hours || 0),
+      minutes: parseInt(timeObject.minutes || 0),
+      seconds: parseInt(timeObject.seconds || 0),
+      milliseconds: parseInt(timeObject.milliseconds || 0)
     }
   };
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -8,7 +8,7 @@ import {
   getSeparator,
   searchAmOrPmToken
 } from './helpers.js';
-import { TimePicker } from '@vaadin/time-picker';
+import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
 
 (function () {
   const tryCatchWrapper = function (callback) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -8,6 +8,7 @@ import {
   getSeparator,
   searchAmOrPmToken
 } from './helpers.js';
+import { TimePicker } from '@vaadin/time-picker';
 
 (function () {
   const tryCatchWrapper = function (callback) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -24,6 +24,20 @@ import {
     }
   }
 
+  function parseISO(text) {
+    // The default i18n parser of the web component is ISO 8601 compliant.
+    const timeObject = TimePicker.properties.i18n.value().parseTime(text);
+
+    // The web component returns an object with string values
+    // while the connector expects number values.
+    return {
+      hours: parseInt(timeObject.hours),
+      minutes: parseInt(timeObject.minutes),
+      seconds: parseInt(timeObject.seconds),
+      milliseconds: parseInt(timeObject.milliseconds)
+    }
+  };
+
   window.Vaadin.Flow.timepickerConnector = {
     initLazy: (timepicker) =>
       tryCatchWrapper(function (timepicker) {
@@ -38,7 +52,7 @@ import {
           // capture previous value if any
           let previousValueObject;
           if (timepicker.value && timepicker.value !== '') {
-            previousValueObject = timepicker.i18n.parseTime(timepicker.value);
+            previousValueObject = parseISO(timepicker.value);
           }
 
           try {
@@ -91,11 +105,7 @@ import {
 
               // milliseconds not part of the time format API
               if (includeMilliSeconds()) {
-                let timeObjectMilliseconds = timeObject.milliseconds;
-                if (typeof timeObjectMilliseconds === 'string') {
-                  timeObjectMilliseconds = timeObjectMilliseconds ? parseDigitsIntoInteger(timeObjectMilliseconds.replace(separator, '')) : 0;
-                }
-                localeTimeString = formatMilliseconds(localeTimeString, timeObjectMilliseconds, amString, pmString);
+                localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds, amString, pmString);
               }
 
               return localeTimeString;

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -91,7 +91,11 @@ import {
 
               // milliseconds not part of the time format API
               if (includeMilliSeconds()) {
-                localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds, amString, pmString);
+                let timeObjectMilliseconds = timeObject.milliseconds;
+                if (typeof timeObjectMilliseconds === 'string') {
+                  timeObjectMilliseconds = timeObjectMilliseconds ? parseDigitsIntoInteger(timeObjectMilliseconds.replace(separator, '')) : 0;
+                }
+                localeTimeString = formatMilliseconds(localeTimeString, timeObjectMilliseconds, amString, pmString);
               }
 
               return localeTimeString;


### PR DESCRIPTION
## Description

Currently, when `formatTime` in the time picker connector calls the helper function `formatMilliseconds`, the provided milliseconds value can be a string or a number. However, the helper function expects a number at this point and the calculations get broken. Therefore, the ms values smaller than 100 gets rounded down to 0. This PR makes sure that the helper function is only called with a number ms value.

Fixes #5101 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.