### PR TITLE
chore: overload constructor in order not to break API

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
@@ -33,6 +33,23 @@ public class FileRejectedEvent extends ComponentEvent<Upload> {
      * Creates a new event using the given source and indicator whether the
      * event originated from the client side or the server side.
      *
+     * @deprecated since 24.4. Use
+     *             {@link #FileRejectedEvent(Upload, String, String)}
+     *
+     * @param source
+     *            the source component
+     * @param errorMessage
+     *            the error message
+     */
+    @Deprecated(since = "24.4")
+    public FileRejectedEvent(Upload source, String errorMessage) {
+        this(source, errorMessage, null);
+    }
+
+    /**
+     * Creates a new event using the given source and indicator whether the
+     * event originated from the client side or the server side.
+     *
      * @param source
      *            the source component
      * @param errorMessage

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
@@ -42,6 +42,25 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
     /**
      * Event constructor method to construct a new progress event.
      *
+     * @deprecated since 24.4. Use
+     *             {@link #ProgressUpdateEvent(Upload, long, long, String)}
+     *
+     * @param source
+     *            the source of the file
+     * @param readBytes
+     *            bytes transferred
+     * @param contentLength
+     *            total size of file currently being uploaded, -1 if unknown
+     */
+    @Deprecated(since = "24.4")
+    public ProgressUpdateEvent(Upload source, long readBytes,
+            long contentLength) {
+        this(source, readBytes, contentLength, null);
+    }
+
+    /**
+     * Event constructor method to construct a new progress event.
+     *
      * @param source
      *            the source of the file
      * @param readBytes

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -500,7 +500,24 @@ public class Upload extends Component implements HasSize, HasStyle {
      *            bytes received so far
      * @param contentLength
      *            actual size of the file being uploaded, if known
+     *
+     * @deprecated since 24.4. Use
+     *             {@link #fireUpdateProgress(long, long, String)}
+     */
+    @Deprecated(since = "24.4")
+    protected void fireUpdateProgress(long totalBytes, long contentLength) {
+        fireEvent(
+                new ProgressUpdateEvent(this, totalBytes, contentLength, null));
+    }
+
+    /**
+     * Emit the progress event.
+     *
+     * @param totalBytes
+     *            bytes received so far
      * @param contentLength
+     *            actual size of the file being uploaded, if known
+     * @param fileName
      *            name of the file being uploaded
      */
     protected void fireUpdateProgress(long totalBytes, long contentLength,


### PR DESCRIPTION
fixes: https://github.com/vaadin/flow-components/issues/6221


