### PR TITLE
fix: remove HasLabel interface from ListBoxElement

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
@@ -15,19 +15,18 @@
  */
 package com.vaadin.flow.component.listbox.testbench;
 
-import com.vaadin.testbench.HasLabel;
-
-import com.vaadin.testbench.HasSelectByText;
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.elementsbase.Element;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.HasSelectByText;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-list-box&gt;</code>
@@ -35,7 +34,7 @@ import java.util.stream.Stream;
  */
 @Element("vaadin-list-box")
 public class ListBoxElement extends TestBenchElement
-        implements HasLabel, HasSelectByText {
+        implements HasSelectByText {
 
     @Override
     public void selectByText(String text) {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.listbox.testbench;
 
-import com.vaadin.testbench.HasLabel;
-
 import com.vaadin.testbench.HasSelectByText;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;

--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
@@ -15,18 +15,19 @@
  */
 package com.vaadin.flow.component.listbox.testbench;
 
+import com.vaadin.testbench.HasLabel;
+
+import com.vaadin.testbench.HasSelectByText;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
-import com.vaadin.testbench.HasSelectByText;
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-list-box&gt;</code>


### PR DESCRIPTION
## Description

The PR removes HasLabel interface from ListBoxElement because ListBox doesn't support labels.

## Type of change

- [x] Bugfix
