### PR TITLE
fix: prevent setting disabled to false with pointer events: auto

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -51,6 +51,7 @@ public class ButtonView extends Div {
         createButtonWithDisableOnClick();
         createButtonWithDisableOnClickThatEnablesInSameRoundtrip();
         createButtonWithDisableOnClickThatIsHidden();
+        createButtonWithDisableOnClickAndPointerEventsAuto();
         addVariantsFeature();
         createButtonsWithShortcuts();
 
@@ -278,6 +279,17 @@ public class ButtonView extends Div {
         enableButton.setId("enable-hidden-button");
 
         addCard("Button disabled on click and hidden", button, enableButton);
+    }
+
+    private void createButtonWithDisableOnClickAndPointerEventsAuto() {
+        Button button = new Button("Disabled and pointer events auto");
+        button.setEnabled(false);
+        button.getStyle().set("pointer-events", "auto");
+        button.setDisableOnClick(true);
+        button.setDisableOnClick(false);
+        button.setId("disable-on-click-pointer-events-auto");
+
+        addCard("Button disabled on click and pointer events auto", button);
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -308,6 +308,21 @@ public class ButtonIT extends AbstractComponentIT {
     }
 
     @Test
+    public void disabledAndPointerEventsAuto_disableOnClick_clientSideButtonIsDisabled() {
+        WebElement button = layout
+                .findElement(By.id("disable-on-click-pointer-events-auto"));
+
+        scrollToElement(button);
+        executeScript("arguments[0].dispatchEvent(new MouseEvent(\"click\"));",
+                button);
+
+        String disabled = button.getAttribute("disabled");
+        Assert.assertTrue(
+                "The button should contain the 'disabled' attribute after click",
+                disabled != null);
+    }
+
+    @Test
     public void buttonShortcuts_shortcutsWork() {
         WebElement button = findElement(By.id("shortcuts-enter-button"));
 

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -316,10 +316,9 @@ public class ButtonIT extends AbstractComponentIT {
         executeScript("arguments[0].dispatchEvent(new MouseEvent(\"click\"));",
                 button);
 
-        String disabled = button.getAttribute("disabled");
-        Assert.assertTrue(
+        Assert.assertNotNull(
                 "The button should contain the 'disabled' attribute after click",
-                disabled != null);
+                button.getAttribute("disabled"));
     }
 
     @Test

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/resources/META-INF/resources/frontend/buttonFunctions.js
@@ -1,5 +1,7 @@
 function disableOnClickListener({currentTarget: button}) {
-  button.disabled = button.hasAttribute('disableOnClick');
+  if (button.hasAttribute('disableOnClick')) {
+    button.disabled = true;
+  }
 }
 
 window.Vaadin.Flow.button = {


### PR DESCRIPTION
## Description

Fixes #6183

This changes the client side JS listener as suggested in the issue to only set `disabled` to `true` and not `false`.

## Type of change

- Bugfix

## Note

The IT setup represents an edge case as it uses `setDisableOnClick(true)` followed by `setDisableOnClick(false)` and is based on the code example https://github.com/vaadin/flow-components/issues/6183#issuecomment-2046669463. Also, clicking the button in the IT requires firing an event manually.