### PR TITLE
feat: add constructor allowing to set Popover content

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -83,6 +83,18 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
+     * Creates a popover with given components inside.
+     *
+     * @param components
+     *            the components inside the popover
+     * @see #add(Component...)
+     */
+    public Popover(Component... components) {
+        this();
+        add(components);
+    }
+
+    /**
      * {@code opened-changed} event is sent when the overlay opened state
      * changes.
      */

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -274,4 +274,13 @@ public class PopoverTest {
         Assert.assertTrue(popover.isAutofocus());
         Assert.assertTrue(popover.getElement().getProperty("autofocus", false));
     }
+
+    @Test
+    public void popoverWithContent() {
+        Div content = new Div();
+        Popover popoverWithContent = new Popover(content);
+        Assert.assertEquals(1, popoverWithContent.getChildren().count());
+        Assert.assertSame(content,
+                popoverWithContent.getChildren().findFirst().get());
+    }
 }


### PR DESCRIPTION
## Description

Added a constructor to align with `Dialog()` which allows to pass content. This is a finding from DX tests.

## Type of change

- Feature