### PR TITLE
feat: add i18n error message support for Select

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/validation/BasicValidationPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/tests/validation/BasicValidationPage.java
@@ -10,8 +10,12 @@ import java.util.List;
 public class BasicValidationPage
         extends AbstractValidationPage<Select<String>> {
     public static final String REQUIRED_BUTTON = "required-button";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
 
     public BasicValidationPage() {
+        testField.setI18n(new Select.SelectI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE));
+
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequiredIndicatorVisible(true);
         }));
@@ -28,7 +32,6 @@ public class BasicValidationPage
         };
         select.setItems(List.of("foo", "bar", "baz"));
         select.setEmptySelectionAllowed(true);
-
         return select;
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.openqa.selenium.Keys;
 
 import static com.vaadin.flow.component.select.tests.validation.BasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.select.tests.validation.BasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-select/validation/basic")
 public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
@@ -15,6 +16,7 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -23,6 +25,7 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -33,6 +36,7 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -43,11 +47,13 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.selectByText("");
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/validation/BasicValidationTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/validation/BasicValidationTest.java
@@ -15,12 +15,63 @@
  */
 package com.vaadin.flow.component.select.validation;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BasicValidationTest
         extends AbstractBasicValidationTest<Select<String>, String> {
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue("foo");
+        testField.setValue(null);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new Select.SelectI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue("foo");
+        testField.setValue(null);
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new Select.SelectI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("foo");
+        testField.setValue(null);
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new Select.SelectI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("foo");
+        testField.setValue(null);
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected Select<String> createTestField() {
-        return new Select<String>();
+        Select<String> select = new Select<>();
+        select.setItems("foo");
+        return select;
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces SelectI18n with a method for setting a required error message and updates the Select's validation logic to show this error message when validation fails.

Part of #4618 

## Type of change

- [x] Feature
