### PR TITLE
fix: allow data fetch for inert grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/InertTreeGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/InertTreeGridPage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.flow.dom.ElementUtil;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/inert-tree-grid")
+public class InertTreeGridPage extends Div {
+
+    public InertTreeGridPage() {
+        var grid = new TreeGrid<String>();
+        ElementUtil.setInert(grid.getElement(), true);
+
+        grid.addHierarchyColumn(String::toString).setHeader("Item");
+        add(grid);
+
+        var data = new TreeGridStringDataBuilder().addLevel("Parent", 100)
+                .addLevel("Child", 100).build();
+
+        grid.setDataProvider(new TreeDataProvider<>(data));
+
+        var expandFirst = new NativeButton("Expand first item",
+                e -> grid.expand(data.getRootItems().get(0)));
+        expandFirst.setId("expand-first");
+
+        var setAllRowsVisible = new NativeButton("Set all rows visible",
+                e -> grid.setAllRowsVisible(true));
+        setAllRowsVisible.setId("set-all-rows-visible");
+
+        add(expandFirst, setAllRowsVisible, grid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/InertTreeGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/InertTreeGridIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-grid/inert-tree-grid")
+public class InertTreeGridIT extends AbstractComponentIT {
+
+    private TreeGridElement treeGrid;
+    private WebElement expandFirstItemButton;
+    private WebElement setAllRowsVisibleButton;
+
+    @Before
+    public void init() {
+        open();
+        treeGrid = $(TreeGridElement.class).first();
+        expandFirstItemButton = $("button").id("expand-first");
+        setAllRowsVisibleButton = $("button").id("set-all-rows-visible");
+    }
+
+    @Test
+    public void setAllRowsVisible_lastParentRowHasData() {
+        setAllRowsVisibleButton.click();
+
+        var cell = treeGrid.getCell(99, 0);
+        Assert.assertEquals("Parent 99", cell.getText());
+    }
+
+    @Test
+    public void expandFirst_setAllRowsVisible_lastChildRowHasData() {
+        expandFirstItemButton.click();
+        setAllRowsVisibleButton.click();
+
+        var cell = treeGrid.getCell(100, 0);
+        Assert.assertEquals("Child 0/99", cell.getText());
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -65,6 +65,7 @@ import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.grid.editor.EditorImpl;
 import com.vaadin.flow.component.grid.editor.EditorRenderer;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.component.shared.SelectionPreservationHandler;
 import com.vaadin.flow.component.shared.SelectionPreservationMode;
@@ -3648,11 +3649,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         return item;
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void confirmUpdate(int id) {
         getDataCommunicator().confirmUpdate(id);
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setRequestedRange(int start, int length) {
         if (length > 500 && length / getPageSize() > 10 && isAllRowsVisible()) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.grid.GridArrayUpdater.UpdateQueueData;
 import com.vaadin.flow.component.grid.dataview.GridDataView;
 import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
+import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.data.binder.PropertyDefinition;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -778,6 +779,7 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setParentRequestedRange(int start, int length,
             String parentKey) {
@@ -787,6 +789,7 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setParentRequestedRanges(JsonArray array) {
         for (int index = 0; index < array.length(); index++) {
@@ -809,6 +812,7 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void confirmParentUpdate(int id, String parentKey) {
         getDataCommunicator().confirmUpdate(id, parentKey);


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6428

The issue occurs because the dialog's server-side modality by default blocks calls to `@ClientCallable` methods for components outside of it. As the grid outside the dialog encounters rows without data, it tries to make a data request but the call gets blocked and the rows will remain empty.

This PR fixes the issue by allowing an inert Grid to fetch data for rows.

Note: We can't rely on the Grid's item preloading logic to fix this (as mentioned [here](https://github.com/vaadin/flow-components/issues/6428#issuecomment-2219610825)) since it's merely a performance optimization and wouldn't help in cases where unloaded rows are revealed due to other reasons, for example, if the grid's height gets increased programmatically or by browser window resize...

## Type of change

Bugfix