### PR TITLE
feat: add setModal override to allow setting backdrop visibility

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -154,6 +154,11 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * popover is modal, interacting with elements behind it will be prevented
      * until the popover is closed.
      * <p>
+     * Setting the modal to {@code true} does not enable showing the backdrop
+     * (modality curtain) automatically. This should be done separately using
+     * {@link #setBackdropVisible(boolean)} or optionally passed as a second
+     * parameter using {@link #setModal(boolean, boolean)}.
+     * <p>
      * NOTE: this setting does not involve server-side modality, as the modal
      * popover is typically not used to prevent anything else from happening
      * while it's open.
@@ -163,9 +168,33 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * @param modal
      *            {@code true} to enable popover to open as modal, {@code false}
      *            otherwise.
+     * @see #setBackdropVisible(boolean)
+     * @see #setModal(boolean, boolean)
      */
     public void setModal(boolean modal) {
         getElement().setProperty("modal", modal);
+    }
+
+    /**
+     * Sets whether component should open modal or modeless popover and whether
+     * the component should show a backdrop (modality curtain) when opened.
+     * <p>
+     * NOTE: this setting does not involve server-side modality, as the modal
+     * popover is typically not used to prevent anything else from happening
+     * while it's open.
+     * <p>
+     * By default, the popover is non-modal and has no modality curtain.
+     *
+     * @param modal
+     *            {@code true} to enable popover to open as modal, {@code false}
+     *            otherwise.
+     * @param backdropVisible
+     *            {@code true} to show the backdrop, {@code false} otherwise.
+     * @see #setBackdropVisible(boolean)
+     */
+    public void setModal(boolean modal, boolean backdropVisible) {
+        setModal(modal);
+        setBackdropVisible(backdropVisible);
     }
 
     /**

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -265,6 +265,17 @@ public class PopoverTest {
     }
 
     @Test
+    public void setModalAndBackdropVisible() {
+        popover.setModal(true, true);
+        Assert.assertTrue(popover.isModal());
+        Assert.assertTrue(popover.isBackdropVisible());
+
+        popover.setModal(false, false);
+        Assert.assertFalse(popover.isModal());
+        Assert.assertFalse(popover.isBackdropVisible());
+    }
+
+    @Test
     public void setAutofocus_isAutofocus() {
         Assert.assertFalse(popover.isAutofocus());
         Assert.assertFalse(


### PR DESCRIPTION
## Description

Added `setModal()` override allowing to also call `setBackdropVisible()` so that the need for setting backdrop separately would be more easily discoverable. Also modified the `setModal()` JavaDoc accordingly. This is a DX test finding.

## Type of change

- Feature