### PR TITLE
refactor!: change DateTimePickerI18n methods to return this

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -426,16 +426,18 @@ public class DateTimePicker
             return dateLabel;
         }
 
-        public void setDateLabel(String dateLabel) {
+        public DateTimePickerI18n setDateLabel(String dateLabel) {
             this.dateLabel = dateLabel;
+            return this;
         }
 
         public String getTimeLabel() {
             return timeLabel;
         }
 
-        public void setTimeLabel(String timeLabel) {
+        public DateTimePickerI18n setTimeLabel(String timeLabel) {
             this.timeLabel = timeLabel;
+            return this;
         }
     }
 


### PR DESCRIPTION
## Description

The PR changes the return type of DateTimePickerI18n methods from `void` to `DateTimePickerI18n` to allow them to be chained, same as i18n methods in other components.

> [!WARNING]
>  It's marked as a behavior-altering change because there is a slight chance it could affect some custom extensions of DateTimePicker.

Part of #4618 

## Type of change

- [x] Refactor
