### PR TITLE
feat: add method to customize Dialog overlay ARIA role

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -126,6 +126,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
             width = event.getWidth();
             height = event.getHeight();
         });
+
+        setOverlayRole("dialog");
     }
 
     /**
@@ -966,6 +968,28 @@ public class Dialog extends Component implements HasComponents, HasSize,
         initHeaderFooterRenderer();
         updateVirtualChildNodeIds();
         registerClientCloseHandler();
+    }
+
+    /**
+     * Sets the ARIA role for the overlay element, used by screen readers.
+     *
+     * @param role
+     *            the role to set
+     */
+    public void setOverlayRole(String role) {
+        Objects.requireNonNull(role, "Role cannot be null");
+
+        getElement().setProperty("overlayRole", role);
+    }
+
+    /**
+     * Gets the ARIA role for the overlay element, used by screen readers.
+     * Defaults to {@code dialog}.
+     *
+     * @return the role
+     */
+    public String getOverlayRole() {
+        return getElement().getProperty("overlayRole");
     }
 
     /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -159,6 +159,31 @@ public class DialogTest {
     }
 
     @Test
+    public void getOverlayRole_defaultDialog() {
+        Dialog dialog = new Dialog();
+
+        Assert.assertEquals("dialog", dialog.getOverlayRole());
+        Assert.assertEquals("dialog",
+                dialog.getElement().getProperty("overlayRole"));
+    }
+
+    @Test
+    public void setOverlayRole_getOverlayRole() {
+        Dialog dialog = new Dialog();
+        dialog.setOverlayRole("alertdialog");
+
+        Assert.assertEquals("alertdialog", dialog.getOverlayRole());
+        Assert.assertEquals("alertdialog",
+                dialog.getElement().getProperty("overlayRole"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setOverlayRole_null_throws() {
+        Dialog dialog = new Dialog();
+        dialog.setOverlayRole(null);
+    }
+
+    @Test
     public void setModal_dialogCanBeModeless() {
         Dialog dialog = new Dialog();
         dialog.setModal(false);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/4977

Depends on https://github.com/vaadin/web-components/pull/7582

Added `setOverlayRole()` and `getOverlayRole()` methods to `Dialog` (the logic is copied from the `Popover`).

## Type of change

- Feature