### PR TITLE
fix: fix setting class name to menu-bar items in overflow

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.menubar.tests;
 
+import java.util.stream.IntStream;
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Hr;
@@ -233,6 +234,24 @@ public class MenuBarTestPage extends Div {
                 });
         setUnsetSubItemClassNameButton.setId("set-unset-sub-item-class-name");
 
+        NativeButton setItem2ClassNameButton = new NativeButton(
+                "set item 2 class", e -> {
+                    item2.setClassName(MENU_ITEM_FIRST_CLASS_NAME);
+                });
+        setItem2ClassNameButton.setId("set-item2-class-name");
+
+        NativeButton removeItem2ClassNameButton = new NativeButton(
+                "remove item 2 class", e -> {
+                    item2.removeClassName(MENU_ITEM_FIRST_CLASS_NAME);
+                });
+        removeItem2ClassNameButton.setId("remove-item2-class-name");
+
+        NativeButton changeItem2ClassNameButton = new NativeButton(
+                "change item 2 class", e -> {
+                    item2.setClassName(MENU_ITEM_SECOND_CLASS_NAME);
+                });
+        changeItem2ClassNameButton.setId("change-item2-class-name");
+
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableItemButton, toggleItem1VisibilityButton,
@@ -240,10 +259,13 @@ public class MenuBarTestPage extends Div {
                 toggleAttachedButton, setI18nButton, toggleAttachedButton,
                 toggleMenuBarThemeButton, toggleItem1ThemeButton,
                 toggleSubItemThemeButton, toggleClassNameButton,
-                setItemClassNameButton, setUnsetClassNameButton,
-                addRemoveMultipleClassNames, toggleSubItemClassNameButton,
-                addSecondSubItemClassButton, removeSubItemClassNameButton,
+                setItemClassNameButton, setItem2ClassNameButton,
+                removeItem2ClassNameButton, changeItem2ClassNameButton,
+                setUnsetClassNameButton, addRemoveMultipleClassNames,
+                toggleSubItemClassNameButton, addSecondSubItemClassButton,
+                removeSubItemClassNameButton,
                 addRemoveMultipleSubItemClassNames,
                 setUnsetSubItemClassNameButton);
     }
+
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.menubar.tests;
 
-import java.util.stream.IntStream;
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Hr;
@@ -242,7 +241,7 @@ public class MenuBarTestPage extends Div {
 
         NativeButton removeItem2ClassNameButton = new NativeButton(
                 "remove item 2 class", e -> {
-                    item2.removeClassName(MENU_ITEM_FIRST_CLASS_NAME);
+                    item2.setClassName(null);
                 });
         removeItem2ClassNameButton.setId("remove-item2-class-name");
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
+import com.google.common.base.Strings;
 import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
@@ -557,6 +558,33 @@ public class MenuBarPageIT extends AbstractComponentIT {
         verifyClosed();
         verifySubMenuItemClassNames(true,
                 MenuBarTestPage.SUB_ITEM_FIRST_CLASS_NAME);
+    }
+
+    @Test
+    public void menuItemWithClassNameInOverflow_changeClassName_classNameIsChanged() {
+        click("set-width");
+        click("set-item2-class-name");
+        waitForResizeObserver();
+        menuBar.getOverflowButton().click();
+        click("change-item2-class-name");
+        menuBar.getOverflowButton().click();
+        TestBenchElement menuItem = menuBar.getSubMenuItems().get(0);
+        Assert.assertEquals(menuItem.getAttribute("class"),
+                MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME);
+    }
+
+    @Test
+    public void menuItemWithClassNameInOverflow_removeClassName_classNameIsRemoved() {
+        click("set-width");
+        click("set-item2-class-name");
+        waitForResizeObserver();
+        menuBar.getOverflowButton().click();
+        click("remove-item2-class-name");
+        menuBar.getOverflowButton().click();
+        TestBenchElement menuItem = menuBar.getSubMenuItems().get(0);
+
+        Assert.assertTrue(
+                Strings.isNullOrEmpty(menuItem.getAttribute("class")));
     }
 
     @Test

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -587,6 +587,25 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void menuItemWithClassNameInOverflow_menuItemLeavesOverflow_classNameCanBeChanged() {
+        click("set-width");
+        click("set-item2-class-name");
+        waitForResizeObserver();
+        menuBar.getOverflowButton().click();
+        click("reset-width");
+        waitForResizeObserver();
+        click("change-item2-class-name");
+        TestBenchElement menuItem = menuBar.getButtons().get(1);
+        Assert.assertEquals(menuItem.getAttribute("class"),
+                MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME);
+
+        click("remove-item2-class-name");
+        menuItem = menuBar.getButtons().get(1);
+        Assert.assertFalse(menuItem.getAttribute("class")
+                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
+    }
+
+    @Test
     public void setMenuItemTheme_toggleVisibility_themeIsPreserved() {
         click("toggle-item-1-theme");
         click("toggle-item-1-visibility");

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.google.common.base.Strings;
 import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
@@ -583,8 +582,8 @@ public class MenuBarPageIT extends AbstractComponentIT {
         menuBar.getOverflowButton().click();
         TestBenchElement menuItem = menuBar.getSubMenuItems().get(0);
 
-        Assert.assertTrue(
-                Strings.isNullOrEmpty(menuItem.getAttribute("class")));
+        Assert.assertFalse(menuItem.getAttribute("class")
+                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
     }
 
     @Test

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -73,8 +73,14 @@ import './contextMenuConnector.js';
 
         let items = menubar.__generatedItems || [];
 
-        // Propagate disabled state from items to parent buttons
-        items.forEach((item) => (item.disabled = item.component.disabled));
+        items.forEach((item) => {
+          // Propagate disabled state from items to parent buttons
+          item.disabled = item.component.disabled;
+
+          // Saving item to component because `_item` can be reassigned to a new value
+          // when the component goes to the overflow menu
+          item.component._rootItem = item;
+        });
 
         // Observe for hidden and disabled attributes in case they are changed by Flow.
         // When a change occurs, the observer will re-generate items on top of the existing tree
@@ -110,9 +116,9 @@ import './contextMenuConnector.js';
     };
   }
 
-  function setClassName (component) {
-    if (component._item) {
-      component._item.className = component.className;
+  function setClassName(component) {
+    if (component._rootItem) {
+      component._rootItem.className = component.className;
     }
   }
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -117,8 +117,10 @@ import './contextMenuConnector.js';
   }
 
   function setClassName(component) {
-    if (component._rootItem) {
-      component._rootItem.className = component.className;
+    const item = component._rootItem || component._item;
+
+    if (item) {
+      item.className = component.className;
     }
   }
 


### PR DESCRIPTION
## Description

The changes done in #6031 don't work if the root item is inside the overflow part of the `MenuBar`. That happens because the `setClassName` method in the connector changes the `className` value in the `component._item` object that should be reflected to the item when the items are regenerated.

Usually, the `_item` object of `component` refers to one instance inside of the `__generatedItems` array in the menu bar instance, but when the menu item becomes part of the overflow, it receives a new instance of `_item` and the reference is lost.

Saving the original reference in another property solves the issue and now the class name is changed properly for items inside the overflow.
