### PR TITLE
refactor: property sort moved to Flow; remove from Grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4033,8 +4033,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         if (autoCreateColumns) {
             propertySet.getProperties()
                     .filter(property -> !property.isSubProperty())
-                    .sorted((prop1, prop2) -> prop1.getName()
-                            .compareTo(prop2.getName()))
                     .forEach(this::addColumn);
         }
 


### PR DESCRIPTION
Remove property sorting from Grid. Logic moves to Flow side (https://github.com/vaadin/flow/pull/19796).