### PR TITLE
feat: add i18n error message support for TimePicker

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationPage.java
@@ -13,8 +13,19 @@ public class BasicValidationPage extends AbstractValidationPage<TimePicker> {
     public static final String MAX_INPUT = "max-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Time has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Time is too small";
+    public static final String MAX_ERROR_MESSAGE = "Time is too big";
+
     public BasicValidationPage() {
         super();
+
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationPage.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationPage.java
@@ -15,8 +15,11 @@ public class BinderValidationPage extends AbstractValidationPage<TimePicker> {
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
     public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Time has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Time is too small";
+    public static final String MAX_ERROR_MESSAGE = "Time is too big";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Time does not match the expected value";
 
     public static class Bean {
         private LocalTime property;
@@ -36,6 +39,11 @@ public class BinderValidationPage extends AbstractValidationPage<TimePicker> {
 
     public BinderValidationPage() {
         super();
+
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
 
         binder = new Binder<>(Bean.class);
         binder.forField(testField).asRequired(REQUIRED_ERROR_MESSAGE)

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
@@ -11,6 +11,10 @@ import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidat
 import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.REQUIRED_BUTTON;
 import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
+import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.MIN_ERROR_MESSAGE;
+import static com.vaadin.flow.component.timepicker.tests.validation.BasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-time-picker/validation/basic")
 public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
@@ -18,6 +22,7 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -26,6 +31,7 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -36,6 +42,7 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -46,11 +53,25 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.selectByText("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.selectByText("INVALID");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        testField.selectByText("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -61,21 +82,25 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         testField.selectByText("11:00");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.selectByText("12:00");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.selectByText("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -86,21 +111,25 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         testField.selectByText("11:00");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.selectByText("10:00");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.selectByText("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -109,21 +138,25 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.selectByText("10:00");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.selectByText("INVALID");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.selectByText("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -131,10 +164,12 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         testField.selectByText("10:00");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -143,11 +178,13 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationIT.java
@@ -11,6 +11,9 @@ import static com.vaadin.flow.component.timepicker.tests.validation.BinderValida
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.EXPECTED_VALUE_INPUT;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.BAD_INPUT_ERROR_MESSAGE;
+import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.MIN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.timepicker.tests.validation.BinderValidationPage.RESET_BEAN_BUTTON;
@@ -47,6 +50,18 @@ public class BinderValidationIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.selectByText("INVALID");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        testField.selectByText("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -72,7 +87,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.selectByText("11:00");
@@ -105,7 +120,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.selectByText("11:00");
@@ -136,7 +151,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.selectByText("10:00");
         assertValidationCount(1);
@@ -147,7 +162,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.selectByText("");
         assertValidationCount(1);
@@ -176,7 +191,7 @@ public class BinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -699,20 +699,19 @@ public class TimePicker
      * <p>
      * NOTE: Updating the instance that is returned from this method will not
      * update the component if not set again using
-     * {@link TimePicker#setI18n(TimePickerI18n)}
+     * {@link #setI18n(TimePickerI18n)}
      *
-     * @return the i18n object. It will be {@code null}, If the i18n properties
-     *         weren't set.
+     * @return the i18n object or {@code null} if no i18n object has been set
      */
     public TimePickerI18n getI18n() {
         return i18n;
     }
 
     /**
-     * Sets the internationalization properties for this component.
+     * Sets the internationalization object for this component.
      *
      * @param i18n
-     *            the internationalized properties, not {@code null}
+     *            the i18n object, not {@code null}
      */
     public void setI18n(TimePickerI18n i18n) {
         this.i18n = Objects.requireNonNull(i18n,

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -102,6 +102,9 @@ public class TimePicker
 
     private boolean manualValidationEnabled = false;
 
+    private String customErrorMessage;
+    private String constraintErrorMessage;
+
     private final CopyOnWriteArrayList<ValidationStatusChangeListener<LocalTime>> validationStatusChangeListeners = new CopyOnWriteArrayList<>();
 
     /**
@@ -230,6 +233,44 @@ public class TimePicker
         this(time);
         setLabel(label);
         addValueChangeListener(listener);
+    }
+
+    /**
+     * Sets an error message to display for all constraint violations.
+     * <p>
+     * This error message takes priority over i18n error messages when both are
+     * set.
+     *
+     * @param errorMessage
+     *            the error message to set, or {@code null} to clear
+     */
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        customErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    /**
+     * Gets the error message displayed for all constraint violations.
+     *
+     * @return the error message
+     */
+    @Override
+    public String getErrorMessage() {
+        return customErrorMessage;
+    }
+
+    private void setConstraintErrorMessage(String errorMessage) {
+        constraintErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    private void updateErrorMessage() {
+        String errorMessage = constraintErrorMessage;
+        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
+            errorMessage = customErrorMessage;
+        }
+        getElement().setProperty("errorMessage", errorMessage);
     }
 
     /**
@@ -518,10 +559,10 @@ public class TimePicker
         ValidationResult result = checkValidity(getValue(), true);
         if (result.isError()) {
             setInvalid(true);
-            setErrorMessage(result.getErrorMessage());
+            setConstraintErrorMessage(result.getErrorMessage());
         } else {
             setInvalid(false);
-            setErrorMessage("");
+            setConstraintErrorMessage("");
         }
     }
 
@@ -752,6 +793,10 @@ public class TimePicker
         /**
          * Sets the error message to display when the field contains user input
          * that the server is unable to convert to type {@link LocalTime}.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TimePicker#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message to set, or {@code null} to clear
@@ -777,6 +822,10 @@ public class TimePicker
         /**
          * Sets the error message to display when the field is required but
          * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TimePicker#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -804,6 +853,10 @@ public class TimePicker
         /**
          * Sets the error message to display when the selected time is earlier
          * than the minimum allowed time.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TimePicker#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -831,6 +884,10 @@ public class TimePicker
         /**
          * Sets the error message to display when the selected time is later
          * than the maximum allowed time.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TimePicker#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -546,8 +546,10 @@ public class TimePicker
 
     /**
      * Validates the current value against the constraints and sets the
-     * {@code invalid} property and the {@code errorMessage} property using the
-     * error messages defined in the i18n object.
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
      */

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AbstractField;
@@ -352,12 +353,15 @@ public class TimePicker
         boolean hasBadInput = Objects.equals(value, getEmptyValue())
                 && isInputValuePresent();
         if (hasBadInput) {
-            return ValidationResult.error(getBadInputErrorMessage());
+            return ValidationResult.error(getI18nErrorMessage(
+                    TimePickerI18n::getBadInputErrorMessage));
         }
 
         if (withRequiredValidator) {
             ValidationResult requiredResult = ValidationUtil
-                    .validateRequiredConstraint(getRequiredErrorMessage(),
+                    .validateRequiredConstraint(
+                            getI18nErrorMessage(
+                                    TimePickerI18n::getRequiredErrorMessage),
                             isRequiredIndicatorVisible(), value,
                             getEmptyValue());
             if (requiredResult.isError()) {
@@ -365,14 +369,16 @@ public class TimePicker
             }
         }
 
-        ValidationResult maxResult = ValidationUtil
-                .validateMaxConstraint(getMaxErrorMessage(), value, max);
+        ValidationResult maxResult = ValidationUtil.validateMaxConstraint(
+                getI18nErrorMessage(TimePickerI18n::getMaxErrorMessage), value,
+                max);
         if (maxResult.isError()) {
             return maxResult;
         }
 
-        ValidationResult minResult = ValidationUtil
-                .validateMinConstraint(getMinErrorMessage(), value, min);
+        ValidationResult minResult = ValidationUtil.validateMinConstraint(
+                getI18nErrorMessage(TimePickerI18n::getMinErrorMessage), value,
+                min);
         if (minResult.isError()) {
             return minResult;
         }
@@ -718,24 +724,9 @@ public class TimePicker
                 "The i18n properties object should not be null");
     }
 
-    private String getBadInputErrorMessage() {
-        return Optional.ofNullable(i18n)
-                .map(TimePickerI18n::getBadInputErrorMessage).orElse("");
-    }
-
-    private String getRequiredErrorMessage() {
-        return Optional.ofNullable(i18n)
-                .map(TimePickerI18n::getRequiredErrorMessage).orElse("");
-    }
-
-    private String getMinErrorMessage() {
-        return Optional.ofNullable(i18n).map(TimePickerI18n::getMinErrorMessage)
-                .orElse("");
-    }
-
-    private String getMaxErrorMessage() {
-        return Optional.ofNullable(i18n).map(TimePickerI18n::getMaxErrorMessage)
-                .orElse("");
+    private String getI18nErrorMessage(
+            Function<TimePickerI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
@@ -17,10 +17,15 @@ package com.vaadin.flow.component.timepicker.tests.validation;
 
 import java.time.LocalTime;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
+
+import elemental.json.Json;
 
 public class BasicValidationTest
         extends AbstractBasicValidationTest<TimePicker, LocalTime> {
@@ -36,7 +41,108 @@ public class BasicValidationTest
         testField.clear();
     }
 
+    @Test
+    public void badInput_validate_emptyErrorMessageDisplayed() {
+        testField.getElement().setProperty("_hasInputValue", true);
+        fireUnparsableChangeDomEvent();
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setBadInputErrorMessage("Time has invalid format"));
+        testField.getElement().setProperty("_hasInputValue", true);
+        fireUnparsableChangeDomEvent();
+        Assert.assertEquals("Time has invalid format",
+                getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue(LocalTime.now());
+        testField.setValue(null);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue(LocalTime.now());
+        testField.setValue(null);
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void min_validate_emptyErrorMessageDisplayed() {
+        testField.setMin(LocalTime.now());
+        testField.setValue(LocalTime.now().minusHours(1));
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMin(LocalTime.now());
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setMinErrorMessage("Time is too small"));
+        testField.setValue(LocalTime.now().minusHours(1));
+        Assert.assertEquals("Time is too small", getErrorMessageProperty());
+    }
+
+    @Test
+    public void max_validate_emptyErrorMessageDisplayed() {
+        testField.setMax(LocalTime.now());
+        testField.setValue(LocalTime.now().plusHours(1));
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMax(LocalTime.now());
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setMaxErrorMessage("Time is too big"));
+        testField.setValue(LocalTime.now().plusHours(1));
+        Assert.assertEquals("Time is too big", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(LocalTime.now());
+        testField.setValue(null);
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TimePicker.TimePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(LocalTime.now());
+        testField.setValue(null);
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
     protected TimePicker createTestField() {
         return new TimePicker();
+    }
+
+    private void fireUnparsableChangeDomEvent() {
+        DomEvent unparsableChangeDomEvent = new DomEvent(testField.getElement(),
+                "unparsable-change", Json.createObject());
+        testField.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(unparsableChangeDomEvent);
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces TimePickerI18n with methods for setting error messages and updates the TimePicker's validation logic to show these error messages when validation fails.

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Part of #4618 

## Type of change

- [x] Feature
