### PR TITLE
feat: add no-padding theme variant

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
@@ -29,6 +29,7 @@ public enum TabSheetVariant implements ThemeVariant {
     LUMO_TABS_HIDE_SCROLL_BUTTONS("hide-scroll-buttons"),
     LUMO_TABS_EQUAL_WIDTH_TABS( "equal-width-tabs"),
     LUMO_BORDERED("bordered"),
+    LUMO_NO_PADDING("no-padding"),
     MATERIAL_TABS_FIXED("fixed"),
     MATERIAL_BORDERED("bordered");
     //@formatter:on

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -334,11 +334,13 @@ public class TabSheetTest {
     @Test
     public void addThemeVariants_hasThemeVariants() {
         tabSheet.addThemeVariants(TabSheetVariant.LUMO_TABS_CENTERED,
-                TabSheetVariant.LUMO_BORDERED);
+                TabSheetVariant.LUMO_BORDERED, TabSheetVariant.LUMO_NO_PADDING);
         Assert.assertTrue(tabSheet.getThemeName()
                 .contains(TabSheetVariant.LUMO_TABS_CENTERED.getVariantName()));
         Assert.assertTrue(tabSheet.getThemeName()
                 .contains(TabSheetVariant.LUMO_BORDERED.getVariantName()));
+        Assert.assertTrue(tabSheet.getThemeName()
+                .contains(TabSheetVariant.LUMO_NO_PADDING.getVariantName()));
     }
 
     @Test


### PR DESCRIPTION
## Description

Add the flow counterpart of https://github.com/vaadin/web-components/pull/7606 (released with 24.5.0-alpha7)

Fixes #4388 (internally decided that a theme variant is enough)

## Type of change

- [X] Feature