### PR TITLE
fix: make getResponsiveSteps getter work properly

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -115,9 +115,6 @@ public class FormLayout extends Component
         private int columns;
         private LabelsPosition labelsPosition;
 
-        private ResponsiveStep() {
-        }
-
         /**
          * Constructs a ResponsiveStep with the given minimum width and number
          * of columns.
@@ -378,7 +375,7 @@ public class FormLayout extends Component
         }
         List<ResponsiveStep> steps = new ArrayList<>();
         for (int i = 0; i < stepsJsonArray.length(); i++) {
-            steps.add(new ResponsiveStep().readJson(stepsJsonArray.get(i)));
+            steps.add(new ResponsiveStep(null, 0).readJson(stepsJsonArray.get(i)));
         }
         return steps;
     }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -173,7 +173,12 @@ public class FormLayout extends Component
 
         @Override
         public ResponsiveStep readJson(JsonObject value) {
-            minWidth = value.getString(MIN_WIDTH_JSON_KEY);
+            JsonValue minWidthValue = value.get(MIN_WIDTH_JSON_KEY);
+            if (minWidthValue != null) {
+                minWidth = minWidthValue.asString();
+            } else {
+                minWidth = null;
+            }
             columns = (int) value.getNumber(COLUMNS_JSON_KEY);
             JsonValue labelsPositionValue = value
                     .get(LABELS_POSITION_JSON_KEY);

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -156,8 +156,7 @@ public class FormLayout extends Component
         @Override
         public JsonObject toJson() {
             JsonObject json = Json.createObject();
-            if (minWidth != null
-                    && !minWidth.chars().allMatch(Character::isWhitespace)) {
+            if (minWidth != null && !minWidth.trim().isEmpty()) {
                 json.put(MIN_WIDTH_JSON_KEY, minWidth);
             }
             json.put(COLUMNS_JSON_KEY, columns);
@@ -175,20 +174,21 @@ public class FormLayout extends Component
             } else {
                 minWidth = null;
             }
+
             columns = (int) value.getNumber(COLUMNS_JSON_KEY);
+
             JsonValue labelsPositionValue = value.get(LABELS_POSITION_JSON_KEY);
-            if (labelsPositionValue == null) {
-                labelsPosition = null;
-                return this;
-            }
-            String labelsPositionString = labelsPositionValue.asString();
-            if ("aside".equals(labelsPositionString)) {
-                labelsPosition = LabelsPosition.ASIDE;
-            } else if ("top".equals(labelsPositionString)) {
-                labelsPosition = LabelsPosition.TOP;
+            if (labelsPositionValue != null) {
+                String labelsPositionString = labelsPositionValue.asString();
+                if ("aside".equals(labelsPositionString)) {
+                    labelsPosition = LabelsPosition.ASIDE;
+                } else if ("top".equals(labelsPositionString)) {
+                    labelsPosition = LabelsPosition.TOP;
+                }
             } else {
                 labelsPosition = null;
             }
+
             return this;
         }
     }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -375,7 +375,8 @@ public class FormLayout extends Component
         }
         List<ResponsiveStep> steps = new ArrayList<>();
         for (int i = 0; i < stepsJsonArray.length(); i++) {
-            steps.add(new ResponsiveStep(null, 0).readJson(stepsJsonArray.get(i)));
+            steps.add(new ResponsiveStep(null, 0)
+                    .readJson(stepsJsonArray.get(i)));
         }
         return steps;
     }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.shared.SlotUtils;
 
-import com.vaadin.flow.internal.JsonSerializer;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
@@ -116,7 +115,7 @@ public class FormLayout extends Component
         private int columns;
         private LabelsPosition labelsPosition;
 
-        public ResponsiveStep() {
+        private ResponsiveStep() {
         }
 
         /**
@@ -180,8 +179,7 @@ public class FormLayout extends Component
                 minWidth = null;
             }
             columns = (int) value.getNumber(COLUMNS_JSON_KEY);
-            JsonValue labelsPositionValue = value
-                    .get(LABELS_POSITION_JSON_KEY);
+            JsonValue labelsPositionValue = value.get(LABELS_POSITION_JSON_KEY);
             if (labelsPositionValue == null) {
                 labelsPosition = null;
                 return this;
@@ -378,7 +376,11 @@ public class FormLayout extends Component
         if (stepsJsonArray == null) {
             return Collections.emptyList();
         }
-        return JsonSerializer.toObjects(ResponsiveStep.class, stepsJsonArray);
+        List<ResponsiveStep> steps = new ArrayList<>();
+        for (int i = 0; i < stepsJsonArray.length(); i++) {
+            steps.add(new ResponsiveStep().readJson(stepsJsonArray.get(i)));
+        }
+        return steps;
     }
 
     /**

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.shared.SlotUtils;
 
+import com.vaadin.flow.internal.JsonSerializer;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
@@ -115,6 +116,9 @@ public class FormLayout extends Component
         private int columns;
         private LabelsPosition labelsPosition;
 
+        public ResponsiveStep() {
+        }
+
         /**
          * Constructs a ResponsiveStep with the given minimum width and number
          * of columns.
@@ -171,8 +175,13 @@ public class FormLayout extends Component
         public ResponsiveStep readJson(JsonObject value) {
             minWidth = value.getString(MIN_WIDTH_JSON_KEY);
             columns = (int) value.getNumber(COLUMNS_JSON_KEY);
-            String labelsPositionString = value
-                    .getString(LABELS_POSITION_JSON_KEY);
+            JsonValue labelsPositionValue = value
+                    .get(LABELS_POSITION_JSON_KEY);
+            if (labelsPositionValue == null) {
+                labelsPosition = null;
+                return this;
+            }
+            String labelsPositionString = labelsPositionValue.asString();
             if ("aside".equals(labelsPositionString)) {
                 labelsPosition = LabelsPosition.ASIDE;
             } else if ("top".equals(labelsPositionString)) {
@@ -364,11 +373,7 @@ public class FormLayout extends Component
         if (stepsJsonArray == null) {
             return Collections.emptyList();
         }
-        List<ResponsiveStep> steps = new ArrayList<>();
-        for (int i = 0; i < stepsJsonArray.length(); i++) {
-            steps.add(stepsJsonArray.get(i));
-        }
-        return steps;
+        return JsonSerializer.toObjects(ResponsiveStep.class, stepsJsonArray);
     }
 
     /**

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -19,8 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.formlayout.FormLayout;
-
-import java.util.List;
+import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 
 public class FormLayoutTest {
 
@@ -85,20 +84,19 @@ public class FormLayoutTest {
     }
 
     @Test
-    public void canSetAndGetResponsiveSteps() {
+    public void setResponsiveSteps_getResponsiveSteps() {
         FormLayout formLayout = new FormLayout();
 
-        formLayout.setResponsiveSteps(new FormLayout.ResponsiveStep("1px", 1));
+        formLayout.setResponsiveSteps(new ResponsiveStep(null, 1));
+        Assert.assertEquals(1, formLayout.getResponsiveSteps().size());
 
-        List<FormLayout.ResponsiveStep> responsiveSteps = formLayout.getResponsiveSteps();
+        formLayout.setResponsiveSteps(new ResponsiveStep(null, 1),
+                new ResponsiveStep("1px", 1));
+        Assert.assertEquals(2, formLayout.getResponsiveSteps().size());
 
-        Assert.assertEquals(responsiveSteps.size(), 1);
-
-        formLayout.setResponsiveSteps(new FormLayout.ResponsiveStep("1px", 1), new FormLayout.ResponsiveStep("1px", 1, FormLayout.ResponsiveStep.LabelsPosition.TOP));
-
-        responsiveSteps = formLayout.getResponsiveSteps();
-
-        Assert.assertEquals(responsiveSteps.size(), 2);
+        formLayout.setResponsiveSteps(new ResponsiveStep(null, 1),
+                new ResponsiveStep("1px", 1), new ResponsiveStep("1px", 1,
+                        ResponsiveStep.LabelsPosition.TOP));
+        Assert.assertEquals(3, formLayout.getResponsiveSteps().size());
     }
-
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.formlayout.FormLayout;
 
+import java.util.List;
+
 public class FormLayoutTest {
 
     @Test
@@ -80,6 +82,23 @@ public class FormLayoutTest {
         layout.add(compUnset);
         Assert.assertEquals(layout.getColspan(compUnset), 1);
 
+    }
+
+    @Test
+    public void canSetAndGetResponsiveSteps() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setResponsiveSteps(new FormLayout.ResponsiveStep("1px", 1));
+
+        List<FormLayout.ResponsiveStep> responsiveSteps = formLayout.getResponsiveSteps();
+
+        Assert.assertEquals(responsiveSteps.size(), 1);
+
+        formLayout.setResponsiveSteps(new FormLayout.ResponsiveStep("1px", 1), new FormLayout.ResponsiveStep("1px", 1, FormLayout.ResponsiveStep.LabelsPosition.TOP));
+
+        responsiveSteps = formLayout.getResponsiveSteps();
+
+        Assert.assertEquals(responsiveSteps.size(), 2);
     }
 
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description
Form layout responsive steps getter does not work at all.
Included test describes the case.

## Type of change

- [x] Bugfix
- [ ] Feature
