### PR TITLE
chore: deprecate grid class name generator

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1052,7 +1052,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * @throws NullPointerException
          *             if {@code classNameGenerator} is {@code null}
          * @see Grid#setClassNameGenerator(SerializableFunction)
+         * @deprecated {@link #setPartNameGenerator} should be used instead.
          */
+        @Deprecated
         public Column<T> setClassNameGenerator(
                 SerializableFunction<T, String> classNameGenerator) {
             Objects.requireNonNull(classNameGenerator,
@@ -4166,7 +4168,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @throws NullPointerException
      *             if {@code classNameGenerator} is {@code null}
      * @see Column#setClassNameGenerator(SerializableFunction)
+     * @deprecated {@link #setPartNameGenerator} should be used instead.
      */
+    @Deprecated
     public void setClassNameGenerator(
             SerializableFunction<T, String> classNameGenerator) {
         Objects.requireNonNull(classNameGenerator,


### PR DESCRIPTION
## Description

Deprecate `grid.setClassNameGenerator` and `gridColumn.setClassNameGenerator` in favor of `setPartNameGenerator`.
The corresponding [web component API](https://github.com/vaadin/web-components/blob/4038b4c30136f9f929ca90df9ade35db231071d0/packages/grid/src/vaadin-grid-styling-mixin.js#L32) is already deprecated.

Even though we don't recommend it, the part names could also be used with shadow DOM style injection so the class names don't serve a purpose anymore.

Closes https://github.com/vaadin/flow-components/pull/6267

## Type of change

Documentation