### PR TITLE
feat: add units size base apis to uploadi18n

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadTestsI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadTestsI18N.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.upload.tests;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -54,7 +55,7 @@ class UploadTestsI18N {
             .setUnits(Stream
                     .of("Б", "Кбайт", "Мбайт", "Гбайт", "Тбайт", "Пбайт",
                             "Эбайт", "Збайт", "Ибайт")
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toList()), 1024);
 
     static final UploadI18N RUSSIAN_PARTIAL = new UploadI18N()
             // Only translate a single property from dropFiles
@@ -62,4 +63,6 @@ class UploadTestsI18N {
                     .setOne("Перетащите файл сюда..."))
             // Set an empty object into addFiles, but don't translate anything
             .setAddFiles(new UploadI18N.AddFiles());
+
+    static final Set<String> OPTIONAL_KEYS = Set.of("units.sizeBase");
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
@@ -114,6 +114,7 @@ public class UploadI18nIT extends AbstractUploadIT {
                 .toJson(fullTranslation);
         deeplyRemoveNullValuesFromJsonObject(fullTranslationJson);
         Map<String, String> fullTranslationMap = jsonToMap(fullTranslationJson);
+        UploadTestsI18N.OPTIONAL_KEYS.forEach(fullTranslationMap::remove);
 
         assertTranslationMapsHaveSameKeys(fullTranslationMap, translationMap);
         assertTranslationMapHasNoMissingTranslations(translationMap);

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
@@ -69,6 +69,7 @@ public class UploadI18nIT extends AbstractUploadIT {
 
         UploadI18N expected = UploadTestsI18N.RUSSIAN_FULL;
         JsonObject expectedJson = (JsonObject) JsonSerializer.toJson(expected);
+        deeplyRemoveNullValuesFromJsonObject(expectedJson);
         Map<String, String> expectedMap = jsonToMap(expectedJson);
 
         assertTranslationMapsAreEqual(expectedMap, translationMap);
@@ -111,6 +112,7 @@ public class UploadI18nIT extends AbstractUploadIT {
         UploadI18N fullTranslation = UploadTestsI18N.RUSSIAN_FULL;
         JsonObject fullTranslationJson = (JsonObject) JsonSerializer
                 .toJson(fullTranslation);
+        deeplyRemoveNullValuesFromJsonObject(fullTranslationJson);
         Map<String, String> fullTranslationMap = jsonToMap(fullTranslationJson);
 
         assertTranslationMapsHaveSameKeys(fullTranslationMap, translationMap);
@@ -213,5 +215,15 @@ public class UploadI18nIT extends AbstractUploadIT {
                 .executeScript("return JSON.stringify(arguments[0].i18n)",
                         upload);
         return Json.parse(i18nJsonString);
+    }
+
+    private void deeplyRemoveNullValuesFromJsonObject(JsonObject jsonObject) {
+        for (String key : jsonObject.keys()) {
+            if (jsonObject.get(key).getType() == JsonType.OBJECT) {
+                deeplyRemoveNullValuesFromJsonObject(jsonObject.get(key));
+            } else if (jsonObject.get(key).getType() == JsonType.NULL) {
+                jsonObject.remove(key);
+            }
+        }
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -750,8 +750,7 @@ public class UploadI18N implements Serializable {
      * @return i18n translations
      */
     public UploadI18N setUnits(List<String> units) {
-        this.units = new Units();
-        this.units.setSize(units);
+        this.units = new Units(units);
         return this;
     }
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -421,6 +421,8 @@ public class UploadI18N implements Serializable {
         private List<String> size = Arrays.asList("B", "kB", "MB", "GB", "TB",
                 "PB", "EB", "ZB", "YB");
 
+        private Integer sizeBase;
+
         /**
          * unit translations with default size:
          *
@@ -433,9 +435,22 @@ public class UploadI18N implements Serializable {
         /**
          *
          * @param size
+         *            list of unit translations
          */
         public Units(List<String> size) {
             this.size = size;
+        }
+
+        /**
+         *
+         * @param size
+         *            list of unit translations
+         * @param sizeBase
+         *            units size base
+         */
+        public Units(List<String> size, Integer sizeBase) {
+            this.size = size;
+            this.sizeBase = sizeBase;
         }
 
         /**
@@ -456,6 +471,27 @@ public class UploadI18N implements Serializable {
          */
         public Units setSize(List<String> size) {
             this.size = size;
+            return this;
+        }
+
+        /**
+         * Gets the units size base.
+         *
+         * @return the units size base
+         */
+        public Integer getSizeBase() {
+            return sizeBase;
+        }
+
+        /**
+         * Sets the units size base.
+         *
+         * @param sizeBase
+         *            units size base
+         * @return units
+         */
+        public Units setSizeBase(Integer sizeBase) {
+            this.sizeBase = sizeBase;
             return this;
         }
     }
@@ -697,10 +733,25 @@ public class UploadI18N implements Serializable {
      *
      * @param units
      *            list of unit translations
+     * @param sizeBase
+     *            units size base
+     * @return i18n translations
+     */
+    public UploadI18N setUnits(List<String> units, int sizeBase) {
+        this.units = new Units(units, sizeBase);
+        return this;
+    }
+
+    /**
+     * Set unit translations.
+     *
+     * @param units
+     *            list of unit translations
      * @return i18n translations
      */
     public UploadI18N setUnits(List<String> units) {
-        this.units = new Units(units);
+        this.units = new Units();
+        this.units.setSize(units);
         return this;
     }
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -750,7 +750,8 @@ public class UploadI18N implements Serializable {
      * @return i18n translations
      */
     public UploadI18N setUnits(List<String> units) {
-        this.units = new Units(units);
+        this.units = new Units();
+        this.units.setSize(units);
         return this;
     }
 


### PR DESCRIPTION
## Description

This PR introduces a way to set units size base in `UploadI18N`. The changes are:

- New field `sizeBase` in `Units` with getter and setter
- New constructor in `Units` including `sizeBase` as a parameter.
- New `setUnits` method in `UploadI18N` including `sizeBase` as a parameter.

Fixes #6404 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.