### PR TITLE
feat: add support to Lumo dropdown-indicator theme in MenuBar

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarVariant.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarVariant.java
@@ -30,6 +30,7 @@ public enum MenuBarVariant implements ThemeVariant {
     LUMO_CONTRAST("contrast"),
     LUMO_ICON("icon"),
     LUMO_END_ALIGNED("end-aligned"),
+    LUMO_DROPDOWN_INDICATORS("dropdown-indicators"),
     MATERIAL_CONTAINED("contained"),
     MATERIAL_OUTLINED("outlined"),
     MATERIAL_END_ALIGNED("end-aligned");


### PR DESCRIPTION
## Description

Add a new entry to `MenuBarVariant` with the "dropdown-indicators" Lumo variant theme added in https://github.com/vaadin/web-components/pull/7381.

Part of https://github.com/vaadin/web-components/issues/7345

## Type of change

- [X] Feature
