### PR TITLE
fix: reset communicator regardless of filter

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilterDebounceIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilterDebounceIT.java
@@ -56,6 +56,32 @@ public class FilterDebounceIT extends AbstractComboBoxIT {
         waitForExpectedItems();
     }
 
+    @Test
+    public void withInitialFilter_clearAndReapplyFilter_doesNotHang() {
+        combo.sendKeys("a");
+        waitForExpectedItems();
+        combo.sendKeys(Keys.BACK_SPACE);
+        combo.sendKeys("a");
+        waitForExpectedItems();
+    }
+
+    @Test
+    public void withInitialFilter_updateAndReapplyFilter_doesNotHang() {
+        combo.sendKeys("a");
+        waitForExpectedItems();
+        combo.sendKeys("b");
+        combo.sendKeys(Keys.BACK_SPACE);
+        waitForExpectedItems();
+    }
+
+    public void withoutInitialFilter_updateAndClearFilter_doesNotHang() {
+        combo.openPopup();
+        waitForItems(combo, items -> items.size() == 3);
+        combo.sendKeys("a");
+        combo.sendKeys(Keys.BACK_SPACE);
+        waitForItems(combo, items -> items.size() == 3);
+    }
+
     private void tabOutAndBackFromCombo() {
         combo.sendKeys("\t");
         input.sendKeys(Keys.chord(Keys.SHIFT, Keys.TAB));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -152,7 +152,7 @@ class ComboBoxDataController<TItem>
     private Registration clearFilterOnCloseRegistration;
     private Registration dataProviderListener = null;
 
-    private boolean forceResetDueToClientSideFilterChange = false;
+    private boolean dataCommunicatorNeedsReset = false;
 
     /**
      * Creates a new data controller for that combo box
@@ -286,14 +286,13 @@ class ComboBoxDataController<TItem>
         }
         dataCommunicator.setRequestedRange(start, length);
         filterSlot.accept(filter);
-        forceResetDueToClientSideFilterChange = Objects.equals(filter,
-                lastFilter);
     }
 
     /**
      * Called by the client-side connector to reset the data communicator
      */
     void resetDataCommunicator() {
+        dataCommunicatorNeedsReset = true;
         /*
          * The client filter from combo box will be used in the data
          * communicator only within 'setRequestedRange' calls to data provider,
@@ -316,9 +315,9 @@ class ComboBoxDataController<TItem>
          * applied filter is the same as the previously applied filter. This has
          * to be done manually here.
          */
-        if (forceResetDueToClientSideFilterChange) {
+        if (dataCommunicatorNeedsReset) {
             dataCommunicator.reset();
-            forceResetDueToClientSideFilterChange = false;
+            dataCommunicatorNeedsReset = false;
         }
     }
 
@@ -539,6 +538,7 @@ class ComboBoxDataController<TItem>
                 @Override
                 public void reset() {
                     super.reset();
+                    dataCommunicatorNeedsReset = false;
                     if (comboBox instanceof MultiSelectComboBox) {
                         // The data is destroyed and rebuilt on data
                         // communicator reset. When component renderers are

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -152,8 +152,6 @@ class ComboBoxDataController<TItem>
     private Registration clearFilterOnCloseRegistration;
     private Registration dataProviderListener = null;
 
-    private boolean dataCommunicatorNeedsReset = false;
-
     /**
      * Creates a new data controller for that combo box
      *
@@ -292,33 +290,7 @@ class ComboBoxDataController<TItem>
      * Called by the client-side connector to reset the data communicator
      */
     void resetDataCommunicator() {
-        dataCommunicatorNeedsReset = true;
-        /*
-         * The client filter from combo box will be used in the data
-         * communicator only within 'setRequestedRange' calls to data provider,
-         * and then will be erased to not affect the data view item count
-         * handling methods. Thus, if the current client filter is not empty,
-         * then we need to re-set it in the data communicator.
-         */
-        if (lastFilter != null && !lastFilter.isEmpty()) {
-            String filter = lastFilter;
-            lastFilter = null;
-            /*
-             * This filter slot will eventually call the filter consumer in data
-             * communicator and 'DataCommunicator::reset' is done inside this
-             * consumer, so we don't need to explicitly call it.
-             */
-            filterSlot.accept(filter);
-        }
-        /*
-         * The filter slot will not call 'DataCommunicator::reset' when the
-         * applied filter is the same as the previously applied filter. This has
-         * to be done manually here.
-         */
-        if (dataCommunicatorNeedsReset) {
-            dataCommunicator.reset();
-            dataCommunicatorNeedsReset = false;
-        }
+        dataCommunicator.reset();
     }
 
     // ****************************************************
@@ -538,7 +510,6 @@ class ComboBoxDataController<TItem>
                 @Override
                 public void reset() {
                     super.reset();
-                    dataCommunicatorNeedsReset = false;
                     if (comboBox instanceof MultiSelectComboBox) {
                         // The data is destroyed and rebuilt on data
                         // communicator reset. When component renderers are


### PR DESCRIPTION
## Description

Currently, when a filter is quickly changed, the combobox is left in a loading state. The reason is the data communicator is never reset because the new filter applied is the same one as before. Even if the connector explicitly [handles](https://github.com/vaadin/flow-components/blob/main/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js#L99-L105) this case, the server side reset does not happen. The client-callable `resetDataCommunicator` is only used for this purpose, and calling it from the client side should be enough to trigger the reset in any case.

This PR removes the legacy workaround in the reset logic in the controller and directly resets the communicator.

Fixes #5468 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.