### PR TITLE
refactor: remove unused class field

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -59,8 +59,6 @@ import com.vaadin.flow.shared.Registration;
 public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         implements HasThemeVariant<TextFieldVariant> {
 
-    private boolean isConnectorAttached;
-
     private Locale locale;
 
     private static final SerializableBiFunction<BigDecimalField, String, BigDecimal> PARSER = (

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -48,8 +48,6 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class EmailField extends TextFieldBase<EmailField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
 
-    private boolean isConnectorAttached;
-
     private TextFieldValidationSupport validationSupport;
 
     private boolean manualValidationEnabled = false;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -42,8 +42,6 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class PasswordField extends TextFieldBase<PasswordField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
 
-    private boolean isConnectorAttached;
-
     private TextFieldValidationSupport validationSupport;
 
     private boolean manualValidationEnabled = false;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -41,8 +41,6 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class TextArea extends TextFieldBase<TextArea, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextAreaVariant> {
 
-    private boolean isConnectorAttached;
-
     private TextFieldValidationSupport validationSupport;
 
     private boolean manualValidationEnabled = false;


### PR DESCRIPTION
## Description

The PR removes the `isConnectorAttached` class field because it's not being used.

## Type of change

- [x] Refactor
