### PR TITLE
feat: add method to customize Select overlay width

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -26,10 +26,12 @@ import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasPlaceholder;
+import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.select.data.SelectDataView;
@@ -779,6 +781,31 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
         // Also do not remove the list box but remove any slotted components
         // (see add())
         getChildren().forEach(this::remove);
+    }
+
+    /**
+     * Sets the dropdown overlay width.
+     *
+     * @param width
+     *            the new dropdown width. Pass in null to set the dropdown width
+     *            back to the default value.
+     */
+    public void setOverlayWidth(String width) {
+        getStyle().set("--vaadin-select-overlay-width", width);
+    }
+
+    /**
+     * Sets the dropdown overlay width. Negative number implies unspecified size
+     * (the dropdown width is reverted back to the default value).
+     *
+     * @param width
+     *            the width of the dropdown.
+     * @param unit
+     *            the unit used for the dropdown.
+     */
+    public void setOverlayWidth(float width, Unit unit) {
+        Objects.requireNonNull(unit, "Unit can not be null");
+        setOverlayWidth(HasSize.getCssSize(width, unit));
     }
 
     /**

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.data.SelectListDataView;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
@@ -862,6 +863,24 @@ public class SelectTest {
         Assert.assertTrue(select.isNoVerticalOverlap());
         select.setNoVerticalOverlap(false);
         Assert.assertFalse(select.isNoVerticalOverlap());
+    }
+
+    @Test
+    public void setOverlayWidth() {
+        Select<String> select = new Select<>();
+
+        select.setOverlayWidth(null);
+        Assert.assertNull(
+                select.getStyle().get("--vaadin-select-overlay-width"));
+        select.setOverlayWidth("30em");
+        Assert.assertEquals("30em",
+                select.getStyle().get("--vaadin-select-overlay-width"));
+        select.setOverlayWidth(-1, Unit.EM);
+        Assert.assertNull(
+                select.getStyle().get("--vaadin-select-overlay-width"));
+        select.setOverlayWidth(100, Unit.PIXELS);
+        Assert.assertEquals("100.0px",
+                select.getStyle().get("--vaadin-select-overlay-width"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/7502

Depends on https://github.com/vaadin/web-components/pull/7578

Added `setOverlayWidth()` method like the one added to `ComboBox` in #5743.

## Type of change

- Feature