### PR TITLE
refactor(ValidationUtil): add methods accepting error message, deprecate old ones

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -346,7 +346,8 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
     private boolean isInvalid(Boolean value) {
         boolean isRequired = isRequiredIndicatorVisible();
         ValidationResult requiredValidation = ValidationUtil
-                .checkRequired(isRequired, value, getEmptyValue());
+                .validateRequiredConstraint("", isRequired, value,
+                        getEmptyValue());
 
         return requiredValidation.isError();
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -908,9 +908,8 @@ public class CheckboxGroup<T>
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isRequired = isRequiredIndicatorVisible();
-            boolean isInvalid = ValidationUtil
-                    .checkRequired(isRequired, getValue(), getEmptyValue())
-                    .isError();
+            boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
+                    isRequired, getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -1139,9 +1139,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isRequired = isRequiredIndicatorVisible();
-            boolean isInvalid = ValidationUtil
-                    .checkRequired(isRequired, getValue(), getEmptyValue())
-                    .isError();
+            boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
+                    isRequired, getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -548,12 +548,14 @@ public class DatePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult resultMax = ValidationUtil.checkMax("", value, max);
+        ValidationResult resultMax = ValidationUtil.validateMaxConstraint("",
+                value, max);
         if (resultMax.isError()) {
             return resultMax;
         }
 
-        ValidationResult resultMin = ValidationUtil.checkMin("", value, min);
+        ValidationResult resultMin = ValidationUtil.validateMinConstraint("",
+                value, min);
         if (resultMin.isError()) {
             return resultMin;
         }
@@ -567,8 +569,8 @@ public class DatePicker
      * constraints using browser development tools.
      */
     private boolean isInvalid(LocalDate value) {
-        var requiredValidation = ValidationUtil.checkRequired("", required,
-                value, getEmptyValue());
+        var requiredValidation = ValidationUtil.validateRequiredConstraint("",
+                required, value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -548,14 +548,14 @@ public class DatePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult greaterThanMax = ValidationUtil
-                .checkGreaterThanMax(value, max);
+        ValidationResult greaterThanMax = ValidationUtil.checkGreaterThanMax("",
+                value, max);
         if (greaterThanMax.isError()) {
             return greaterThanMax;
         }
 
-        ValidationResult smallerThanMin = ValidationUtil
-                .checkSmallerThanMin(value, min);
+        ValidationResult smallerThanMin = ValidationUtil.checkSmallerThanMin("",
+                value, min);
         if (smallerThanMin.isError()) {
             return smallerThanMin;
         }
@@ -569,8 +569,8 @@ public class DatePicker
      * constraints using browser development tools.
      */
     private boolean isInvalid(LocalDate value) {
-        var requiredValidation = ValidationUtil.checkRequired(required, value,
-                getEmptyValue());
+        var requiredValidation = ValidationUtil.checkRequired("", required,
+                value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -548,16 +548,14 @@ public class DatePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult greaterThanMax = ValidationUtil.checkGreaterThanMax("",
-                value, max);
-        if (greaterThanMax.isError()) {
-            return greaterThanMax;
+        ValidationResult resultMax = ValidationUtil.checkMax("", value, max);
+        if (resultMax.isError()) {
+            return resultMax;
         }
 
-        ValidationResult smallerThanMin = ValidationUtil.checkSmallerThanMin("",
-                value, min);
-        if (smallerThanMin.isError()) {
-            return smallerThanMin;
+        ValidationResult resultMin = ValidationUtil.checkMin("", value, min);
+        if (resultMin.isError()) {
+            return resultMin;
         }
 
         return ValidationResult.ok();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -771,14 +771,14 @@ public class DateTimePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult greaterThanMax = ValidationUtil
-                .checkGreaterThanMax(value, max);
+        ValidationResult greaterThanMax = ValidationUtil.checkGreaterThanMax("",
+                value, max);
         if (greaterThanMax.isError()) {
             return greaterThanMax;
         }
 
-        ValidationResult smallerThanMin = ValidationUtil
-                .checkSmallerThanMin(value, min);
+        ValidationResult smallerThanMin = ValidationUtil.checkSmallerThanMin("",
+                value, min);
         if (smallerThanMin.isError()) {
             return smallerThanMin;
         }
@@ -792,8 +792,8 @@ public class DateTimePicker
      * @return the current validity of the value.
      */
     private boolean isInvalid(LocalDateTime value) {
-        var requiredValidation = ValidationUtil.checkRequired(required, value,
-                getEmptyValue());
+        var requiredValidation = ValidationUtil.checkRequired("", required,
+                value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -771,16 +771,14 @@ public class DateTimePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult greaterThanMax = ValidationUtil.checkGreaterThanMax("",
-                value, max);
-        if (greaterThanMax.isError()) {
-            return greaterThanMax;
+        ValidationResult maxResult = ValidationUtil.checkMax("", value, max);
+        if (maxResult.isError()) {
+            return maxResult;
         }
 
-        ValidationResult smallerThanMin = ValidationUtil.checkSmallerThanMin("",
-                value, min);
-        if (smallerThanMin.isError()) {
-            return smallerThanMin;
+        ValidationResult minResult = ValidationUtil.checkMin("", value, min);
+        if (minResult.isError()) {
+            return minResult;
         }
 
         return ValidationResult.ok();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -771,12 +771,14 @@ public class DateTimePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult maxResult = ValidationUtil.checkMax("", value, max);
+        ValidationResult maxResult = ValidationUtil.validateMaxConstraint("",
+                value, max);
         if (maxResult.isError()) {
             return maxResult;
         }
 
-        ValidationResult minResult = ValidationUtil.checkMin("", value, min);
+        ValidationResult minResult = ValidationUtil.validateMinConstraint("",
+                value, min);
         if (minResult.isError()) {
             return minResult;
         }
@@ -790,8 +792,8 @@ public class DateTimePicker
      * @return the current validity of the value.
      */
     private boolean isInvalid(LocalDateTime value) {
-        var requiredValidation = ValidationUtil.checkRequired("", required,
-                value, getEmptyValue());
+        var requiredValidation = ValidationUtil.validateRequiredConstraint("",
+                required, value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -33,14 +33,14 @@ public class ValidationUtil {
      * empty error message depending on the result.
      *
      * @param <V>
-     *            the type of the component value
+     *            the type of the value
      * @param required
-     *            the required state of the component
+     *            whether the constraint is enabled
      * @param value
-     *            the current value set on the component
+     *            the value to check
      * @param emptyValue
-     *            the empty value for the component
-     * @return {@code ValidationResult.ok()} if the value is not empty,
+     *            the value considered to be empty
+     * @return {@code ValidationResult.ok()} if the value does not equal to the empty value,
      *         {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
      *             {@link #validateRequiredConstraint(String, boolean, Object, Object)}
@@ -58,16 +58,16 @@ public class ValidationUtil {
      * the given error message depending on the result.
      *
      * @param <V>
-     *            the type of the component value
+     *            the type of the value
      * @param errorMessage
      *            the error message to return if the check fails
      * @param required
-     *            the required state of the component
+     *            whether the constraint is enabled
      * @param value
-     *            the current value set on the component
+     *            the value to check
      * @param emptyValue
-     *            the empty value for the component
-     * @return {@code ValidationResult.ok()} if the value is not empty,
+     *            the value considered to be empty
+     * @return {@code ValidationResult.ok()} if the value does not equal to the empty value,
      *         {@code ValidationResult.error()} otherwise
      */
     public static <V> ValidationResult validateRequiredConstraint(
@@ -83,13 +83,13 @@ public class ValidationUtil {
      * empty error message depending on the result.
      *
      * @param <V>
-     *            the type of the component value
+     *            the type of the value
      * @param value
-     *            the current value set on the component
+     *            the value to check
      * @param maxValue
-     *            the maximum value set on the component
+     *            the maximum allowed value
      * @return {@code ValidationResult.ok()} if the value is smaller or equal to
-     *         the maximum, {@code ValidationResult.error()} otherwise
+     *         the maximum value, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
      *             {@link #validateMaxConstraint(String, Comparable, Comparable)}
      *             instead.
@@ -106,15 +106,15 @@ public class ValidationUtil {
      * the given error message depending on the result.
      *
      * @param <V>
-     *            the type of the component value
+     *            the type of the value
      * @param errorMessage
      *            the error message to return if the check fails
      * @param value
-     *            the current value set on the component
+     *            the value to check
      * @param maxValue
-     *            the maximum value set on the component
+     *            the maximum allowed value
      * @return {@code ValidationResult.ok()} if the value is smaller or equal to
-     *         the maximum, {@code ValidationResult.error()} otherwise
+     *         the maximum value, {@code ValidationResult.error()} otherwise
      */
     public static <V extends Comparable<V>> ValidationResult validateMaxConstraint(
             String errorMessage, V value, V maxValue) {
@@ -130,13 +130,13 @@ public class ValidationUtil {
      * empty error message depending on the result.
      *
      * @param <V>
-     *            the type of the component value
+     *            the type of the value
      * @param value
-     *            the current value set on the component
+     *            the value to check
      * @param minValue
-     *            the minimum value set on the component
+     *            the minimum allowed value
      * @return {@code ValidationResult.ok()} if the value is greater or equal to
-     *         the minimum, {@code ValidationResult.error()} otherwise
+     *         the minimum value, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
      *             {@link #validateMinConstraint(String, Comparable, Comparable)}
      *             instead.
@@ -153,15 +153,15 @@ public class ValidationUtil {
      * the given error message depending on the result.
      *
      * @param <V>
-     *            the type of the component value
+     *            the type of the value
      * @param errorMessage
      *            the error message to return if the check fails
      * @param value
-     *            the current value set on the component
+     *            the value to check
      * @param minValue
-     *            the minimum value set on the component
+     *            the minimum allowed value
      * @return {@code ValidationResult.ok()} if the value is greater or equal to
-     *         the minimum, {@code ValidationResult.error()} otherwise
+     *         the minimum value, {@code ValidationResult.error()} otherwise
      */
     public static <V extends Comparable<V>> ValidationResult validateMinConstraint(
             String errorMessage, V value, V minValue) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -28,72 +28,140 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks the required validation constraint
+     * Checks if the given value is empty and returns a ValidationResult with an
+     * empty error message if it is.
      *
+     * @param <V>
+     *            the type of the component value
      * @param required
      *            the required state of the component
      * @param value
      *            the current value set on the component
      * @param emptyValue
      *            the empty value for the component
-     * @return <code>Validation.ok()</code> if the validation passes,
-     *         <code>Validation.error()</code> otherwise
-     * @param <V>
-     *            the type of the component value
+     * @return {@code ValidationResult.ok()} if the validation passes,
+     *         {@code ValidationResult.error()} otherwise
+     * @deprecated since 24.5, use
+     *             {@link #checkRequired(String, boolean, Object, Object)}
+     *             instead.
      */
+    @Deprecated
     public static <V> ValidationResult checkRequired(boolean required, V value,
             V emptyValue) {
-        final boolean isRequiredButEmpty = required
-                && Objects.equals(emptyValue, value);
-        if (isRequiredButEmpty) {
-            return ValidationResult.error("");
-        }
-        return ValidationResult.ok();
+        return checkRequired("", required, value, emptyValue);
     }
 
     /**
-     * Checks if the value being set to the component is greater than the max
-     * value defined
+     * Checks if the given value is empty and returns a ValidationResult with
+     * the given error message if it is.
      *
+     * @param <V>
+     *            the type of the component value
+     * @param errorMessage
+     *            the error message to use if the validation fails
+     * @param required
+     *            the required state of the component
+     * @param value
+     *            the current value set on the component
+     * @param emptyValue
+     *            the empty value for the component
+     * @return {@code ValidationResult.ok()} if the validation passes,
+     *         {@code ValidationResult.error()} otherwise
+     */
+    public static <V> ValidationResult checkRequired(String errorMessage,
+            boolean required, V value, V emptyValue) {
+        boolean isError = required && Objects.equals(emptyValue, value);
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
+    }
+
+    /**
+     * Checks if the given value is greater than the maximum value and returns a
+     * ValidationResult with an empty error message if it is.
+     *
+     * @param <V>
+     *            the type of the component value
      * @param value
      *            the current value set on the component
      * @param maxValue
-     *            the max value set on the component
-     * @return <code>Validation.ok()</code> if the validation passes,
-     *         <code>Validation.error()</code> otherwise
-     * @param <V>
-     *            the type of the component value
+     *            the maximum value set on the component
+     * @return {@code ValidationResult.ok()} if the validation passes,
+     *         {@code ValidationResult.error()} otherwise
+     * @deprecated since 24.5, use
+     *            {@link #checkGreaterThanMax(String, Comparable, Comparable)}
+     *           instead.
      */
+    @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkGreaterThanMax(
             V value, V maxValue) {
-        final boolean isGreaterThanMax = value != null && maxValue != null
-                && value.compareTo(maxValue) > 0;
-        if (isGreaterThanMax) {
-            return ValidationResult.error("");
-        }
-        return ValidationResult.ok();
+        return checkGreaterThanMax("", value, maxValue);
     }
 
     /**
-     * Checks if the value being set to the component is smaller than the max
-     * value defined
+     * Checks if the given value is greater than the maximum value and returns a
+     * ValidationResult with an empty error message if it is.
      *
+     * @param <V>
+     *            the type of the component value
+     * @param errorMessage
+     *            the error message to use if the validation fails
+     * @param value
+     *            the current value set on the component
+     * @param maxValue
+     *            the maximum value set on the component
+     * @return {@code ValidationResult.ok()} if the validation passes,
+     *         {@code ValidationResult.error()} otherwise
+     */
+    public static <V extends Comparable<V>> ValidationResult checkGreaterThanMax(
+            String errorMessage, V value, V maxValue) {
+        boolean isError = value != null && maxValue != null
+                && value.compareTo(maxValue) > 0;
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
+    }
+
+    /**
+     * Checks if the given value is smaller than the minimum value and returns a
+     * ValidationResult with an empty error message if it is.
+     *
+     * @param <V>
+     *            the type of the component value
      * @param value
      *            the current value set on the component
      * @param minValue
-     *            the min value set on the component
-     * @return <code>Validation.ok()</code> if the validation passes,
-     *         <code>Validation.error()</code> otherwise
-     * @param <V>
-     *            the type of the component value
+     *            the minimum value set on the component
+     * @return {@code ValidationResult.ok()} if the validation passes,
+     *         {@code ValidationResult.error()} otherwise
+     * @deprecated since 24.5, use
+     *           {@link #checkSmallerThanMin(String, Comparable, Comparable)}
+     *          instead.
      */
+    @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkSmallerThanMin(
             V value, V minValue) {
-        final boolean isSmallerThanMin = value != null && minValue != null
+        return checkSmallerThanMin("", value, minValue);
+    }
+
+    /**
+     * Checks if the given value is smaller than the minimum value and returns a
+     * ValidationResult with an empty error message if it is.
+     *
+     * @param <V>
+     *            the type of the component value
+     * @param errorMessage
+     *            the error message to use if the validation fails
+     * @param value
+     *            the current value set on the component
+     * @param minValue
+     *            the minimum value set on the component
+     * @return {@code ValidationResult.ok()} if the validation passes,
+     *         {@code ValidationResult.error()} otherwise
+     */
+    public static <V extends Comparable<V>> ValidationResult checkSmallerThanMin(
+            String errorMessage, V value, V minValue) {
+        boolean isError = value != null && minValue != null
                 && value.compareTo(minValue) < 0;
-        if (isSmallerThanMin) {
-            return ValidationResult.error("");
-        }
-        return ValidationResult.ok();
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -37,7 +37,7 @@ public class ValidationUtil {
      * @param required
      *            whether the constraint is enabled
      * @param value
-     *            the value to check
+     *            the value to validate
      * @param emptyValue
      *            the value considered to be empty
      * @return {@code ValidationResult.ok()} if the value does not equal to the
@@ -64,7 +64,7 @@ public class ValidationUtil {
      * @param required
      *            whether the constraint is enabled
      * @param value
-     *            the value to check
+     *            the value to validate
      * @param emptyValue
      *            the value considered to be empty
      * @return {@code ValidationResult.ok()} if the value does not equal to the
@@ -85,7 +85,7 @@ public class ValidationUtil {
      * @param <V>
      *            the type of the value
      * @param value
-     *            the value to check
+     *            the value to validate
      * @param maxValue
      *            the maximum allowed value
      * @return {@code ValidationResult.ok()} if the value is smaller or equal to
@@ -110,7 +110,7 @@ public class ValidationUtil {
      * @param errorMessage
      *            the error message to return if the check fails
      * @param value
-     *            the value to check
+     *            the value to validate
      * @param maxValue
      *            the maximum allowed value
      * @return {@code ValidationResult.ok()} if the value is smaller or equal to
@@ -132,7 +132,7 @@ public class ValidationUtil {
      * @param <V>
      *            the type of the value
      * @param value
-     *            the value to check
+     *            the value to validate
      * @param minValue
      *            the minimum allowed value
      * @return {@code ValidationResult.ok()} if the value is greater or equal to
@@ -157,7 +157,7 @@ public class ValidationUtil {
      * @param errorMessage
      *            the error message to return if the check fails
      * @param value
-     *            the value to check
+     *            the value to validate
      * @param minValue
      *            the minimum allowed value
      * @return {@code ValidationResult.ok()} if the value is greater or equal to

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -43,13 +43,13 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the value is not empty,
      *         {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *             {@link #checkRequired(String, boolean, Object, Object)}
+     *             {@link #validateRequiredConstraint(String, boolean, Object, Object)}
      *             instead.
      */
     @Deprecated
     public static <V> ValidationResult checkRequired(boolean required, V value,
             V emptyValue) {
-        return checkRequired("", required, value, emptyValue);
+        return validateRequiredConstraint("", required, value, emptyValue);
     }
 
     /**
@@ -70,8 +70,8 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the value is not empty,
      *         {@code ValidationResult.error()} otherwise
      */
-    public static <V> ValidationResult checkRequired(String errorMessage,
-            boolean required, V value, V emptyValue) {
+    public static <V> ValidationResult validateRequiredConstraint(
+            String errorMessage, boolean required, V value, V emptyValue) {
         boolean isError = required && Objects.equals(emptyValue, value);
         return isError ? ValidationResult.error(errorMessage)
                 : ValidationResult.ok();
@@ -91,12 +91,13 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the value is smaller or equal to
      *         the maximum, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *             {@link #checkMax(String, Comparable, Comparable)} instead.
+     *             {@link #validateMaxConstraint(String, Comparable, Comparable)}
+     *             instead.
      */
     @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkGreaterThanMax(
             V value, V maxValue) {
-        return checkMax("", value, maxValue);
+        return validateMaxConstraint("", value, maxValue);
     }
 
     /**
@@ -115,7 +116,7 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the value is smaller or equal to
      *         the maximum, {@code ValidationResult.error()} otherwise
      */
-    public static <V extends Comparable<V>> ValidationResult checkMax(
+    public static <V extends Comparable<V>> ValidationResult validateMaxConstraint(
             String errorMessage, V value, V maxValue) {
         boolean isError = value != null && maxValue != null
                 && value.compareTo(maxValue) > 0;
@@ -137,12 +138,13 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the value is greater or equal to
      *         the minimum, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *             {@link #checkMin(String, Comparable, Comparable)} instead.
+     *             {@link #validateMinConstraint(String, Comparable, Comparable)}
+     *             instead.
      */
     @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkSmallerThanMin(
             V value, V minValue) {
-        return checkMin("", value, minValue);
+        return validateMinConstraint("", value, minValue);
     }
 
     /**
@@ -161,7 +163,7 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the value is greater or equal to
      *         the minimum, {@code ValidationResult.error()} otherwise
      */
-    public static <V extends Comparable<V>> ValidationResult checkMin(
+    public static <V extends Comparable<V>> ValidationResult validateMinConstraint(
             String errorMessage, V value, V minValue) {
         boolean isError = value != null && minValue != null
                 && value.compareTo(minValue) < 0;

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -88,8 +88,8 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the validation passes,
      *         {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *            {@link #checkGreaterThanMax(String, Comparable, Comparable)}
-     *           instead.
+     *             {@link #checkGreaterThanMax(String, Comparable, Comparable)}
+     *             instead.
      */
     @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkGreaterThanMax(
@@ -133,8 +133,8 @@ public class ValidationUtil {
      * @return {@code ValidationResult.ok()} if the validation passes,
      *         {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *           {@link #checkSmallerThanMin(String, Comparable, Comparable)}
-     *          instead.
+     *             {@link #checkSmallerThanMin(String, Comparable, Comparable)}
+     *             instead.
      */
     @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkSmallerThanMin(

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -28,8 +28,9 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks if the given value is empty and returns a ValidationResult with an
-     * empty error message if it is.
+     * Checks if the value satistifies the required constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with an
+     * empty error message depending on the result.
      *
      * @param <V>
      *            the type of the component value
@@ -39,7 +40,7 @@ public class ValidationUtil {
      *            the current value set on the component
      * @param emptyValue
      *            the empty value for the component
-     * @return {@code ValidationResult.ok()} if the validation passes,
+     * @return {@code ValidationResult.ok()} if the value is not empty,
      *         {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
      *             {@link #checkRequired(String, boolean, Object, Object)}
@@ -52,20 +53,21 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks if the given value is empty and returns a ValidationResult with
-     * the given error message if it is.
+     * Checks if the value satistifies the required constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
+     * the given error message depending on the result.
      *
      * @param <V>
      *            the type of the component value
      * @param errorMessage
-     *            the error message to use if the validation fails
+     *            the error message to return if the check fails
      * @param required
      *            the required state of the component
      * @param value
      *            the current value set on the component
      * @param emptyValue
      *            the empty value for the component
-     * @return {@code ValidationResult.ok()} if the validation passes,
+     * @return {@code ValidationResult.ok()} if the value is not empty,
      *         {@code ValidationResult.error()} otherwise
      */
     public static <V> ValidationResult checkRequired(String errorMessage,
@@ -76,8 +78,9 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks if the given value is greater than the maximum value and returns a
-     * ValidationResult with an empty error message if it is.
+     * Checks if the value satisfies the maximum value constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with an
+     * empty error message depending on the result.
      *
      * @param <V>
      *            the type of the component value
@@ -85,34 +88,34 @@ public class ValidationUtil {
      *            the current value set on the component
      * @param maxValue
      *            the maximum value set on the component
-     * @return {@code ValidationResult.ok()} if the validation passes,
-     *         {@code ValidationResult.error()} otherwise
+     * @return {@code ValidationResult.ok()} if the value is smaller or equal to
+     *         the maximum, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *             {@link #checkGreaterThanMax(String, Comparable, Comparable)}
-     *             instead.
+     *             {@link #checkMax(String, Comparable, Comparable)} instead.
      */
     @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkGreaterThanMax(
             V value, V maxValue) {
-        return checkGreaterThanMax("", value, maxValue);
+        return checkMax("", value, maxValue);
     }
 
     /**
-     * Checks if the given value is greater than the maximum value and returns a
-     * ValidationResult with an empty error message if it is.
+     * Checks if the value satisfies the maximum value constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
+     * the given error message depending on the result.
      *
      * @param <V>
      *            the type of the component value
      * @param errorMessage
-     *            the error message to use if the validation fails
+     *            the error message to return if the check fails
      * @param value
      *            the current value set on the component
      * @param maxValue
      *            the maximum value set on the component
-     * @return {@code ValidationResult.ok()} if the validation passes,
-     *         {@code ValidationResult.error()} otherwise
+     * @return {@code ValidationResult.ok()} if the value is smaller or equal to
+     *         the maximum, {@code ValidationResult.error()} otherwise
      */
-    public static <V extends Comparable<V>> ValidationResult checkGreaterThanMax(
+    public static <V extends Comparable<V>> ValidationResult checkMax(
             String errorMessage, V value, V maxValue) {
         boolean isError = value != null && maxValue != null
                 && value.compareTo(maxValue) > 0;
@@ -121,8 +124,9 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks if the given value is smaller than the minimum value and returns a
-     * ValidationResult with an empty error message if it is.
+     * Checks if the value satisfies the minimum value constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with an
+     * empty error message depending on the result.
      *
      * @param <V>
      *            the type of the component value
@@ -130,34 +134,34 @@ public class ValidationUtil {
      *            the current value set on the component
      * @param minValue
      *            the minimum value set on the component
-     * @return {@code ValidationResult.ok()} if the validation passes,
-     *         {@code ValidationResult.error()} otherwise
+     * @return {@code ValidationResult.ok()} if the value is greater or equal to
+     *         the minimum, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
-     *             {@link #checkSmallerThanMin(String, Comparable, Comparable)}
-     *             instead.
+     *             {@link #checkMin(String, Comparable, Comparable)} instead.
      */
     @Deprecated
     public static <V extends Comparable<V>> ValidationResult checkSmallerThanMin(
             V value, V minValue) {
-        return checkSmallerThanMin("", value, minValue);
+        return checkMin("", value, minValue);
     }
 
     /**
-     * Checks if the given value is smaller than the minimum value and returns a
-     * ValidationResult with an empty error message if it is.
+     * Checks if the value satisfies the minimum value constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
+     * the given error message depending on the result.
      *
      * @param <V>
      *            the type of the component value
      * @param errorMessage
-     *            the error message to use if the validation fails
+     *            the error message to return if the check fails
      * @param value
      *            the current value set on the component
      * @param minValue
      *            the minimum value set on the component
-     * @return {@code ValidationResult.ok()} if the validation passes,
-     *         {@code ValidationResult.error()} otherwise
+     * @return {@code ValidationResult.ok()} if the value is greater or equal to
+     *         the minimum, {@code ValidationResult.error()} otherwise
      */
-    public static <V extends Comparable<V>> ValidationResult checkSmallerThanMin(
+    public static <V extends Comparable<V>> ValidationResult checkMin(
             String errorMessage, V value, V minValue) {
         boolean isError = value != null && minValue != null
                 && value.compareTo(minValue) < 0;

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -40,8 +40,8 @@ public class ValidationUtil {
      *            the value to check
      * @param emptyValue
      *            the value considered to be empty
-     * @return {@code ValidationResult.ok()} if the value does not equal to the empty value,
-     *         {@code ValidationResult.error()} otherwise
+     * @return {@code ValidationResult.ok()} if the value does not equal to the
+     *         empty value, {@code ValidationResult.error()} otherwise
      * @deprecated since 24.5, use
      *             {@link #validateRequiredConstraint(String, boolean, Object, Object)}
      *             instead.
@@ -67,8 +67,8 @@ public class ValidationUtil {
      *            the value to check
      * @param emptyValue
      *            the value considered to be empty
-     * @return {@code ValidationResult.ok()} if the value does not equal to the empty value,
-     *         {@code ValidationResult.error()} otherwise
+     * @return {@code ValidationResult.ok()} if the value does not equal to the
+     *         empty value, {@code ValidationResult.error()} otherwise
      */
     public static <V> ValidationResult validateRequiredConstraint(
             String errorMessage, boolean required, V value, V emptyValue) {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -798,9 +798,8 @@ public class RadioButtonGroup<T>
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isRequired = isRequiredIndicatorVisible();
-            boolean isInvalid = ValidationUtil
-                    .checkRequired(isRequired, getValue(), getEmptyValue())
-                    .isError();
+            boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
+                    isRequired, getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -1027,9 +1027,8 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isRequired = this.isRequiredIndicatorVisible();
-            boolean isInvalid = ValidationUtil
-                    .checkRequired(isRequired, getValue(), getEmptyValue())
-                    .isError();
+            boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
+                    isRequired, getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -332,14 +332,14 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
         Double doubleValue = value != null ? value.doubleValue() : null;
 
-        ValidationResult maxResult = ValidationUtil.checkMax("", doubleValue,
-                max);
+        ValidationResult maxResult = ValidationUtil.validateMaxConstraint("",
+                doubleValue, max);
         if (maxResult.isError()) {
             return maxResult;
         }
 
-        ValidationResult minResult = ValidationUtil.checkMin("", doubleValue,
-                min);
+        ValidationResult minResult = ValidationUtil.validateMinConstraint("",
+                doubleValue, min);
         if (minResult.isError()) {
             return minResult;
         }
@@ -366,7 +366,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             T value = getValue();
 
             final var requiredValidation = ValidationUtil
-                    .checkRequired(required, value, getEmptyValue());
+                    .validateRequiredConstraint("", required, value,
+                            getEmptyValue());
 
             setInvalid(requiredValidation.isError()
                     || checkValidity(value).isError());

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -332,14 +332,14 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
         Double doubleValue = value != null ? value.doubleValue() : null;
 
-        ValidationResult greaterThanMax = ValidationUtil
-                .checkGreaterThanMax(doubleValue, max);
+        ValidationResult greaterThanMax = ValidationUtil.checkGreaterThanMax("",
+                doubleValue, max);
         if (greaterThanMax.isError()) {
             return greaterThanMax;
         }
 
-        ValidationResult smallerThanMin = ValidationUtil
-                .checkSmallerThanMin(doubleValue, min);
+        ValidationResult smallerThanMin = ValidationUtil.checkSmallerThanMin("",
+                doubleValue, min);
         if (smallerThanMin.isError()) {
             return smallerThanMin;
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -332,16 +332,16 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
         Double doubleValue = value != null ? value.doubleValue() : null;
 
-        ValidationResult greaterThanMax = ValidationUtil.checkGreaterThanMax("",
-                doubleValue, max);
-        if (greaterThanMax.isError()) {
-            return greaterThanMax;
+        ValidationResult maxResult = ValidationUtil.checkMax("", doubleValue,
+                max);
+        if (maxResult.isError()) {
+            return maxResult;
         }
 
-        ValidationResult smallerThanMin = ValidationUtil.checkSmallerThanMin("",
-                doubleValue, min);
-        if (smallerThanMin.isError()) {
-            return smallerThanMin;
+        ValidationResult minResult = ValidationUtil.checkMin("", doubleValue,
+                min);
+        if (minResult.isError()) {
+            return minResult;
         }
 
         if (!isValidByStep(value)) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -289,7 +289,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
             boolean isRequired = isRequiredIndicatorVisible();
             ValidationResult requiredValidation = ValidationUtil
-                    .checkRequired(isRequired, value, getEmptyValue());
+                    .validateRequiredConstraint("", isRequired, value,
+                            getEmptyValue());
 
             setInvalid(requiredValidation.isError()
                     || checkValidity(value).isError());

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldValidationSupport.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldValidationSupport.java
@@ -63,8 +63,8 @@ final class TextFieldValidationSupport implements Serializable {
      * @return <code>true</code> if the value is invalid.
      */
     boolean isInvalid(String value) {
-        var requiredValidation = ValidationUtil.checkRequired(required, value,
-                field.getEmptyValue());
+        var requiredValidation = ValidationUtil.checkRequired("", required,
+                value, field.getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldValidationSupport.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldValidationSupport.java
@@ -63,8 +63,8 @@ final class TextFieldValidationSupport implements Serializable {
      * @return <code>true</code> if the value is invalid.
      */
     boolean isInvalid(String value) {
-        var requiredValidation = ValidationUtil.checkRequired("", required,
-                value, field.getEmptyValue());
+        var requiredValidation = ValidationUtil.validateRequiredConstraint("",
+                required, value, field.getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -352,12 +352,14 @@ public class TimePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult maxResult = ValidationUtil.checkMax("", value, max);
+        ValidationResult maxResult = ValidationUtil.validateMaxConstraint("",
+                value, max);
         if (maxResult.isError()) {
             return maxResult;
         }
 
-        ValidationResult minResult = ValidationUtil.checkMin("", value, min);
+        ValidationResult minResult = ValidationUtil.validateMinConstraint("",
+                value, min);
         if (minResult.isError()) {
             return minResult;
         }
@@ -371,8 +373,8 @@ public class TimePicker
      * constraints using browser development tools.
      */
     private boolean isInvalid(LocalTime value) {
-        var requiredValidation = ValidationUtil.checkRequired("", required,
-                value, getEmptyValue());
+        var requiredValidation = ValidationUtil.validateRequiredConstraint("",
+                required, value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -352,16 +352,14 @@ public class TimePicker
             return ValidationResult.error("");
         }
 
-        ValidationResult greaterThanMaxValidation = ValidationUtil
-                .checkGreaterThanMax("", value, max);
-        if (greaterThanMaxValidation.isError()) {
-            return greaterThanMaxValidation;
+        ValidationResult maxResult = ValidationUtil.checkMax("", value, max);
+        if (maxResult.isError()) {
+            return maxResult;
         }
 
-        ValidationResult smallThanMinValidation = ValidationUtil
-                .checkSmallerThanMin("", value, min);
-        if (smallThanMinValidation.isError()) {
-            return smallThanMinValidation;
+        ValidationResult minResult = ValidationUtil.checkMin("", value, min);
+        if (minResult.isError()) {
+            return minResult;
         }
 
         return ValidationResult.ok();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -353,13 +353,13 @@ public class TimePicker
         }
 
         ValidationResult greaterThanMaxValidation = ValidationUtil
-                .checkGreaterThanMax(value, max);
+                .checkGreaterThanMax("", value, max);
         if (greaterThanMaxValidation.isError()) {
             return greaterThanMaxValidation;
         }
 
         ValidationResult smallThanMinValidation = ValidationUtil
-                .checkSmallerThanMin(value, min);
+                .checkSmallerThanMin("", value, min);
         if (smallThanMinValidation.isError()) {
             return smallThanMinValidation;
         }
@@ -373,8 +373,8 @@ public class TimePicker
      * constraints using browser development tools.
      */
     private boolean isInvalid(LocalTime value) {
-        var requiredValidation = ValidationUtil.checkRequired(required, value,
-                getEmptyValue());
+        var requiredValidation = ValidationUtil.checkRequired("", required,
+                value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }


### PR DESCRIPTION
## Description

- Added new methods `validateRequiredConstraint`, `validateMinConstraint` and `validateMaxConstraint` to `ValidationUtil`. They accept a string error message to return in the `ValidationResult` when the check fails.
- Deprecated the previous methods without an error message in favor of the new ones.

Part of https://github.com/vaadin/flow-components/issues/4618

## Type of change

- [x] Refactor
