### PR TITLE
feat: add i18n error message support for TextArea

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationPage.java
@@ -27,8 +27,19 @@ public class TextAreaBasicValidationPage
     public static final String MIN_LENGTH_INPUT = "min-length-input";
     public static final String MAX_LENGTH_INPUT = "max-length-input";
 
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String MIN_LENGTH_ERROR_MESSAGE = "Value is too short";
+    public static final String MAX_LENGTH_ERROR_MESSAGE = "Value is too long";
+    public static final String PATTERN_ERROR_MESSAGE = "Value does not match the pattern";
+
     public TextAreaBasicValidationPage() {
         super();
+
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
+                .setMinLengthErrorMessage(MIN_LENGTH_ERROR_MESSAGE)
+                .setMaxLengthErrorMessage(MAX_LENGTH_ERROR_MESSAGE)
+                .setPatternErrorMessage(PATTERN_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationPage.java
@@ -28,8 +28,11 @@ public class TextAreaBinderValidationPage
     public static final String MAX_LENGTH_INPUT = "max-length-input";
     public static final String EXPECTED_VALUE_INPUT = "expected-value-input";
 
-    public static final String REQUIRED_ERROR_MESSAGE = "The field is required";
-    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "The field doesn't match the expected value";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+    public static final String MIN_LENGTH_ERROR_MESSAGE = "Value is too short";
+    public static final String MAX_LENGTH_ERROR_MESSAGE = "Value is too long";
+    public static final String PATTERN_ERROR_MESSAGE = "Value does not match the pattern";
+    public static final String UNEXPECTED_VALUE_ERROR_MESSAGE = "Value does not match the expected value";
 
     public static class Bean {
         private String property;
@@ -58,6 +61,11 @@ public class TextAreaBinderValidationPage
         binder.addStatusChangeListener(event -> {
             incrementServerValidationCounter();
         });
+
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setMinLengthErrorMessage(MIN_LENGTH_ERROR_MESSAGE)
+                .setMaxLengthErrorMessage(MAX_LENGTH_ERROR_MESSAGE)
+                .setPatternErrorMessage(PATTERN_ERROR_MESSAGE));
 
         add(createInput(EXPECTED_VALUE_INPUT, "Set expected value", event -> {
             expectedValue = event.getValue();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
@@ -21,10 +21,14 @@ import com.vaadin.tests.validation.AbstractValidationIT;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.MAX_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.MIN_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.MIN_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.PATTERN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.PATTERN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-text-area/validation/basic")
 public class TextAreaBasicValidationIT
@@ -33,6 +37,7 @@ public class TextAreaBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -41,6 +46,7 @@ public class TextAreaBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -51,6 +57,7 @@ public class TextAreaBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -61,11 +68,13 @@ public class TextAreaBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.setValue("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -76,16 +85,19 @@ public class TextAreaBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MIN_LENGTH_ERROR_MESSAGE);
 
         testField.setValue("AA");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("AAA");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -96,16 +108,19 @@ public class TextAreaBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(MAX_LENGTH_ERROR_MESSAGE);
 
         testField.setValue("AA");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
 
         testField.setValue("A");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test
@@ -116,11 +131,13 @@ public class TextAreaBasicValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         testField.setValue("1234");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBinderValidationIT.java
@@ -22,8 +22,11 @@ import org.junit.Test;
 import org.openqa.selenium.Keys;
 
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.EXPECTED_VALUE_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.MAX_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.MAX_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.MIN_LENGTH_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.MIN_LENGTH_INPUT;
+import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.PATTERN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.PATTERN_INPUT;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.REQUIRED_ERROR_MESSAGE;
 import static com.vaadin.flow.component.textfield.tests.validation.TextAreaBinderValidationPage.UNEXPECTED_VALUE_ERROR_MESSAGE;
@@ -44,6 +47,7 @@ public class TextAreaBinderValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -72,7 +76,7 @@ public class TextAreaBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MIN_LENGTH_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("AA");
@@ -98,7 +102,7 @@ public class TextAreaBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(MAX_LENGTH_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("AA");
@@ -124,7 +128,7 @@ public class TextAreaBinderValidationIT
         assertValidationCount(1);
         assertClientInvalid();
         assertServerInvalid();
-        assertErrorMessage("");
+        assertErrorMessage(PATTERN_ERROR_MESSAGE);
 
         // Binder validation fails:
         testField.setValue("12");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -456,7 +456,7 @@ public class TextArea extends TextFieldBase<TextArea, String>
     }
 
     /**
-     * The internationalization properties for {@link TextField}.
+     * The internationalization properties for {@link TextArea}.
      */
     public static class TextAreaI18n implements Serializable {
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -15,6 +15,11 @@
  */
 package com.vaadin.flow.component.textfield;
 
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -22,7 +27,9 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 
@@ -41,9 +48,12 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class TextArea extends TextFieldBase<TextArea, String>
         implements HasAllowedCharPattern, HasThemeVariant<TextAreaVariant> {
 
-    private TextFieldValidationSupport validationSupport;
+    private TextAreaI18n i18n;
 
     private boolean manualValidationEnabled = false;
+
+    private String customErrorMessage;
+    private String constraintErrorMessage;
 
     /**
      * Constructs an empty {@code TextArea}.
@@ -174,11 +184,42 @@ public class TextArea extends TextFieldBase<TextArea, String>
         addValueChangeListener(listener);
     }
 
-    private TextFieldValidationSupport getValidationSupport() {
-        if (validationSupport == null) {
-            validationSupport = new TextFieldValidationSupport(this);
+    /**
+     * Sets an error message to display for all constraint violations.
+     * <p>
+     * This error message takes priority over i18n error messages when both are
+     * set.
+     *
+     * @param errorMessage
+     *            the error message to set, or {@code null} to clear
+     */
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        customErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    /**
+     * Gets the error message displayed for all constraint violations.
+     *
+     * @return the error message
+     */
+    @Override
+    public String getErrorMessage() {
+        return customErrorMessage;
+    }
+
+    private void setConstraintErrorMessage(String errorMessage) {
+        constraintErrorMessage = errorMessage;
+        updateErrorMessage();
+    }
+
+    private void updateErrorMessage() {
+        String errorMessage = constraintErrorMessage;
+        if (customErrorMessage != null && !customErrorMessage.isEmpty()) {
+            errorMessage = customErrorMessage;
         }
-        return validationSupport;
+        getElement().setProperty("errorMessage", errorMessage);
     }
 
     /**
@@ -190,7 +231,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
      */
     public void setMaxLength(int maxLength) {
         getElement().setProperty("maxlength", maxLength);
-        getValidationSupport().setMaxLength(maxLength);
     }
 
     /**
@@ -203,6 +243,10 @@ public class TextArea extends TextFieldBase<TextArea, String>
         return (int) getElement().getProperty("maxlength", 0.0);
     }
 
+    private boolean hasMaxLength() {
+        return getElement().getProperty("maxlength") != null;
+    }
+
     /**
      * Minimum number of characters (in Unicode code points) that the user can
      * enter.
@@ -212,7 +256,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
      */
     public void setMinLength(int minLength) {
         getElement().setProperty("minlength", minLength);
-        getValidationSupport().setMinLength(minLength);
     }
 
     /**
@@ -240,22 +283,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
     }
 
     /**
-     * <p>
-     * Specifies that the user must fill in a value.
-     * </p>
-     * NOTE: The required indicator will not be visible, if there is no
-     * {@code label} property set for the textfield.
-     *
-     * @param required
-     *            the boolean value to set
-     */
-    @Override
-    public void setRequired(boolean required) {
-        super.setRequired(required);
-        getValidationSupport().setRequired(required);
-    }
-
-    /**
      * Sets a regular expression for the value to pass on the client-side. The
      * pattern must be a valid JavaScript Regular Expression that matches the
      * entire value, not just some subset.
@@ -272,7 +299,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
      */
     public void setPattern(String pattern) {
         getElement().setProperty("pattern", pattern == null ? "" : pattern);
-        getValidationSupport().setPattern(pattern);
     }
 
     /**
@@ -318,14 +344,8 @@ public class TextArea extends TextFieldBase<TextArea, String>
     }
 
     @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        getValidationSupport().setRequired(requiredIndicatorVisible);
-    }
-
-    @Override
     public Validator<String> getDefaultValidator() {
-        return (value, context) -> getValidationSupport().checkValidity(value);
+        return (value, context) -> checkValidity(value, false);
     }
 
     @Override
@@ -333,14 +353,71 @@ public class TextArea extends TextFieldBase<TextArea, String>
         this.manualValidationEnabled = enabled;
     }
 
+    private ValidationResult checkValidity(String value,
+            boolean withRequiredValidator) {
+        if (withRequiredValidator) {
+            ValidationResult requiredResult = ValidationUtil
+                    .validateRequiredConstraint(
+                            getI18nErrorMessage(
+                                    TextAreaI18n::getRequiredErrorMessage),
+                            isRequiredIndicatorVisible(), value,
+                            getEmptyValue());
+            if (requiredResult.isError()) {
+                return requiredResult;
+            }
+        }
+
+        ValidationResult maxLengthResult = ValidationUtil
+                .validateMaxLengthConstraint(
+                        getI18nErrorMessage(
+                                TextAreaI18n::getMaxLengthErrorMessage),
+                        value, hasMaxLength() ? getMaxLength() : null);
+        if (maxLengthResult.isError()) {
+            return maxLengthResult;
+        }
+
+        ValidationResult minLengthResult = ValidationUtil
+                .validateMinLengthConstraint(
+                        getI18nErrorMessage(
+                                TextAreaI18n::getMinLengthErrorMessage),
+                        value, getMinLength());
+        if (minLengthResult.isError()) {
+            return minLengthResult;
+        }
+
+        ValidationResult patternResult = ValidationUtil
+                .validatePatternConstraint(
+                        getI18nErrorMessage(
+                                TextAreaI18n::getPatternErrorMessage),
+                        value, getPattern());
+        if (patternResult.isError()) {
+            return patternResult;
+        }
+
+        return ValidationResult.ok();
+    }
+
     /**
-     * Performs server-side validation of the current value. This is needed
-     * because it is possible to circumvent the client-side validation
-     * constraints using browser development tools.
+     * Validates the current value against the constraints and sets the
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
+     * <p>
+     * The method does nothing if the manual validation mode is enabled.
      */
     protected void validate() {
-        if (!this.manualValidationEnabled) {
-            setInvalid(getValidationSupport().isInvalid(getValue()));
+        if (this.manualValidationEnabled) {
+            return;
+        }
+
+        ValidationResult result = checkValidity(getValue(), true);
+        if (result.isError()) {
+            setInvalid(true);
+            setConstraintErrorMessage(result.getErrorMessage());
+        } else {
+            setInvalid(false);
+            setConstraintErrorMessage("");
         }
     }
 
@@ -348,5 +425,168 @@ public class TextArea extends TextFieldBase<TextArea, String>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(TextAreaI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public TextAreaI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(TextAreaI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+    }
+
+    private String getI18nErrorMessage(Function<TextAreaI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
+    }
+
+    /**
+     * The internationalization properties for {@link TextField}.
+     */
+    public static class TextAreaI18n implements Serializable {
+
+        private String requiredErrorMessage;
+        private String minLengthErrorMessage;
+        private String maxLengthErrorMessage;
+        private String patternErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextArea#isRequiredIndicatorVisible()
+         * @see TextArea#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextArea#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextArea#isRequiredIndicatorVisible()
+         * @see TextArea#setRequiredIndicatorVisible(boolean)
+         */
+        public TextAreaI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is shorter than
+         * the minimum allowed length.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextArea#getMinLength()
+         * @see TextArea#setMinLength(int)
+         */
+        public String getMinLengthErrorMessage() {
+            return minLengthErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is shorter
+         * than the minimum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextArea#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextArea#getMinLength()
+         * @see TextArea#setMinLength(int)
+         */
+        public TextAreaI18n setMinLengthErrorMessage(String errorMessage) {
+            minLengthErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value is longer than
+         * the maximum allowed length.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextArea#getMaxLength()
+         * @see TextArea#setMaxLength(int)
+         */
+        public String getMaxLengthErrorMessage() {
+            return maxLengthErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value is longer than
+         * the maximum allowed length.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextArea#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextArea#getMaxLength()
+         * @see TextArea#setMaxLength(int)
+         */
+        public TextAreaI18n setMaxLengthErrorMessage(String errorMessage) {
+            maxLengthErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the field value does not match
+         * the pattern.
+         *
+         * @return the error message or {@code null} if not set
+         * @see TextArea#getPattern()
+         * @see TextArea#setPattern(String)
+         */
+        public String getPatternErrorMessage() {
+            return patternErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field value does not match
+         * the pattern.
+         * <p>
+         * Note, custom error messages set with
+         * {@link TextArea#setErrorMessage(String)} take priority over i18n
+         * error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see TextArea#getPattern()
+         * @see TextArea#setPattern(String)
+         */
+        public TextAreaI18n setPatternErrorMessage(String errorMessage) {
+            patternErrorMessage = errorMessage;
+            return this;
+        }
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextAreaBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/TextAreaBasicValidationTest.java
@@ -15,12 +15,110 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class TextAreaBasicValidationTest
         extends AbstractBasicValidationTest<TextArea, String> {
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue("AAA");
+        testField.setValue("");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue("AAA");
+        testField.setValue("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void minLength_validate_emptyErrorMessageDisplayed() {
+        testField.setMinLength(3);
+        testField.setValue("AA");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void minLength_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMinLength(3);
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setMinLengthErrorMessage("Value is too short"));
+        testField.setValue("AA");
+        Assert.assertEquals("Value is too short", getErrorMessageProperty());
+    }
+
+    @Test
+    public void maxLength_validate_emptyErrorMessageDisplayed() {
+        testField.setMaxLength(3);
+        testField.setValue("AAAA");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void maxLength_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setMaxLength(3);
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setMaxLengthErrorMessage("Value is too long"));
+        testField.setValue("AAAA");
+        Assert.assertEquals("Value is too long", getErrorMessageProperty());
+    }
+
+    @Test
+    public void pattern_validate_emptyErrorMessageDisplayed() {
+        testField.setPattern("\\d+");
+        testField.setValue("AAAA");
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void pattern_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setPattern("\\d+");
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setPatternErrorMessage("Value does not match the pattern"));
+        testField.setValue("AAAA");
+        Assert.assertEquals("Value does not match the pattern",
+                getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("AAAA");
+        testField.setValue("");
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new TextArea.TextAreaI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("AAAA");
+        testField.setValue("");
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected TextArea createTestField() {
         return new TextArea();
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces TextAreaI18n with methods for setting error messages and updates the TextArea's validation logic to show these error messages when validation fails.

> [!NOTE]
> It's still possible to use the `setErrorMessage` method to configure a single static error message. This error message will be displayed for all constraints and will take priority over any i18n error messages that are also set. However, when more than one error message is needed, i18n should be used or manual validation mode should be enabled.

Part of #4618 

## Type of change

- [x] Feature
