### PR TITLE
fix: mark `DataSeriesItemSankey` as customized to ensure its proper serialization

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemSankey.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemSankey.java
@@ -22,6 +22,7 @@ public class DataSeriesItemSankey extends DataSeriesItem {
 
     public DataSeriesItemSankey() {
         super();
+        makeCustomized();
     }
 
     /**
@@ -32,7 +33,7 @@ public class DataSeriesItemSankey extends DataSeriesItem {
      * @param weight
      */
     public DataSeriesItemSankey(String from, String to, Number weight) {
-        super();
+        this();
         setFrom(from);
         setTo(to);
         setWeight(weight);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/DataSeriesItemSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/DataSeriesItemSerializationTest.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.component.charts;
+
+import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.DataSeriesItemSankey;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.vaadin.flow.component.charts.util.ChartSerialization.toJSON;
+
+/**
+ * Tests for the serialization of custom data series items extending
+ * {@link DataSeriesItem}
+ */
+public class DataSeriesItemSerializationTest {
+    @Test
+    public void dataSeriesItemSankey_empty_toJSON() {
+        var json = toJSON(new DataSeriesItemSankey());
+        Assert.assertEquals("{}", json);
+    }
+
+    @Test
+    public void dataSeriesItemSankey_withValues_toJSON() {
+        var item = new DataSeriesItemSankey("A", "B", 1);
+        var json = toJSON(item);
+        Assert.assertEquals("{\"from\":\"A\",\"to\":\"B\",\"weight\":1}", json);
+    }
+}


### PR DESCRIPTION
## Description

Without this call, the object would be serialized as [an array containing two values](https://github.com/vaadin/flow-components/blob/main/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/DataSeriesItemBeanSerializer.java#L75-L80) from `bean.getLow()` and `bean.getHigh()`, which are not usually set on the Sankey type, so the result would be `[null, null]`, instead of the actual JSON string expected (containing the `from`, `to`, and `weight` keys).

The Sankey example in the IT works because it uses `setDataLabels`, which in turn [calls `makeCustomized`](https://github.com/vaadin/flow-components/blob/main/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItem.java#L366-L369) and then make the instance to be properly serialized.


## Type of change

- [X] Bugfix
- [ ] Feature
