### PR TITLE
feat: make MessageInput implement Focusable

### DIFF
--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageInput.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -49,8 +50,8 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/message-input/src/vaadin-message-input.js")
 @NpmPackage(value = "@vaadin/message-input", version = "24.5.0-alpha3")
-public class MessageInput extends Component
-        implements HasSize, HasStyle, HasEnabled, HasTooltip {
+public class MessageInput extends Component implements Focusable<MessageInput>,
+        HasSize, HasStyle, HasEnabled, HasTooltip {
 
     private MessageInputI18n i18n;
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.messages.MessageInput;
 import com.vaadin.flow.component.messages.MessageInputI18n;
 import com.vaadin.flow.component.shared.HasTooltip;
@@ -73,5 +74,11 @@ public class MessageInputTest {
     @Test
     public void implementsHasTooltip() {
         Assert.assertTrue(messageInput instanceof HasTooltip);
+    }
+
+    @Test
+    public void implementsFocusable() {
+        Assert.assertTrue("MessageInput should be focusable",
+                Focusable.class.isAssignableFrom(messageInput.getClass()));
     }
 }


### PR DESCRIPTION
## Description

Fixes #6243

Note: this will only make `focus()` work once https://github.com/vaadin/web-components/pull/7364 is released.

Also, there will be problems with `addFocusListener` like the one we have in `DateTimePicker`, see #2284

## Type of change

- Feature