### PR TITLE
fix: prevent potential deserialization issue in LitRenderer

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLitRendererSerializationPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLitRendererSerializationPage.java
@@ -83,7 +83,6 @@ public class GridLitRendererSerializationPage extends Div {
             in.readObject();
         } catch (IOException | ClassNotFoundException | ClassCastException ex) {
             exceptionMessageSpan.setText(ex.getMessage());
-            ex.printStackTrace();
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLitRendererSerializationPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLitRendererSerializationPage.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/lit-renderer-serialization")
+public class GridLitRendererSerializationPage extends Div {
+
+    public static class Data implements Serializable {
+        private Integer number;
+
+        public Data(Integer number) {
+            this.number = number;
+        }
+
+        public Integer getNumber() {
+            return number;
+        }
+
+        public String getNumberAsString() {
+            return String.valueOf(number);
+        }
+
+    }
+
+    private Span exceptionMessageSpan;
+
+    public GridLitRendererSerializationPage() {
+        Grid<Data> grid = new Grid<>(Data.class, true);
+        grid.addColumn(new TextRenderer<>(d -> String.valueOf(d.number * 100)))
+                .setHeader("R1");
+        grid.addColumn(new TextRenderer<>(d -> String.valueOf(d.number * 100)))
+                .setHeader("R2");
+
+        NativeButton serializeAndDeserializeUiButton = new NativeButton(
+                "Serialize&Deserialize UI");
+        serializeAndDeserializeUiButton
+                .addClickListener(event -> serializeAndDeserialize());
+        serializeAndDeserializeUiButton.setId("serialize-and-deserialize-ui");
+
+        exceptionMessageSpan = new Span();
+        exceptionMessageSpan.setId("exception-message-span");
+
+        add(grid, exceptionMessageSpan, serializeAndDeserializeUiButton);
+    }
+
+    private void serializeAndDeserialize() {
+        ByteArrayOutputStream bs = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bs)) {
+            out.writeObject(UI.getCurrent());
+        } catch (IOException ex) {
+            exceptionMessageSpan.setText(ex.getMessage());
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bs.toByteArray()))) {
+            in.readObject();
+        } catch (IOException | ClassNotFoundException | ClassCastException ex) {
+            exceptionMessageSpan.setText(ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridLitRendererSerializationIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridLitRendererSerializationIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/lit-renderer-serialization")
+public class GridLitRendererSerializationIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.tagName("vaadin-grid"));
+    }
+
+    @Test
+    public void serializeAndDeserializeUi_noExceptionIsThrown() {
+        $("button").id("serialize-and-deserialize-ui").click();
+        Assert.assertEquals("",
+                $("span").id("exception-message-span").getText());
+    }
+
+}


### PR DESCRIPTION
## Description

When a LitRenderer is used in a Grid, it may happen that UI deserialization fails because of a self-reference lambda caused by the DataGenerator instance provided by LitRenderer and store into the Grid CompositeDataGenerator.
Using an anonymous class instead of a lambda expression fixes the issues.

Fixes #6256

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
