### PR TITLE
feat: add i18n error message support for BigDecimalField

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationPage.java
@@ -25,8 +25,15 @@ public class BigDecimalFieldBasicValidationPage
     public static final String REQUIRED_BUTTON = "required-button";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Number has incorrect format";
+
     public BigDecimalFieldBasicValidationPage() {
         super();
+
+        testField.setI18n(new BigDecimalField.BigDecimalFieldI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationPage.java
@@ -25,9 +25,11 @@ import com.vaadin.tests.validation.AbstractValidationPage;
 @Route("vaadin-big-decimal-field/validation/binder")
 public class BigDecimalFieldBinderValidationPage
         extends AbstractValidationPage<BigDecimalField> {
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
     public static final String RESET_BEAN_BUTTON = "reset-bean-button";
+
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String BAD_INPUT_ERROR_MESSAGE = "Number has incorrect format";
 
     public static class Bean {
         private BigDecimal property;
@@ -52,6 +54,9 @@ public class BigDecimalFieldBinderValidationPage
         binder.addStatusChangeListener(event -> {
             incrementServerValidationCounter();
         });
+
+        testField.setI18n(new BigDecimalField.BigDecimalFieldI18n()
+                .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE));
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
@@ -24,6 +24,8 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBasicValidationPage.REQUIRED_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBasicValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
 
 @TestPath("vaadin-big-decimal-field/validation/basic")
 public class BigDecimalFieldBasicValidationIT
@@ -32,6 +34,7 @@ public class BigDecimalFieldBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -40,6 +43,7 @@ public class BigDecimalFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -50,6 +54,7 @@ public class BigDecimalFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -60,11 +65,25 @@ public class BigDecimalFieldBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+
+        testField.sendKeys("--2", Keys.ENTER);
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
+
+        testField.setValue("");
+        assertValidationCount(1);
+        assertServerInvalid();
+        assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -73,21 +92,25 @@ public class BigDecimalFieldBasicValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.sendKeys("--2", Keys.ENTER);
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -95,10 +118,12 @@ public class BigDecimalFieldBasicValidationIT
         testField.setValue("2");
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -107,11 +132,13 @@ public class BigDecimalFieldBasicValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBinderValidationIT.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.validation.AbstractValidationIT;
 
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.BAD_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.CLEAR_VALUE_BUTTON;
 import static com.vaadin.flow.component.textfield.tests.validation.BigDecimalFieldBinderValidationPage.RESET_BEAN_BUTTON;
 
@@ -42,6 +43,7 @@ public class BigDecimalFieldBinderValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -75,7 +77,7 @@ public class BigDecimalFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("2");
         assertValidationCount(1);
@@ -86,7 +88,7 @@ public class BigDecimalFieldBinderValidationIT
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         testField.setValue("");
         assertValidationCount(1);
@@ -112,7 +114,7 @@ public class BigDecimalFieldBinderValidationIT
         testField.sendKeys("--2", Keys.ENTER);
         assertServerInvalid();
         assertClientInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(BAD_INPUT_ERROR_MESSAGE);
 
         $("button").id(CLEAR_VALUE_BUTTON).click();
         assertServerInvalid();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -15,12 +15,14 @@
  */
 package com.vaadin.flow.component.textfield;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Synchronize;
@@ -59,6 +61,8 @@ import com.vaadin.flow.shared.Registration;
 public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         implements HasThemeVariant<TextFieldVariant> {
 
+    private BigDecimalFieldI18n i18n;
+
     private Locale locale;
 
     private static final SerializableBiFunction<BigDecimalField, String, BigDecimal> PARSER = (
@@ -82,6 +86,9 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     private boolean manualValidationEnabled = false;
 
     private final CopyOnWriteArrayList<ValidationStatusChangeListener<BigDecimal>> validationStatusChangeListeners = new CopyOnWriteArrayList<>();
+
+    private String customErrorMessage;
+    private String constraintErrorMessage;
 
     /**
      * Constructs an empty {@code BigDecimalField}.
@@ -196,6 +203,45 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         addValueChangeListener(listener);
     }
 
+    /**
+     * Sets an error message to display for all constraint violations.
+     * <p>
+     * This error message takes priority over i18n error messages when both are
+     * set.
+     *
+     * @param errorMessage
+     *            the error message to set, or {@code null} to clear
+     *
+     */
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        customErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    /**
+     * Gets the error message displayed for all constraint violations.
+     *
+     * @return the error message
+     */
+    @Override
+    public String getErrorMessage() {
+        return customErrorMessage;
+    }
+
+    private void setConstraintErrorMessage(String errorMessage) {
+        constraintErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    private void updateErrorMessage() {
+        String errorMessage = constraintErrorMessage;
+        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
+            errorMessage = customErrorMessage;
+        }
+        getElement().setProperty("errorMessage", errorMessage);
+    }
+
     @Override
     public BigDecimal getEmptyValue() {
         return null;
@@ -277,29 +323,46 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     }
 
     /**
-     * Performs server-side validation of the current value. This is needed
-     * because it is possible to circumvent the client-side validation
-     * constraints using browser development tools.
+     * Validates the current value against the constraints and sets the
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
+     * <p>
+     * The method does nothing if the manual validation mode is enabled.
      */
     protected void validate() {
-        if (!this.manualValidationEnabled) {
-            BigDecimal value = getValue();
+        if (this.manualValidationEnabled) {
+            return;
+        }
 
-            ValidationResult requiredValidation = ValidationUtil
-                    .validateRequiredConstraint("",
-                            isRequiredIndicatorVisible(), value,
-                            getEmptyValue());
-
-            setInvalid(requiredValidation.isError()
-                    || checkValidity(value).isError());
+        ValidationResult result = checkValidity(getValue(), true);
+        if (result.isError()) {
+            setInvalid(true);
+            setConstraintErrorMessage(result.getErrorMessage());
+        } else {
+            setInvalid(false);
+            setConstraintErrorMessage("");
         }
     }
 
-    private ValidationResult checkValidity(BigDecimal value) {
-        boolean hasNonParsableValue = valueEquals(value, getEmptyValue())
+    private ValidationResult checkValidity(BigDecimal value, boolean withRequiredValidator) {
+        boolean hasBadInput = valueEquals(value, getEmptyValue())
                 && isInputValuePresent();
-        if (hasNonParsableValue) {
-            return ValidationResult.error("");
+        if (hasBadInput) {
+            return ValidationResult.error(getI18nErrorMessage(
+                    BigDecimalFieldI18n::getBadInputErrorMessage));
+        }
+
+        if (withRequiredValidator) {
+            ValidationResult requiredResult = ValidationUtil
+                    .validateRequiredConstraint(getI18nErrorMessage(
+                            BigDecimalFieldI18n::getRequiredErrorMessage),
+                            isRequiredIndicatorVisible(), value,
+                            getEmptyValue());
+            if (requiredResult.isError()) {
+                return requiredResult;
+            }
         }
 
         return ValidationResult.ok();
@@ -307,7 +370,7 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
     @Override
     public Validator<BigDecimal> getDefaultValidator() {
-        return (value, context) -> checkValidity(value);
+        return (value, context) -> checkValidity(value, false);
     }
 
     @Override
@@ -386,5 +449,101 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(BigDecimalFieldI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public BigDecimalFieldI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(BigDecimalFieldI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+    }
+
+    private String getI18nErrorMessage(
+            Function<BigDecimalFieldI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
+    }
+
+    /**
+     * The internationalization properties for {@link BigDecimalField}.
+     */
+    public static class BigDecimalFieldI18n implements Serializable {
+
+        private String requiredErrorMessage;
+        private String badInputErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field contains user input
+         * that the server is unable to convert to type {@link BigDecimal}.
+         *
+         * @return the error message or {@code null} if not set
+         */
+        public String getBadInputErrorMessage() {
+            return badInputErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field contains user input
+         * that the server is unable to convert to type {@link BigDecimal}.
+         * <p>
+         * Note, custom error messages set with
+         * {@link BigDecimalField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message to set, or {@code null} to clear
+         * @return this instance for method chaining
+         */
+        public BigDecimalFieldI18n setBadInputErrorMessage(String errorMessage) {
+            badInputErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see BigDecimalField#isRequiredIndicatorVisible()
+         * @see BigDecimalField#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link BigDecimalField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see BigDecimalField#isRequiredIndicatorVisible()
+         * @see BigDecimalField#setRequiredIndicatorVisible(boolean)
+         */
+        public BigDecimalFieldI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -346,7 +346,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         }
     }
 
-    private ValidationResult checkValidity(BigDecimal value, boolean withRequiredValidator) {
+    private ValidationResult checkValidity(BigDecimal value,
+            boolean withRequiredValidator) {
         boolean hasBadInput = valueEquals(value, getEmptyValue())
                 && isInputValuePresent();
         if (hasBadInput) {
@@ -503,14 +504,15 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
          * that the server is unable to convert to type {@link BigDecimal}.
          * <p>
          * Note, custom error messages set with
-         * {@link BigDecimalField#setErrorMessage(String)} take priority over i18n
-         * error messages.
+         * {@link BigDecimalField#setErrorMessage(String)} take priority over
+         * i18n error messages.
          *
          * @param errorMessage
          *            the error message to set, or {@code null} to clear
          * @return this instance for method chaining
          */
-        public BigDecimalFieldI18n setBadInputErrorMessage(String errorMessage) {
+        public BigDecimalFieldI18n setBadInputErrorMessage(
+                String errorMessage) {
             badInputErrorMessage = errorMessage;
             return this;
         }
@@ -532,8 +534,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
          * empty.
          * <p>
          * Note, custom error messages set with
-         * {@link BigDecimalField#setErrorMessage(String)} take priority over i18n
-         * error messages.
+         * {@link BigDecimalField#setErrorMessage(String)} take priority over
+         * i18n error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it
@@ -541,7 +543,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
          * @see BigDecimalField#isRequiredIndicatorVisible()
          * @see BigDecimalField#setRequiredIndicatorVisible(boolean)
          */
-        public BigDecimalFieldI18n setRequiredErrorMessage(String errorMessage) {
+        public BigDecimalFieldI18n setRequiredErrorMessage(
+                String errorMessage) {
             requiredErrorMessage = errorMessage;
             return this;
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -386,8 +386,8 @@ public class TextField extends TextFieldBase<TextField, String>
      * Validates the current value against the constraints and sets the
      * {@code invalid} property and the {@code errorMessage} property based on
      * the result. If a custom error message is provided with
-     * {@link #setErrorMessage(String)}, it is used. Otherwise,
-     * the error message defined in the i18n object is used.
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
      */


### PR DESCRIPTION
## Description

The PR introduces BigDecimalFieldI18n with methods for setting error messages and updates the BigDecimalField's validation logic to show these error messages when validation fails.

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Part of #4618 

## Type of change

- [x] Feature
