### PR TITLE
fix: run grid dnd filters on dropmode and draggable change

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
@@ -225,7 +225,7 @@ public class DragAndDropGridIT extends AbstractComponentIT {
 
         click("set-filters");
         click("BETWEEN");
-        fireDrop(0, "on-top");
+        fireDrop(0, "below");
         assertMessages("", "", "");
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
@@ -210,6 +210,26 @@ public class DragAndDropGridIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setDragFilter_setRowsDraggable_filtersApply() {
+        click("toggle-rows-draggable");
+
+        click("set-filters");
+        click("toggle-rows-draggable");
+        fireDragStart(0);
+        assertMessages("", "", "");
+    }
+
+    @Test
+    public void setDropFilter_setDropMode_filtersApply() {
+        click("no-drop-mode");
+
+        click("set-filters");
+        click("BETWEEN");
+        fireDrop(0, "on-top");
+        assertMessages("", "", "");
+    }
+
+    @Test
     public void removeOnItemClick_noError() {
         click("remove-on-item-click");
         grid.getCell("0").click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4532,6 +4532,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void setDropMode(GridDropMode dropMode) {
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
+        getDataCommunicator().reset();
     }
 
     /**
@@ -4556,6 +4557,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void setRowsDraggable(boolean rowsDraggable) {
         getElement().setProperty("rowsDraggable", rowsDraggable);
+        getDataCommunicator().reset();
     }
 
     /**


### PR DESCRIPTION
## Description

- Run `getDataCommunicator().reset();` when "drop mode" changes dynamically because the [drop filters only apply if drop mode is non-null](https://github.com/vaadin/flow-components/blob/836f59b092a52a1a01e08ddb9cc7f307659fe6cc/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java#L4314).
- Run `getDataCommunicator().reset();` when "rows draggable" changes dynamically because the [drag filters apply if the rows are draggable](https://github.com/vaadin/flow-components/blob/836f59b092a52a1a01e08ddb9cc7f307659fe6cc/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java#L4318).

Fixes https://github.com/vaadin/flow-components/issues/6310

## Type of change

Bugfix