### PR TITLE
chore: bump net.revelc.code.formatter:formatter-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.24.0</version>
+                <version>2.24.1</version>
                 <configuration>
                     <configFile>https://raw.githubusercontent.com/vaadin/flow/main/eclipse/VaadinJavaConventions.xml</configFile>
                     <skipHtmlFormatting>true</skipHtmlFormatting>


### PR DESCRIPTION
## Description

The PR bumps `net.revelc.code.formatter:formatter-maven-plugin` from 2.24.0 to 2.24.1, which contains a fix for the issue where the formatter skipped all files despite changes.

Related to https://github.com/vaadin/flow-components/pull/6335

## Type of change

- [x] Internal
