### PR TITLE
chore: remove workaround comments [skip ci]

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountUnknownComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountUnknownComboBoxIT.java
@@ -147,8 +147,6 @@ public class ItemCountUnknownComboBoxIT extends AbstractItemCountComboBoxIT {
     public void undefinedItemCount_enterClientFilter_displaysFilteredItem() {
         open(300);
 
-        // TODO: Temporary workaround. Remove once overlay position mixin is
-        // fixed to not close the overlay for hidden target element
         comboBoxElement.openPopup();
 
         assertLoadedItemsCount("Should be 50 items before filtering", 50,


### PR DESCRIPTION
We/DS team concluded that it actually works as expected now. So that “temporary workaround” is now a permanent one

