### PR TITLE
feat: add i18n error message support for IntegerField

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationPage.java
@@ -28,8 +28,21 @@ public class IntegerFieldBasicValidationPage
     public static final String MAX_INPUT = "max-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Number has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Number is too small";
+    public static final String MAX_ERROR_MESSAGE = "Number is too big";
+    public static final String STEP_ERROR_MESSAGE = "Number does not match the step";
+
     public IntegerFieldBasicValidationPage() {
         super();
+
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE)
+                .setStepErrorMessage(STEP_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationPage.java
@@ -30,8 +30,12 @@ public class IntegerFieldBinderValidationPage
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
     public static final String RESET_BEAN_BUTTON = "reset-bean-button";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Number has incorrect format";
+    public static final String MIN_ERROR_MESSAGE = "Number is too small";
+    public static final String MAX_ERROR_MESSAGE = "Number is too big";
+    public static final String STEP_ERROR_MESSAGE = "Number does not match the step";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Number does not match the expected value";
 
     public static class Bean {
         private Integer property;
@@ -60,6 +64,12 @@ public class IntegerFieldBinderValidationPage
         binder.addStatusChangeListener(event -> {
             incrementServerValidationCounter();
         });
+
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
+                .setMinErrorMessage(MIN_ERROR_MESSAGE)
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE)
+                .setStepErrorMessage(STEP_ERROR_MESSAGE));
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = Integer.parseInt(event.getValue());

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
@@ -28,6 +27,11 @@ import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldB
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.STEP_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.REQUIRED_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.MIN_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBasicValidationPage.STEP_ERROR_MESSAGE;
 
 @TestPath("vaadin-integer-field/validation/basic")
 public class IntegerFieldBasicValidationIT
@@ -36,6 +40,7 @@ public class IntegerFieldBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -44,6 +49,7 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -54,6 +60,7 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -64,11 +71,25 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -79,21 +100,25 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("3");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -104,21 +129,25 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("1");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -129,21 +158,25 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(STEP_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("3");
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(STEP_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -152,21 +185,25 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.sendKeys("--2", Keys.ENTER);
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -174,10 +211,12 @@ public class IntegerFieldBasicValidationIT
         testField.setValue("2");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -186,11 +225,13 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -199,11 +240,13 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -212,11 +255,13 @@ public class IntegerFieldBasicValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBinderValidationIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.tests.validation;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
@@ -29,7 +28,11 @@ import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldB
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.RESET_BEAN_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.MAX_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.MIN_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.BAD_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.STEP_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.IntegerFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
 @TestPath("vaadin-integer-field/validation/binder")
@@ -64,6 +67,18 @@ public class IntegerFieldBinderValidationIT
         assertServerInvalid();
         assertClientInvalid();
         assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -89,7 +104,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("2");
@@ -122,7 +137,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("2");
@@ -155,7 +170,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(STEP_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("2");
@@ -186,7 +201,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
@@ -197,7 +212,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
@@ -226,7 +241,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);
@@ -241,7 +256,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
@@ -256,7 +271,7 @@ public class IntegerFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
@@ -244,7 +244,7 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
 
         /**
          * Gets the error message displayed when the field contains user input
-         * that the server is unable to convert to type {@link Number}.
+         * that the server is unable to convert to type {@link Integer}.
          *
          * @return the error message or {@code null} if not set
          */
@@ -255,7 +255,7 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
 
         /**
          * Sets the error message to display when the field contains user input
-         * that the server is unable to convert to type {@link Number}.
+         * that the server is unable to convert to type {@link Integer}.
          * <p>
          * Note, custom error messages set with
          * {@link IntegerField#setErrorMessage(String)} take priority over i18n

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
@@ -207,4 +207,195 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
     public int getStep() {
         return (int) getStepDouble();
     }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(IntegerFieldI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    @Override
+    public IntegerFieldI18n getI18n() {
+        return (IntegerFieldI18n) super.getI18n();
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(IntegerFieldI18n i18n) {
+        super.setI18n(i18n);
+    }
+
+    /**
+     * The internationalization properties for {@link IntegerField}.
+     */
+    public static class IntegerFieldI18n implements AbstractNumberFieldI18n {
+        private String requiredErrorMessage;
+        private String badInputErrorMessage;
+        private String minErrorMessage;
+        private String maxErrorMessage;
+        private String stepErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field contains user input
+         * that the server is unable to convert to type {@link Number}.
+         *
+         * @return the error message or {@code null} if not set
+         */
+        @Override
+        public String getBadInputErrorMessage() {
+            return badInputErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field contains user input
+         * that the server is unable to convert to type {@link Number}.
+         * <p>
+         * Note, custom error messages set with
+         * {@link IntegerField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         */
+        public IntegerFieldI18n setBadInputErrorMessage(String errorMessage) {
+            badInputErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see IntegerField#isRequired()
+         * @see IntegerField#setRequired(boolean)
+         */
+        @Override
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link IntegerField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         * @see IntegerField#isRequired()
+         * @see IntegerField#setRequired(boolean)
+         */
+        public IntegerFieldI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is smaller than
+         * the minimum allowed value.
+         *
+         * @return the error message or {@code null} if not set
+         * @see IntegerField#setMin(int)
+         * @see IntegerField#getMin()
+         */
+        @Override
+        public String getMinErrorMessage() {
+            return minErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is smaller
+         * than the minimum allowed value.
+         * <p>
+         * Note, custom error messages set with
+         * {@link IntegerField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         * @see IntegerField#setMin(int)
+         * @see IntegerField#getMin()
+         */
+        public IntegerFieldI18n setMinErrorMessage(String errorMessage) {
+            minErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is greater than
+         * the maximum allowed value.
+         *
+         * @return the error message or {@code null} if not set
+         * @see IntegerField#setMax(int)
+         * @see IntegerField#getMax()
+         */
+        @Override
+        public String getMaxErrorMessage() {
+            return maxErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is greater
+         * than the maximum allowed value.
+         * <p>
+         * Note, custom error messages set with
+         * {@link IntegerField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         * @see IntegerField#setMax(int)
+         * @see IntegerField#getMax()
+         */
+        public IntegerFieldI18n setMaxErrorMessage(String errorMessage) {
+            maxErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is not a
+         * multiple of the step value.
+         *
+         * @return the error message or {@code null} if not set
+         * @see IntegerField#setStep(int)
+         * @see IntegerField#getStep()
+         */
+        @Override
+        public String getStepErrorMessage() {
+            return stepErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is not a
+         * multiple of the step value.
+         * <p>
+         * Note, custom error messages set with
+         * {@link IntegerField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         * @see IntegerField#setStep(int)
+         * @see IntegerField#getStep()
+         */
+        public IntegerFieldI18n setStepErrorMessage(String errorMessage) {
+            stepErrorMessage = errorMessage;
+            return this;
+        }
+    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -386,8 +386,8 @@ public class TextField extends TextFieldBase<TextField, String>
      * Validates the current value against the constraints and sets the
      * {@code invalid} property and the {@code errorMessage} property based on
      * the result. If a custom error message is provided with
-     * {@link #setErrorMessage(String)}, it is used. Otherwise,
-     * the error message defined in the i18n object is used.
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
      */

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/IntegerFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/IntegerFieldBasicValidationTest.java
@@ -15,10 +15,15 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
+
+import elemental.json.Json;
 
 public class IntegerFieldBasicValidationTest
         extends AbstractBasicValidationTest<IntegerField, Integer> {
@@ -34,7 +39,109 @@ public class IntegerFieldBasicValidationTest
         testField.clear();
     }
 
+    @Test
+    public void badInput_validate_emptyErrorMessageDisplayed() {
+        testField.getElement().setProperty("_hasInputValue", true);
+        fireUnparsableChangeDomEvent();
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setBadInputErrorMessage("Value has invalid format"));
+        testField.getElement().setProperty("_hasInputValue", true);
+        fireUnparsableChangeDomEvent();
+        Assert.assertEquals("Value has invalid format",
+                getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue(1);
+        testField.setValue(null);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue(1);
+        testField.setValue(null);
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void min_validate_emptyErrorMessageDisplayed() {
+        testField.setMin(3);
+        testField.setValue(1);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMin(3);
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setMinErrorMessage("Value is too small"));
+        testField.setValue(1);
+        Assert.assertEquals("Value is too small", getErrorMessageProperty());
+    }
+
+    @Test
+    public void max_validate_emptyErrorMessageDisplayed() {
+        testField.setMax(1);
+        testField.setValue(3);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMax(1);
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setMaxErrorMessage("Value is too big"));
+        testField.setValue(3);
+        Assert.assertEquals("Value is too big", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(1);
+        testField.setValue(null);
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new IntegerField.IntegerFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(1);
+        testField.setValue(null);
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected IntegerField createTestField() {
         return new IntegerField();
+    }
+
+    private void fireUnparsableChangeDomEvent() {
+        DomEvent unparsableChangeDomEvent = new DomEvent(testField.getElement(),
+                "unparsable-change", Json.createObject());
+        testField.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(unparsableChangeDomEvent);
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces IntegerFieldI18n with methods for setting error messages and updates the IntegerField's validation logic to show these error messages when validation fails. 

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Part of #4618 

## Type of change

- [x] Feature
