### PR TITLE
feat: add i18n error message support for TextField

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -28,6 +28,11 @@ public interface HasValidationProperties extends HasElement, HasValidation {
 
     /**
      * Sets the error message to show to the user when the component is invalid.
+     * <p>
+     * NOTE: If you need to manually control error messages, consider enabling
+     * manual validation mode with {@link #setManualValidation(boolean)} to
+     * avoid conflicts between your custom validation and the component's
+     * built-in validation.
      *
      * @param errorMessage
      *            the error message or {@code null} to clear it
@@ -53,8 +58,8 @@ public interface HasValidationProperties extends HasElement, HasValidation {
      * <p>
      * NOTE: If you need to manually control the invalid state, consider
      * enabling manual validation mode with
-     * {@link #setManualValidation(boolean)} to avoid potential conflicts
-     * between your custom validation and the component's built-in validation.
+     * {@link #setManualValidation(boolean)} to avoid conflicts between your
+     * custom validation and the component's built-in validation.
      *
      * @param invalid
      *            {@code true} for invalid, {@code false} for valid

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -28,11 +28,6 @@ public interface HasValidationProperties extends HasElement, HasValidation {
 
     /**
      * Sets the error message to show to the user when the component is invalid.
-     * <p>
-     * NOTE: If you need to manually control error messages, consider enabling
-     * manual validation mode with {@link #setManualValidation(boolean)} to
-     * avoid conflicts between your custom validation and the component's
-     * built-in validation.
      *
      * @param errorMessage
      *            the error message or {@code null} to clear it
@@ -58,8 +53,8 @@ public interface HasValidationProperties extends HasElement, HasValidation {
      * <p>
      * NOTE: If you need to manually control the invalid state, consider
      * enabling manual validation mode with
-     * {@link #setManualValidation(boolean)} to avoid conflicts between your
-     * custom validation and the component's built-in validation.
+     * {@link #setManualValidation(boolean)} to avoid potential conflicts
+     * between your custom validation and the component's built-in validation.
      *
      * @param invalid
      *            {@code true} for invalid, {@code false} for valid

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -170,4 +170,72 @@ public class ValidationUtil {
         return isError ? ValidationResult.error(errorMessage)
                 : ValidationResult.ok();
     }
+
+    /**
+     * Checks if the value satisfies the minimum length constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
+     * the given error message depending on the result.
+     *
+     * @param errorMessage
+     *            the error message to return if the check fails
+     * @param value
+     *            the value to validate
+     * @param minLength
+     *            the minimum allowed length
+     * @return {@code ValidationResult.ok()} if the value is shorter than or
+     *         equal to the minimum length, {@code ValidationResult.error()}
+     *         otherwise
+     */
+    public static ValidationResult validateMinLengthConstraint(
+            String errorMessage, String value, Integer minLength) {
+        boolean isError = value != null && !value.isEmpty() && minLength != null
+                && value.length() < minLength;
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
+    }
+
+    /**
+     * Checks if the value satisfies the maximum length constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
+     * the given error message depending on the result.
+     *
+     * @param errorMessage
+     *            the error message to return if the check fails
+     * @param value
+     *            the value to validate
+     * @param maxLength
+     *            the maximum allowed length
+     * @return {@code ValidationResult.ok()} if the value is longer than or
+     *         equal to the minimum length, {@code ValidationResult.error()}
+     *         otherwise
+     */
+    public static ValidationResult validateMaxLengthConstraint(
+            String errorMessage, String value, Integer maxLength) {
+        boolean isError = value != null && maxLength != null
+                && value.length() > maxLength;
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
+    }
+
+    /**
+     * Checks if the value satisfies the pattern constraint and returns a
+     * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
+     * the given error message depending on the result.
+     *
+     * @param errorMessage
+     *            the error message to return if the check fails
+     * @param value
+     *            the value to validate
+     * @param pattern
+     *            the pattern to match
+     * @return {@code ValidationResult.ok()} if the value matches the pattern,
+     *         {@code ValidationResult.error()} otherwise
+     */
+    public static ValidationResult validatePatternConstraint(
+            String errorMessage, String value, String pattern) {
+        boolean isError = value != null && !value.isEmpty() && pattern != null
+                && !pattern.isEmpty() && !value.matches(pattern);
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
+    }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -182,7 +182,7 @@ public class ValidationUtil {
      *            the value to validate
      * @param minLength
      *            the minimum allowed length
-     * @return {@code ValidationResult.ok()} if the value is shorter than or
+     * @return {@code ValidationResult.ok()} if the value is longer than or
      *         equal to the minimum length, {@code ValidationResult.error()}
      *         otherwise
      */
@@ -205,8 +205,8 @@ public class ValidationUtil {
      *            the value to validate
      * @param maxLength
      *            the maximum allowed length
-     * @return {@code ValidationResult.ok()} if the value is longer than or
-     *         equal to the minimum length, {@code ValidationResult.error()}
+     * @return {@code ValidationResult.ok()} if the value is shorter than or
+     *         equal to the maximum length, {@code ValidationResult.error()}
      *         otherwise
      */
     public static ValidationResult validateMaxLengthConstraint(

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationPage.java
@@ -27,8 +27,19 @@ public class TextFieldBasicValidationPage
     public static final String MIN_LENGTH_INPUT = "min-length-input";
     public static final String MAX_LENGTH_INPUT = "max-length-input";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String MIN_LENGTH_ERROR_MESSAGE = "Value is too short";
+    public static final String MAX_LENGTH_ERROR_MESSAGE = "Value is too long";
+    public static final String PATTERN_ERROR_MESSAGE = "Value does not match the pattern";
+
     public TextFieldBasicValidationPage() {
         super();
+
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setMinLengthErrorMessage(MIN_LENGTH_ERROR_MESSAGE)
+                .setMaxLengthErrorMessage(MAX_LENGTH_ERROR_MESSAGE)
+                .setPatternErrorMessage(PATTERN_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationPage.java
@@ -28,8 +28,11 @@ public class TextFieldBinderValidationPage
     public static final String MAX_LENGTH_INPUT = "max-length-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String MIN_LENGTH_ERROR_MESSAGE = "Value is too short";
+    public static final String MAX_LENGTH_ERROR_MESSAGE = "Value is too long";
+    public static final String PATTERN_ERROR_MESSAGE = "Value does not match the pattern";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Value does not match the expected value";
 
     public static class Bean {
         private String property;
@@ -49,6 +52,11 @@ public class TextFieldBinderValidationPage
 
     public TextFieldBinderValidationPage() {
         super();
+
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setMinLengthErrorMessage(MIN_LENGTH_ERROR_MESSAGE)
+                .setMaxLengthErrorMessage(MAX_LENGTH_ERROR_MESSAGE)
+                .setPatternErrorMessage(PATTERN_ERROR_MESSAGE));
 
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
@@ -24,8 +24,12 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.MIN_LENGTH_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.MIN_LENGTH_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.MAX_LENGTH_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.PATTERN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.PATTERN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-text-field/validation/basic")
 public class TextFieldBasicValidationIT
@@ -34,6 +38,7 @@ public class TextFieldBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -42,6 +47,7 @@ public class TextFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -52,6 +58,7 @@ public class TextFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -62,11 +69,13 @@ public class TextFieldBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -77,16 +86,19 @@ public class TextFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_LENGTH_ERROR_MESSAGE);
 
         testField.setValue("AA");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("AAA");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -97,16 +109,19 @@ public class TextFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_LENGTH_ERROR_MESSAGE);
 
         testField.setValue("AA");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("A");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -117,11 +132,13 @@ public class TextFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         testField.setValue("1234");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationIT.java
@@ -26,6 +26,9 @@ import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBind
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.MIN_LENGTH_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.MAX_LENGTH_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.MIN_LENGTH_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.MAX_LENGTH_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.PATTERN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -45,6 +48,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -55,6 +59,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
@@ -73,7 +78,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_LENGTH_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("AA");
@@ -87,6 +92,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -99,7 +105,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_LENGTH_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("AA");
@@ -113,6 +119,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -125,7 +132,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("12");
@@ -139,6 +146,7 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBinderValidationIT.java
@@ -59,7 +59,6 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
-        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
@@ -92,7 +91,6 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-        assertErrorMessage("");
     }
 
     @Test
@@ -119,7 +117,6 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-        assertErrorMessage("");
     }
 
     @Test
@@ -146,7 +143,6 @@ public class TextFieldBinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
-        assertErrorMessage("");
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -446,7 +446,7 @@ public class TextField extends TextFieldBase<TextField, String>
 
         /**
          * Gets the error message displayed when the field value is shorter than
-         * the minimum length.
+         * the minimum allowed length.
          *
          * @return the error message or {@code null} if not set
          * @see TextField#getMinLength()
@@ -458,7 +458,7 @@ public class TextField extends TextFieldBase<TextField, String>
 
         /**
          * Sets the error message to display when the field value is shorter
-         * than the minimum length.
+         * than the minimum allowed length.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -473,7 +473,7 @@ public class TextField extends TextFieldBase<TextField, String>
 
         /**
          * Gets the error message displayed when the field value is longer than
-         * the maximum length.
+         * the maximum allowed length.
          *
          * @return the error message or {@code null} if not set
          * @see TextField#getMaxLength()
@@ -485,7 +485,7 @@ public class TextField extends TextFieldBase<TextField, String>
 
         /**
          * Sets the error message to display when the field value is longer than
-         * the maximum length.
+         * the maximum allowed length.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -367,20 +367,19 @@ public class TextField extends TextFieldBase<TextField, String>
      * <p>
      * NOTE: Updating the instance that is returned from this method will not
      * update the component if not set again using
-     * {@link TextField#setI18n(TextFieldI18n)}
+     * {@link #setI18n(TextFieldI18n)}
      *
-     * @return the i18n object. It will be {@code null}, If the i18n properties
-     *         weren't set.
+     * @return the i18n object or {@code null} if no i18n object has been set
      */
     public TextFieldI18n getI18n() {
         return i18n;
     }
 
     /**
-     * Sets the internationalization properties for this component.
+     * Sets the internationalization object for this component.
      *
      * @param i18n
-     *            the internationalized properties, not {@code null}
+     *            the i18n object, not {@code null}
      */
     public void setI18n(TextFieldI18n i18n) {
         this.i18n = Objects.requireNonNull(i18n,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
@@ -302,7 +303,9 @@ public class TextField extends TextFieldBase<TextField, String>
             boolean withRequiredValidator) {
         if (withRequiredValidator) {
             ValidationResult requiredResult = ValidationUtil
-                    .validateRequiredConstraint(getRequiredErrorMessage(),
+                    .validateRequiredConstraint(
+                            getI18nErrorMessage(
+                                    TextFieldI18n::getRequiredErrorMessage),
                             isRequiredIndicatorVisible(), value,
                             getEmptyValue());
             if (requiredResult.isError()) {
@@ -311,22 +314,28 @@ public class TextField extends TextFieldBase<TextField, String>
         }
 
         ValidationResult maxLengthResult = ValidationUtil
-                .validateMaxLengthConstraint(getMaxLengthErrorMessage(), value,
-                        hasMaxLength() ? getMaxLength() : null);
+                .validateMaxLengthConstraint(
+                        getI18nErrorMessage(
+                                TextFieldI18n::getMaxLengthErrorMessage),
+                        value, hasMaxLength() ? getMaxLength() : null);
         if (maxLengthResult.isError()) {
             return maxLengthResult;
         }
 
         ValidationResult minLengthResult = ValidationUtil
-                .validateMinLengthConstraint(getMinLengthErrorMessage(), value,
-                        getMinLength());
+                .validateMinLengthConstraint(
+                        getI18nErrorMessage(
+                                TextFieldI18n::getMinLengthErrorMessage),
+                        value, getMinLength());
         if (minLengthResult.isError()) {
             return minLengthResult;
         }
 
         ValidationResult patternResult = ValidationUtil
-                .validatePatternConstraint(getPatternErrorMessage(), value,
-                        getPattern());
+                .validatePatternConstraint(
+                        getI18nErrorMessage(
+                                TextFieldI18n::getPatternErrorMessage),
+                        value, getPattern());
         if (patternResult.isError()) {
             return patternResult;
         }
@@ -386,24 +395,8 @@ public class TextField extends TextFieldBase<TextField, String>
                 "The i18n properties object should not be null");
     }
 
-    private String getRequiredErrorMessage() {
-        return Optional.ofNullable(i18n)
-                .map(TextFieldI18n::getRequiredErrorMessage).orElse("");
-    }
-
-    private String getMinLengthErrorMessage() {
-        return Optional.ofNullable(i18n)
-                .map(TextFieldI18n::getMinLengthErrorMessage).orElse("");
-    }
-
-    private String getMaxLengthErrorMessage() {
-        return Optional.ofNullable(i18n)
-                .map(TextFieldI18n::getMaxLengthErrorMessage).orElse("");
-    }
-
-    private String getPatternErrorMessage() {
-        return Optional.ofNullable(i18n)
-                .map(TextFieldI18n::getPatternErrorMessage).orElse("");
+    private String getI18nErrorMessage(Function<TextFieldI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -384,8 +384,10 @@ public class TextField extends TextFieldBase<TextField, String>
 
     /**
      * Validates the current value against the constraints and sets the
-     * {@code invalid} property and the {@code errorMessage} property using the
-     * error messages defined in the i18n object.
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise,
+     * the error message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
      */

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -49,9 +49,10 @@ public class TextField extends TextFieldBase<TextField, String>
 
     private TextFieldI18n i18n;
 
-    private boolean isConnectorAttached;
-
     private boolean manualValidationEnabled = false;
+
+    private String customErrorMessage;
+    private String constraintErrorMessage;
 
     /**
      * Constructs an empty {@code TextField}.
@@ -180,6 +181,44 @@ public class TextField extends TextFieldBase<TextField, String>
         this(label);
         setValue(initialValue);
         addValueChangeListener(listener);
+    }
+
+    /**
+     * Sets an error message to display for all constraint violations.
+     * <p>
+     * This error message takes priority over i18n error messages when both are
+     * set.
+     *
+     * @param errorMessage
+     *            the error message to set, or {@code null} to clear
+     */
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        customErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    /**
+     * Gets the error message displayed for all constraint violations.
+     *
+     * @return the error message
+     */
+    @Override
+    public String getErrorMessage() {
+        return customErrorMessage;
+    }
+
+    private void setConstraintErrorMessage(String errorMessage) {
+        constraintErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    private void updateErrorMessage() {
+        String errorMessage = constraintErrorMessage;
+        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
+            errorMessage = customErrorMessage;
+        }
+        getElement().setProperty("errorMessage", errorMessage);
     }
 
     /**
@@ -358,10 +397,10 @@ public class TextField extends TextFieldBase<TextField, String>
         ValidationResult result = checkValidity(getValue(), true);
         if (result.isError()) {
             setInvalid(true);
-            setErrorMessage(result.getErrorMessage());
+            setConstraintErrorMessage(result.getErrorMessage());
         } else {
             setInvalid(false);
-            setErrorMessage(null);
+            setConstraintErrorMessage(null);
         }
     }
 
@@ -424,6 +463,10 @@ public class TextField extends TextFieldBase<TextField, String>
         /**
          * Sets the error message to display when the field is required but
          * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -451,6 +494,10 @@ public class TextField extends TextFieldBase<TextField, String>
         /**
          * Sets the error message to display when the field value is shorter
          * than the minimum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -478,6 +525,10 @@ public class TextField extends TextFieldBase<TextField, String>
         /**
          * Sets the error message to display when the field value is longer than
          * the maximum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -505,6 +556,10 @@ public class TextField extends TextFieldBase<TextField, String>
         /**
          * Sets the error message to display when the field value does not match
          * the pattern.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -400,7 +400,7 @@ public class TextField extends TextFieldBase<TextField, String>
             setConstraintErrorMessage(result.getErrorMessage());
         } else {
             setInvalid(false);
-            setConstraintErrorMessage(null);
+            setConstraintErrorMessage("");
         }
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
@@ -159,6 +159,8 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
 
     /**
      * Specifies that the user must fill in a value.
+     * <p>
+     * NOTE: The required indicator is only visible when the field has a label.
      *
      * @param required
      *            the boolean value to set

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -207,4 +207,16 @@ public class TextFieldTest {
         Assert.assertTrue(
                 field instanceof InputField<AbstractField.ComponentValueChangeEvent<TextField, String>, String>);
     }
+
+    @Test
+    public void setI18n_getI18n() {
+        TextField textField = new TextField();
+        TextField.TextFieldI18n i18n = new TextField.TextFieldI18n()
+                .setRequiredErrorMessage("Required error")
+                .setMinLengthErrorMessage("Min length error")
+                .setMaxLengthErrorMessage("Max length error")
+                .setPatternErrorMessage("Pattern error");
+        textField.setI18n(i18n);
+        Assert.assertEquals(i18n, textField.getI18n());
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextFieldBasicValidationTest.java
@@ -15,11 +15,82 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class TextFieldBasicValidationTest
         extends AbstractBasicValidationTest<TextField, String> {
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue("AAA");
+        testField.setValue("");
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue("AAA");
+        testField.setValue("");
+        Assert.assertEquals("Field is required", testField.getErrorMessage());
+    }
+
+    @Test
+    public void minLength_validate_emptyErrorMessageDisplayed() {
+        testField.setMinLength(3);
+        testField.setValue("AA");
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void minLength_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMinLength(3);
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setMinLengthErrorMessage("Value is too short"));
+        testField.setValue("AA");
+        Assert.assertEquals("Value is too short", testField.getErrorMessage());
+    }
+
+    @Test
+    public void maxLength_validate_emptyErrorMessageDisplayed() {
+        testField.setMaxLength(3);
+        testField.setValue("AAAA");
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void maxLength_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMaxLength(3);
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setMaxLengthErrorMessage("Value is too long"));
+        testField.setValue("AAAA");
+        Assert.assertEquals("Value is too long", testField.getErrorMessage());
+    }
+
+    @Test
+    public void pattern_validate_emptyErrorMessageDisplayed() {
+        testField.setPattern("\\d+");
+        testField.setValue("AAAA");
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void pattern_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setPattern("\\d+");
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setPatternErrorMessage("Value does not match the pattern"));
+        testField.setValue("AAAA");
+        Assert.assertEquals("Value does not match the pattern",
+                testField.getErrorMessage());
+    }
+
+    @Override
     protected TextField createTestField() {
         return new TextField();
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextFieldBasicValidationTest.java
@@ -28,7 +28,7 @@ public class TextFieldBasicValidationTest
         testField.setRequiredIndicatorVisible(true);
         testField.setValue("AAA");
         testField.setValue("");
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assert.assertEquals("", getErrorMessageProperty());
     }
 
     @Test
@@ -38,14 +38,14 @@ public class TextFieldBasicValidationTest
                 .setRequiredErrorMessage("Field is required"));
         testField.setValue("AAA");
         testField.setValue("");
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
     }
 
     @Test
     public void minLength_validate_emptyErrorMessageDisplayed() {
         testField.setMinLength(3);
         testField.setValue("AA");
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assert.assertEquals("", getErrorMessageProperty());
     }
 
     @Test
@@ -54,14 +54,14 @@ public class TextFieldBasicValidationTest
         testField.setI18n(new TextField.TextFieldI18n()
                 .setMinLengthErrorMessage("Value is too short"));
         testField.setValue("AA");
-        Assert.assertEquals("Value is too short", testField.getErrorMessage());
+        Assert.assertEquals("Value is too short", getErrorMessageProperty());
     }
 
     @Test
     public void maxLength_validate_emptyErrorMessageDisplayed() {
         testField.setMaxLength(3);
         testField.setValue("AAAA");
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assert.assertEquals("", getErrorMessageProperty());
     }
 
     @Test
@@ -70,14 +70,14 @@ public class TextFieldBasicValidationTest
         testField.setI18n(new TextField.TextFieldI18n()
                 .setMaxLengthErrorMessage("Value is too long"));
         testField.setValue("AAAA");
-        Assert.assertEquals("Value is too long", testField.getErrorMessage());
+        Assert.assertEquals("Value is too long", getErrorMessageProperty());
     }
 
     @Test
     public void pattern_validate_emptyErrorMessageDisplayed() {
         testField.setPattern("\\d+");
         testField.setValue("AAAA");
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assert.assertEquals("", getErrorMessageProperty());
     }
 
     @Test
@@ -87,11 +87,38 @@ public class TextFieldBasicValidationTest
                 .setPatternErrorMessage("Value does not match the pattern"));
         testField.setValue("AAAA");
         Assert.assertEquals("Value does not match the pattern",
-                testField.getErrorMessage());
+                getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("AAAA");
+        testField.setValue("");
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TextField.TextFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("AAAA");
+        testField.setValue("");
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
     }
 
     @Override
     protected TextField createTestField() {
         return new TextField();
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces TextFieldI18n with methods for setting error messages and updates the TextField's validation logic to show these error messages when validation fails.

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Depends on
- https://github.com/vaadin/flow-components/pull/6322

Part of #4618 

## Type of change

- [x] Feature
