### PR TITLE
fix: use correct default value for getAlignItems in VerticalLayout

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
@@ -166,7 +166,7 @@ public class VerticalLayout extends Component implements ThemableLayout,
      * can be aligned by using the
      * {@link #setHorizontalComponentAlignment(Alignment, Component...)} method.
      * <p>
-     * The default alignment is {@link Alignment#STRETCH}.
+     * The default alignment is {@link Alignment#START}.
      * <p>
      * It's the same as the {@link #setAlignItems(Alignment)} method.
      *
@@ -182,7 +182,7 @@ public class VerticalLayout extends Component implements ThemableLayout,
      * Gets the default horizontal alignment used by all components without
      * individual alignments inside the layout.
      * <p>
-     * The default alignment is {@link Alignment#STRETCH}.
+     * The default alignment is {@link Alignment#START}.
      * <p>
      * It's the same as the {@link #getAlignItems()} method.
      *
@@ -219,7 +219,9 @@ public class VerticalLayout extends Component implements ThemableLayout,
         // this method is overridden to make javadocs point to the correct
         // method to be used, and since FlexComponent has different default
         // value.
-        return FlexComponent.super.getAlignItems();
+        return Alignment.toAlignment(
+                getStyle().get(FlexConstants.ALIGN_ITEMS_CSS_PROPERTY),
+                Alignment.START);
     }
 
     /**

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/LayoutDefaultsTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/LayoutDefaultsTest.java
@@ -102,7 +102,7 @@ public class LayoutDefaultsTest {
     @Test
     public void defaultAlignmentValues() {
         VerticalLayout verticalLayout = new VerticalLayout();
-        Assert.assertEquals(Alignment.STRETCH,
+        Assert.assertEquals(Alignment.START,
                 verticalLayout.getDefaultHorizontalComponentAlignment());
 
         HorizontalLayout horizontalLayout = new HorizontalLayout();


### PR DESCRIPTION
## Description

Fixes #6206

Updated `VerticalLayout` to use correct default value to align with `flex-start` used by the [web component](https://github.com/vaadin/web-components/blob/e6281faa75364c97beb220b220f414aec58c679a/packages/vertical-layout/src/vaadin-vertical-layout.js#L43).
This seems to be the only case where Flow counterpart default value was actually misaligned.

## Type of change

- Bugfix