### PR TITLE
fix: warn and revert to prev index when selecting invalid index (#6543) (CP: 14.12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>3.10.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>1.3</version>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -46,6 +46,23 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins/>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -52,15 +52,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -13,6 +13,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
@@ -65,8 +67,19 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      */
     public Tabs() {
         setSelectedIndex(-1);
-        getElement().addPropertyChangeListener(SELECTED,
-                event -> updateSelectedTab(event.isUserOriginated()));
+        getElement().addPropertyChangeListener(SELECTED, event -> {
+            int oldIndex = selectedTab != null ? indexOf(selectedTab) : -1;
+            int newIndex = getSelectedIndex();
+            if (newIndex >= getComponentCount()) {
+                LoggerFactory.getLogger(getClass()).warn(String.format(
+                        "The selected index is out of range: %d. Reverting to the previous index: %d.",
+                        newIndex, oldIndex));
+                setSelectedIndex(oldIndex);
+                return;
+            }
+
+            updateSelectedTab(event.isUserOriginated());
+        });
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -16,7 +16,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -17,10 +17,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +28,6 @@ import com.vaadin.flow.component.tabs.Tabs;
 /**
  * @author Vaadin Ltd.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ LoggerFactory.class })
 public class TabsTest {
 
     @Rule
@@ -126,15 +122,17 @@ public class TabsTest {
         Tabs tabs = new Tabs(tab);
 
         Logger mockedLogger = Mockito.mock(Logger.class);
-        PowerMockito.mockStatic(LoggerFactory.class);
-        PowerMockito.when(LoggerFactory.getLogger(Tabs.class))
-                .thenReturn(mockedLogger);
+        try (MockedStatic<LoggerFactory> context = Mockito
+                .mockStatic(LoggerFactory.class)) {
+            context.when(() -> LoggerFactory.getLogger(Tabs.class))
+                    .thenReturn(mockedLogger);
 
-        // Select index out of range
-        tabs.setSelectedIndex(10);
+            // Select index out of range
+            tabs.setSelectedIndex(10);
 
-        Mockito.verify(mockedLogger, Mockito.times(1)).warn(
-                "The selected index is out of range: 10. Reverting to the previous index: 0.");
+            Mockito.verify(mockedLogger, Mockito.times(1)).warn(
+                    "The selected index is out of range: 10. Reverting to the previous index: 0.");
+        }
     }
 
     @Test

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -16,6 +16,13 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
@@ -23,6 +30,8 @@ import com.vaadin.flow.component.tabs.Tabs;
 /**
  * @author Vaadin Ltd.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ LoggerFactory.class })
 public class TabsTest {
 
     @Rule
@@ -93,6 +102,38 @@ public class TabsTest {
 
         assertThat("Selected tab is invalid", tabs.getSelectedTab(), is(tab3));
         assertThat("Selected index is invalid", tabs.getSelectedIndex(), is(2));
+    }
+
+    @Test
+    public void selectInvalidIndex_previousIndexIsReverted() {
+        Tab tab = new Tab("Tab");
+        Tabs tabs = new Tabs(tab);
+
+        // Select index out of range
+        tabs.setSelectedIndex(10);
+        Assert.assertEquals(0, tabs.getSelectedIndex());
+
+        // Deselect the active tab
+        tabs.setSelectedIndex(-1);
+        // Select index out of range
+        tabs.setSelectedIndex(10);
+        Assert.assertEquals(-1, tabs.getSelectedIndex());
+    }
+
+    @Test
+    public void selectInvalidIndex_warningIsShown() {
+        Tab tab = new Tab("Tab");
+        Tabs tabs = new Tabs(tab);
+
+        Logger mockedLogger = Mockito.mock(Logger.class);
+        PowerMockito.mockStatic(LoggerFactory.class);
+        PowerMockito.when(LoggerFactory.getLogger(Tabs.class)).thenReturn(mockedLogger);
+
+        // Select index out of range
+        tabs.setSelectedIndex(10);
+
+        Mockito.verify(mockedLogger, Mockito.times(1)).warn(
+                "The selected index is out of range: 10. Reverting to the previous index: 0.");
     }
 
     @Test

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -127,7 +127,8 @@ public class TabsTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         PowerMockito.mockStatic(LoggerFactory.class);
-        PowerMockito.when(LoggerFactory.getLogger(Tabs.class)).thenReturn(mockedLogger);
+        PowerMockito.when(LoggerFactory.getLogger(Tabs.class))
+                .thenReturn(mockedLogger);
 
         // Select index out of range
         tabs.setSelectedIndex(10);


### PR DESCRIPTION
## Description

The PR backports #6543 to 14.12

Fixes https://github.com/vaadin/flow-components/issues/5214

## Type of change

- [x] Bugfix
