### PR TITLE
feat: add methods to set modal and withBackdrop to Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -81,7 +81,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents {
         setOverlayRole("dialog");
     }
 
-
     /**
      * {@code opened-changed} event is sent when the overlay opened state
      * changes.
@@ -147,6 +146,53 @@ public class Popover extends Component implements HasAriaLabel, HasComponents {
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
         return addListener(OpenedChangeEvent.class, listener);
+    }
+
+    /**
+     * Sets whether component should open modal or modeless popover. When the
+     * popover is modal, interacting with elements behind it will be prevented
+     * until the popover is closed.
+     * <p>
+     * By default, the popover is non-modal.
+     *
+     * @param modal
+     *            {@code true} to enable popover to open as modal, {@code false}
+     *            otherwise.
+     */
+    public void setModal(boolean modal) {
+        getElement().setProperty("modal", modal);
+    }
+
+    /**
+     * Gets whether component is set as modal or modeless popover. By default,
+     * the popover is non-modal.
+     *
+     * @return {@code true} if modal popover, {@code false} otherwise.
+     */
+    public boolean isModal() {
+        return getElement().getProperty("modal", false);
+    }
+
+    /**
+     * Sets whether component should show a backdrop (modality curtain) when
+     * opened.
+     * <p>
+     * By default, the backdrop is not shown.
+     *
+     * @param backdropVisible
+     *            {@code true} to show the backdrop, {@code false} otherwise.
+     */
+    public void setBackdropVisible(boolean backdropVisible) {
+        getElement().setProperty("withBackdrop", backdropVisible);
+    }
+
+    /**
+     * Gets whether component shows a backdrop (modality curtain) when opened.
+     *
+     * @return {@code true} if backdrop is visible, {@code false} otherwise.
+     */
+    public boolean isBackdropVisible() {
+        return getElement().getProperty("withBackdrop", false);
     }
 
     @Override

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -153,6 +153,10 @@ public class Popover extends Component implements HasAriaLabel, HasComponents {
      * popover is modal, interacting with elements behind it will be prevented
      * until the popover is closed.
      * <p>
+     * NOTE: this setting does not involve server-side modality, as the modal
+     * popover is typically not used to prevent anything else from happening
+     * while it's open.
+     * <p>
      * By default, the popover is non-modal.
      *
      * @param modal

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -242,4 +242,26 @@ public class PopoverTest {
     public void setOverlayRole_null_throws() {
         popover.setOverlayRole(null);
     }
+
+    @Test
+    public void setModal_isModal() {
+        Assert.assertFalse(popover.isModal());
+        Assert.assertFalse(popover.getElement().getProperty("modal", false));
+
+        popover.setModal(true);
+        Assert.assertTrue(popover.isModal());
+        Assert.assertTrue(popover.getElement().getProperty("modal", false));
+    }
+
+    @Test
+    public void setBackdropVisible_isBackdropVisible() {
+        Assert.assertFalse(popover.isBackdropVisible());
+        Assert.assertFalse(
+                popover.getElement().getProperty("withBackdrop", false));
+
+        popover.setBackdropVisible(true);
+        Assert.assertTrue(popover.isBackdropVisible());
+        Assert.assertTrue(
+                popover.getElement().getProperty("withBackdrop", false));
+    }
 }


### PR DESCRIPTION
## Description

Replaces #6446

Added the following methods to `Popover`:

- `setModal()` / `isModal()`
- `setBackdropVisible()` / `isBackdropVisible()`

Note: as discussed internally, for now we only add web component property without using server-side modality.

## Type of change

- Feature