### PR TITLE
refactor: always set flex styles in server state, without delay

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -370,8 +370,7 @@ public class SplitLayout extends Component
      */
     public Registration addSplitterDragendListener(
             ComponentEventListener<SplitterDragendEvent> listener) {
-        return addListener(SplitterDragendEvent.class,
-                (ComponentEventListener) listener);
+        return addListener(SplitterDragendEvent.class, listener);
     }
 
     private void setInnerComponentStyle(String styleName, String value,

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -258,4 +258,24 @@ public class SplitLayoutUnitTest {
 
         Assert.assertEquals(61.81, splitLayout.getSplitterPosition(), 0.01);
     }
+
+    @Test
+    public void testUpdateSplitterPosition_updatesFlexStyle() {
+        var primaryComponent = new Div();
+        var secondaryComponent = new Div();
+        SplitLayout splitLayout = new SplitLayout(primaryComponent,
+                secondaryComponent);
+
+        // Set initial flex style
+        primaryComponent.getStyle().set("flex", "1 1 50%");
+        secondaryComponent.getStyle().set("flex", "1 1 50%");
+
+        ComponentUtil.fireEvent(splitLayout,
+                new SplitterDragendEvent(splitLayout, true, "30px", "70px"));
+
+        Assert.assertEquals("1 1 30px",
+                primaryComponent.getStyle().get("flex"));
+        Assert.assertEquals("1 1 70px",
+                secondaryComponent.getStyle().get("flex"));
+    }
 }

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -126,6 +126,127 @@ public class SplitLayoutUnitTest {
     }
 
     @Test
+    public void withoutSplitterPosition_addComponents_noFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout();
+        splitLayout.addToPrimary(new Div());
+        splitLayout.addToSecondary(new Div());
+
+        Assert.assertNull(
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertNull(
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
+    public void addComponents_setSplitterPosition_appliesFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout();
+        splitLayout.addToPrimary(new Div());
+        splitLayout.addToSecondary(new Div());
+
+        splitLayout.setSplitterPosition(75);
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
+    public void setSplitterPosition_addComponents_appliesFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout();
+        splitLayout.setSplitterPosition(75);
+
+        splitLayout.addToPrimary(new Div());
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+
+        splitLayout.addToSecondary(new Div());
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
+    public void setSplitterPosition_replaceComponents_restoresFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout(new Div(), new Div());
+        splitLayout.setSplitterPosition(75);
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+
+        splitLayout.removeAll();
+
+        splitLayout.addToPrimary(new Div());
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        splitLayout.addToSecondary(new Div());
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
+    public void setSplitterPosition_dragEndEvent_updatesFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout(new Div(), new Div());
+        splitLayout.setSplitterPosition(75);
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+
+        ComponentUtil.fireEvent(splitLayout,
+                new SplitterDragendEvent(splitLayout, true, "30px", "70px"));
+
+        Assert.assertEquals("1 1 30px",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 70px",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
+    public void dragEndEvent_setSplitterPosition_updatesFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout(new Div(), new Div());
+        ComponentUtil.fireEvent(splitLayout,
+                new SplitterDragendEvent(splitLayout, true, "30px", "70px"));
+        Assert.assertEquals("1 1 30px",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 70px",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+
+        splitLayout.setSplitterPosition(75);
+
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
+    public void setSplitterPosition_dragEndEvent_replaceComponents_restoresFlexStyle() {
+        SplitLayout splitLayout = new SplitLayout(new Div(), new Div());
+        splitLayout.setSplitterPosition(75);
+        Assert.assertEquals("1 1 75.0%",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 25.0%",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+
+        ComponentUtil.fireEvent(splitLayout,
+                new SplitterDragendEvent(splitLayout, true, "30px", "70px"));
+
+        Assert.assertEquals("1 1 30px",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        Assert.assertEquals("1 1 70px",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+
+        splitLayout.removeAll();
+
+        splitLayout.addToPrimary(new Div());
+        Assert.assertEquals("1 1 30px",
+                splitLayout.getPrimaryComponent().getStyle().get("flex"));
+        splitLayout.addToSecondary(new Div());
+        Assert.assertEquals("1 1 70px",
+                splitLayout.getSecondaryComponent().getStyle().get("flex"));
+    }
+
+    @Test
     public void testGetSplitterPosition() {
         SplitLayout splitLayout = new SplitLayout();
         double splitterPosition = 45.66;
@@ -257,25 +378,5 @@ public class SplitLayoutUnitTest {
                 splitLayout, true, "432.68px", "267.32px"));
 
         Assert.assertEquals(61.81, splitLayout.getSplitterPosition(), 0.01);
-    }
-
-    @Test
-    public void testUpdateSplitterPosition_updatesFlexStyle() {
-        var primaryComponent = new Div();
-        var secondaryComponent = new Div();
-        SplitLayout splitLayout = new SplitLayout(primaryComponent,
-                secondaryComponent);
-
-        // Set initial flex style
-        primaryComponent.getStyle().set("flex", "1 1 50%");
-        secondaryComponent.getStyle().set("flex", "1 1 50%");
-
-        ComponentUtil.fireEvent(splitLayout,
-                new SplitterDragendEvent(splitLayout, true, "30px", "70px"));
-
-        Assert.assertEquals("1 1 30px",
-                primaryComponent.getStyle().get("flex"));
-        Assert.assertEquals("1 1 70px",
-                secondaryComponent.getStyle().get("flex"));
     }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description

The current mechanism for setting the splitter position is problematic:
- It relies on the `setInnerComponentStyle` method
- That method either sets the `flex` style for the primary/secondary child in the server state if they exist, or executes some JS to update the style on the client, I guess in case children get added after setting the splitter position
- There's several issues with this:
  - Updating the `flex` style, regardless whether on server or client, is always delayed, as everything is wrapped into `beforeClientResponse`
  - Server-side state might not get set all 
  - Setting splitter position and adding a child in a later roundtrip does not apply the correct `flex` style to it
  - Removing children, and adding new children does not restore the `flex` style on them, so whatever splitter position is stored on the server gets out of sync with the children styles

This replaces the mechanism with a simpler one:
- The `flex` styles for primary/secondary children are stored in a state whenever the splitter position changes
- Whenever a child is added, the style is applied to it again

Based on changes from https://github.com/vaadin/flow-components/pull/6484
