### PR TITLE
refactor: use native label in formitem instead of deprecated label

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -32,9 +32,10 @@ import com.vaadin.flow.component.JsonSerializable;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.shared.SlotUtils;
 
+import com.vaadin.flow.dom.Element;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
@@ -430,7 +431,7 @@ public class FormLayout extends Component
      * @return the created form item
      */
     public FormItem addFormItem(Component field, String label) {
-        return addFormItem(field, new Label(label));
+        return addFormItem(field, new NativeLabel(label));
     }
 
     /**

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.shared.SlotUtils;
 
-import com.vaadin.flow.dom.Element;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;


### PR DESCRIPTION
## Description

This PR replaces the use of the deprecated `Label` with `NativeLabel` in `FormItem`.

Fixes #5171 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.