### PR TITLE
fix: preserve flex-basis after splitter drag end

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -122,6 +122,8 @@ public class SplitterPositionIT extends AbstractComponentIT {
         // Check that the splitter position is not 30% anymore
         var flexBasisAfterDrag = primaryComponent.getCssValue("flex-basis");
         Assert.assertNotEquals(flexBasisInitial, flexBasisAfterDrag);
+        // Check that splitter position still is in px
+        Assert.assertTrue(flexBasisAfterDrag.endsWith("px"));
 
         // Reset splitter position to 30%
         $(NativeButtonElement.class).id("setSplitPositionJavaApi").click();

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -81,11 +81,14 @@ public class SplitLayout extends Component
         addAttachListener(
                 e -> this.requestStylesUpdatesForSplitterPosition(e.getUI()));
         addSplitterDragendListener(e -> {
-            var splitterPosition = calcNewSplitterPosition(
+            splitterPosition = calcNewSplitterPosition(
                     e.primaryComponentFlexBasis, e.secondaryComponentFlexBasis);
-            setSplitterPosition(splitterPosition);
-        });
 
+            setPrimaryStyle("flex",
+                    String.format("1 1 %s", e.primaryComponentFlexBasis));
+            setSecondaryStyle("flex",
+                    String.format("1 1 %s", e.secondaryComponentFlexBasis));
+        });
     }
 
     /**


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description

Update server-side `flex` style with px values from client instead of recalculating percentage values on the server.

Fixes https://github.com/vaadin/web-components/issues/7583