### PR TITLE
feat: add API to set color options to RichTextEditor

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.richtexteditor;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -271,15 +272,19 @@ public class RichTextEditor
     }
 
     /**
-     * Gets the list of colors in HEX format used by the text color picker and
-     * background color picker controls of the text editor.
+     * Gets an unmodifiable list of colors in HEX format used by the text color
+     * picker and background color picker controls of the text editor.
+     * <p>
+     * Returns {@code null} by default, which means the web component shows a
+     * default color palette.
      *
      * @since 24.5
-     * @return the list of colors options
+     * @return an unmodifiable list of colors options
      */
     public List<String> getColorOptions() {
-        return JsonSerializer.toObjects(String.class,
+        List options = JsonSerializer.toObjects(String.class,
                 (JsonArray) getElement().getPropertyRaw("colorOptions"));
+        return Collections.unmodifiableList(options);
     }
 
     /**

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -271,8 +271,8 @@ public class RichTextEditor
     }
 
     /**
-     * Gets the list of colors used by the text color picker and background
-     * color picker controls of the text editor.
+     * Gets the list of colors in HEX format used by the text color picker and
+     * background color picker controls of the text editor.
      *
      * @since 24.5
      * @return the list of colors options
@@ -283,8 +283,8 @@ public class RichTextEditor
     }
 
     /**
-     * Sets the list of colors used by the text color picker and background
-     * color picker controls of the text editor.
+     * Sets the list of colors in HEX format to use by the text color picker and
+     * background color picker controls of the text editor.
      *
      * @since 24.5
      * @param colorOptions

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.richtexteditor;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 import com.vaadin.flow.component.AbstractSinglePropertyField;
@@ -35,6 +36,7 @@ import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.shared.Registration;
 
+import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
 /**
@@ -266,6 +268,32 @@ public class RichTextEditor
     @Synchronize(property = "value", value = "value-changed")
     private String getDeltaValue() {
         return getElement().getProperty("value");
+    }
+
+    /**
+     * Gets the list of colors used by the text color picker and background
+     * color picker controls of the text editor.
+     *
+     * @since 24.5
+     * @return the list of colors options
+     */
+    public List<String> getColorOptions() {
+        return JsonSerializer.toObjects(String.class,
+                (JsonArray) getElement().getPropertyRaw("colorOptions"));
+    }
+
+    /**
+     * Sets the list of colors used by the text color picker and background
+     * color picker controls of the text editor.
+     *
+     * @since 24.5
+     * @param colorOptions
+     *            the list of colors to set, not null
+     */
+    public void setColorOptions(List<String> colorOptions) {
+        Objects.requireNonNull(colorOptions, "Color options must not be null");
+        getElement().setPropertyJson("colorOptions",
+                JsonSerializer.toJson(colorOptions));
     }
 
     static String sanitize(String html) {

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorSanitizationTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorSanitizationTest.java
@@ -65,6 +65,24 @@ public class RichTextEditorSanitizationTest {
                 RichTextEditor.sanitize("<h3>Foo</h3>"));
     }
 
+    // Style group sanitization
+
+    @Test
+    public void sanitizeStyleColor_StyleColorPersist() {
+        Assert.assertEquals(
+                "<p><span style=\"color: rgb(230, 0, 0);\">Foo</span></p>",
+                RichTextEditor.sanitize(
+                        "<p><span style=\"color: rgb(230, 0, 0);\">Foo</span></p>"));
+    }
+
+    @Test
+    public void sanitizeStyleBackgroundColor_StyleBackgroundColorPersist() {
+        Assert.assertEquals(
+                "<p><span style=\"background-color: rgb(230, 0, 0);\">Foo</span></p>",
+                RichTextEditor.sanitize(
+                        "<p><span style=\"background-color: rgb(230, 0, 0);\">Foo</span></p>"));
+    }
+
     // Super - / Sub - scripts group sanitization
 
     @Test

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -11,7 +11,6 @@ package com.vaadin.flow.component.richtexteditor;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-import elemental.json.JsonArray;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -27,6 +26,8 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+
+import elemental.json.JsonArray;
 
 /**
  * Tests for the {@link RichTextEditor}.

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -10,6 +10,9 @@ package com.vaadin.flow.component.richtexteditor;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
+import elemental.json.JsonArray;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -229,5 +232,24 @@ public class RichTextEditorTest {
 
         RichTextEditor field = Component.from(element, RichTextEditor.class);
         Assert.assertEquals("foo", field.getElement().getPropertyRaw("value"));
+    }
+
+    @Test
+    public void setColorOptions_propertyIsUpdated() {
+        RichTextEditor rte = new RichTextEditor();
+        rte.setColorOptions(
+                List.of("#000000", "#0066cc", "#008a00", "#e60000"));
+        JsonArray jsonArray = (JsonArray) rte.getElement()
+                .getPropertyRaw("colorOptions");
+        Assert.assertEquals(4, jsonArray.length());
+    }
+
+    @Test
+    public void setColorOptions_getColorOptions() {
+        RichTextEditor rte = new RichTextEditor();
+        rte.setColorOptions(
+                List.of("#000000", "#0066cc", "#008a00", "#e60000"));
+        List<String> options = rte.getColorOptions();
+        Assert.assertEquals(4, options.size());
     }
 }


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/pull/7392

## Type of change

- Enhancement

## Note

Currently `getColorOptions()` doesn't return the default value of the corresponding web component property.
This could be probably workarounded by adding `notify: true` and using `@Synchronize` annotation.