### PR TITLE
feat: add i18n error message support for ComboBox, MultiSelectComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationPage.java
@@ -10,9 +10,13 @@ import java.util.List;
 public class ComboBoxBasicValidationPage
         extends AbstractValidationPage<ComboBox<String>> {
     public static final String REQUIRED_BUTTON = "required-button";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
     public static final String ENABLE_CUSTOM_VALUE_BUTTON = "enable-custom-value-button";
 
     public ComboBoxBasicValidationPage() {
+        testField.setI18n(new ComboBox.ComboBoxI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE));
+
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);
         }));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationPage.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.component.combobox.test.validation;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.combobox.MultiSelectComboBoxI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
 
@@ -10,9 +11,13 @@ import java.util.List;
 public class MultiSelectComboBoxBasicValidationPage
         extends AbstractValidationPage<MultiSelectComboBox<String>> {
     public static final String REQUIRED_BUTTON = "required-button";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
     public static final String ENABLE_CUSTOM_VALUE_BUTTON = "enable-custom-value-button";
 
     public MultiSelectComboBoxBasicValidationPage() {
+        testField.setI18n(new MultiSelectComboBoxI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE));
+
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);
         }));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.Keys;
 
 import static com.vaadin.flow.component.combobox.test.validation.ComboBoxBasicValidationPage.ENABLE_CUSTOM_VALUE_BUTTON;
 import static com.vaadin.flow.component.combobox.test.validation.ComboBoxBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.combobox.test.validation.ComboBoxBasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-combo-box/validation/basic")
 public class ComboBoxBasicValidationIT
@@ -17,6 +18,7 @@ public class ComboBoxBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -25,6 +27,7 @@ public class ComboBoxBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -35,6 +38,7 @@ public class ComboBoxBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -45,11 +49,13 @@ public class ComboBoxBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.clear();
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -60,6 +66,7 @@ public class ComboBoxBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -71,6 +78,7 @@ public class ComboBoxBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.Keys;
 
 import static com.vaadin.flow.component.combobox.test.validation.MultiSelectComboBoxBasicValidationPage.ENABLE_CUSTOM_VALUE_BUTTON;
 import static com.vaadin.flow.component.combobox.test.validation.MultiSelectComboBoxBasicValidationPage.REQUIRED_BUTTON;
+import static com.vaadin.flow.component.combobox.test.validation.MultiSelectComboBoxBasicValidationPage.REQUIRED_ERROR_MESSAGE;
 
 @TestPath("vaadin-multi-select-combo-box/validation/basic")
 public class MultiSelectComboBoxBasicValidationIT
@@ -17,6 +18,7 @@ public class MultiSelectComboBoxBasicValidationIT
     public void fieldIsInitiallyValid() {
         assertClientValid();
         assertServerValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -25,6 +27,7 @@ public class MultiSelectComboBoxBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -35,6 +38,7 @@ public class MultiSelectComboBoxBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -45,11 +49,13 @@ public class MultiSelectComboBoxBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.deselectAll();
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test
@@ -60,6 +66,7 @@ public class MultiSelectComboBoxBasicValidationIT
         assertValidationCount(0);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage(null);
     }
 
     @Test
@@ -71,11 +78,13 @@ public class MultiSelectComboBoxBasicValidationIT
         assertValidationCount(1);
         assertServerValid();
         assertClientValid();
+        assertErrorMessage("");
 
         testField.deselectAll();
         assertValidationCount(1);
         assertServerInvalid();
         assertClientInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.combobox;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.HasSize;
@@ -352,5 +354,66 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     public void setOverlayWidth(float width, Unit unit) {
         Objects.requireNonNull(unit, "Unit can not be null");
         setOverlayWidth(HasSize.getCssSize(width, unit));
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using {@link #setI18n(ComboBoxI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public ComboBoxI18n getI18n() {
+        return (ComboBoxI18n) super.getI18n();
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(ComboBoxI18n i18n) {
+        super.setI18n(i18n);
+    }
+
+    /**
+     * The internationalization properties for {@link ComboBox}.
+     */
+    public static class ComboBoxI18n implements ComboBoxBaseI18n {
+
+        private String requiredErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see ComboBox#isRequiredIndicatorVisible()
+         * @see ComboBox#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link ComboBox#setErrorMessage(String)} take priority over i18n error
+         * messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see ComboBox#isRequiredIndicatorVisible()
+         * @see ComboBox#setRequiredIndicatorVisible(boolean)
+         */
+        public ComboBoxI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -360,7 +360,8 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * Gets the internationalization object previously set for this component.
      * <p>
      * NOTE: Updating the instance that is returned from this method will not
-     * update the component if not set again using {@link #setI18n(ComboBoxI18n)}
+     * update the component if not set again using
+     * {@link #setI18n(ComboBoxI18n)}
      *
      * @return the i18n object or {@code null} if no i18n object has been set
      */
@@ -402,8 +403,8 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
          * empty.
          * <p>
          * Note, custom error messages set with
-         * {@link ComboBox#setErrorMessage(String)} take priority over i18n error
-         * messages.
+         * {@link ComboBox#setErrorMessage(String)} take priority over i18n
+         * error messages.
          *
          * @param errorMessage
          *            the error message or {@code null} to clear it

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBaseI18n.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBaseI18n.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox;
+
+import java.io.Serializable;
+
+/**
+ * The internationalization properties for {@link ComboBoxBase}.
+ */
+public interface ComboBoxBaseI18n extends Serializable {
+    /**
+     * Gets the error message displayed when the field is required but empty.
+     *
+     * @return the error message or {@code null} if not set
+     */
+    String getRequiredErrorMessage();
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -565,6 +565,10 @@ public class MultiSelectComboBox<TItem>
         // translations with empty ones
         removeNullValuesFromJsonObject(i18nJson);
 
+        // Remove the error message properties because they aren't used on
+        // the client-side.
+        i18nJson.remove("requiredErrorMessage");
+
         // Assign new I18N object to WC, by merging the existing
         // WC I18N, and the values from the new I18n instance,
         // into an empty object

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -84,7 +84,6 @@ public class MultiSelectComboBox<TItem>
         HasThemeVariant<MultiSelectComboBoxVariant> {
 
     private final MultiSelectComboBoxSelectionModel<TItem> selectionModel;
-    private MultiSelectComboBoxI18n i18n;
     private AutoExpandMode autoExpand;
 
     /**
@@ -241,8 +240,8 @@ public class MultiSelectComboBox<TItem>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
 
-        if (i18n != null) {
-            this.updateI18n();
+        if (getI18n() != null) {
+            updateI18n();
         }
     }
 
@@ -540,7 +539,7 @@ public class MultiSelectComboBox<TItem>
      * @return the i18n object or {@code null} if no i18n object has been set
      */
     public MultiSelectComboBoxI18n getI18n() {
-        return i18n;
+        return (MultiSelectComboBoxI18n) super.getI18n();
     }
 
     /**
@@ -550,8 +549,7 @@ public class MultiSelectComboBox<TItem>
      *            the i18n object, not {@code null}
      */
     public void setI18n(MultiSelectComboBoxI18n i18n) {
-        this.i18n = Objects.requireNonNull(i18n,
-                "The i18n properties object should not be null");
+        super.setI18n(i18n);
         updateI18n();
     }
 
@@ -561,7 +559,7 @@ public class MultiSelectComboBox<TItem>
      * settings of the web component.
      */
     private void updateI18n() {
-        JsonObject i18nJson = (JsonObject) JsonSerializer.toJson(this.i18n);
+        JsonObject i18nJson = (JsonObject) JsonSerializer.toJson(getI18n());
 
         // Remove null values so that we don't overwrite existing WC
         // translations with empty ones

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxI18n.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxI18n.java
@@ -27,8 +27,7 @@ public class MultiSelectComboBoxI18n implements ComboBoxBaseI18n {
     private String requiredErrorMessage;
 
     /**
-     * Gets the error message displayed when the field is required but
-     * empty.
+     * Gets the error message displayed when the field is required but empty.
      *
      * @return the error message or {@code null} if not set
      * @see MultiSelectComboBox#isRequiredIndicatorVisible()
@@ -39,12 +38,11 @@ public class MultiSelectComboBoxI18n implements ComboBoxBaseI18n {
     }
 
     /**
-     * Sets the error message to display when the field is required but
-     * empty.
+     * Sets the error message to display when the field is required but empty.
      * <p>
      * Note, custom error messages set with
-     * {@link MultiSelectComboBox#setErrorMessage(String)} take priority over i18n error
-     * messages.
+     * {@link MultiSelectComboBox#setErrorMessage(String)} take priority over
+     * i18n error messages.
      *
      * @param errorMessage
      *            the error message or {@code null} to clear it
@@ -52,7 +50,8 @@ public class MultiSelectComboBoxI18n implements ComboBoxBaseI18n {
      * @see MultiSelectComboBox#isRequiredIndicatorVisible()
      * @see MultiSelectComboBox#setRequiredIndicatorVisible(boolean)
      */
-    public MultiSelectComboBoxI18n setRequiredErrorMessage(String errorMessage) {
+    public MultiSelectComboBoxI18n setRequiredErrorMessage(
+            String errorMessage) {
         requiredErrorMessage = errorMessage;
         return this;
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxI18n.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxI18n.java
@@ -15,17 +15,47 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import java.io.Serializable;
-
 /**
  * Class for localization of the {@link MultiSelectComboBox}
  */
-public class MultiSelectComboBoxI18n implements Serializable {
+public class MultiSelectComboBoxI18n implements ComboBoxBaseI18n {
     private String cleared;
     private String focused;
     private String selected;
     private String deselected;
     private String total;
+    private String requiredErrorMessage;
+
+    /**
+     * Gets the error message displayed when the field is required but
+     * empty.
+     *
+     * @return the error message or {@code null} if not set
+     * @see MultiSelectComboBox#isRequiredIndicatorVisible()
+     * @see MultiSelectComboBox#setRequiredIndicatorVisible(boolean)
+     */
+    public String getRequiredErrorMessage() {
+        return requiredErrorMessage;
+    }
+
+    /**
+     * Sets the error message to display when the field is required but
+     * empty.
+     * <p>
+     * Note, custom error messages set with
+     * {@link MultiSelectComboBox#setErrorMessage(String)} take priority over i18n error
+     * messages.
+     *
+     * @param errorMessage
+     *            the error message or {@code null} to clear it
+     * @return this instance for method chaining
+     * @see MultiSelectComboBox#isRequiredIndicatorVisible()
+     * @see MultiSelectComboBox#setRequiredIndicatorVisible(boolean)
+     */
+    public MultiSelectComboBoxI18n setRequiredErrorMessage(String errorMessage) {
+        requiredErrorMessage = errorMessage;
+        return this;
+    }
 
     /**
      * The text that is announced by screen readers when the clear button is

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/ComboBoxBasicValidationTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/ComboBoxBasicValidationTest.java
@@ -15,12 +15,63 @@
  */
 package com.vaadin.flow.component.combobox.validation;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class ComboBoxBasicValidationTest
         extends AbstractBasicValidationTest<ComboBox<String>, String> {
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue("foo");
+        testField.setValue(null);
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new ComboBox.ComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue("foo");
+        testField.setValue(null);
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new ComboBox.ComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("foo");
+        testField.setValue(null);
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new ComboBox.ComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue("foo");
+        testField.setValue(null);
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected ComboBox<String> createTestField() {
-        return new ComboBox<String>();
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems("foo");
+        return comboBox;
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/validation/MultiSelectComboBoxBasicValidationTest.java
@@ -17,12 +17,64 @@ package com.vaadin.flow.component.combobox.validation;
 
 import java.util.Set;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.combobox.MultiSelectComboBoxI18n;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class MultiSelectComboBoxBasicValidationTest extends
         AbstractBasicValidationTest<MultiSelectComboBox<String>, Set<String>> {
+    @Test
+    public void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue(Set.of("foo"));
+        testField.setValue(Set.of());
+        Assert.assertEquals("", getErrorMessageProperty());
+    }
+
+    @Test
+    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new MultiSelectComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue(Set.of("foo"));
+        testField.setValue(Set.of());
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new MultiSelectComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(Set.of("foo"));
+        testField.setValue(Set.of());
+        Assert.assertEquals("Custom error message", getErrorMessageProperty());
+    }
+
+    @Test
+    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new MultiSelectComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(Set.of("foo"));
+        testField.setValue(Set.of());
+        testField.setErrorMessage("");
+        Assert.assertEquals("Field is required", getErrorMessageProperty());
+    }
+
+    @Override
     protected MultiSelectComboBox<String> createTestField() {
-        return new MultiSelectComboBox<String>();
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        comboBox.setItems("foo");
+        return comboBox;
+    }
+
+    private String getErrorMessageProperty() {
+        return testField.getElement().getProperty("errorMessage");
     }
 }


### PR DESCRIPTION
## Description

The PR introduces ComboBoxI18n and enhances the existing MultiSelectComboBoxI18n with a method for setting a required error message and updates the corresponding validation logic to show this error message when validation fails.

Part of #4618 

## Type of change

- [x] Feature
