### PR TITLE
proto: test spotless formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you need to make any modification in a component, consider whether it is conv
 
 ### Formatting
 
-Run `mvn formatter:format` before pushing your code.
+Run `mvn spotless:apply` before pushing your code.
 
 ## Bug and enhancement tickets
 - Bug tickets and enhancement requests for the web component implementations should go to the Vaadin web components monorepo https://github.com/vaadin/web-components/.

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         <!-- spreadsheet -->
         <poi.version>5.2.5</poi.version>
         <javaparser.version>3.25.3</javaparser.version>
+
+        <!-- spotless -->
+        <spotless.version>2.43.0</spotless.version>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/apache2-license-header.txt</spotless.licence-header>
     </properties>
     <modules>
         <module>vaadin-renderer-flow-parent</module>
@@ -442,15 +446,25 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.24.1</version>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
                 <configuration>
-                    <configFile>https://raw.githubusercontent.com/vaadin/flow/main/eclipse/VaadinJavaConventions.xml</configFile>
-                    <skipHtmlFormatting>true</skipHtmlFormatting>
-                    <excludes>
-                        <exclude>**/*.css</exclude>
-                    </excludes>
+                    <java>
+                        <eclipse>
+                            <file>https://raw.githubusercontent.com/vaadin/flow/main/eclipse/VaadinJavaConventions.xml</file>
+                        </eclipse>
+
+                        <removeUnusedImports />
+                        <importOrder>
+                            <wildcardsLast>true</wildcardsLast>
+                            <order>java|javax,org,com</order>
+                        </importOrder>
+
+                        <licenseHeader>
+                            <file>${spotless.licence-header}</file>
+                        </licenseHeader>
+                    </java>
                 </configuration>
             </plugin>
         </plugins>

--- a/scripts/templates/apache2-license-header.txt
+++ b/scripts/templates/apache2-license-header.txt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */

--- a/scripts/templates/pom-parent-pro.xml
+++ b/scripts/templates/pom-parent-pro.xml
@@ -20,11 +20,15 @@
             <name>Vaadin Commercial License and Service Terms</name>
             <url>https://vaadin.com/commercial-license-and-service-terms</url>
         </license>
-    </licenses>    
+    </licenses>
 
     <modules>
         <module>component-flow</module>
     </modules>
+
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
 
     <profiles>
         <profile>

--- a/scripts/templates/vaadin-commercial-license-header.txt
+++ b/scripts/templates/vaadin-commercial-license-header.txt
@@ -1,0 +1,8 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */

--- a/vaadin-board-flow-parent/pom.xml
+++ b/vaadin-board-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-board-flow</module>
         <module>vaadin-board-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>

--- a/vaadin-charts-flow-parent/pom.xml
+++ b/vaadin-charts-flow-parent/pom.xml
@@ -16,6 +16,9 @@
             <url>https://vaadin.com/commercial-license-and-service-terms</url>
         </license>
     </licenses>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <modules>
         <module>vaadin-charts-flow</module>
         <module>vaadin-charts-testbench</module>

--- a/vaadin-cookie-consent-flow-parent/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-cookie-consent-flow</module>
         <module>vaadin-cookie-consent-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>

--- a/vaadin-crud-flow-parent/pom.xml
+++ b/vaadin-crud-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-crud-flow</module>
         <module>vaadin-crud-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>

--- a/vaadin-grid-pro-flow-parent/pom.xml
+++ b/vaadin-grid-pro-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-grid-pro-flow</module>
         <module>vaadin-grid-pro-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>

--- a/vaadin-map-flow-parent/pom.xml
+++ b/vaadin-map-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-map-flow</module>
         <module>vaadin-map-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>

--- a/vaadin-rich-text-editor-flow-parent/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-rich-text-editor-flow</module>
         <module>vaadin-rich-text-editor-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>

--- a/vaadin-spreadsheet-flow-parent/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/pom.xml
@@ -20,6 +20,9 @@
         <module>vaadin-spreadsheet-flow</module>
         <module>vaadin-spreadsheet-testbench</module>
     </modules>
+    <properties>
+        <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
+    </properties>
     <profiles>
         <profile>
             <id>default</id>


### PR DESCRIPTION
Replaces the formatter plugin with [spotless](https://github.com/diffplug/spotless/tree/main/plugin-maven), which has some additional features.

This configures spotless to:
- Use the same Eclipse formatter config that we were using before
- Remove unused imports
- Consistently order imports
- Add or update license headers, based on a template file
  - By default it uses Apache 2
  - Pro modules override a Maven property to use Vaadin Commercial License
  - Can later be used to easily update copyright years or apply other changes to all license headers