### PR TITLE
feat: add setWidth and setHeight methods to Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -225,6 +225,40 @@ public class Popover extends Component implements HasComponents {
     }
 
     /**
+     * Sets the width of the popover overlay content area.
+     * <p>
+     * The width should be in a format understood by the browser, e.g. "100px"
+     * or "2.5em" (Using relative unit, such as percentage, will lead to
+     * unexpected results).
+     * <p>
+     * If the provided {@code width} value is {@literal null} then width is
+     * removed, and the popover overlay is auto-sized based on the content.
+     *
+     * @param width
+     *            the width to set, may be {@code null}
+     */
+    public void setWidth(String width) {
+        getElement().setProperty("contentWidth", width);
+    }
+
+    /**
+     * Sets the height of the popover overlay content area.
+     * <p>
+     * The height should be in a format understood by the browser, e.g. "100px"
+     * or "2.5em" (Using relative unit, such as percentage, will lead to
+     * unexpected results).
+     * <p>
+     * If the provided {@code height} value is {@literal null} then height is
+     * removed, and the popover overlay is auto-sized based on the content.
+     *
+     * @param height
+     *            the height to set, may be {@code null}
+     */
+    public void setHeight(String height) {
+        getElement().setProperty("contentHeight", height);
+    }
+
+    /**
      * Adds the given components into this popover.
      * <p>
      * The elements in the DOM will not be children of the

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -67,6 +67,28 @@ public class PopoverTest {
     }
 
     @Test
+    public void setWidth_contentWidthPropertyUpdated() {
+        popover.setWidth("200px");
+        Assert.assertEquals("200px",
+                popover.getElement().getProperty("contentWidth", ""));
+
+        popover.setWidth(null);
+        Assert.assertEquals("",
+                popover.getElement().getProperty("contentWidth", ""));
+    }
+
+    @Test
+    public void setHeight_contentHeightPropertyUpdated() {
+        popover.setHeight("200px");
+        Assert.assertEquals("200px",
+                popover.getElement().getProperty("contentHeight", ""));
+
+        popover.setHeight(null);
+        Assert.assertEquals("",
+                popover.getElement().getProperty("contentHeight", ""));
+    }
+
+    @Test
     public void setFocusDelay_getFocusDelay() {
         Assert.assertEquals(0, popover.getFocusDelay());
 


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/web-components/pull/7442

The API looks similar to what we have in `ConfirmDialog` as implemented in https://github.com/vaadin/vaadin-confirm-dialog-flow/pull/89.

Note, I didn't add `HasSize` interface because it also has methods like `setMinWidth`, `setMaxWidth` etc. 
If users request these, we can consider adding them later like it's done in `Dialog`- see [`setDimension()`](https://github.com/vaadin/flow-components/blob/60244a7113d203871efe5da6735927ce370d9512/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java#L1011-L1014).

## Type of change

- Feature