### PR TITLE
feat: add i18n error message support for EmailField

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationPage.java
@@ -27,8 +27,19 @@ public class EmailFieldBasicValidationPage
     public static final String MIN_LENGTH_INPUT = "min-length-input";
     public static final String MAX_LENGTH_INPUT = "max-length-input";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String MIN_LENGTH_ERROR_MESSAGE = "Value is too short";
+    public static final String MAX_LENGTH_ERROR_MESSAGE = "Value is too long";
+    public static final String PATTERN_ERROR_MESSAGE = "Value has incorrect format";
+
     public EmailFieldBasicValidationPage() {
         super();
+
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setMinLengthErrorMessage(MIN_LENGTH_ERROR_MESSAGE)
+                .setMaxLengthErrorMessage(MAX_LENGTH_ERROR_MESSAGE)
+                .setPatternErrorMessage(PATTERN_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationPage.java
@@ -28,8 +28,11 @@ public class EmailFieldBinderValidationPage
     public static final String MAX_LENGTH_INPUT = "max-length-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String MIN_LENGTH_ERROR_MESSAGE = "Value is too short";
+    public static final String MAX_LENGTH_ERROR_MESSAGE = "Value is too long";
+    public static final String PATTERN_ERROR_MESSAGE = "Value does not match the pattern";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Value does not match the expected value";
 
     public static class Bean {
         private String property;
@@ -58,6 +61,11 @@ public class EmailFieldBinderValidationPage
         binder.addStatusChangeListener(event -> {
             incrementServerValidationCounter();
         });
+
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setMinLengthErrorMessage(MIN_LENGTH_ERROR_MESSAGE)
+                .setMaxLengthErrorMessage(MAX_LENGTH_ERROR_MESSAGE)
+                .setPatternErrorMessage(PATTERN_ERROR_MESSAGE));
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = event.getValue();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
@@ -23,9 +23,13 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.validation.AbstractValidationIT;
 
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.MIN_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.PATTERN_ERROR_MESSAGE;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.MAX_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.MIN_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.PATTERN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-email-field/validation/basic")
 public class EmailFieldBasicValidationIT
@@ -34,6 +38,7 @@ public class EmailFieldBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -42,6 +47,7 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -52,6 +58,7 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -62,11 +69,13 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -77,16 +86,19 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_LENGTH_ERROR_MESSAGE);
 
         testField.setValue("aa@vaadin.com");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("aaa@vaadin.com");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -97,16 +109,19 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_LENGTH_ERROR_MESSAGE);
 
         testField.setValue("aa@vaadin.com");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("a@vaadin.com");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -115,11 +130,13 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         testField.setValue("john@vaadin.com");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -131,11 +148,13 @@ public class EmailFieldBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         testField.setValue("john@vaadin.com");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBinderValidationIT.java
@@ -24,8 +24,11 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.PATTERN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.MIN_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.PATTERN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.MIN_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.MAX_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.EmailFieldBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
 
@@ -45,6 +48,7 @@ public class EmailFieldBinderValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -75,7 +79,7 @@ public class EmailFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_LENGTH_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("aa@vaadin.com");
@@ -102,7 +106,7 @@ public class EmailFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_LENGTH_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("aa@vaadin.com");
@@ -127,7 +131,7 @@ public class EmailFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         testField.setValue("john@vaadin.com");
         assertValidationCount(1);
@@ -147,7 +151,7 @@ public class EmailFieldBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("oliver@vaadin.com");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -16,6 +16,11 @@
 
 package com.vaadin.flow.component.textfield;
 
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -23,7 +28,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.data.validator.EmailValidator;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -48,9 +55,12 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class EmailField extends TextFieldBase<EmailField, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextFieldVariant> {
 
-    private TextFieldValidationSupport validationSupport;
+    private EmailFieldI18n i18n;
 
     private boolean manualValidationEnabled = false;
+
+    private String customErrorMessage;
+    private String constraintErrorMessage;
 
     /**
      * Constructs an empty {@code EmailField}.
@@ -145,12 +155,42 @@ public class EmailField extends TextFieldBase<EmailField, String>
         addValueChangeListener(listener);
     }
 
-    private TextFieldValidationSupport getValidationSupport() {
-        if (validationSupport == null) {
-            validationSupport = new TextFieldValidationSupport(this);
-            validationSupport.setPattern(EmailValidator.PATTERN);
+    /**
+     * Sets an error message to display for all constraint violations.
+     * <p>
+     * This error message takes priority over i18n error messages when both are
+     * set.
+     *
+     * @param errorMessage
+     *            the error message to set, or {@code null} to clear
+     */
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        customErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    /**
+     * Gets the error message displayed for all constraint violations.
+     *
+     * @return the error message
+     */
+    @Override
+    public String getErrorMessage() {
+        return customErrorMessage;
+    }
+
+    private void setConstraintErrorMessage(String errorMessage) {
+        constraintErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    private void updateErrorMessage() {
+        String errorMessage = constraintErrorMessage;
+        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
+            errorMessage = customErrorMessage;
         }
-        return validationSupport;
+        getElement().setProperty("errorMessage", errorMessage);
     }
 
     /**
@@ -162,7 +202,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     public void setMaxLength(int maxLength) {
         getElement().setProperty("maxlength", maxLength);
-        getValidationSupport().setMaxLength(maxLength);
     }
 
     /**
@@ -175,6 +214,10 @@ public class EmailField extends TextFieldBase<EmailField, String>
         return (int) getElement().getProperty("maxlength", 0.0);
     }
 
+    private boolean hasMaxLength() {
+        return getElement().getProperty("maxlength") != null;
+    }
+
     /**
      * Minimum number of characters (in Unicode code points) that the user can
      * enter.
@@ -184,7 +227,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     public void setMinLength(int minLength) {
         getElement().setProperty("minlength", minLength);
-        getValidationSupport().setMinLength(minLength);
     }
 
     /**
@@ -195,22 +237,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     public int getMinLength() {
         return (int) getElement().getProperty("minlength", 0.0);
-    }
-
-    /**
-     * <p>
-     * Specifies that the user must fill in a value.
-     * </p>
-     * NOTE: The required indicator will not be visible, if there is no
-     * {@code label} property set for the textfield.
-     *
-     * @param required
-     *            the boolean value to set
-     */
-    @Override
-    public void setRequired(boolean required) {
-        super.setRequired(required);
-        getValidationSupport().setRequired(required);
     }
 
     /**
@@ -230,7 +256,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     public void setPattern(String pattern) {
         getElement().setProperty("pattern", pattern == null ? "" : pattern);
-        getValidationSupport().setPattern(pattern);
     }
 
     /**
@@ -241,6 +266,10 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     public String getPattern() {
         return getElement().getProperty("pattern");
+    }
+
+    private boolean hasPattern() {
+        return getPattern() != null;
     }
 
     @Override
@@ -276,14 +305,8 @@ public class EmailField extends TextFieldBase<EmailField, String>
     }
 
     @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        getValidationSupport().setRequired(requiredIndicatorVisible);
-    }
-
-    @Override
     public Validator<String> getDefaultValidator() {
-        return (value, context) -> getValidationSupport().checkValidity(value);
+        return (value, context) -> checkValidity(value, false);
     }
 
     @Override
@@ -291,14 +314,72 @@ public class EmailField extends TextFieldBase<EmailField, String>
         this.manualValidationEnabled = enabled;
     }
 
+    private ValidationResult checkValidity(String value,
+            boolean withRequiredValidator) {
+        if (withRequiredValidator) {
+            ValidationResult requiredResult = ValidationUtil
+                    .validateRequiredConstraint(
+                            getI18nErrorMessage(
+                                    EmailFieldI18n::getRequiredErrorMessage),
+                            isRequiredIndicatorVisible(), value,
+                            getEmptyValue());
+            if (requiredResult.isError()) {
+                return requiredResult;
+            }
+        }
+
+        ValidationResult maxLengthResult = ValidationUtil
+                .validateMaxLengthConstraint(
+                        getI18nErrorMessage(
+                                EmailFieldI18n::getMaxLengthErrorMessage),
+                        value, hasMaxLength() ? getMaxLength() : null);
+        if (maxLengthResult.isError()) {
+            return maxLengthResult;
+        }
+
+        ValidationResult minLengthResult = ValidationUtil
+                .validateMinLengthConstraint(
+                        getI18nErrorMessage(
+                                EmailFieldI18n::getMinLengthErrorMessage),
+                        value, getMinLength());
+        if (minLengthResult.isError()) {
+            return minLengthResult;
+        }
+
+        ValidationResult patternResult = ValidationUtil
+                .validatePatternConstraint(
+                        getI18nErrorMessage(
+                                EmailFieldI18n::getPatternErrorMessage),
+                        value,
+                        hasPattern() ? getPattern() : EmailValidator.PATTERN);
+        if (patternResult.isError()) {
+            return patternResult;
+        }
+
+        return ValidationResult.ok();
+    }
+
     /**
-     * Performs server-side validation of the current value. This is needed
-     * because it is possible to circumvent the client-side validation
-     * constraints using browser development tools.
+     * Validates the current value against the constraints and sets the
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
+     * <p>
+     * The method does nothing if the manual validation mode is enabled.
      */
     protected void validate() {
-        if (!this.manualValidationEnabled) {
-            setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (this.manualValidationEnabled) {
+            return;
+        }
+
+        ValidationResult result = checkValidity(getValue(), true);
+        if (result.isError()) {
+            setInvalid(true);
+            setConstraintErrorMessage(result.getErrorMessage());
+        } else {
+            setInvalid(false);
+            setConstraintErrorMessage("");
         }
     }
 
@@ -306,5 +387,169 @@ public class EmailField extends TextFieldBase<EmailField, String>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(EmailFieldI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public EmailFieldI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(EmailFieldI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+    }
+
+    private String getI18nErrorMessage(
+            Function<EmailFieldI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
+    }
+
+    /**
+     * The internationalization properties for {@link EmailField}.
+     */
+    public static class EmailFieldI18n implements Serializable {
+
+        private String requiredErrorMessage;
+        private String minLengthErrorMessage;
+        private String maxLengthErrorMessage;
+        private String patternErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see EmailField#isRequiredIndicatorVisible()
+         * @see EmailField#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link EmailField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see EmailField#isRequiredIndicatorVisible()
+         * @see EmailField#setRequiredIndicatorVisible(boolean)
+         */
+        public EmailFieldI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is shorter than
+         * the minimum allowed length.
+         *
+         * @return the error message or {@code null} if not set
+         * @see EmailField#getMinLength()
+         * @see EmailField#setMinLength(int)
+         */
+        public String getMinLengthErrorMessage() {
+            return minLengthErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is shorter
+         * than the minimum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link EmailField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see EmailField#getMinLength()
+         * @see EmailField#setMinLength(int)
+         */
+        public EmailFieldI18n setMinLengthErrorMessage(String errorMessage) {
+            minLengthErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is longer than
+         * the maximum allowed length.
+         *
+         * @return the error message or {@code null} if not set
+         * @see EmailField#getMaxLength()
+         * @see EmailField#setMaxLength(int)
+         */
+        public String getMaxLengthErrorMessage() {
+            return maxLengthErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is longer than
+         * the maximum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link EmailField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see EmailField#getMaxLength()
+         * @see EmailField#setMaxLength(int)
+         */
+        public EmailFieldI18n setMaxLengthErrorMessage(String errorMessage) {
+            maxLengthErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value does not match
+         * the pattern.
+         *
+         * @return the error message or {@code null} if not set
+         * @see EmailField#getPattern()
+         * @see EmailField#setPattern(String)
+         */
+        public String getPatternErrorMessage() {
+            return patternErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value does not match
+         * the pattern.
+         * <p>
+         * Note, custom error messages set with
+         * {@link EmailField#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see EmailField#getPattern()
+         * @see EmailField#setPattern(String)
+         */
+        public EmailFieldI18n setPatternErrorMessage(String errorMessage) {
+            patternErrorMessage = errorMessage;
+            return this;
+        }
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/EmailFieldBasicValidationTest.java
@@ -54,7 +54,100 @@ public class EmailFieldBasicValidationTest
         }
     }
 
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue("john@vaadin.com");
+        testField.setValue("");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue("john@vaadin.com");
+        testField.setValue("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void minLength_validate_emptyErrorMessageDisplayed() {
+        testField.setMinLength(13);
+        testField.setValue("a@vaadin.com");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void minLength_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMinLength(13);
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setMinLengthErrorMessage("Value is too short"));
+        testField.setValue("a@vaadin.com");
+        Assert.assertEquals("Value is too short", getErrorMessageProperty());
+    }
+
+    @Test
+    public void maxLength_validate_emptyErrorMessageDisplayed() {
+        testField.setMaxLength(13);
+        testField.setValue("aaa@vaadin.com");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void maxLength_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMaxLength(13);
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setMaxLengthErrorMessage("Value is too long"));
+        testField.setValue("aaa@vaadin.com");
+        Assert.assertEquals("Value is too long", getErrorMessageProperty());
+    }
+
+    @Test
+    public void pattern_validate_emptyErrorMessageDisplayed() {
+        testField.setValue("foobar");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void pattern_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setPatternErrorMessage("Value has incorrect format"));
+        testField.setValue("foobar");
+        Assert.assertEquals("Value has incorrect format",
+                getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("john@vaadin.com");
+        testField.setValue("");
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new EmailField.EmailFieldI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("john@vaadin.com");
+        testField.setValue("");
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected EmailField createTestField() {
         return new EmailField();
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces EmailFieldI18n with methods for setting error messages and updates the EmailField's validation logic to show these error messages when validation fails.

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Part of #4618 

## Type of change

- [x] Feature
