### PR TITLE
feat: add no-padding theme variant to Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
@@ -21,7 +21,11 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for the {@link Popover} component.
  */
 public enum PopoverVariant implements ThemeVariant {
-    ARROW("arrow");
+    //@formatter:off
+    ARROW("arrow"),
+    LUMO_NO_PADDING("no-padding"),
+    MATERIAL_NO_PADDING("no-padding");
+    //@formatter:on
 
     private final String variant;
 


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/web-components/pull/7650

Added `LUMO_NO_PADDING` and `MATERIAL_NO_PADDING` to align with `DialogVariant`:

https://github.com/vaadin/flow-components/blob/7cf4900e4e756f53ae25e37db6429c16079a2fd6/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/DialogVariant.java#L24

## Type of change

- Feature