### PR TITLE
feat: introduce gettabcount and deprecate getcomponentcount

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -251,7 +251,7 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
     }
 
     /**
-     * Gets the number of children tabs.
+     * Gets the number of tabs.
      *
      * @return the number of tabs
      */

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -251,6 +251,15 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
     }
 
     /**
+     * Gets the number of children tabs.
+     *
+     * @return the number of tabs
+     */
+    public int getTabCount() {
+        return tabs.getTabCount();
+    }
+
+    /**
      * Returns the tab at the given position.
      *
      * @param position

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -173,7 +173,7 @@ public class Tabs extends Component
      */
     public void add(Tab... tabs) {
         Objects.requireNonNull(tabs, "Tabs should not be null");
-        boolean wasEmpty = getComponentCount() == 0;
+        boolean wasEmpty = getTabCount() == 0;
         Arrays.stream(tabs).map(
                 tab -> Objects.requireNonNull(tab, "Tab to add cannot be null"))
                 .map(Tab::getElement).forEach(getElement()::appendChild);
@@ -248,11 +248,11 @@ public class Tabs extends Component
         int newSelectedIndex = getSelectedIndex() - lowerIndices;
 
         // In case the last tab was removed
-        if (newSelectedIndex > 0 && newSelectedIndex >= getComponentCount()) {
-            newSelectedIndex = getComponentCount() - 1;
+        if (newSelectedIndex > 0 && newSelectedIndex >= getTabCount()) {
+            newSelectedIndex = getTabCount() - 1;
         }
 
-        if (getComponentCount() == 0 || (isSelectedTab && !isAutoselect())) {
+        if (getTabCount() == 0 || (isSelectedTab && !isAutoselect())) {
             newSelectedIndex = -1;
         }
 
@@ -749,8 +749,19 @@ public class Tabs extends Component
      * Gets the number of children tabs.
      *
      * @return the number of tabs
+     * @deprecated since 24.5, use {@link #getTabCount} instead.
      */
+    @Deprecated
     public int getComponentCount() {
+        return getTabCount();
+    }
+
+    /**
+     * Gets the number of children tabs.
+     *
+     * @return the number of tabs
+     */
+    public int getTabCount() {
         return (int) getChildren().count();
     }
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -757,7 +757,7 @@ public class Tabs extends Component
     }
 
     /**
-     * Gets the number of children tabs.
+     * Gets the number of tabs.
      *
      * @return the number of tabs
      */

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -156,6 +156,16 @@ public class TabSheetTest {
     }
 
     @Test
+    public void addTabs_tabCountCorrect() {
+        Assert.assertEquals(0, tabSheet.getTabCount());
+
+        tabSheet.add("Tab 0", new Span("Content 0"));
+        tabSheet.add("Tab 1", new Span("Content 1"));
+
+        Assert.assertEquals(2, tabSheet.getTabCount());
+    }
+
+    @Test
     public void changeTab_contentEnabled() {
         tabSheet.add("Tab 0", new Span("Content 0"));
 
@@ -261,6 +271,7 @@ public class TabSheetTest {
         var tab = tabSheet.add("Tab 0", new Span("Content 0"));
         tabSheet.remove(tab);
         Assert.assertFalse(tab.getParent().isPresent());
+        Assert.assertEquals(0, tabSheet.getTabCount());
     }
 
     @Test

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -42,8 +42,7 @@ public class TabsTest {
     public void createTabsInDefaultState() {
         Tabs tabs = new Tabs();
 
-        assertThat("Initial child count is invalid", tabs.getComponentCount(),
-                is(0));
+        assertThat("Initial tab count is invalid", tabs.getTabCount(), is(0));
         assertThat("Initial orientation is invalid", tabs.getOrientation(),
                 is(Tabs.Orientation.HORIZONTAL));
         assertThat("Initial selected index is invalid", tabs.getSelectedIndex(),
@@ -59,8 +58,7 @@ public class TabsTest {
         Tab tab3 = new Tab("Tab three");
         Tabs tabs = new Tabs(tab1, tab2, tab3);
 
-        assertThat("Initial child count is invalid", tabs.getComponentCount(),
-                is(3));
+        assertThat("Initial tab count is invalid", tabs.getTabCount(), is(3));
         assertThat("Initial orientation is invalid", tabs.getOrientation(),
                 is(Tabs.Orientation.HORIZONTAL));
         assertThat("Initial selected tab is invalid", tabs.getSelectedTab(),


### PR DESCRIPTION
## Description

This PR

- deprecates `Tabs::getComponentCount`
- introduces `getTabCount` for both `Tabs` and `TabSheet`

Fixes #6015 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
