### PR TITLE
fix: make sure select all checkbox is clicked on cell Space (14.11)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -20,7 +20,9 @@ import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
@@ -114,6 +116,26 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         Assert.assertNull(
                 "Select all checkbox is in indeterminate state even though no items are selected",
                 selectAllCheckbox.getAttribute("indeterminate"));
+    }
+
+    @Test
+    public void selectAllCheckbox_cellSpaceKey_toggleSelection() {
+        open();
+        GridElement grid = $(GridElement.class).id("in-memory-grid");
+        WebElement selectAllCheckbox = grid
+                .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
+
+        grid.getHeaderCell(0).focus();
+        new Actions(getDriver()).sendKeys(Keys.SPACE).perform();
+
+        Assert.assertEquals(
+                "Select all checkbox is not checked even though all items selected",
+                "true", selectAllCheckbox.getAttribute("checked"));
+
+        new Actions(getDriver()).sendKeys(Keys.SPACE).perform();
+        Assert.assertNull(
+                "Select all checkbox is checked even though no items selected",
+                selectAllCheckbox.getAttribute("checked"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
@@ -3,12 +3,6 @@
 <dom-module id="vaadin-grid-flow-selection-column">
   <template>
     <template class="header" id="defaultHeaderTemplate">
-      <style>
-          /* Fix a grid web-component style that sets the font-size to small for all header contents */
-          #selectAllCheckbox {
-              font-size: var(--lumo-font-size-m);
-          }
-      </style>
       <vaadin-checkbox
         id="selectAllCheckbox"
         aria-label="Select All"
@@ -18,6 +12,12 @@
         indeterminate="[[indeterminate]]"
         focus-target
       ></vaadin-checkbox>
+      <style>
+        /* Fix a grid web-component style that sets the font-size to small for all header contents */
+        #selectAllCheckbox {
+            font-size: var(--lumo-font-size-m);
+        }
+      </style>
     </template>
     <template id="defaultBodyTemplate">
       <vaadin-checkbox

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -6,12 +6,6 @@ import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js
     static get template() {
       return html`
     <template class="header" id="defaultHeaderTemplate">
-      <style>
-        /* Fix a grid web-component style that sets the font-size to small for all header contents */
-        #selectAllCheckbox {
-          font-size: var(--lumo-font-size-m);
-        }
-      </style>
       <vaadin-checkbox
         id="selectAllCheckbox"
         aria-label="Select All"
@@ -21,6 +15,12 @@ import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js
         indeterminate="[[indeterminate]]"
         focus-target
       ></vaadin-checkbox>
+      <style>
+        /* Fix a grid web-component style that sets the font-size to small for all header contents */
+        #selectAllCheckbox {
+          font-size: var(--lumo-font-size-m);
+        }
+      </style>
     </template>
     <template id="defaultBodyTemplate">
       <vaadin-checkbox aria-label="Select Row" checked="[[selected]]" on-click="_onSelectClick">


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/7503 for V14.11

As described in https://github.com/vaadin/web-components/issues/7503#issuecomment-2210637653, the actual fix is to make `vaadin-checkbox` element the first child of its corresponding header cell, so that the [click logic](https://github.com/vaadin/vaadin-grid/blob/d0663ccaebcdcae17c52226975fde60cc693243f/src/vaadin-grid-keyboard-navigation-mixin.html#L484) on <kbd>Space</kbd> key press works as expected.

## Type of change

- Bugfix