### PR TITLE
refactor: align setRequired implementation across components

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationPage.java
@@ -13,7 +13,7 @@ public class BasicValidationPage
 
     public BasicValidationPage() {
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -344,9 +344,8 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
      * constraints using browser development tools.
      */
     private boolean isInvalid(Boolean value) {
-        boolean isRequired = isRequiredIndicatorVisible();
         ValidationResult requiredValidation = ValidationUtil
-                .validateRequiredConstraint("", isRequired, value,
+                .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
                         getEmptyValue());
 
         return requiredValidation.isError();

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -345,8 +345,8 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
      */
     private boolean isInvalid(Boolean value) {
         ValidationResult requiredValidation = ValidationUtil
-                .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
-                        getEmptyValue());
+                .validateRequiredConstraint("", isRequiredIndicatorVisible(),
+                        value, getEmptyValue());
 
         return requiredValidation.isError();
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -620,7 +620,7 @@ public class CheckboxGroup<T>
      *            the boolean value to set
      */
     public void setRequired(boolean required) {
-        getElement().setProperty("required", required);
+        setRequiredIndicatorVisible(required);
     }
 
     /**
@@ -632,7 +632,7 @@ public class CheckboxGroup<T>
      * @return {@code true} if the input is required, {@code false} otherwise
      */
     public boolean isRequired() {
-        return getElement().getProperty("required", false);
+        return isRequiredIndicatorVisible();
     }
 
     /**
@@ -907,9 +907,8 @@ public class CheckboxGroup<T>
 
     protected void validate() {
         if (!this.manualValidationEnabled) {
-            boolean isRequired = isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
-                    isRequired, getValue(), getEmptyValue()).isError();
+                    isRequiredIndicatorVisible(), getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -908,7 +908,8 @@ public class CheckboxGroup<T>
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
-                    isRequiredIndicatorVisible(), getValue(), getEmptyValue()).isError();
+                    isRequiredIndicatorVisible(), getValue(), getEmptyValue())
+                    .isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -339,7 +339,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * @return {@code true} if the component requires a value to be valid
      */
     public boolean isRequired() {
-        return super.isRequiredIndicatorVisible();
+        return isRequiredIndicatorVisible();
     }
 
     /**
@@ -349,7 +349,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      *            {@code true} if the component requires a value to be valid
      */
     public void setRequired(boolean required) {
-        super.setRequiredIndicatorVisible(required);
+        setRequiredIndicatorVisible(required);
     }
 
     @Override
@@ -1138,9 +1138,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
 
     protected void validate() {
         if (!this.manualValidationEnabled) {
-            boolean isRequired = isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
-                    isRequired, getValue(), getEmptyValue()).isError();
+                    isRequiredIndicatorVisible(), getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -1139,7 +1139,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
-                    isRequiredIndicatorVisible(), getValue(), getEmptyValue()).isError();
+                    isRequiredIndicatorVisible(), getValue(), getEmptyValue())
+                    .isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BasicValidationPage.java
@@ -17,7 +17,7 @@ public class BasicValidationPage extends AbstractValidationPage<DatePicker> {
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(MIN_INPUT, "Set min date", event -> {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -110,7 +110,6 @@ public class DatePicker
 
     private LocalDate max;
     private LocalDate min;
-    private boolean required;
 
     private StateTree.ExecutionRegistration pendingI18nUpdate;
 
@@ -570,7 +569,7 @@ public class DatePicker
      */
     private boolean isInvalid(LocalDate value) {
         var requiredValidation = ValidationUtil.validateRequiredConstraint("",
-                required, value, getEmptyValue());
+                isRequiredIndicatorVisible(), value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }
@@ -674,14 +673,7 @@ public class DatePicker
      *            the boolean value to set
      */
     public void setRequired(boolean required) {
-        getElement().setProperty("required", required);
-        this.required = required;
-    }
-
-    @Override
-    public void setRequiredIndicatorVisible(boolean required) {
-        super.setRequiredIndicatorVisible(required);
-        this.required = required;
+        setRequiredIndicatorVisible(required);
     }
 
     /**
@@ -693,7 +685,7 @@ public class DatePicker
      * @return {@code true} if the input is required, {@code false} otherwise
      */
     public boolean isRequired() {
-        return getElement().getProperty("required", false);
+        return isRequiredIndicatorVisible();
     }
 
     /**

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
@@ -18,7 +18,7 @@ public class BasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequired(true);
+            testField.setRequiredIndicatorVisible(true);
         }));
 
         add(createInput(MIN_INPUT, "Set min date time", event -> {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
@@ -18,7 +18,7 @@ public class BasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(MIN_INPUT, "Set min date time", event -> {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -140,7 +140,6 @@ public class DateTimePicker
 
     private LocalDateTime max;
     private LocalDateTime min;
-    private boolean required;
 
     private boolean manualValidationEnabled = false;
 
@@ -793,7 +792,7 @@ public class DateTimePicker
      */
     private boolean isInvalid(LocalDateTime value) {
         var requiredValidation = ValidationUtil.validateRequiredConstraint("",
-                required, value, getEmptyValue());
+                isRequiredIndicatorVisible(), value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }
@@ -888,18 +887,6 @@ public class DateTimePicker
                 "The i18n properties object should not be null");
         this.datePickerI18n = i18n;
         datePicker.setI18n(i18n);
-    }
-
-    /**
-     * Sets whether the date time picker is marked as input required.
-     *
-     * @param requiredIndicatorVisible
-     *            the value of the requiredIndicatorVisible to be set
-     */
-    @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        this.required = requiredIndicatorVisible;
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationPage.java
@@ -14,7 +14,7 @@ public class BasicValidationPage
 
     public BasicValidationPage() {
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createButton(SET_INVALID_BUTTON, "Set invalid state", event -> {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -798,7 +798,8 @@ public class RadioButtonGroup<T>
     protected void validate() {
         if (!this.manualValidationEnabled) {
             boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
-                    isRequiredIndicatorVisible(), getValue(), getEmptyValue()).isError();
+                    isRequiredIndicatorVisible(), getValue(), getEmptyValue())
+                    .isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -498,7 +498,7 @@ public class RadioButtonGroup<T>
      *            the boolean value to set
      */
     public void setRequired(boolean required) {
-        getElement().setProperty("required", required);
+        setRequiredIndicatorVisible(required);
     }
 
     /**
@@ -510,7 +510,7 @@ public class RadioButtonGroup<T>
      * @return the {@code required} property from the webcomponent
      */
     public boolean isRequired() {
-        return getElement().getProperty("required", false);
+        return isRequiredIndicatorVisible();
     }
 
     /**
@@ -797,9 +797,8 @@ public class RadioButtonGroup<T>
 
     protected void validate() {
         if (!this.manualValidationEnabled) {
-            boolean isRequired = isRequiredIndicatorVisible();
             boolean isInvalid = ValidationUtil.validateRequiredConstraint("",
-                    isRequired, getValue(), getEmptyValue()).isError();
+                    isRequiredIndicatorVisible(), getValue(), getEmptyValue()).isError();
 
             setInvalid(isInvalid);
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationPage.java
@@ -29,7 +29,7 @@ public class BigDecimalFieldBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationPage.java
@@ -31,7 +31,7 @@ public class EmailFieldBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(PATTERN_INPUT, "Set pattern", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
@@ -32,7 +32,7 @@ public class IntegerFieldBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(STEP_INPUT, "Set step", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationPage.java
@@ -31,7 +31,7 @@ public class PasswordFieldBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(PATTERN_INPUT, "Set pattern", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationPage.java
@@ -31,7 +31,7 @@ public class TextAreaBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(PATTERN_INPUT, "Set pattern", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationPage.java
@@ -31,7 +31,7 @@ public class TextFieldBasicValidationPage
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(PATTERN_INPUT, "Set pattern", event -> {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -364,7 +364,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             T value = getValue();
 
             final var requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("", isRequired(), value,
+                    .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
                             getEmptyValue());
 
             setInvalid(requiredValidation.isError()

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -364,7 +364,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             T value = getValue();
 
             final var requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
+                    .validateRequiredConstraint("",
+                            isRequiredIndicatorVisible(), value,
                             getEmptyValue());
 
             setInvalid(requiredValidation.isError()

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -288,7 +288,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
             BigDecimal value = getValue();
 
             ValidationResult requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
+                    .validateRequiredConstraint("",
+                            isRequiredIndicatorVisible(), value,
                             getEmptyValue());
 
             setInvalid(requiredValidation.isError()

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -287,9 +287,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         if (!this.manualValidationEnabled) {
             BigDecimal value = getValue();
 
-            boolean isRequired = isRequiredIndicatorVisible();
             ValidationResult requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("", isRequired, value,
+                    .validateRequiredConstraint("", isRequiredIndicatorVisible(), value,
                             getEmptyValue());
 
             setInvalid(requiredValidation.isError()

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationPage.java
@@ -17,7 +17,7 @@ public class BasicValidationPage extends AbstractValidationPage<TimePicker> {
         super();
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
-            testField.setRequiredIndicatorVisible(true);
+            testField.setRequired(true);
         }));
 
         add(createInput(MIN_INPUT, "Set min time", event -> {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -94,7 +94,6 @@ public class TimePicker
 
     private LocalTime max;
     private LocalTime min;
-    private boolean required;
     private StateTree.ExecutionRegistration pendingLocaleUpdate;
 
     private boolean manualValidationEnabled = false;
@@ -374,7 +373,7 @@ public class TimePicker
      */
     private boolean isInvalid(LocalTime value) {
         var requiredValidation = ValidationUtil.validateRequiredConstraint("",
-                required, value, getEmptyValue());
+                isRequiredIndicatorVisible(), value, getEmptyValue());
 
         return requiredValidation.isError() || checkValidity(value).isError();
     }
@@ -397,14 +396,7 @@ public class TimePicker
      *            the boolean value to set
      */
     public void setRequired(boolean required) {
-        getElement().setProperty("required", required);
-        this.required = required;
-    }
-
-    @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        this.required = requiredIndicatorVisible;
+        setRequiredIndicatorVisible(required);
     }
 
     /**
@@ -416,7 +408,7 @@ public class TimePicker
      * @return {@code true} if the input is required, {@code false} otherwise
      */
     public boolean isRequired() {
-        return getElement().getProperty("required", false);
+        return isRequiredIndicatorVisible();
     }
 
     /**


### PR DESCRIPTION
## Description

Continuation of #6347 

The PR refactors the implementation of the `setRequired` and `isRequired` methods to delegate their calls to the `setRequiredIndicatorVisible` and `isRequiredIndicatorVisible` methods, which are considered the primary methods.

## Type of change

- [x] Internal
