### PR TITLE
fix: do not fire ItemClickListener on focusable element click

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -98,6 +98,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-icons-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-core</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
@@ -15,10 +15,12 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
@@ -45,6 +47,9 @@ public class GridViewClickListenersPage extends LegacyTestView {
                     "$0.addEventListener('click', e => e.preventDefault())");
             return span;
         })).setHeader("Action");
+        grid.addColumn(new ComponentRenderer<>(person -> {
+            return new Button(VaadinIcon.PENCIL.create());
+        })).setHeader("Button");
 
         // Disable selection: will receive only click events instead
         grid.setSelectionMode(SelectionMode.NONE);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
@@ -78,6 +78,23 @@ public class GridViewClickListenersIT extends AbstractComponentIT {
     }
 
     @Test
+    public void itemClickListener_singleClick_focusableElementClickIgnored() {
+        GridElement grid = $(GridElement.class).id("item-click-listener");
+        scrollToElement(grid);
+        waitUntil(driver -> grid.getRowCount() > 0);
+
+        GridTRElement row = grid.getRow(0);
+        GridTHTDElement cell = row.getCell(grid.getColumn("Button"));
+
+        WebElement icon = cell.getContext().findElement(By.tagName("vaadin-icon"));
+        icon.click();
+
+        WebElement clickInfo = findElement(By.id("clicked-item"));
+
+        Assert.assertEquals("", clickInfo.getText());
+    }
+
+    @Test
     public void itemDoubleClickListener() {
         GridElement grid = $(GridElement.class).id("item-doubleclick-listener");
         scrollToElement(grid);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -1130,9 +1130,14 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             return;
           }
 
-          const target = event.target;
+          const path = event.composedPath();
+          const idx = path.findIndex((node) => node.localName === 'td' || node.localName === 'th');
+          const content = path.slice(0, idx);
 
-          if (isFocusable(target) || target instanceof HTMLLabelElement) {
+          // Do not fire item click event if cell content contains focusable elements.
+          // Use this instead of event.target to detect cases like icon inside button.
+          // See https://github.com/vaadin/flow-components/issues/4065
+          if (content.some((node) => isFocusable(node) || node instanceof HTMLLabelElement)) {
             return;
           }
 


### PR DESCRIPTION
## Description

Fixes #4065

This fixes the case with "a Button with only an Icon inside" to make sure clicking the `vaadin-icon` element doesn't cause `ItemClickListener` to be fired, making it consistent with a regular `vaadin-button` element click.

## Type of change

- Bugfix

## Note

I don't think we should add special logic to stop `ItemClickListener` for `Icon` component when it's not inside a focusable element like `Button`. In fact, a standalone `Icon` should be used inside a `Button` to convey its interactive meaning.

As mentioned in https://github.com/vaadin/flow-components/issues/4065#issuecomment-2210829465, as a workaround it's possible to use `.addEventData("event.preventDefault()")` on the `Icon` click listener in this case, in order to prevent `ItemClickListener` from being fired:

```java
grid.addColumn(new ComponentRenderer<>(person -> {
    Icon icon = new Icon(VaadinIcon.PENCIL);
    icon.getElement().addEventListener("click", e -> {
    }).addEventData("event.preventDefault()");
    return icon;
})).setHeader("Icon");
```