### PR TITLE
feat: add PopoverVariant enum with the arrow variant

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.internal.OverlayClassListProxy;
 import com.vaadin.flow.dom.ClassList;
 import com.vaadin.flow.dom.Element;
@@ -59,7 +60,8 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@vaadin/popover", version = "24.5.0-alpha7")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/popover/src/vaadin-popover.js")
-public class Popover extends Component implements HasAriaLabel, HasComponents {
+public class Popover extends Component implements HasAriaLabel, HasComponents,
+        HasThemeVariant<PopoverVariant> {
 
     private Component target;
     private Registration targetAttachRegistration;

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.popover;
+
+import com.vaadin.flow.component.shared.ThemeVariant;
+
+/**
+ * Set of theme variants applicable for the {@code vaadin-popover} component.
+ */
+public enum PopoverVariant implements ThemeVariant {
+    ARROW("arrow");
+
+    private final String variant;
+
+    PopoverVariant(String variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the variant name.
+     *
+     * @return variant name
+     */
+    public String getVariantName() {
+        return variant;
+    }
+}

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
@@ -1,17 +1,25 @@
-/**
+/*
  * Copyright 2000-2024 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
  */
 package com.vaadin.flow.component.popover;
 
 import com.vaadin.flow.component.shared.ThemeVariant;
 
 /**
- * Set of theme variants applicable for the {@code vaadin-popover} component.
+ * Set of theme variants applicable for the {@link Popover} component.
  */
 public enum PopoverVariant implements ThemeVariant {
     ARROW("arrow");


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/web-components/pull/7550

Note: the `arrow` variant is available for both Lumo and Material.

## Type of change

- Feature