### PR TITLE
test: ensure the combo-box overlay is visible in IT

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/dataview/AbstractItemCountComboBoxPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/dataview/AbstractItemCountComboBoxPage.java
@@ -116,6 +116,8 @@ public abstract class AbstractItemCountComboBoxPage extends VerticalLayout
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         comboBox.setOpened(true);
+        comboBox.getElement().executeJs(
+                "setTimeout(() => this.$.overlay._updateOverlayWidth())");
     }
 
     private void initNavigationLinks() {


### PR DESCRIPTION
## Description

Currently some ITs based on `AbstractItemCountComboBoxIT` open the ComboBox on `beforeEnter`. This causes a timing issue where the overlay is opened before the `vaadin-input-container` is rendered so the overlay has zero width.

## Type of change

- Test