### PR TITLE
fix: make setRequired also activate required validation

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationPage.java
@@ -32,7 +32,7 @@ public class NumberFieldBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(STEP_INPUT, "Set step", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -364,7 +364,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             T value = getValue();
 
             final var requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
+                    .validateRequiredConstraint("", isRequired(), value,
                             getEmptyValue());
 
             setInvalid(requiredValidation.isError()

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -40,8 +40,6 @@ import com.vaadin.flow.shared.Registration;
 public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T extends Number>
         extends TextFieldBase<C, T> {
 
-    private boolean required;
-
     /*
      * Note: setters and getters for min/max/step needed to be duplicated in
      * NumberField and IntegerField, because they use primitive double and int
@@ -366,7 +364,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             T value = getValue();
 
             final var requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("", required, value,
+                    .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
                             getEmptyValue());
 
             setInvalid(requiredValidation.isError()
@@ -394,12 +392,6 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
                 .subtract(BigDecimal.valueOf(stepBasis))
                 .remainder(BigDecimal.valueOf(step))
                 .compareTo(BigDecimal.ZERO) == 0;
-    }
-
-    @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        this.required = requiredIndicatorVisible;
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
@@ -164,7 +164,7 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
      *            the boolean value to set
      */
     public void setRequired(boolean required) {
-        getElement().setProperty("required", required);
+        setRequiredIndicatorVisible(required);
     }
 
     /**
@@ -173,7 +173,7 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
      * @return {@code true} if the input is required, {@code false} otherwise
      */
     public boolean isRequired() {
-        return getElement().getProperty("required", false);
+        return isRequiredIndicatorVisible();
     }
 
     @Override


### PR DESCRIPTION
## Description

Finding from #6346 

The PR fixes a bug where the `setRequired` method didn't activate the required validation for number fields, unlike `setRequiredIndicatorVisible` which did.

## Type of change

- [x] Bugfix
