### PR TITLE
fix: update formula bar after the other executions are done

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaFieldFormatIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaFieldFormatIT.java
@@ -37,6 +37,16 @@ public class FormulaFieldFormatIT extends AbstractSpreadsheetIT {
     }
 
     @Test
+    public void formulaLocaleFormatting_selectCellUsingAddressField_formulaFieldContentsFormattedForLocale() {
+        setLocale(Locale.ITALY);
+        createNewSpreadsheet();
+        setCellValue("A1", "=0,123456");
+        clickCell("B1");
+        setAddressFieldValue("A1");
+        Assert.assertEquals("=0,123", getFormulaFieldValue());
+    }
+
+    @Test
     public void rounding_sheetWithNumberFormatRuleForNumericCells_formulaFieldContentsUnformatted() {
         loadFile("rounding.xlsx");
         assertFormat("B2", "5", "4.99999");

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -765,8 +765,9 @@ public class Spreadsheet extends Component
 
         @Override
         public void updateFormulaBar(String possibleName, int col, int row) {
-            getElement().callJsFunction("updateFormulaBar", possibleName, col,
-                    row);
+            getElement().executeJs(
+                    "queueMicrotask(() => this.updateFormulaBar($0, $1, $2));",
+                    possibleName, col, row);
         }
 
         @Override


### PR DESCRIPTION
## Description

This PR defers the update of the formula bar so that all the calculations are done beforehand. This fixes the case where the formula bar displays the number using the wrong locale when the cell is selected using the address field. This also applies for the case changing sheet after setting the value and returning to the sheet.

Partially fixes #5731

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.