### PR TITLE
fix!: throw when setting value that is not present in key mapper

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -352,8 +352,8 @@ public class CheckboxGroup<T>
                     item -> Objects.equals(getItemId(item.item), otherItemId))
                     .findFirst().ifPresent(this::updateCheckbox);
         } else {
-            keyMapper.removeAll();
             selectionPreservationHandler.handleDataChange(dataChangeEvent);
+            keyMapper.removeAll();
             rebuild();
         }
     }
@@ -424,6 +424,12 @@ public class CheckboxGroup<T>
         Objects.requireNonNull(value,
                 "Cannot set a null value to checkbox group. "
                         + "Use the clear-method to reset the component's value to an empty set.");
+
+        if (value.stream().anyMatch(item -> !keyMapper.has(item))) {
+            throw new IllegalArgumentException(
+                    "Value must be one of the items in CheckboxGroup");
+        }
+
         super.setValue(value);
         refreshCheckboxes();
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -523,8 +523,8 @@ public class CheckboxGroupTest {
         Assert.assertArrayEquals(new long[] { 2L }, selectedIds);
     }
 
-    @Test
-    public void setIdentifierProviderOnId_setItemWithNullId_shouldFailToSelectExistingItemById() {
+    @Test(expected = IllegalArgumentException.class)
+    public void setIdentifierProviderOnId_setItemWithNullId_throws() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -540,8 +540,6 @@ public class CheckboxGroupTest {
 
         checkboxGroup
                 .setValue(Collections.singleton(new CustomItem(null, "First")));
-        Assert.assertNull(checkboxGroup.getSelectedItems().stream().findFirst()
-                .get().getId());
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -84,7 +84,7 @@ public class RadioButtonGroup<T>
         HasThemeVariant<RadioGroupVariant>, HasValidationProperties,
         HasValidator<T>, SingleSelect<RadioButtonGroup<T>, T> {
 
-    private final KeyMapper<T> keyMapper = new KeyMapper<>();
+    private final KeyMapper<T> keyMapper = new KeyMapper<>(this::getItemId);
 
     private final AtomicReference<DataProvider<T, ?>> dataProvider = new AtomicReference<>(
             DataProvider.ofItems());
@@ -121,6 +121,9 @@ public class RadioButtonGroup<T>
 
     private static <T> String modelToPresentation(
             RadioButtonGroup<T> radioButtonGroup, T model) {
+        if (model == null) {
+            return "";
+        }
         if (!radioButtonGroup.keyMapper.has(model)) {
             return null;
         }
@@ -374,6 +377,11 @@ public class RadioButtonGroup<T>
 
     @Override
     public void setValue(T value) {
+        if (value != null && !keyMapper.has(value)) {
+            throw new IllegalArgumentException(
+                    "Value must be one of the items in RadioButtonGroup");
+        }
+
         super.setValue(value);
         if (value == null) {
             getRadioButtons().forEach(rb -> rb.setChecked(false));

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -422,8 +422,8 @@ public class RadioButtonGroupTest {
                 radioButtonGroup.getValue().getId());
     }
 
-    @Test
-    public void setIdentifierProviderOnId_setItemWithNullId_shouldFailToSelectExistingItemById() {
+    @Test(expected = IllegalArgumentException.class)
+    public void setIdentifierProviderOnId_setItemWithNullId_throws() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -438,7 +438,6 @@ public class RadioButtonGroupTest {
         listDataView.setIdentifierProvider(CustomItem::getId);
 
         radioButtonGroup.setValue(new CustomItem(null, "First"));
-        Assert.assertNull(radioButtonGroup.getValue().getId());
     }
 
     @Test

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -830,6 +830,16 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         return getItemId(value1).equals(getItemId(value2));
     }
 
+    @Override
+    public void setValue(T value) {
+        if (value != null && !keyMapper.has(value)) {
+            throw new IllegalArgumentException(
+                    "Value must be one of the items in Select");
+        }
+
+        super.setValue(value);
+    }
+
     private void initConnector() {
         runBeforeClientResponse(ui -> {
             ui.getPage().executeJs(

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -772,8 +772,8 @@ public class SelectTest {
         Assert.assertEquals(Long.valueOf(2L), select.getValue().getId());
     }
 
-    @Test
-    public void setIdentifierProviderOnId_setItemWithNullId_shouldFailToSelectExistingItemById() {
+    @Test(expected = IllegalArgumentException.class)
+    public void setIdentifierProviderOnId_setItemWithNullId_throws() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -787,7 +787,6 @@ public class SelectTest {
         listDataView.setIdentifierProvider(CustomItem::getId);
 
         select.setValue(new CustomItem(null, "First"));
-        Assert.assertNull(select.getValue().getId());
     }
 
     @Test


### PR DESCRIPTION
## Description

Setting values that aren't present in the key mapper shouldn't be allowed, as they cannot be represented on the client-side.

Related to https://github.com/vaadin/flow/pull/19310

Fixes https://github.com/vaadin/flow-components/issues/6605

## Type of change

- [x] Bugfix
