### PR TITLE
test: use large window in confirm dialog dimensions tests

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/DimensionsIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/DimensionsIT.java
@@ -18,6 +18,7 @@ public class DimensionsIT extends AbstractParallelTest {
 
     @Before
     public void init() {
+        getDriver().manage().window().setSize(WINDOW_SIZE_LARGE);
         String url = getBaseURL().replace(super.getBaseURL(),
                 super.getBaseURL() + "/vaadin-confirm-dialog") + "/Dimensions";
         getDriver().get(url);


### PR DESCRIPTION
## Description

Use a large window in confirm dialog dimensions tests. Fixes some failing ITs.

## Type of change

Tests