### PR TITLE
docs: improve Popover JavaDoc, add default values

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -163,6 +163,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * @param modal
      *            {@code true} to enable popover to open as modal, {@code false}
      *            otherwise.
+     * @see #setBackdropVisible(boolean)
      */
     public void setModal(boolean modal) {
         getElement().setProperty("modal", modal);
@@ -186,6 +187,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      *
      * @param backdropVisible
      *            {@code true} to show the backdrop, {@code false} otherwise.
+     * @see #setModal(boolean)
      */
     public void setBackdropVisible(boolean backdropVisible) {
         getElement().setProperty("withBackdrop", backdropVisible);

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -316,17 +316,25 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets position of the popover with respect to its target.
+     * Sets position of the popover with respect to its {@code target}.
+     * <p>
+     * NOTE: when the target component is not set, the position does not take
+     * any effect and the popover is rendered in the middle of the screen.
      *
      * @param position
      *            the position to set
+     * @see #setFor(String)
+     * @see #setTarget(Component)
      */
     public void setPosition(PopoverPosition position) {
         getElement().setProperty("position", position.getPosition());
     }
 
     /**
-     * Gets position of the popover with respect to its target.
+     * Gets position of the popover with respect to its {@code target}.
+     * <p>
+     * NOTE: when the target component is not set, the position does not take
+     * any effect and the popover is rendered in the middle of the screen.
      *
      * @return the position
      */
@@ -345,18 +353,18 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * otherwise a warning in the Javascript console is shown.
      *
      * @param id
-     *            the id of component for this popup, can be {@code null} to
-     *            remove the target
+     *            the id of target component for this popover, can be
+     *            {@code null} to remove the target
      */
     public void setFor(String id) {
         getElement().setProperty("for", id);
     }
 
     /**
-     * Gets the {@code id} of target component of this popup, or {@code null} if
-     * the {@code id} was not set.
+     * Gets the {@code id} of target component of the popover, or {@code null}
+     * if the {@code id} was not set.
      *
-     * @return the id of target component of this popup
+     * @return the id of target component for this popover
      * @see #setFor(String)
      */
     public String getFor() {
@@ -364,8 +372,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * The delay in milliseconds before the popover is opened on target keyboard
-     * focus.
+     * The delay in milliseconds before the popover is opened on target focus.
+     * Defaults to {@code 0}.
      *
      * @param focusDelay
      *            the delay in milliseconds
@@ -375,8 +383,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * The delay in milliseconds before the popover is opened on target keyboard
-     * focus.
+     * The delay in milliseconds before the popover is opened on target focus.
+     * Defaults to {@code 0}.
      *
      * @return the delay in milliseconds
      */
@@ -386,6 +394,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     /**
      * The delay in milliseconds before the popover is opened on target hover.
+     * Defaults to {@code 0}.
      *
      * @param hoverDelay
      *            the delay in milliseconds
@@ -396,6 +405,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     /**
      * The delay in milliseconds before the popover is opened on target hover.
+     * Defaults to {@code 0}.
      *
      * @return the delay in milliseconds
      */
@@ -405,7 +415,9 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     /**
      * The delay in milliseconds before the popover is closed on losing hover.
-     * On target blur, the popover is closed immediately.
+     * Defaults to {@code 0}.
+     * <p>
+     * NOTE: on target blur, the popover is closed immediately.
      *
      * @param hideDelay
      *            the delay in milliseconds
@@ -416,7 +428,9 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     /**
      * The delay in milliseconds before the popover is closed on losing hover.
-     * On target blur, the popover is closed immediately.
+     * Defaults to {@code 0}.
+     * <p>
+     * NOTE: on target blur, the popover is closed immediately.
      *
      * @return the delay in milliseconds
      */
@@ -425,7 +439,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets whether the popover can be opened via target click.
+     * Sets whether the popover can be opened via target click. Defaults to
+     * {@code true}.
      *
      * @param openOnClick
      *            {@code true} to allow opening the popover via target click,
@@ -437,8 +452,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Gets whether the popover can be opened via target click, which is
-     * {@code true} by default.
+     * Gets whether the popover can be opened via target click. Defaults to
+     * {@code true}.
      *
      * @return {@code true} if the popover can be opened with target click,
      *         {@code false} otherwise.
@@ -448,7 +463,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets whether the popover can be opened via target focus.
+     * Sets whether the popover can be opened via target focus. Defaults to
+     * {@code false}.
      *
      * @param openOnFocus
      *            {@code true} to allow opening the popover via target focus,
@@ -460,8 +476,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Gets whether the popover can be opened via target focus, which is
-     * {@code false} by default.
+     * Gets whether the popover can be opened via target focus. Defaults to
+     * {@code false}.
      *
      * @return {@code true} if the popover can be opened with target focus,
      *         {@code false} otherwise.
@@ -471,7 +487,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets whether the popover can be opened via target hover.
+     * Sets whether the popover can be opened via target hover. Defaults to
+     * {@code false}.
      *
      * @param openOnHover
      *            {@code true} to allow opening the popover via target hover,
@@ -483,8 +500,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Gets whether the popover can be opened via target hover, which is
-     * {@code false} by default.
+     * Gets whether the popover can be opened via target hover. Defaults to
+     * {@code false}.
      *
      * @return {@code true} if the popover can be opened with target hover,
      *         {@code false} otherwise.


### PR DESCRIPTION
## Description

- Added default values to `setHoverDelay()`, `setFocusDelay()` and `setHideDelay()`
- Aligned default values for `setOpenOnClick()`, `setOpenOnFocus()` and `setOpenOnHover()`
- Added mention that `setPosition()` only works when the target is set
- Replaced a few mentions of "popup" with "popover" (copy-paste leftovers from VCF Popup)

## Type of change

- Documentation