### PR TITLE
docs: add note about 'em' unit on Column#setWidth javadoc

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -578,8 +578,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * <p>
          * Please note that using the {@code em} length unit is discouraged as
          * it might lead to misalignment issues if the header, body, and footer
-         * cells have different font sizes. Use {@code rem} instead, in case you
-         * need to use a relative to font size length unit.
+         * cells have different font sizes. Instead, use {@code rem} if you need
+         * a length unit relative to the font size.
          *
          * @see #setFlexGrow(int)
          *

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -575,6 +575,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         /**
          * Sets the width of this column as a CSS-string.
+         * <p>
+         * Please note that using the {@code em} length unit is discouraged as
+         * it might lead to misalignment issues if the header, body, and footer
+         * cells have different font sizes. Use {@code rem} instead, in case you
+         * need to use a relative to font size length unit.
          *
          * @see #setFlexGrow(int)
          *


### PR DESCRIPTION
## Description

Add a new paragraph to mention the issue of using `em` length unit in columns width.

Part of #6260
