### PR TITLE
feat: add i18n error message support for DateTimePicker

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
@@ -14,8 +14,19 @@ public class BasicValidationPage
     public static final String MAX_INPUT = "max-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Value has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Value is too small";
+    public static final String MAX_ERROR_MESSAGE = "Value is too big";
+
     public BasicValidationPage() {
         super();
+
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequiredIndicatorVisible(true);

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationPage.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.datetimepicker.validation;
 
 import java.time.LocalDateTime;
 
+import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
@@ -15,8 +16,11 @@ public class BinderValidationPage
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Value has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Value is too small";
+    public static final String MAX_ERROR_MESSAGE = "Value is too big";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Value does not match the expected value";
 
     public static class Bean {
         private LocalDateTime property;
@@ -42,6 +46,11 @@ public class BinderValidationPage
                 .withValidator(value -> value.equals(expectedValue),
                         UNEXPECTED_VALUE_ERROR_MESSAGE)
                 .bind("property");
+
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected date time",
                 event -> {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -13,6 +13,10 @@ import static com.vaadin.flow.component.datetimepicker.validation.BasicValidatio
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MAX_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.REQUIRED_BUTTON;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MIN_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-date-time-picker/validation/basic")
 public class BasicValidationIT
@@ -31,6 +35,7 @@ public class BasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -39,6 +44,7 @@ public class BasicValidationIT
         timeInput.sendKeys(Keys.TAB);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -49,6 +55,7 @@ public class BasicValidationIT
         timeInput.sendKeys(Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -59,14 +66,30 @@ public class BasicValidationIT
         setInputValue(timeInput, "12:00");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         setInputValue(dateInput, "");
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
 
         setInputValue(timeInput, "");
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        setInputValue(dateInput, "");
+        setInputValue(timeInput, "");
+        timeInput.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -77,26 +100,31 @@ public class BasicValidationIT
         setInputValue(timeInput, "11:00");
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "11:00");
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "12:00");
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "13:00");
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         setInputValue(dateInput, "3/3/2000");
         setInputValue(timeInput, "11:00");
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -107,26 +135,31 @@ public class BasicValidationIT
         setInputValue(timeInput, "13:00");
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "13:00");
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "12:00");
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "11:00");
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         setInputValue(dateInput, "1/1/2000");
         setInputValue(timeInput, "13:00");
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -135,10 +168,12 @@ public class BasicValidationIT
         setInputValue(timeInput, "10:00");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -147,16 +182,19 @@ public class BasicValidationIT
         setInputValue(timeInput, "INVALID");
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         setInputValue(dateInput, "1/1/2000");
         setInputValue(timeInput, "10:00");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         setInputValue(dateInput, "INVALID");
         setInputValue(timeInput, "INVALID");
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
     }
 
     @Test
@@ -166,6 +204,7 @@ public class BasicValidationIT
         timeInput.sendKeys(Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
     }
 
     @Test
@@ -174,6 +213,7 @@ public class BasicValidationIT
         timeInput.sendKeys(Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
     }
 
     @Test
@@ -182,10 +222,12 @@ public class BasicValidationIT
         setInputValue(timeInput, "INVALID");
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -195,10 +237,12 @@ public class BasicValidationIT
         timeInput.sendKeys(Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -207,10 +251,12 @@ public class BasicValidationIT
         timeInput.sendKeys(Keys.TAB);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationIT.java
@@ -14,6 +14,9 @@ import static com.vaadin.flow.component.datetimepicker.validation.BinderValidati
 import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.EXPECTED_VALUE_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.BAD_INPUT_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.MIN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.BinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
 @TestPath("vaadin-date-time-picker/validation/binder")
@@ -72,6 +75,19 @@ public class BinderValidationIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        setInputValue(dateInput, "INVALID");
+        setInputValue(timeInput, "INVALID");
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        setInputValue(dateInput, "");
+        setInputValue(timeInput, "");
+        timeInput.sendKeys(Keys.TAB);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -84,13 +100,13 @@ public class BinderValidationIT
         setInputValue(timeInput, "11:00");
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "11:00");
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "12:00");
@@ -120,13 +136,13 @@ public class BinderValidationIT
         setInputValue(timeInput, "13:00");
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "13:00");
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         setInputValue(dateInput, "2/2/2000");
         setInputValue(timeInput, "12:00");
@@ -171,7 +187,7 @@ public class BinderValidationIT
         setInputValue(timeInput, "INVALID");
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         setInputValue(dateInput, "1/1/2000");
         setInputValue(timeInput, "10:00");
@@ -182,7 +198,7 @@ public class BinderValidationIT
         setInputValue(timeInput, "INVALID");
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
     }
 
     @Test
@@ -191,7 +207,7 @@ public class BinderValidationIT
         setInputValue(timeInput, "INVALID");
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerInvalid();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -901,6 +901,13 @@ public class DateTimePicker
             i18nJson.put("timeLabel", timeAriaLabel);
         }
 
+        // Remove the error message properties because they aren't used on
+        // the client-side.
+        i18nJson.remove("badInputErrorMessage");
+        i18nJson.remove("requiredErrorMessage");
+        i18nJson.remove("minErrorMessage");
+        i18nJson.remove("maxErrorMessage");
+
         getElement().setPropertyJson("i18n", i18nJson);
     }
 
@@ -923,12 +930,36 @@ public class DateTimePicker
         ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
+    private String getBadInputErrorMessage() {
+        return Optional.ofNullable(i18n)
+                .map(DateTimePickerI18n::getBadInputErrorMessage).orElse("");
+    }
+
+    private String getRequiredErrorMessage() {
+        return Optional.ofNullable(i18n)
+                .map(DateTimePickerI18n::getRequiredErrorMessage).orElse("");
+    }
+
+    private String getMinErrorMessage() {
+        return Optional.ofNullable(i18n)
+                .map(DateTimePickerI18n::getMinErrorMessage).orElse("");
+    }
+
+    private String getMaxErrorMessage() {
+        return Optional.ofNullable(i18n)
+                .map(DateTimePickerI18n::getMaxErrorMessage).orElse("");
+    }
+
     /**
      * The internationalization properties for {@link DateTimePicker}.
      */
     public static class DateTimePickerI18n implements Serializable {
         private String dateLabel;
         private String timeLabel;
+        private String badInputErrorMessage;
+        private String requiredErrorMessage;
+        private String minErrorMessage;
+        private String maxErrorMessage;
 
         /**
          * Gets the aria-label suffix for the date picker.
@@ -987,6 +1018,110 @@ public class DateTimePicker
          */
         public DateTimePickerI18n setTimeLabel(String timeLabel) {
             this.timeLabel = timeLabel;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field contains user input
+         * that the server is unable to convert to type {@link LocalDateTime}.
+         *
+         * @return the error message or {@code null} if not set
+         */
+        public String getBadInputErrorMessage() {
+            return badInputErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field contains user input
+         * that the server is unable to convert to type {@link LocalDateTime}.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         */
+        public DateTimePickerI18n setBadInputErrorMessage(String errorMessage) {
+            badInputErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DateTimePicker#isRequiredIndicatorVisible()
+         * @see DateTimePicker#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DateTimePicker#isRequiredIndicatorVisible()
+         * @see DateTimePicker#setRequiredIndicatorVisible(boolean)
+         */
+        public DateTimePickerI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the selected date and time are
+         * earlier than the minimum allowed date and time.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DateTimePicker#getMin()
+         * @see DateTimePicker#setMin(LocalDateTime)
+         */
+        public String getMinErrorMessage() {
+            return minErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the selected date and time are
+         * earlier than the minimum allowed time.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DateTimePicker#getMin()
+         * @see DateTimePicker#setMin(LocalDateTime)
+         */
+        public DateTimePickerI18n setMinErrorMessage(String errorMessage) {
+            minErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the selected date and time are
+         * later than the maximum allowed date and time.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DateTimePicker#getMax()
+         * @see DateTimePicker#setMax(LocalDateTime)
+         */
+        public String getMaxErrorMessage() {
+            return maxErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the selected date and time are
+         * later than the maximum allowed date and time.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DateTimePicker#getMax()
+         * @see DateTimePicker#setMax(LocalDateTime)
+         */
+        public DateTimePickerI18n setMaxErrorMessage(String errorMessage) {
+            maxErrorMessage = errorMessage;
             return this;
         }
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Focusable;
-import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.dependency.JsModule;

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -1075,6 +1075,10 @@ public class DateTimePicker
         /**
          * Sets the error message to display when the field contains user input
          * that the server is unable to convert to type {@link LocalDateTime}.
+         * <p>
+         * Note, custom error messages set with
+         * {@link DateTimePicker#setErrorMessage(String)} take priority over
+         * i18n error messages.
          *
          * @param errorMessage
          *            the error message to set, or {@code null} to clear
@@ -1100,6 +1104,10 @@ public class DateTimePicker
         /**
          * Sets the error message to display when the field is required but
          * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link DateTimePicker#setErrorMessage(String)} take priority over
+         * i18n error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -1127,6 +1135,10 @@ public class DateTimePicker
         /**
          * Sets the error message to display when the selected date and time are
          * earlier than the minimum allowed time.
+         * <p>
+         * Note, custom error messages set with
+         * {@link DateTimePicker#setErrorMessage(String)} take priority over
+         * i18n error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -1154,6 +1166,10 @@ public class DateTimePicker
         /**
          * Sets the error message to display when the selected date and time are
          * later than the maximum allowed date and time.
+         * <p>
+         * Note, custom error messages set with
+         * {@link DateTimePicker#setErrorMessage(String)} take priority over
+         * i18n error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
@@ -17,12 +17,127 @@ package com.vaadin.flow.component.datetimepicker.validation;
 
 import java.time.LocalDateTime;
 
+import org.junit.Assert;
+import org.junit.Test;
+
+import elemental.json.Json;
+
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
+import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
         extends AbstractBasicValidationTest<DateTimePicker, LocalDateTime> {
+    @Test
+    public void badInput_validate_emptyErrorMessageDisplayed() {
+        getDatePicker().getElement().setProperty("_hasInputValue", true);
+        fireValidatedDomEvent();
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setBadInputErrorMessage("Value has invalid format"));
+        getDatePicker().getElement().setProperty("_hasInputValue", true);
+        fireValidatedDomEvent();
+        Assert.assertEquals("Value has invalid format",
+                getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue(LocalDateTime.now());
+        testField.setValue(null);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue(LocalDateTime.now());
+        testField.setValue(null);
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void min_validate_emptyErrorMessageDisplayed() {
+        testField.setMin(LocalDateTime.now());
+        testField.setValue(LocalDateTime.now().minusDays(1));
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMin(LocalDateTime.now());
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setMinErrorMessage("Value is too small"));
+        testField.setValue(LocalDateTime.now().minusDays(1));
+        Assert.assertEquals("Value is too small", getErrorMessageProperty());
+    }
+
+    @Test
+    public void max_validate_emptyErrorMessageDisplayed() {
+        testField.setMax(LocalDateTime.now());
+        testField.setValue(LocalDateTime.now().plusDays(1));
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMax(LocalDateTime.now());
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setMaxErrorMessage("Value is too big"));
+        testField.setValue(LocalDateTime.now().plusDays(1));
+        Assert.assertEquals("Value is too big", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(LocalDateTime.now());
+        testField.setValue(null);
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new DateTimePicker.DateTimePickerI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(LocalDateTime.now());
+        testField.setValue(null);
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected DateTimePicker createTestField() {
         return new DateTimePicker();
+    }
+
+    private DatePicker getDatePicker() {
+        return (DatePicker) SlotUtils.getChildInSlot(testField, "date-picker");
+    }
+
+    private void fireValidatedDomEvent() {
+        DomEvent validatedDomEvent = new DomEvent(testField.getElement(),
+                "validated", Json.createObject());
+        testField.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(validatedDomEvent);
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -15,6 +15,11 @@
  */
 package com.vaadin.flow.component.textfield;
 
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -22,7 +27,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 
@@ -40,11 +47,12 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class TextField extends TextFieldBase<TextField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
 
-    private boolean isConnectorAttached;
-
-    private TextFieldValidationSupport validationSupport;
+    private TextFieldI18n i18n;
 
     private boolean manualValidationEnabled = false;
+
+    private String customErrorMessage;
+    private String constraintErrorMessage;
 
     /**
      * Constructs an empty {@code TextField}.
@@ -175,11 +183,42 @@ public class TextField extends TextFieldBase<TextField, String>
         addValueChangeListener(listener);
     }
 
-    private TextFieldValidationSupport getValidationSupport() {
-        if (validationSupport == null) {
-            validationSupport = new TextFieldValidationSupport(this);
+    /**
+     * Sets an error message to display for all constraint violations.
+     * <p>
+     * This error message takes priority over i18n error messages when both are
+     * set.
+     *
+     * @param errorMessage
+     *            the error message to set, or {@code null} to clear
+     */
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        customErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    /**
+     * Gets the error message displayed for all constraint violations.
+     *
+     * @return the error message
+     */
+    @Override
+    public String getErrorMessage() {
+        return customErrorMessage;
+    }
+
+    private void setConstraintErrorMessage(String errorMessage) {
+        constraintErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    private void updateErrorMessage() {
+        String errorMessage = constraintErrorMessage;
+        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
+            errorMessage = customErrorMessage;
         }
-        return validationSupport;
+        getElement().setProperty("errorMessage", errorMessage);
     }
 
     /**
@@ -191,7 +230,6 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public void setMaxLength(int maxLength) {
         getElement().setProperty("maxlength", maxLength);
-        getValidationSupport().setMaxLength(maxLength);
     }
 
     /**
@@ -204,6 +242,10 @@ public class TextField extends TextFieldBase<TextField, String>
         return (int) getElement().getProperty("maxlength", 0.0);
     }
 
+    private boolean hasMaxLength() {
+        return getElement().getProperty("maxlength") != null;
+    }
+
     /**
      * Minimum number of characters (in Unicode code points) that the user can
      * enter.
@@ -213,7 +255,6 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public void setMinLength(int minLength) {
         getElement().setProperty("minlength", minLength);
-        getValidationSupport().setMinLength(minLength);
     }
 
     /**
@@ -224,22 +265,6 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public int getMinLength() {
         return (int) getElement().getProperty("minlength", 0.0);
-    }
-
-    /**
-     * <p>
-     * Specifies that the user must fill in a value.
-     * </p>
-     * NOTE: The required indicator will not be visible, if there is no
-     * {@code label} property set for the textfield.
-     *
-     * @param required
-     *            the boolean value to set
-     */
-    @Override
-    public void setRequired(boolean required) {
-        super.setRequired(required);
-        getValidationSupport().setRequired(required);
     }
 
     /**
@@ -259,7 +284,6 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public void setPattern(String pattern) {
         getElement().setProperty("pattern", pattern == null ? "" : pattern);
-        getValidationSupport().setPattern(pattern);
     }
 
     /**
@@ -305,14 +329,8 @@ public class TextField extends TextFieldBase<TextField, String>
     }
 
     @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        getValidationSupport().setRequired(requiredIndicatorVisible);
-    }
-
-    @Override
     public Validator<String> getDefaultValidator() {
-        return (value, context) -> getValidationSupport().checkValidity(value);
+        return (value, context) -> checkValidity(value, false);
     }
 
     @Override
@@ -320,15 +338,71 @@ public class TextField extends TextFieldBase<TextField, String>
         this.manualValidationEnabled = enabled;
     }
 
+    private ValidationResult checkValidity(String value,
+            boolean withRequiredValidator) {
+        if (withRequiredValidator) {
+            ValidationResult requiredResult = ValidationUtil
+                    .validateRequiredConstraint(
+                            getI18nErrorMessage(
+                                    TextFieldI18n::getRequiredErrorMessage),
+                            isRequiredIndicatorVisible(), value,
+                            getEmptyValue());
+            if (requiredResult.isError()) {
+                return requiredResult;
+            }
+        }
+
+        ValidationResult maxLengthResult = ValidationUtil
+                .validateMaxLengthConstraint(
+                        getI18nErrorMessage(
+                                TextFieldI18n::getMaxLengthErrorMessage),
+                        value, hasMaxLength() ? getMaxLength() : null);
+        if (maxLengthResult.isError()) {
+            return maxLengthResult;
+        }
+
+        ValidationResult minLengthResult = ValidationUtil
+                .validateMinLengthConstraint(
+                        getI18nErrorMessage(
+                                TextFieldI18n::getMinLengthErrorMessage),
+                        value, getMinLength());
+        if (minLengthResult.isError()) {
+            return minLengthResult;
+        }
+
+        ValidationResult patternResult = ValidationUtil
+                .validatePatternConstraint(
+                        getI18nErrorMessage(
+                                TextFieldI18n::getPatternErrorMessage),
+                        value, getPattern());
+        if (patternResult.isError()) {
+            return patternResult;
+        }
+
+        return ValidationResult.ok();
+    }
+
     /**
-     * Performs server-side validation of the current value and the validation
-     * constraints of the field, such as {@link #setPattern(String)}. This is
-     * needed because it is possible to circumvent the client-side validation
-     * constraints using browser development tools.
+     * Validates the current value against the constraints and sets the
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise,
+     * the error message defined in the i18n object is used.
+     * <p>
+     * The method does nothing if the manual validation mode is enabled.
      */
     protected void validate() {
-        if (!this.manualValidationEnabled) {
-            setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (this.manualValidationEnabled) {
+            return;
+        }
+
+        ValidationResult result = checkValidity(getValue(), true);
+        if (result.isError()) {
+            setInvalid(true);
+            setConstraintErrorMessage(result.getErrorMessage());
+        } else {
+            setInvalid(false);
+            setConstraintErrorMessage("");
         }
     }
 
@@ -336,5 +410,168 @@ public class TextField extends TextFieldBase<TextField, String>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(TextFieldI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public TextFieldI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(TextFieldI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+    }
+
+    private String getI18nErrorMessage(Function<TextFieldI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
+    }
+
+    /**
+     * The internationalization properties for {@link TextField}.
+     */
+    public static class TextFieldI18n implements Serializable {
+
+        private String requiredErrorMessage;
+        private String minLengthErrorMessage;
+        private String maxLengthErrorMessage;
+        private String patternErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextField#isRequiredIndicatorVisible()
+         * @see TextField#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextField#isRequiredIndicatorVisible()
+         * @see TextField#setRequiredIndicatorVisible(boolean)
+         */
+        public TextFieldI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is shorter than
+         * the minimum allowed length.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextField#getMinLength()
+         * @see TextField#setMinLength(int)
+         */
+        public String getMinLengthErrorMessage() {
+            return minLengthErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is shorter
+         * than the minimum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextField#getMinLength()
+         * @see TextField#setMinLength(int)
+         */
+        public TextFieldI18n setMinLengthErrorMessage(String errorMessage) {
+            minLengthErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is longer than
+         * the maximum allowed length.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextField#getMaxLength()
+         * @see TextField#setMaxLength(int)
+         */
+        public String getMaxLengthErrorMessage() {
+            return maxLengthErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is longer than
+         * the maximum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextField#getMaxLength()
+         * @see TextField#setMaxLength(int)
+         */
+        public TextFieldI18n setMaxLengthErrorMessage(String errorMessage) {
+            maxLengthErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value does not match
+         * the pattern.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextField#getPattern()
+         * @see TextField#setPattern(String)
+         */
+        public String getPatternErrorMessage() {
+            return patternErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value does not match
+         * the pattern.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextField#getPattern()
+         * @see TextField#setPattern(String)
+         */
+        public TextFieldI18n setPatternErrorMessage(String errorMessage) {
+            patternErrorMessage = errorMessage;
+            return this;
+        }
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import java.io.Serializable;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
-
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -27,9 +22,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
-import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.Binder;
-import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 
@@ -47,12 +40,11 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class TextField extends TextFieldBase<TextField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
 
-    private TextFieldI18n i18n;
+    private boolean isConnectorAttached;
+
+    private TextFieldValidationSupport validationSupport;
 
     private boolean manualValidationEnabled = false;
-
-    private String customErrorMessage;
-    private String constraintErrorMessage;
 
     /**
      * Constructs an empty {@code TextField}.
@@ -183,42 +175,11 @@ public class TextField extends TextFieldBase<TextField, String>
         addValueChangeListener(listener);
     }
 
-    /**
-     * Sets an error message to display for all constraint violations.
-     * <p>
-     * This error message takes priority over i18n error messages when both are
-     * set.
-     *
-     * @param errorMessage
-     *            the error message to set, or {@code null} to clear
-     */
-    @Override
-    public void setErrorMessage(String errorMessage) {
-        customErrorMessage = errorMessage;
-        updateErrorMessage();
-    }
-
-    /**
-     * Gets the error message displayed for all constraint violations.
-     *
-     * @return the error message
-     */
-    @Override
-    public String getErrorMessage() {
-        return customErrorMessage;
-    }
-
-    private void setConstraintErrorMessage(String errorMessage) {
-        constraintErrorMessage = errorMessage;
-        updateErrorMessage();
-    }
-
-    private void updateErrorMessage() {
-        String errorMessage = constraintErrorMessage;
-        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
-            errorMessage = customErrorMessage;
+    private TextFieldValidationSupport getValidationSupport() {
+        if (validationSupport == null) {
+            validationSupport = new TextFieldValidationSupport(this);
         }
-        getElement().setProperty("errorMessage", errorMessage);
+        return validationSupport;
     }
 
     /**
@@ -230,6 +191,7 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public void setMaxLength(int maxLength) {
         getElement().setProperty("maxlength", maxLength);
+        getValidationSupport().setMaxLength(maxLength);
     }
 
     /**
@@ -242,10 +204,6 @@ public class TextField extends TextFieldBase<TextField, String>
         return (int) getElement().getProperty("maxlength", 0.0);
     }
 
-    private boolean hasMaxLength() {
-        return getElement().getProperty("maxlength") != null;
-    }
-
     /**
      * Minimum number of characters (in Unicode code points) that the user can
      * enter.
@@ -255,6 +213,7 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public void setMinLength(int minLength) {
         getElement().setProperty("minlength", minLength);
+        getValidationSupport().setMinLength(minLength);
     }
 
     /**
@@ -265,6 +224,22 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public int getMinLength() {
         return (int) getElement().getProperty("minlength", 0.0);
+    }
+
+    /**
+     * <p>
+     * Specifies that the user must fill in a value.
+     * </p>
+     * NOTE: The required indicator will not be visible, if there is no
+     * {@code label} property set for the textfield.
+     *
+     * @param required
+     *            the boolean value to set
+     */
+    @Override
+    public void setRequired(boolean required) {
+        super.setRequired(required);
+        getValidationSupport().setRequired(required);
     }
 
     /**
@@ -284,6 +259,7 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public void setPattern(String pattern) {
         getElement().setProperty("pattern", pattern == null ? "" : pattern);
+        getValidationSupport().setPattern(pattern);
     }
 
     /**
@@ -329,8 +305,14 @@ public class TextField extends TextFieldBase<TextField, String>
     }
 
     @Override
+    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
+        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
+        getValidationSupport().setRequired(requiredIndicatorVisible);
+    }
+
+    @Override
     public Validator<String> getDefaultValidator() {
-        return (value, context) -> checkValidity(value, false);
+        return (value, context) -> getValidationSupport().checkValidity(value);
     }
 
     @Override
@@ -338,71 +320,15 @@ public class TextField extends TextFieldBase<TextField, String>
         this.manualValidationEnabled = enabled;
     }
 
-    private ValidationResult checkValidity(String value,
-            boolean withRequiredValidator) {
-        if (withRequiredValidator) {
-            ValidationResult requiredResult = ValidationUtil
-                    .validateRequiredConstraint(
-                            getI18nErrorMessage(
-                                    TextFieldI18n::getRequiredErrorMessage),
-                            isRequiredIndicatorVisible(), value,
-                            getEmptyValue());
-            if (requiredResult.isError()) {
-                return requiredResult;
-            }
-        }
-
-        ValidationResult maxLengthResult = ValidationUtil
-                .validateMaxLengthConstraint(
-                        getI18nErrorMessage(
-                                TextFieldI18n::getMaxLengthErrorMessage),
-                        value, hasMaxLength() ? getMaxLength() : null);
-        if (maxLengthResult.isError()) {
-            return maxLengthResult;
-        }
-
-        ValidationResult minLengthResult = ValidationUtil
-                .validateMinLengthConstraint(
-                        getI18nErrorMessage(
-                                TextFieldI18n::getMinLengthErrorMessage),
-                        value, getMinLength());
-        if (minLengthResult.isError()) {
-            return minLengthResult;
-        }
-
-        ValidationResult patternResult = ValidationUtil
-                .validatePatternConstraint(
-                        getI18nErrorMessage(
-                                TextFieldI18n::getPatternErrorMessage),
-                        value, getPattern());
-        if (patternResult.isError()) {
-            return patternResult;
-        }
-
-        return ValidationResult.ok();
-    }
-
     /**
-     * Validates the current value against the constraints and sets the
-     * {@code invalid} property and the {@code errorMessage} property based on
-     * the result. If a custom error message is provided with
-     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
-     * message defined in the i18n object is used.
-     * <p>
-     * The method does nothing if the manual validation mode is enabled.
+     * Performs server-side validation of the current value and the validation
+     * constraints of the field, such as {@link #setPattern(String)}. This is
+     * needed because it is possible to circumvent the client-side validation
+     * constraints using browser development tools.
      */
     protected void validate() {
-        if (this.manualValidationEnabled) {
-            return;
-        }
-
-        ValidationResult result = checkValidity(getValue(), true);
-        if (result.isError()) {
-            setInvalid(true);
-            setConstraintErrorMessage(result.getErrorMessage());
-        } else {
-            setInvalid(false);
-            setConstraintErrorMessage("");
+        if (!this.manualValidationEnabled) {
+            setInvalid(getValidationSupport().isInvalid(getValue()));
         }
     }
 
@@ -410,168 +336,5 @@ public class TextField extends TextFieldBase<TextField, String>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
-    }
-
-    /**
-     * Gets the internationalization object previously set for this component.
-     * <p>
-     * NOTE: Updating the instance that is returned from this method will not
-     * update the component if not set again using
-     * {@link #setI18n(TextFieldI18n)}
-     *
-     * @return the i18n object or {@code null} if no i18n object has been set
-     */
-    public TextFieldI18n getI18n() {
-        return i18n;
-    }
-
-    /**
-     * Sets the internationalization object for this component.
-     *
-     * @param i18n
-     *            the i18n object, not {@code null}
-     */
-    public void setI18n(TextFieldI18n i18n) {
-        this.i18n = Objects.requireNonNull(i18n,
-                "The i18n properties object should not be null");
-    }
-
-    private String getI18nErrorMessage(Function<TextFieldI18n, String> getter) {
-        return Optional.ofNullable(i18n).map(getter).orElse("");
-    }
-
-    /**
-     * The internationalization properties for {@link TextField}.
-     */
-    public static class TextFieldI18n implements Serializable {
-
-        private String requiredErrorMessage;
-        private String minLengthErrorMessage;
-        private String maxLengthErrorMessage;
-        private String patternErrorMessage;
-
-        /**
-         * Gets the error message displayed when the field is required but
-         * empty.
-         *
-         * @return the error message or {@code null} if not set
-         * @see TextField#isRequiredIndicatorVisible()
-         * @see TextField#setRequiredIndicatorVisible(boolean)
-         */
-        public String getRequiredErrorMessage() {
-            return requiredErrorMessage;
-        }
-
-        /**
-         * Sets the error message to display when the field is required but
-         * empty.
-         * <p>
-         * Note, custom error messages set with
-         * {@link TextField#setErrorMessage(String)} take priority over i18n
-         * error messages.
-         *
-         * @param errorMessage
-         *            the error message or {@code null} to clear it
-         * @return this instance for method chaining
-         * @see TextField#isRequiredIndicatorVisible()
-         * @see TextField#setRequiredIndicatorVisible(boolean)
-         */
-        public TextFieldI18n setRequiredErrorMessage(String errorMessage) {
-            requiredErrorMessage = errorMessage;
-            return this;
-        }
-
-        /**
-         * Gets the error message displayed when the field value is shorter than
-         * the minimum allowed length.
-         *
-         * @return the error message or {@code null} if not set
-         * @see TextField#getMinLength()
-         * @see TextField#setMinLength(int)
-         */
-        public String getMinLengthErrorMessage() {
-            return minLengthErrorMessage;
-        }
-
-        /**
-         * Sets the error message to display when the field value is shorter
-         * than the minimum allowed length.
-         * <p>
-         * Note, custom error messages set with
-         * {@link TextField#setErrorMessage(String)} take priority over i18n
-         * error messages.
-         *
-         * @param errorMessage
-         *            the error message or {@code null} to clear it
-         * @return this instance for method chaining
-         * @see TextField#getMinLength()
-         * @see TextField#setMinLength(int)
-         */
-        public TextFieldI18n setMinLengthErrorMessage(String errorMessage) {
-            minLengthErrorMessage = errorMessage;
-            return this;
-        }
-
-        /**
-         * Gets the error message displayed when the field value is longer than
-         * the maximum allowed length.
-         *
-         * @return the error message or {@code null} if not set
-         * @see TextField#getMaxLength()
-         * @see TextField#setMaxLength(int)
-         */
-        public String getMaxLengthErrorMessage() {
-            return maxLengthErrorMessage;
-        }
-
-        /**
-         * Sets the error message to display when the field value is longer than
-         * the maximum allowed length.
-         * <p>
-         * Note, custom error messages set with
-         * {@link TextField#setErrorMessage(String)} take priority over i18n
-         * error messages.
-         *
-         * @param errorMessage
-         *            the error message or {@code null} to clear it
-         * @return this instance for method chaining
-         * @see TextField#getMaxLength()
-         * @see TextField#setMaxLength(int)
-         */
-        public TextFieldI18n setMaxLengthErrorMessage(String errorMessage) {
-            maxLengthErrorMessage = errorMessage;
-            return this;
-        }
-
-        /**
-         * Gets the error message displayed when the field value does not match
-         * the pattern.
-         *
-         * @return the error message or {@code null} if not set
-         * @see TextField#getPattern()
-         * @see TextField#setPattern(String)
-         */
-        public String getPatternErrorMessage() {
-            return patternErrorMessage;
-        }
-
-        /**
-         * Sets the error message to display when the field value does not match
-         * the pattern.
-         * <p>
-         * Note, custom error messages set with
-         * {@link TextField#setErrorMessage(String)} take priority over i18n
-         * error messages.
-         *
-         * @param errorMessage
-         *            the error message or {@code null} to clear it
-         * @return this instance for method chaining
-         * @see TextField#getPattern()
-         * @see TextField#setPattern(String)
-         */
-        public TextFieldI18n setPatternErrorMessage(String errorMessage) {
-            patternErrorMessage = errorMessage;
-            return this;
-        }
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -386,8 +386,8 @@ public class TextField extends TextFieldBase<TextField, String>
      * Validates the current value against the constraints and sets the
      * {@code invalid} property and the {@code errorMessage} property based on
      * the result. If a custom error message is provided with
-     * {@link #setErrorMessage(String)}, it is used. Otherwise,
-     * the error message defined in the i18n object is used.
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
      */


### PR DESCRIPTION
## Description

The PR enhances DateTimePickerI18n with methods for setting error messages and updates the DateTimePicker's validation logic to show these error messages when validation fails.

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Part of #4618 

## Type of change

- [x] Feature
