### PR TITLE
feat: add server-side modality support to Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/main/java/com/vaadin/flow/component/popover/tests/ModalityPage.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/main/java/com/vaadin/flow/component/popover/tests/ModalityPage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.component.popover.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.popover.Popover;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "vaadin-popover/modality")
+public class ModalityPage extends Div {
+    public ModalityPage() {
+        Popover popover = new Popover();
+        Div content = new Div("Popover content");
+        popover.add(content);
+
+        NativeButton target = new NativeButton("Toggle popover");
+        target.setId("popover-target");
+        popover.setTarget(target);
+
+        NativeButton setModal = new NativeButton("Set modal",
+                e -> popover.setModal(true));
+        setModal.setId("set-modal");
+
+        NativeButton setNonModal = new NativeButton("Set non modal",
+                e -> popover.setModal(false));
+        setNonModal.setId("set-non-modal");
+
+        Span testClickResult = new Span();
+        testClickResult.setId("test-click-result");
+
+        NativeButton testClick = new NativeButton("Test click",
+                event -> testClickResult.setText("Click event received"));
+        testClick.setId("test-click");
+
+        add(new Div(popover, setModal, setNonModal, target));
+        add(new Div(testClick, testClickResult));
+    }
+}

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/ModalityIT.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/ModalityIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.component.popover.tests;
+
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.openqa.selenium.By;
+
+@TestPath("vaadin-popover/modality")
+public class ModalityIT extends AbstractComponentIT {
+
+    static final String POPOVER_OVERLAY_TAG = "vaadin-popover-overlay";
+
+    private NativeButtonElement target;
+    private NativeButtonElement setModal;
+    private NativeButtonElement setNonModal;
+    private NativeButtonElement testClick;
+    private SpanElement testClickResult;
+
+    @Before
+    public void init() {
+        open();
+        target = $(NativeButtonElement.class).id("popover-target");
+        setModal = $(NativeButtonElement.class).id("set-modal");
+        setNonModal = $(NativeButtonElement.class).id("set-non-modal");
+        testClick = $(NativeButtonElement.class).id("test-click");
+        testClickResult = $(SpanElement.class).id("test-click-result");
+    }
+
+    @Test
+    public void openPopover_clicksOnElementsInBackgroundAllowed() {
+        target.click();
+        checkPopoverIsOpened();
+        assertBackgroundButtonIsClickable();
+    }
+
+    @Test
+    public void setModal_openPopover_noClicksOnElementsInBackgroundAllowed() {
+        setModal.click();
+        target.click();
+        checkPopoverIsOpened();
+        assertBackgroundButtonIsNotClickable();
+    }
+
+    @Test
+    public void setModal_openAndClosePopover_clicksOnElementsInBackgroundAllowed() {
+        setModal.click();
+        target.click();
+        checkPopoverIsOpened();
+
+        target.click();
+        checkPopoverIsClosed();
+        assertBackgroundButtonIsClickable();
+    }
+
+    @Test
+    public void setNonModal_openPopover_clicksOnElementsInBackgroundAllowed() {
+        setModal.click();
+        setNonModal.click();
+        target.click();
+        checkPopoverIsOpened();
+        assertBackgroundButtonIsClickable();
+    }
+
+    private void assertBackgroundButtonIsNotClickable() {
+        testClick.click();
+        Assert.assertEquals("Button in background is clickable", "",
+                testClickResult.getText());
+    }
+
+    private void assertBackgroundButtonIsClickable() {
+        testClick.click();
+        Assert.assertEquals("Button in background is not clickable",
+                "Click event received", testClickResult.getText());
+    }
+
+    private void checkPopoverIsClosed() {
+        waitForElementNotPresent(By.tagName(POPOVER_OVERLAY_TAG));
+    }
+
+    private void checkPopoverIsOpened() {
+        waitForElementPresent(By.tagName(POPOVER_OVERLAY_TAG));
+    }
+}

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -79,8 +79,13 @@ public class Popover extends Component implements HasAriaLabel, HasComponents {
 
         updateTrigger();
         setOverlayRole("dialog");
-    }
 
+        getElement().addPropertyChangeListener("opened", event -> {
+            if (event.isUserOriginated()) {
+                setModality(isOpened() && isModal());
+            }
+        });
+    }
 
     /**
      * {@code opened-changed} event is sent when the overlay opened state
@@ -108,6 +113,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents {
      */
     public void setOpened(boolean opened) {
         if (opened != isOpened()) {
+            setModality(opened && isModal());
             getElement().setProperty("opened", opened);
             fireEvent(new OpenedChangeEvent(this, false));
         }
@@ -147,6 +153,33 @@ public class Popover extends Component implements HasAriaLabel, HasComponents {
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
         return addListener(OpenedChangeEvent.class, listener);
+    }
+
+    /**
+     * Sets whether component will open modal or modeless popover.
+     *
+     * @param modal
+     *            {@code false} to enable popover to open as modeless modal,
+     *            {@code true} otherwise.
+     */
+    public void setModal(boolean modal) {
+        getElement().setProperty("modal", modal);
+    }
+
+    /**
+     * Gets whether component is set as modal or modeless popover. By default,
+     * the popover is non-modal.
+     *
+     * @return {@code true} if modal popover, {@code false} otherwise.
+     */
+    public boolean isModal() {
+        return getElement().getProperty("modal", false);
+    }
+
+    private void setModality(boolean modal) {
+        if (isAttached()) {
+            getUI().ifPresent(ui -> ui.setChildComponentModal(this, modal));
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Mostly based on `Dialog` / `ConfirmDialog` implementation (and `ModalityIT` from `ConfirmDialog`).
The main difference is that `vaadin-popover` has `modal` property which defaults to `false`.

## Type of change

- Feature