### PR TITLE
docs: improve JavaDoc of TestBench setValue method

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -40,7 +40,7 @@ public class BigDecimalFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -34,7 +34,7 @@ public class BigDecimalFieldElement extends TestBenchElement
 
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -36,7 +36,7 @@ public class BigDecimalFieldElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -33,9 +33,14 @@ public class BigDecimalFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code input} element to the given value and then
-     * triggering {@code input}, {@code change} and {@code focusout} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -33,11 +33,10 @@ public class BigDecimalFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -33,14 +33,14 @@ public class BigDecimalFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -40,7 +40,7 @@ public class BigDecimalFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -33,9 +33,14 @@ public class EmailFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code input} element to the given value and then
-     * triggering {@code input}, {@code change} and {@code focusout} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -36,7 +36,7 @@ public class EmailFieldElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -34,7 +34,7 @@ public class EmailFieldElement extends TestBenchElement
 
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -33,11 +33,10 @@ public class EmailFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -40,7 +40,7 @@ public class EmailFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -33,14 +33,14 @@ public class EmailFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -40,7 +40,7 @@ public class EmailFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -42,9 +42,9 @@ public class IntegerFieldElement extends TestBenchElement
      * field's value updated. If you want to simulate real user input with the
      * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      * <p>
-     * Note, this method doesn't support values that aren't parsable into an
-     * integer. To enter such values, use {@link #sendKeys(CharSequence...)}
-     * instead.
+     * WARNING: Setting values that aren't parsable into an integer isn't
+     * supported. If you need to enter such values e.g. to test the validation
+     * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -40,7 +40,7 @@ public class IntegerFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      * <p>
      * WARNING: Setting values that aren't parsable into an integer is not
      * supported. If you need to enter such values e.g. to test the validation

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -36,7 +36,7 @@ public class IntegerFieldElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -33,11 +33,10 @@ public class IntegerFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -33,9 +33,18 @@ public class IntegerFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code input} element to the given value and then
-     * triggering {@code input}, {@code change} and {@code focusout} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get
+     * the field's value updated. If you want to simulate real user input with
+     * the keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * <p>
+     * Note, this method doesn't support values that aren't parsable into an
+     * integer. To enter such values, use {@link #sendKeys(CharSequence...)}
+     * instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -38,9 +38,9 @@ public class IntegerFieldElement extends TestBenchElement
      * then triggers {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get
-     * the field's value updated. If you want to simulate real user input with
-     * the keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      * <p>
      * Note, this method doesn't support values that aren't parsable into an
      * integer. To enter such values, use {@link #sendKeys(CharSequence...)}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -40,7 +40,7 @@ public class IntegerFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
      * WARNING: Setting values that aren't parsable into an integer is not
      * supported. If you need to enter such values e.g. to test the validation

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -41,8 +41,8 @@ public class IntegerFieldElement extends TestBenchElement
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
-     * WARNING: Setting values that aren't parsable into an integer is not
-     * supported. If you need to enter such values e.g. to test the validation
+     * WARNING: This method does not support values that aren't parsable into an
+     * integer. If you need to enter such values e.g. to test the validation
      * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -33,14 +33,14 @@ public class IntegerFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
      * WARNING: Setting values that aren't parsable into an integer is not
      * supported. If you need to enter such values e.g. to test the validation

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -42,7 +42,7 @@ public class IntegerFieldElement extends TestBenchElement
      * field's value updated. If you want to simulate real user input with the
      * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      * <p>
-     * WARNING: Setting values that aren't parsable into an integer isn't
+     * WARNING: Setting values that aren't parsable into an integer is not
      * supported. If you need to enter such values e.g. to test the validation
      * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -34,7 +34,7 @@ public class IntegerFieldElement extends TestBenchElement
 
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -42,9 +42,9 @@ public class NumberFieldElement extends TestBenchElement
      * field's value updated. If you want to simulate real user input with the
      * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      * <p>
-     * Note, this method doesn't support values that aren't parsable into an
-     * integer. To enter such values, use {@link #sendKeys(CharSequence...)}
-     * instead.
+     * WARNING: Setting values that aren't parsable into an integer isn't
+     * supported. If you need to enter such values e.g. to test the validation
+     * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -33,9 +33,18 @@ public class NumberFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code input} element to the given value and then
-     * triggering {@code input}, {@code change} and {@code focusout} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * <p>
+     * Note, this method doesn't support values that aren't parsable into an
+     * integer. To enter such values, use {@link #sendKeys(CharSequence...)}
+     * instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -36,7 +36,7 @@ public class NumberFieldElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -40,7 +40,7 @@ public class NumberFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      * <p>
      * WARNING: Setting values that aren't parsable into a number is not
      * supported. If you need to enter such values e.g. to test the validation

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -33,11 +33,10 @@ public class NumberFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -41,8 +41,8 @@ public class NumberFieldElement extends TestBenchElement
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
-     * WARNING: Setting values that aren't parsable into a number is not
-     * supported. If you need to enter such values e.g. to test the validation
+     * WARNING: This method does not support values that aren't parsable into a
+     * number. If you need to enter such values e.g. to test the validation
      * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -42,7 +42,7 @@ public class NumberFieldElement extends TestBenchElement
      * field's value updated. If you want to simulate real user input with the
      * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      * <p>
-     * WARNING: Setting values that aren't parsable into an integer isn't
+     * WARNING: Setting values that aren't parsable into a number is not
      * supported. If you need to enter such values e.g. to test the validation
      * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -34,7 +34,7 @@ public class NumberFieldElement extends TestBenchElement
 
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -33,16 +33,16 @@ public class NumberFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
-     * WARNING: Setting values that aren't parsable into a number is not
+     * WARNING: Setting values that aren't parsable into an integer is not
      * supported. If you need to enter such values e.g. to test the validation
      * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -40,7 +40,7 @@ public class NumberFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
      * WARNING: Setting values that aren't parsable into a number is not
      * supported. If you need to enter such values e.g. to test the validation

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -41,7 +41,7 @@ public class NumberFieldElement extends TestBenchElement
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.
      * <p>
-     * WARNING: Setting values that aren't parsable into an integer is not
+     * WARNING: Setting values that aren't parsable into a number is not
      * supported. If you need to enter such values e.g. to test the validation
      * workflow, use {@link #sendKeys(CharSequence...)} instead.
      *

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -56,11 +56,10 @@ public class PasswordFieldElement extends TestBenchElement
     }
 
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -63,7 +63,7 @@ public class PasswordFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -56,9 +56,14 @@ public class PasswordFieldElement extends TestBenchElement
     }
 
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code input} element to the given value and then
-     * triggering {@code input}, {@code change} and {@code focusout} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -63,7 +63,7 @@ public class PasswordFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -56,14 +56,14 @@ public class PasswordFieldElement extends TestBenchElement
     }
 
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -59,7 +59,7 @@ public class PasswordFieldElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -57,7 +57,7 @@ public class PasswordFieldElement extends TestBenchElement
 
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -32,9 +32,14 @@ import com.vaadin.testbench.elementsbase.Element;
 public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code textarea} element to the given value and then
-     * triggering {@code input} and {@code change} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -33,7 +33,7 @@ public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -35,7 +35,7 @@ public class TextAreaElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -39,7 +39,7 @@ public class TextAreaElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -39,7 +39,7 @@ public class TextAreaElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -32,11 +32,10 @@ import com.vaadin.testbench.elementsbase.Element;
 public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -32,14 +32,14 @@ import com.vaadin.testbench.elementsbase.Element;
 public class TextAreaElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -40,7 +40,7 @@ public class TextFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -40,7 +40,7 @@ public class TextFieldElement extends TestBenchElement
      * <p>
      * This method is intended for basic cases where you just need to get the
      * field's value updated. If you want to simulate real user input with the
-     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
+     * keyboard, use {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -34,7 +34,7 @@ public class TextFieldElement extends TestBenchElement
 
     /**
      * Emulates the user setting the value. This triggers server value change
-     * listeners and validation. The emulation is done by updating the value
+     * listeners and validation. The emulation is done by setting the value
      * property of the input element to the given value and then triggering
      * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -36,7 +36,7 @@ public class TextFieldElement extends TestBenchElement
      * Emulates the user setting the value. This triggers server value change
      * listeners and validation. The emulation is done by updating the value
      * property of the input element to the given value and then triggering
-     * {@code input}, {@code change}, and {@code focusout} DOM events.
+     * synthetic {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -33,14 +33,14 @@ public class TextFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter. In practice, this
-     * updates the value property of the input element to the given value and
-     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * Emulates the user setting the value and pressing Enter, which triggers
+     * server value change listeners and validation. The emulation is done by
+     * updating the value property of the input element to the given value and
+     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
      * events.
      * <p>
-     * This method is intended for basic cases where you just need to get the
-     * field's value updated. If you want to simulate real user input with the
-     * keyboard, use {@link #sendKeys(CharSequence...)} instead.
+     * For more complex scenarios that require a full browser simulation of
+     * typing, use {@link #sendKeys(CharSequence...)} instead.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -33,9 +33,14 @@ public class TextFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user changing the value, which in practice means setting
-     * {@code value} of the {@code input} element to the given value and then
-     * triggering {@code input}, {@code change} and {@code focusout} DOM events.
+     * Emulates the user setting the value and pressing Enter. In practice, this
+     * updates the value property of the input element to the given value and
+     * then triggers {@code input}, {@code keydown}, and {@code change} DOM
+     * events.
+     * <p>
+     * This method is intended for basic cases where you just need to get the
+     * field's value updated. If you want to simulate real user input with the
+     * keyboard, consider using {@link #sendKeys(CharSequence...)}.
      *
      * @param string
      *            the value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -33,11 +33,10 @@ public class TextFieldElement extends TestBenchElement
         implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
-     * Emulates the user setting the value and pressing Enter, which triggers
-     * server value change listeners and validation. The emulation is done by
-     * updating the value property of the input element to the given value and
-     * then triggering {@code input}, {@code keydown}, and {@code change} DOM
-     * events.
+     * Emulates the user setting the value. This triggers server value change
+     * listeners and validation. The emulation is done by updating the value
+     * property of the input element to the given value and then triggering
+     * {@code input}, {@code change}, and {@code focusout} DOM events.
      * <p>
      * For more complex scenarios that require a full browser simulation of
      * typing, use {@link #sendKeys(CharSequence...)} instead.

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
@@ -9,16 +9,9 @@ class TextFieldElementHelper {
         element.setProperty("value", value);
         element.dispatchEvent("input",
                 Collections.singletonMap("bubbles", true));
-
-        element.getCommandExecutor().executeScript("""
-                const event = new CustomEvent('keydown', { bubbles: true });
-                event.key = 'Enter';
-                event.code = 'Enter';
-                event.keyCode = 13;
-                arguments[0].dispatchEvent(event);
-                """, element);
-
         element.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+        element.dispatchEvent("focusout",
                 Collections.singletonMap("bubbles", true));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
@@ -13,6 +13,7 @@ class TextFieldElementHelper {
         element.getCommandExecutor().executeScript("""
                 const event = new CustomEvent('keydown', { bubbles: true });
                 event.key = 'Enter';
+                event.code = 'Enter';
                 event.keyCode = 13;
                 arguments[0].dispatchEvent(event);
                 """, element);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElementHelper.java
@@ -9,9 +9,15 @@ class TextFieldElementHelper {
         element.setProperty("value", value);
         element.dispatchEvent("input",
                 Collections.singletonMap("bubbles", true));
+
+        element.getCommandExecutor().executeScript("""
+                const event = new CustomEvent('keydown', { bubbles: true });
+                event.key = 'Enter';
+                event.keyCode = 13;
+                arguments[0].dispatchEvent(event);
+                """, element);
+
         element.dispatchEvent("change",
-                Collections.singletonMap("bubbles", true));
-        element.dispatchEvent("focusout",
                 Collections.singletonMap("bubbles", true));
     }
 }


### PR DESCRIPTION
## Description

The PR aims to improve the JavaDoc of the TestBench `setValue` method by mentioning
- that the events it fires are synthetic
- that sendKeys should be used for more complex scenarios
- that  sendKeys should be used when needing to enter unparsable values to test the validation workflow

Related to https://github.com/vaadin/flow-components/pull/6138

## Type of change

- [x] Docs
