### PR TITLE
fix: allow editing items outside grid's active range

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
@@ -55,13 +55,14 @@ public class GridEditorPage extends Div {
                 items.add(new Person("foo" + i, 10 + i));
             }
             grid.getDataProvider().refreshAll();
-            
+
         });
         add100Items.setId("add-100-items");
 
-        NativeButton editLastItem = new NativeButton("Edit last item", event -> {
-            editor.editItem(items.get(items.size() - 1));
-        });
+        NativeButton editLastItem = new NativeButton("Edit last item",
+                event -> {
+                    editor.editItem(items.get(items.size() - 1));
+                });
         editLastItem.setId("edit-last-item");
 
         add(grid, subsequentEditRequests, add100Items, editLastItem);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
@@ -50,7 +50,21 @@ public class GridEditorPage extends Div {
                 });
         subsequentEditRequests.setId("subsequent-edit-requests");
 
-        add(grid, subsequentEditRequests);
+        NativeButton add100Items = new NativeButton("Add 100 items", event -> {
+            for (int i = 0; i < 100; i++) {
+                items.add(new Person("foo" + i, 10 + i));
+            }
+            grid.getDataProvider().refreshAll();
+            
+        });
+        add100Items.setId("add-100-items");
+
+        NativeButton editLastItem = new NativeButton("Edit last item", event -> {
+            editor.editItem(items.get(items.size() - 1));
+        });
+        editLastItem.setId("edit-last-item");
+
+        add(grid, subsequentEditRequests, add100Items, editLastItem);
     }
 
     private void createColumnWithEditor(Grid<Person> grid) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
@@ -86,7 +86,9 @@ public class GridEditorIT extends AbstractComponentIT {
     }
 
     private void assertEditorOpenedOnRow(int rowIndex) {
-        Assert.assertTrue(getEditor(rowIndex).isDisplayed());
+        var editor = getEditor(rowIndex);
+        Assert.assertNotNull(editor);
+        Assert.assertTrue(editor.isDisplayed());
     }
 
     private GridTHTDElement getNameCellForRow(int rowIndex) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.ElementQuery;
-import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-grid/editor")

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.By;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
@@ -49,11 +50,44 @@ public class GridEditorIT extends AbstractComponentIT {
         assertEditorOpenedOnRow(1);
     }
 
-    private void assertEditorOpenedOnRow(int rowIndex) {
+    @Test
+    public void editItemOutsideActiveRange_rowEdited() {
+        clickElementWithJs("add-100-items");
+        clickElementWithJs("edit-last-item");
+
+        var lastRowIndex = grid.getRowCount() - 1;
+
+        // Check that the editor is opened on the last row
+        grid.scrollToRow(lastRowIndex);
+        assertEditorOpenedOnRow(lastRowIndex);
+
+        // Update the item name
+        getEditor(lastRowIndex).setValue("Updated name");
+
+        // Close the editor to save the changes
+        grid.getCell(lastRowIndex - 1, 0).click();
+        Assert.assertNull(getEditor(lastRowIndex));
+
+        // Scroll back to the first row
+        grid.scrollToRow(0);
+
+        // Scroll back to the last row
+        grid.scrollToRow(lastRowIndex);
+
+        // Check that the item name is updated
+        Assert.assertEquals("Updated name",
+                grid.getCell(lastRowIndex, 0).getText());
+    }
+
+    private TextFieldElement getEditor(int rowIndex) {
         final GridTHTDElement nameCell = getNameCellForRow(rowIndex);
-        final ElementQuery<TestBenchElement> editor = nameCell
-                .$("vaadin-text-field");
-        Assert.assertTrue(editor.exists());
+        final ElementQuery<TextFieldElement> editor = nameCell
+                .$(TextFieldElement.class);
+        return editor.exists() ? editor.first() : null;
+    }
+
+    private void assertEditorOpenedOnRow(int rowIndex) {
+        Assert.assertTrue(getEditor(rowIndex).isDisplayed());
     }
 
     private GridTHTDElement getNameCellForRow(int rowIndex) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/Editor.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/Editor.java
@@ -130,8 +130,6 @@ public interface Editor<T> extends Serializable {
      *            the edited item
      * @throws IllegalStateException
      *             if already editing a different item in buffered mode
-     * @throws IllegalArgumentException
-     *             if the {@code item} is not in the backing data provider
      */
     void editItem(T item);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
@@ -216,11 +216,6 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
             throw new IllegalStateException("Editing item " + item
                     + " failed. Item editor is already editing item " + edited);
         }
-
-        if (!getGrid().getDataCommunicator().getKeyMapper().has(item)) {
-            throw new IllegalStateException("The item " + item
-                    + " is not in the backing data provider");
-        }
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorImplTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorImplTest.java
@@ -77,10 +77,15 @@ public class EditorImplTest {
         grid.getDataCommunicator().getKeyMapper().key("bar");
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void editItem_itemIsNotKnown_throw() {
-        editor.editItem("foo");
-        fakeClientResponse();
+    @Test()
+    public void editItem_itemIsNotKnown_noException() {
+        try {
+            // Edit an item that is not in the grid's active range yet
+            editor.editItem("foo");
+            fakeClientResponse();
+        } catch (Exception e) {
+            Assert.fail("No exception should be thrown");
+        }
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6384

The current Flow Grid editor implementation has a [validation rule](https://github.com/vaadin/flow-components/blob/403b1809b5058de2537b5dc2ca979e61b228d4f3/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java#L220-L223) that throws an exception when [`editItem(item)`](https://github.com/vaadin/flow-components/blob/403b1809b5058de2537b5dc2ca979e61b228d4f3/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java#L130) is called with an item that is not in the active range (i.e., there is no key for it in the key mapper). However, the exception is [documented](https://github.com/vaadin/flow-components/blob/403b1809b5058de2537b5dc2ca979e61b228d4f3/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/Editor.java#L133-L134) to be thrown if `"the item is not in the backing data provider"`, which is different from the item not having yet been loaded.

Due to this rule, it is not possible, for example, to instantiate a grid with 100 items and have the last one open for editing:

```java
grid.setItems(listOf100Items);
grid.getEditor().editItem(listOf100Items.get(listOf100Items.size() - 1));
```

The [referenced issue](https://github.com/vaadin/flow-components/issues/6384) documents a similar scenario where this bug occurs.

This PR fixes the issue by removing the validation rule as it does not serve a significant purpose. If the application logic attempts to programmatically edit an item that is not included in the item set of the active data provider, it is sufficient for nothing to happen, rather than having an exception thrown when editing items that just haven't been loaded yet.

## Type of change

Bugfix