### PR TITLE
feat: make dialogheaderfooter implement hascomponents

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -635,59 +635,40 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
         @Override
         public void add(Component... components) {
-            Objects.requireNonNull(components, "Components should not be null");
-            for (Component component : components) {
-                Objects.requireNonNull(component,
-                        "Component to add cannot be null");
-                root.appendChild(component.getElement());
-            }
-            if (!isRendererCreated()) {
-                initRenderer();
-            }
+            HasComponents.super.add(components);
+            updateRendererState();
         }
 
         @Override
         public void remove(Component... components) {
-            Objects.requireNonNull(components, "Components should not be null");
-            for (Component component : components) {
-                Objects.requireNonNull(component,
-                        "Component to remove cannot be null");
-                if (root.equals(component.getElement().getParent())) {
-                    root.removeChild(component.getElement());
-                }
-            }
-            if (root.getChildCount() == 0) {
-                dialog.getElement()
-                        .executeJs("this." + rendererFunction + " = null;");
-                setRendererCreated(false);
-            }
+            HasComponents.super.remove(components);
+            updateRendererState();
         }
 
         @Override
         public void removeAll() {
-            root.removeAllChildren();
-            dialog.getElement()
-                    .executeJs("this." + rendererFunction + " = null;");
-            setRendererCreated(false);
+            HasComponents.super.removeAll();
+            updateRendererState();
         }
 
         @Override
         public void addComponentAtIndex(int index, Component component) {
-            Objects.requireNonNull(component, "Component should not be null");
-            if (index < 0) {
-                throw new IllegalArgumentException(
-                        "Cannot add a component with a negative index");
-            } else {
-                root.insertChild(index, component.getElement());
-            }
-            if (!isRendererCreated()) {
-                initRenderer();
-            }
+            HasComponents.super.addComponentAtIndex(index, component);
+            updateRendererState();
         }
 
         @Override
         public void addComponentAsFirst(Component component) {
-            this.addComponentAtIndex(0, component);
+            HasComponents.super.addComponentAsFirst(component);
+            updateRendererState();
+        }
+
+        private void updateRendererState() {
+            if (root.getChildCount() == 0) {
+                removeRenderer();
+            } else if (!isRendererCreated()) {
+                initRenderer();
+            }
         }
 
         /**
@@ -705,6 +686,12 @@ public class Dialog extends Component implements HasComponents, HasSize,
                     + " = (root) => {" + "if (root.firstChild) { "
                     + "   return;" + "}" + "root.appendChild($0);" + "}", root);
             setRendererCreated(true);
+        }
+
+        private void removeRenderer() {
+            dialog.getElement()
+                    .executeJs("this." + rendererFunction + " = null;");
+            setRendererCreated(false);
         }
 
         /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.dialog;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -620,7 +620,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * components will be attached to as well as the renderer function used by
      * the dialog.
      */
-    abstract static class DialogHeaderFooter implements Serializable {
+    abstract static class DialogHeaderFooter implements HasComponents {
         protected final Element root;
         private final String rendererFunction;
         private final Component dialog;
@@ -640,6 +640,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
          * @param components
          *            the components to be added.
          */
+        @Override
         public void add(Component... components) {
             Objects.requireNonNull(components, "Components should not be null");
             for (Component component : components) {
@@ -662,6 +663,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
          * @param components
          *            the components to be removed.
          */
+        @Override
         public void remove(Component... components) {
             Objects.requireNonNull(components, "Components should not be null");
             for (Component component : components) {
@@ -681,11 +683,47 @@ public class Dialog extends Component implements HasComponents, HasSize,
         /**
          * Removes all components from the container.
          */
+        @Override
         public void removeAll() {
             root.removeAllChildren();
             dialog.getElement()
                     .executeJs("this." + rendererFunction + " = null;");
             setRendererCreated(false);
+        }
+
+        /**
+         * Adds the given component to the container at the specific index.
+         *
+         * @param index
+         *            the index, where the component will be added. The index
+         *            must be non-negative and may not exceed the children count
+         *            component – the component to add, value should not be null
+         * @param component
+         *            the component to be added.
+         */
+        @Override
+        public void addComponentAtIndex(int index, Component component) {
+            Objects.requireNonNull(component, "Component should not be null");
+            if (index < 0) {
+                throw new IllegalArgumentException(
+                        "Cannot add a component with a negative index");
+            } else {
+                root.insertChild(index, component.getElement());
+            }
+            if (!isRendererCreated()) {
+                initRenderer();
+            }
+        }
+
+        /**
+         * Adds the given component as the first child of the container.
+         *
+         * @param component
+         *            the component to be added.
+         */
+        @Override
+        public void addComponentAsFirst(Component component) {
+            this.addComponentAtIndex(0, component);
         }
 
         /**
@@ -726,6 +764,11 @@ public class Dialog extends Component implements HasComponents, HasSize,
          */
         void setRendererCreated(boolean rendererCreated) {
             this.rendererCreated = rendererCreated;
+        }
+
+        @Override
+        public Element getElement() {
+            return root;
         }
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -640,7 +640,25 @@ public class Dialog extends Component implements HasComponents, HasSize,
         }
 
         @Override
+        public void add(Collection<Component> components) {
+            HasComponents.super.add(components);
+            updateRendererState();
+        }
+
+        @Override
+        public void add(String text) {
+            HasComponents.super.add(text);
+            updateRendererState();
+        }
+
+        @Override
         public void remove(Component... components) {
+            HasComponents.super.remove(components);
+            updateRendererState();
+        }
+
+        @Override
+        public void remove(Collection<Component> components) {
             HasComponents.super.remove(components);
             updateRendererState();
         }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -633,12 +633,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
             root.getStyle().set("display", "contents");
         }
 
-        /**
-         * Adds the given components to the container.
-         *
-         * @param components
-         *            the components to be added.
-         */
         @Override
         public void add(Component... components) {
             Objects.requireNonNull(components, "Components should not be null");
@@ -652,16 +646,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
             }
         }
 
-        /**
-         * Removes the given components from the container.
-         *
-         * <p>
-         * Note that the component needs to be removed from this method in order
-         * to guarantee the correct state of the component.
-         *
-         * @param components
-         *            the components to be removed.
-         */
         @Override
         public void remove(Component... components) {
             Objects.requireNonNull(components, "Components should not be null");
@@ -679,9 +663,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
             }
         }
 
-        /**
-         * Removes all components from the container.
-         */
         @Override
         public void removeAll() {
             root.removeAllChildren();
@@ -690,16 +671,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
             setRendererCreated(false);
         }
 
-        /**
-         * Adds the given component to the container at the specific index.
-         *
-         * @param index
-         *            the index, where the component will be added. The index
-         *            must be non-negative and may not exceed the children count
-         *            component – the component to add, value should not be null
-         * @param component
-         *            the component to be added.
-         */
         @Override
         public void addComponentAtIndex(int index, Component component) {
             Objects.requireNonNull(component, "Component should not be null");
@@ -714,12 +685,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
             }
         }
 
-        /**
-         * Adds the given component as the first child of the container.
-         *
-         * @param component
-         *            the component to be added.
-         */
         @Override
         public void addComponentAsFirst(Component component) {
             this.addComponentAtIndex(0, component);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -249,6 +249,18 @@ public class DialogTest {
 
         Assert.assertTrue(thirdContent.getParent().isPresent());
         Assert.assertEquals(thirdContent.getParent().get(), dialog);
+
+        Span fourthContent = new Span("fourth_content");
+        dialog.getHeader().addComponentAsFirst(fourthContent);
+
+        Assert.assertTrue(fourthContent.getParent().isPresent());
+        Assert.assertEquals(fourthContent.getParent().get(), dialog);
+
+        Span fifthContent = new Span("fifth_content");
+        dialog.getHeader().addComponentAtIndex(2, fifthContent);
+
+        Assert.assertTrue(fifthContent.getParent().isPresent());
+        Assert.assertEquals(fifthContent.getParent().get(), dialog);
     }
 
     @Test
@@ -304,7 +316,7 @@ public class DialogTest {
     @Test(expected = NullPointerException.class)
     public void callAddToHeaderOrFooter_withNull_shouldThrowError() {
         Dialog dialog = new Dialog();
-        dialog.getHeader().add(null);
+        dialog.getHeader().add((Component) null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
## Description

This PR makes `DialogHeaderFooter` implement `HasComponents`. This introduces the following APIs to both `DialogHeader` and `DialogFooter`:

- `add(Collection<Component> components)`
- `add(String text)`
- `remove(Collection<Component> components)`
- `removeAll()`
- `addComponentAtIndex(int index, Component component`
- `addComponentAsFirst(Component component)`

NOTE:
This might be breaking if `dialog.getHeader().add(null);` is used anywhere since it is going to be ambiguous after the refactoring. However, this is unlikely in practice since it is not supported and would throw a `NullPonterException` anyway.

Fixes #5735 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
