### PR TITLE
test: add a test for item click on edit column cell

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
@@ -45,6 +45,8 @@ public class MainView extends VerticalLayout {
         mapLists(personList, cityList);
         grid.setItems(personList);
 
+        grid.addItemClickListener(e -> eventsPanel
+                .add("ItemClicked - " + e.getItem().toString()));
         grid.addCellEditStartedListener(e -> eventsPanel
                 .add("CellEditStarted - " + e.getItem().toString()));
         grid.addItemPropertyChangedListener(e -> eventsPanel

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -146,6 +146,20 @@ public class BasicIT extends AbstractParallelTest {
     }
 
     @Test
+    public void itemClickListenerListenerCalledOnce() {
+        GridTHTDElement cell = grid.getCell(0, 2);
+        cell.click();
+
+        assertCellEnterEditModeOnDoubleClick(0, 2, "vaadin-combo-box");
+        String eventsPanelText = getPanelText("events-panel");
+        Assert.assertEquals(1, eventsPanelText.split("ItemClicked").length - 1);
+        Assert.assertTrue(eventsPanelText
+                .contains("Person{id=1, age=23, name='Person 1', "
+                        + "isSubscriber=false, email='person1@vaadin.com', "
+                        + "department=sales, city='City 1', employmentYear=2019}"));
+    }
+
+    @Test
     public void customComboBoxIsUsedForEditColumn() {
         assertCellEnterEditModeOnDoubleClick(0, 2, "vaadin-combo-box");
     }

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -150,7 +150,6 @@ public class BasicIT extends AbstractParallelTest {
         GridTHTDElement cell = grid.getCell(0, 2);
         cell.click();
 
-        assertCellEnterEditModeOnDoubleClick(0, 2, "vaadin-combo-box");
         String eventsPanelText = getPanelText("events-panel");
         Assert.assertEquals(1, eventsPanelText.split("ItemClicked").length - 1);
         Assert.assertTrue(eventsPanelText


### PR DESCRIPTION
## Description

Add a test case to verify https://github.com/vaadin/web-components/pull/7453 fixes the [item click listener regression](https://github.com/vaadin/web-components/issues/637#issuecomment-2133068801) in Grid Pro which manifested after [this addition](https://github.com/vaadin/flow-components/blob/62acdd978b3d1a6c04c7c836019c76e4d5d628cf/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts#L1128-L1131) to the grid connector.

Related to https://github.com/vaadin/web-components/issues/637

## Type of change

Tests