### PR TITLE
chore: bump Testbench to 9.3.0.alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>https://vaadin.com/components</url>
     <properties>
         <flow.version>24.4-SNAPSHOT</flow.version>
-        <testbench.version>9.2.7</testbench.version>
+        <testbench.version>9.3.0.alpha1</testbench.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CompositeIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CompositeIT.java
@@ -28,7 +28,8 @@ public class CompositeIT extends AbstractParallelTest {
         $(TextFieldElement.class).attribute("editor-role", "language-field")
                 .first().setValue("English");
 
-        $(TestBenchElement.class).id("overlay").$(ButtonElement.class).first()
+        $(TestBenchElement.class).withId("overlay").last()
+                .$(ButtonElement.class).first()
                 .click();
 
         Assert.assertTrue(

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CompositeIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CompositeIT.java
@@ -29,8 +29,7 @@ public class CompositeIT extends AbstractParallelTest {
                 .first().setValue("English");
 
         $(TestBenchElement.class).withId("overlay").last()
-                .$(ButtonElement.class).first()
-                .click();
+                .$(ButtonElement.class).first().click();
 
         Assert.assertTrue(
                 $(CrudElement.class).first().getEditorSaveButton().isEnabled());

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldPage.java
@@ -110,7 +110,7 @@ public class NumberFieldPage extends Div {
 
         dollarField.setId("dollar-field");
         euroField.setId("euro-field");
-        stepperField.setId("step-number-field");
+        stepperField.setId("step-number-field-2");
 
         add(dollarField, euroField, stepperField);
     }


### PR DESCRIPTION
Fixed tests to adapt to the new semantic of 'id()' query selector throwing an exception when there are more elements with the same id.
   
For CompositeIT, two modal dialogs are opened, adding two elements with 'overlay' id. The test now takes the last one, that corresponds to the Language edit dialog.

