### PR TITLE
test: drop obsolete workaround from grid ITs

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsPage.java
@@ -39,15 +39,6 @@ public class RecalculateColumnWidthsPage extends VerticalLayout {
 
         add(grid1);
 
-        // Ensure _recalculateColumnWidthOnceLoadingFinished flag is cleared,
-        // otherwise the flag would trigger the column recalculation
-        // automatically when refreshing the data
-        // The web component has some flaky behaviour where the flag is not
-        // always cleared after the initial data load
-        // See https://github.com/vaadin/web-components/issues/268
-        grid1.getElement().executeJs(
-                "$0._recalculateColumnWidthOnceLoadingFinished = false");
-
         Button button = new Button("Add Text");
         button.setId("change-data-button");
         button.addClickListener(event -> {


### PR DESCRIPTION
## Description

The grid web component used to have several different flags for delaying column width recalculation, and some could end up not being properly reset in some scenarios, as highlighted in https://github.com/vaadin/web-components/issues/268. However, https://github.com/vaadin/web-components/pull/5926 has combined these into a single flag, which only remains set if the data provider returns an empty data set (expected). So, the workaround appears to be obsolete also considering that the flag it resets doesn't exist anymore.

## Type of change

- [x] Internal
