### PR TITLE
fix: allow editing items outside grid's active range (#6476)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorPage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.editor.Editor;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/editor")
+public class GridEditorPage extends Div {
+
+    private final Binder<Person> binder = new Binder<>(Person.class);
+
+    public GridEditorPage() {
+        Grid<Person> grid = new Grid<>();
+
+        final List<Person> items = createGridData();
+        grid.setItems(items);
+
+        Editor<Person> editor = grid.getEditor();
+        editor.setBinder(binder);
+
+        createColumnWithEditor(grid);
+
+        NativeButton subsequentEditRequests = new NativeButton(
+                "Subsequent edits", event -> {
+                    editor.editItem(items.get(0));
+                    editor.editItem(items.get(1));
+                });
+        subsequentEditRequests.setId("subsequent-edit-requests");
+
+        NativeButton add100Items = new NativeButton("Add 100 items", event -> {
+            for (int i = 0; i < 100; i++) {
+                items.add(new Person("foo" + i, 10 + i));
+            }
+            grid.getDataProvider().refreshAll();
+
+        });
+        add100Items.setId("add-100-items");
+
+        NativeButton editLastItem = new NativeButton("Edit last item",
+                event -> {
+                    editor.editItem(items.get(items.size() - 1));
+                });
+        editLastItem.setId("edit-last-item");
+
+        add(grid, subsequentEditRequests, add100Items, editLastItem);
+    }
+
+    private void createColumnWithEditor(Grid<Person> grid) {
+        Grid.Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
+                .setHeader("Name");
+
+        TextField field = new TextField();
+        binder.bind(field, "firstName");
+        nameColumn.setEditorComponent(field);
+    }
+
+    private List<Person> createGridData() {
+        List<Person> items = new ArrayList<>();
+        items.add(new Person("foo", 10));
+        items.add(new Person("bar", 11));
+        items.add(new Person("yxz", 12));
+        return items;
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/editor")
+public class GridEditorIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.tagName("vaadin-grid"));
+        grid = $(GridElement.class).first();
+
+        waitUntil(driver -> grid.getRowCount() > 0);
+    }
+
+    @Test
+    public void editItemOutsideActiveRange_rowEdited() {
+        clickElementWithJs("add-100-items");
+        clickElementWithJs("edit-last-item");
+
+        var lastRowIndex = grid.getRowCount() - 1;
+
+        // Check that the editor is opened on the last row
+        grid.scrollToRow(lastRowIndex);
+        assertEditorOpenedOnRow(lastRowIndex);
+
+        // Update the item name
+        getEditor(lastRowIndex).setValue("Updated name");
+
+        // Close the editor to save the changes
+        grid.getCell(lastRowIndex - 1, 0).click();
+        Assert.assertNull(getEditor(lastRowIndex));
+
+        // Scroll back to the first row
+        grid.scrollToRow(0);
+
+        // Scroll back to the last row
+        grid.scrollToRow(lastRowIndex);
+
+        // Check that the item name is updated
+        Assert.assertEquals("Updated name",
+                grid.getCell(lastRowIndex, 0).getText());
+    }
+
+    private TextFieldElement getEditor(int rowIndex) {
+        final GridTHTDElement nameCell = getNameCellForRow(rowIndex);
+        final ElementQuery<TextFieldElement> editor = nameCell
+                .$(TextFieldElement.class);
+        return editor.exists() ? editor.first() : null;
+    }
+
+    private void assertEditorOpenedOnRow(int rowIndex) {
+        var editor = getEditor(rowIndex);
+        Assert.assertNotNull(editor);
+        Assert.assertTrue(editor.isDisplayed());
+    }
+
+    private GridTHTDElement getNameCellForRow(int rowIndex) {
+        GridTRElement row = grid.getRow(rowIndex);
+        return row.getCell(grid.getColumn("Name"));
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/Editor.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/Editor.java
@@ -130,8 +130,6 @@ public interface Editor<T> extends Serializable {
      *            the edited item
      * @throws IllegalStateException
      *             if already editing a different item in buffered mode
-     * @throws IllegalArgumentException
-     *             if the {@code item} is not in the backing data provider
      */
     void editItem(T item);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/editor/EditorImpl.java
@@ -216,11 +216,6 @@ public class EditorImpl<T> extends AbstractGridExtension<T>
             throw new IllegalStateException("Editing item " + item
                     + " failed. Item editor is already editing item " + edited);
         }
-
-        if (!getGrid().getDataCommunicator().getKeyMapper().has(item)) {
-            throw new IllegalStateException("The item " + item
-                    + " is not in the backing data provider");
-        }
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorImplTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/editor/EditorImplTest.java
@@ -77,10 +77,15 @@ public class EditorImplTest {
         grid.getDataCommunicator().getKeyMapper().key("bar");
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void editItem_itemIsNotKnown_throw() {
-        editor.editItem("foo");
-        fakeClientResponse();
+    @Test()
+    public void editItem_itemIsNotKnown_noException() {
+        try {
+            // Edit an item that is not in the grid's active range yet
+            editor.editItem("foo");
+            fakeClientResponse();
+        } catch (Exception e) {
+            Assert.fail("No exception should be thrown");
+        }
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
## Description

Manually cherry-pick #6476 to `24.3`