### PR TITLE
feat!: support setting error messages with DatePickerI18n

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BasicValidationPage.java
@@ -13,8 +13,19 @@ public class BasicValidationPage extends AbstractValidationPage<DatePicker> {
     public static final String MAX_INPUT = "max-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Date has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Date is too small";
+    public static final String MAX_ERROR_MESSAGE = "Date is too big";
+
     public BasicValidationPage() {
         super();
+
+        testField.setI18n(new DatePicker.DatePickerI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BinderValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BinderValidationPage.java
@@ -15,8 +15,11 @@ public class BinderValidationPage extends AbstractValidationPage<DatePicker> {
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Date has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Date is too small";
+    public static final String MAX_ERROR_MESSAGE = "Date is too big";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Date does not match the expected value";
 
     public static class Bean {
         private LocalDate property;
@@ -36,6 +39,11 @@ public class BinderValidationPage extends AbstractValidationPage<DatePicker> {
 
     public BinderValidationPage() {
         super();
+
+        testField.setI18n(new DatePicker.DatePickerI18n()
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
 
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
@@ -7,10 +7,14 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MIN_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.REQUIRED_BUTTON;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MIN_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-date-picker/validation/basic")
 public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
@@ -18,6 +22,7 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -26,6 +31,7 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -36,6 +42,7 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -46,11 +53,25 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setInputValue("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.setInputValue("INVALID");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        testField.setInputValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -61,21 +82,25 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         testField.setInputValue("3/1/2022");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setInputValue("4/1/2022");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setInputValue("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -86,21 +111,25 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         testField.setInputValue("3/1/2022");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setInputValue("2/1/2022");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setInputValue("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -109,21 +138,25 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setInputValue("1/1/2022");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setInputValue("INVALID");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setInputValue("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -131,10 +164,12 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         testField.setInputValue("1/1/2022");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -143,11 +178,13 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BinderValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BinderValidationIT.java
@@ -7,12 +7,15 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
+import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.BAD_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.MIN_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.EXPECTED_VALUE_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.MIN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BinderValidationPage.RESET_BEAN_BUTTON;
 
 @TestPath("vaadin-date-picker/validation/binder")
@@ -31,6 +34,7 @@ public class BinderValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -41,6 +45,19 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
+
+        testField.setInputValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.setInputValue("INVALID");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setInputValue("");
         assertValidationCount(1);
@@ -56,10 +73,12 @@ public class BinderValidationIT
         testField.setInputValue("1/1/2022");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(RESET_BEAN_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -72,7 +91,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setInputValue("3/1/2022");
@@ -86,6 +105,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         // Binder validation fails:
         testField.setInputValue("");
@@ -105,7 +125,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setInputValue("3/1/2022");
@@ -119,6 +139,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         // Binder validation fails:
         testField.setInputValue("");
@@ -136,18 +157,19 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setInputValue("1/1/2022");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setInputValue("INVALID");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setInputValue("");
         assertValidationCount(1);
@@ -163,6 +185,7 @@ public class BinderValidationIT
         testField.setInputValue("1/1/2022");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerInvalid();
@@ -176,7 +199,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -496,6 +496,14 @@ public class DatePicker
             i18nObject.put("referenceDate",
                     i18n.getReferenceDate().format(DateTimeFormatter.ISO_DATE));
         }
+
+        // Remove the error message properties because they aren't used on
+        // the client-side.
+        i18nObject.remove("badInputErrorMessage");
+        i18nObject.remove("requiredErrorMessage");
+        i18nObject.remove("minErrorMessage");
+        i18nObject.remove("maxErrorMessage");
+
         // Remove properties with null values to prevent errors in web component
         removeNullValuesFromJsonObject(i18nObject);
         return i18nObject;
@@ -516,7 +524,7 @@ public class DatePicker
 
     @Override
     public Validator<LocalDate> getDefaultValidator() {
-        return (value, context) -> checkValidity(value);
+        return (value, context) -> checkValidity(value, false);
     }
 
     @Override
@@ -539,38 +547,45 @@ public class DatePicker
                 .forEach(listener -> listener.validationStatusChanged(event));
     }
 
-    private ValidationResult checkValidity(LocalDate value) {
-        boolean hasNonParsableValue = valueEquals(value, getEmptyValue())
-                && isInputValuePresent();
-        if (hasNonParsableValue) {
-            return ValidationResult.error("");
+    private ValidationResult checkValidity(LocalDate value,
+            boolean withRequiredValidator) {
+        ValidationResult badInputResult = validateBadInputConstraint(
+                getBadInputErrorMessage(), value);
+        if (badInputResult.isError()) {
+            return badInputResult;
         }
 
-        ValidationResult resultMax = ValidationUtil.validateMaxConstraint("",
-                value, max);
-        if (resultMax.isError()) {
-            return resultMax;
+        if (withRequiredValidator) {
+            ValidationResult requiredResult = ValidationUtil
+                    .validateRequiredConstraint(getRequiredErrorMessage(),
+                            isRequiredIndicatorVisible(), value,
+                            getEmptyValue());
+            if (requiredResult.isError()) {
+                return requiredResult;
+            }
         }
 
-        ValidationResult resultMin = ValidationUtil.validateMinConstraint("",
-                value, min);
-        if (resultMin.isError()) {
-            return resultMin;
+        ValidationResult maxResult = ValidationUtil
+                .validateMaxConstraint(getMaxErrorMessage(), value, max);
+        if (maxResult.isError()) {
+            return maxResult;
+        }
+
+        ValidationResult minResult = ValidationUtil
+                .validateMinConstraint(getMinErrorMessage(), value, min);
+        if (minResult.isError()) {
+            return minResult;
         }
 
         return ValidationResult.ok();
     }
 
-    /**
-     * Performs a server-side validation of the given value. This is needed
-     * because it is possible to circumvent the client side validation
-     * constraints using browser development tools.
-     */
-    private boolean isInvalid(LocalDate value) {
-        var requiredValidation = ValidationUtil.validateRequiredConstraint("",
-                isRequiredIndicatorVisible(), value, getEmptyValue());
-
-        return requiredValidation.isError() || checkValidity(value).isError();
+    private ValidationResult validateBadInputConstraint(String errorMessage,
+            LocalDate value) {
+        boolean isError = valueEquals(value, getEmptyValue())
+                && isInputValuePresent();
+        return isError ? ValidationResult.error(errorMessage)
+                : ValidationResult.ok();
     }
 
     /**
@@ -778,13 +793,24 @@ public class DatePicker
     }
 
     /**
-     * Performs server-side validation of the current value. This is needed
-     * because it is possible to circumvent the client-side validation
-     * constraints using browser development tools.
+     * Validates the current value against the constraints and sets the
+     * {@code invalid} property and the {@code errorMessage} property using the
+     * error messages defined in the i18n object.
+     * <p>
+     * The method does nothing if the manual validation mode is enabled.
      */
     protected void validate() {
-        if (!this.manualValidationEnabled) {
-            setInvalid(isInvalid(getValue()));
+        if (this.manualValidationEnabled) {
+            return;
+        }
+
+        ValidationResult result = checkValidity(getValue(), true);
+        if (result.isError()) {
+            setInvalid(true);
+            setErrorMessage(result.getErrorMessage());
+        } else {
+            setInvalid(false);
+            setErrorMessage("");
         }
     }
 
@@ -847,6 +873,26 @@ public class DatePicker
         return addListener(InvalidChangeEvent.class, listener);
     }
 
+    private String getBadInputErrorMessage() {
+        return Optional.ofNullable(i18n)
+                .map(DatePickerI18n::getBadInputErrorMessage).orElse("");
+    }
+
+    private String getRequiredErrorMessage() {
+        return Optional.ofNullable(i18n)
+                .map(DatePickerI18n::getRequiredErrorMessage).orElse("");
+    }
+
+    private String getMinErrorMessage() {
+        return Optional.ofNullable(i18n).map(DatePickerI18n::getMinErrorMessage)
+                .orElse("");
+    }
+
+    private String getMaxErrorMessage() {
+        return Optional.ofNullable(i18n).map(DatePickerI18n::getMaxErrorMessage)
+                .orElse("");
+    }
+
     /**
      * The internationalization properties for {@link DatePicker}.
      */
@@ -859,6 +905,10 @@ public class DatePicker
         private String today;
         private String cancel;
         private LocalDate referenceDate;
+        private String badInputErrorMessage;
+        private String requiredErrorMessage;
+        private String minErrorMessage;
+        private String maxErrorMessage;
 
         /**
          * Gets the name of the months.
@@ -1118,6 +1168,110 @@ public class DatePicker
          */
         public DatePickerI18n setReferenceDate(LocalDate referenceDate) {
             this.referenceDate = referenceDate;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field contains user input
+         * that the server is unable to convert to type {@link LocalDate}.
+         *
+         * @return the error message or {@code null} if not set
+         */
+        public String getBadInputErrorMessage() {
+            return badInputErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field contains user input
+         * that the server is unable to convert to type {@link LocalDate}.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         */
+        public DatePickerI18n setBadInputErrorMessage(String errorMessage) {
+            badInputErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DatePicker#isRequiredIndicatorVisible()
+         * @see DatePicker#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DatePicker#isRequiredIndicatorVisible()
+         * @see DatePicker#setRequiredIndicatorVisible(boolean)
+         */
+        public DatePickerI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the selected date is earlier
+         * than the minimum allowed date.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DatePicker#getMin()
+         * @see DatePicker#setMin(LocalDate)
+         */
+        public String getMinErrorMessage() {
+            return minErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the selected date is earlier
+         * than the minimum allowed date.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DatePicker#getMin()
+         * @see DatePicker#setMin(LocalDate)
+         */
+        public DatePickerI18n setMinErrorMessage(String errorMessage) {
+            minErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the selected date is later than
+         * the maximum allowed date.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DatePicker#getMax()
+         * @see DatePicker#setMax(LocalDate)
+         */
+        public String getMaxErrorMessage() {
+            return maxErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the selected date is later
+         * than the maximum allowed date.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DatePicker#getMax()
+         * @see DatePicker#setMax(LocalDate)
+         */
+        public DatePickerI18n setMaxErrorMessage(String errorMessage) {
+            maxErrorMessage = errorMessage;
             return this;
         }
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationTest.java
@@ -17,9 +17,14 @@ package com.vaadin.flow.component.datepicker.validation;
 
 import java.time.LocalDate;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import elemental.json.Json;
+
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
@@ -36,7 +41,82 @@ public class BasicValidationTest
         testField.clear();
     }
 
+    @Test
+    public void badInput_validate_emptyErrorMessageDisplayed() {
+        testField.getElement().setProperty("_hasInputValue", true);
+        fireUnparsableChangeDomEvent();
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setI18n(new DatePicker.DatePickerI18n()
+                .setBadInputErrorMessage("Date has invalid format"));
+        testField.getElement().setProperty("_hasInputValue", true);
+        fireUnparsableChangeDomEvent();
+        Assert.assertEquals("Date has invalid format",
+                testField.getErrorMessage());
+    }
+
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue(LocalDate.now());
+        testField.setValue(null);
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new DatePicker.DatePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue(LocalDate.now());
+        testField.setValue(null);
+        Assert.assertEquals("Field is required", testField.getErrorMessage());
+    }
+
+    @Test
+    public void min_validate_emptyErrorMessageDisplayed() {
+        testField.setMin(LocalDate.now());
+        testField.setValue(LocalDate.now().minusDays(1));
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMin(LocalDate.now());
+        testField.setI18n(new DatePicker.DatePickerI18n()
+                .setMinErrorMessage("Date is too small"));
+        testField.setValue(LocalDate.now().minusDays(1));
+        Assert.assertEquals("Date is too small", testField.getErrorMessage());
+    }
+
+    @Test
+    public void max_validate_emptyErrorMessageDisplayed() {
+        testField.setMax(LocalDate.now());
+        testField.setValue(LocalDate.now().plusDays(1));
+        Assert.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    public void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMax(LocalDate.now());
+        testField.setI18n(new DatePicker.DatePickerI18n()
+                .setMaxErrorMessage("Date is too big"));
+        testField.setValue(LocalDate.now().plusDays(1));
+        Assert.assertEquals("Date is too big", testField.getErrorMessage());
+    }
+
+    @Override
     protected DatePicker createTestField() {
         return new DatePicker();
+    }
+
+    private void fireUnparsableChangeDomEvent() {
+        DomEvent unparsableChangeDomEvent = new DomEvent(testField.getElement(),
+                "unparsable-change", Json.createObject());
+        testField.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(unparsableChangeDomEvent);
     }
 }


### PR DESCRIPTION
## Description

The PR introduces DatePickerI18n with methods for setting error messages and updates the DatePicker's validation logic to show these error messages when validation fails.

> [!WARNING]
> The PR is marked as breaking because it causes the component to start overriding any custom error messages that were set manually with the `setErrorMessage` method before validation. If you need to set error messages manually, use `setManualValidation(true)`, which prevents the component from updating the `invalid` and `errorMessage` properties, allowing you to control them manually.

Part of #4618 

## Type of change

- [x] Feature
