### PR TITLE
fix: set maxFiles to Infinity when setting a MultiFileReceiver

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/SwitchReceiversPage.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/SwitchReceiversPage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.flow.component.html.NativeButton;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
+import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-upload/switch-receivers")
+public class SwitchReceiversPage extends Div {
+
+    public SwitchReceiversPage() {
+        Upload upload = new Upload();
+
+        NativeButton setSingleFileReceiver = new NativeButton(
+                "Set single file receiver", event -> {
+                    MemoryBuffer buffer = new MemoryBuffer();
+                    upload.setReceiver(buffer);
+                });
+        setSingleFileReceiver.setId("set-single-file-receiver");
+
+        NativeButton setMultiFileReceiver = new NativeButton(
+                "Set multi file receiver", event -> {
+                    MultiFileMemoryBuffer buffer = new MultiFileMemoryBuffer();
+                    upload.setReceiver(buffer);
+                });
+        setMultiFileReceiver.setId("set-multi-file-receiver");
+
+        add(upload, setSingleFileReceiver, setMultiFileReceiver);
+    }
+
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
@@ -35,21 +35,22 @@ public class SwitchReceiversIT extends AbstractUploadIT {
     }
 
     @Test
-    public void setSingleFileReceiver_setMultiFileReceiver_moreThanOneFileCanBeSelected() {
+    public void switchBetweenSingleAndMultiFileReceiver_assertMaxFilesProperty() {
         $("button").id("set-single-file-receiver").click();
-        $("button").id("set-multi-file-receiver").click();
+        Assert.assertTrue(
+                "The maxFiles property should equal 1 when single file receiver is set",
+                (boolean) executeScript("return arguments[0].maxFiles === 1",
+                        upload));
 
-        Assert.assertTrue("The maxFiles property should equal to Infinity",
+        $("button").id("set-multi-file-receiver").click();
+        Assert.assertTrue(
+                "The maxFiles property should equal Infinity when multi file receiver is set",
                 (boolean) executeScript(
                         "return arguments[0].maxFiles === Infinity", upload));
-    }
 
-    @Test
-    public void setMultiFileReceiver_setSingleFileReceiver_onlyOneFileCanBeSelected() {
-        $("button").id("set-multi-file-receiver").click();
         $("button").id("set-single-file-receiver").click();
-
-        Assert.assertTrue("The maxFiles property should equal to 1",
+        Assert.assertTrue(
+                "The maxFiles property should equal 1 when single file receiver is set again",
                 (boolean) executeScript("return arguments[0].maxFiles === 1",
                         upload));
     }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
@@ -36,10 +36,9 @@ public class SwitchReceiversIT extends AbstractUploadIT {
     @Test
     public void switchBetweenSingleAndMultiFileReceiver_assertMaxFilesProperty() {
         $("button").id("set-single-file-receiver").click();
-        Assert.assertTrue(
+        Assert.assertEquals(
                 "The maxFiles property should equal 1 when single file receiver is set",
-                (boolean) executeScript("return arguments[0].maxFiles === 1",
-                        upload));
+                1, (int) upload.getPropertyInteger("maxFiles"));
 
         $("button").id("set-multi-file-receiver").click();
         Assert.assertTrue(
@@ -48,9 +47,8 @@ public class SwitchReceiversIT extends AbstractUploadIT {
                         "return arguments[0].maxFiles === Infinity", upload));
 
         $("button").id("set-single-file-receiver").click();
-        Assert.assertTrue(
-                "The maxFiles property should equal 1 when single file receiver is set again",
-                (boolean) executeScript("return arguments[0].maxFiles === 1",
-                        upload));
+        Assert.assertEquals(
+                "The maxFiles property should equal 1 when single file receiver is set",
+                1, (int) upload.getPropertyInteger("maxFiles"));
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.upload.testbench.UploadElement;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-upload/switch-receivers")
+public class SwitchReceiversIT extends AbstractUploadIT {
+
+    private UploadElement upload;
+
+    @Before
+    public void init() {
+        open();
+        upload = $(UploadElement.class).first();
+        waitUntil(_driver -> upload.isDisplayed());
+    }
+
+    @Test
+    public void setSingleFileReceiver_setMultiFileReceiver_moreThanOneFileCanBeSelected() {
+        $("button").id("set-single-file-receiver").click();
+        $("button").id("set-multi-file-receiver").click();
+
+        Assert.assertTrue("The maxFiles property should equal to Infinity",
+                (boolean) executeScript(
+                        "return arguments[0].maxFiles === Infinity", upload));
+    }
+
+    @Test
+    public void setMultiFileReceiver_setSingleFileReceiver_onlyOneFileCanBeSelected() {
+        $("button").id("set-multi-file-receiver").click();
+        $("button").id("set-single-file-receiver").click();
+
+        Assert.assertTrue("The maxFiles property should equal to 1",
+                (boolean) executeScript("return arguments[0].maxFiles === 1",
+                        upload));
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
@@ -31,7 +31,6 @@ public class SwitchReceiversIT extends AbstractUploadIT {
     public void init() {
         open();
         upload = $(UploadElement.class).first();
-        waitUntil(_driver -> upload.isDisplayed());
     }
 
     @Test

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.upload;
 
-import java.awt.geom.Arc2D;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -35,8 +34,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.dom.DomEventListener;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonSerializer;

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.upload;
 
+import java.awt.geom.Arc2D;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.Arrays;

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -34,8 +34,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.dom.DomEventListener;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonSerializer;
@@ -616,10 +616,11 @@ public class Upload extends Component implements HasSize, HasStyle {
      */
     public void setReceiver(Receiver receiver) {
         this.receiver = receiver;
-        if (!(receiver instanceof MultiFileReceiver)) {
-            setMaxFiles(1);
+        if (receiver instanceof MultiFileReceiver) {
+            getElement().removeProperty("maxFiles");
+            getElement().executeJs("this.maxFiles = Infinity");
         } else {
-            getElement().removeAttribute("maxFiles");
+            setMaxFiles(1);
         }
     }
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
@@ -3,6 +3,10 @@ package com.vaadin.flow.component.upload.tests;
 import com.vaadin.flow.component.upload.Upload;
 
 import org.junit.Test;
+import org.junit.Assert;
+
+import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
+import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
 
 public class UploadTest {
 
@@ -10,5 +14,19 @@ public class UploadTest {
     public void uploadNewUpload() {
         // Test no NPE due missing UI when setAttribute is called.
         Upload upload = new Upload();
+    }
+
+    @Test
+    public void switchBetweenSingleAndMultiFileReceiver_assertMaxFilesProperty() {
+        Upload upload = new Upload();
+
+        upload.setReceiver(new MemoryBuffer());
+        Assert.assertEquals(1, upload.getElement().getProperty("maxFiles", 0));
+
+        upload.setReceiver(new MultiFileMemoryBuffer());
+        Assert.assertNull(upload.getElement().getProperty("maxFiles"));
+
+        upload.setReceiver(new MemoryBuffer());
+        Assert.assertEquals(1, upload.getElement().getProperty("maxFiles", 0));
     }
 }


### PR DESCRIPTION
## Description

Fixes an issue where the user was unable to select more than one file after switching from a single-file receiver to a multi-file one. It was because the Flow component didn't set the `maxFiles` client-side property to `Infinity` – the web component's default value for that property – when a multi-file receiver was set.

Fixes https://github.com/vaadin/flow-components/issues/6227

## Type of change

- [x] Bugfix
