### PR TITLE
feat: add logic for Popover auto-adding on setting target

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -687,14 +687,14 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
             targetDetachRegistration.remove();
         }
 
+        if (autoAddedToTheUi) {
+            getElement().removeFromParent();
+            autoAddedToTheUi = false;
+        }
+
         this.target = target;
 
         if (target == null) {
-            if (autoAddedToTheUi) {
-                getElement().removeFromParent();
-                autoAddedToTheUi = false;
-            }
-
             getElement().executeJs("this.target = null");
             return;
         }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -43,8 +43,6 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementDetachEvent;
 import com.vaadin.flow.dom.ElementDetachListener;
 import com.vaadin.flow.dom.Style;
-import com.vaadin.flow.internal.StateTree;
-import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
 
@@ -73,7 +71,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     private Component target;
     private Registration targetAttachRegistration;
-    private Registration afterProgrammaticNavigationListenerRegistration;
     private boolean autoAddedToTheUi;
 
     private boolean openOnClick = true;
@@ -88,14 +85,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
         // Workaround for: https://github.com/vaadin/flow/issues/3496
         getElement().setProperty("opened", false);
-
-        getElement().addPropertyChangeListener("opened", event -> {
-            // Only handle client-side changes, server-side changes are already
-            // handled by setOpened
-            if (event.isUserOriginated()) {
-                doSetOpened(this.isOpened(), event.isUserOriginated());
-            }
-        });
 
         updateTrigger();
         setOverlayRole("dialog");
@@ -221,31 +210,13 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      */
     public void setOpened(boolean opened) {
         if (opened != isOpened()) {
-            doSetOpened(opened, false);
+            getElement().setProperty("opened", opened);
+            fireEvent(new OpenedChangeEvent(this, false));
         }
-    }
-
-    private void doSetOpened(boolean opened, boolean fromClient) {
-        if (opened) {
-            ensureAttached();
-        } else if (autoAddedToTheUi) {
-            getElement().removeFromParent();
-            autoAddedToTheUi = false;
-        }
-        getElement().setProperty("opened", opened);
-        fireEvent(new OpenedChangeEvent(this, fromClient));
     }
 
     /**
      * Opens the popover.
-     * <p>
-     * Note: You don't need to add the popover component before opening it,
-     * because opening a popover will automatically add it to the {@code <body>}
-     * if it's not yet attached anywhere.
-     * <p>
-     * When using {@link #setFor(String)} it is recommended to manually add the
-     * popover to the UI instead, and to ensure it is placed in the same DOM
-     * scope (document or shadow root) as the component with the given ID.
      */
     public void open() {
         setOpened(true);
@@ -253,9 +224,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     /**
      * Closes the popover.
-     * <p>
-     * Note: This method also removes the popover component from the DOM after
-     * closing it, unless you have added the component manually.
      */
     public void close() {
         setOpened(false);
@@ -697,6 +665,9 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * <p>
      * By default, the popover can be opened with a click on the target
      * component.
+     * <p>
+     * Note: setting target will also add the popover to the {@code <body>} if
+     * it's not yet attached anywhere.
      *
      * @param target
      *            the target component for this popover, can be {@code null} to
@@ -717,6 +688,11 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         this.target = target;
 
         if (target == null) {
+            if (autoAddedToTheUi) {
+                getElement().removeFromParent();
+                autoAddedToTheUi = false;
+            }
+
             getElement().executeJs("this.target = null");
             return;
         }
@@ -726,10 +702,22 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         target.getUI().ifPresent(this::onTargetAttach);
         targetAttachRegistration = target
                 .addAttachListener(e -> onTargetAttach(e.getUI()));
+        target.addDetachListener(e -> {
+            if (autoAddedToTheUi) {
+                getElement().removeFromParent();
+                autoAddedToTheUi = false;
+            }
+        });
     }
 
     private void onTargetAttach(UI ui) {
         if (target != null) {
+            ui.beforeClientResponse(ui, context -> {
+                if (getElement().getNode().getParent() == null) {
+                    ui.addToModalComponent(this);
+                    autoAddedToTheUi = true;
+                }
+            });
             getElement().executeJs("this.target = $0", target.getElement());
         }
     }
@@ -856,45 +844,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         super.onAttach(attachEvent);
 
         updateVirtualChildNodeIds();
-    }
-
-    private UI getCurrentUI() {
-        UI ui = UI.getCurrent();
-        if (ui == null) {
-            throw new IllegalStateException("UI instance is not available. "
-                    + "It means that you are calling this method "
-                    + "out of a normal workflow where it's always implicitly set. "
-                    + "That may happen if you call the method from the custom thread without "
-                    + "'UI::access' or from tests without proper initialization.");
-        }
-        return ui;
-    }
-
-    private void ensureAttached() {
-        UI ui = getCurrentUI();
-        StateTree.ExecutionRegistration addToUiRegistration = ui
-                .beforeClientResponse(ui, context -> {
-                    if (getElement().getNode().getParent() == null
-                            && isOpened()) {
-                        ui.addToModalComponent(this);
-                        autoAddedToTheUi = true;
-                    }
-                    if (afterProgrammaticNavigationListenerRegistration != null) {
-                        afterProgrammaticNavigationListenerRegistration
-                                .remove();
-                    }
-                });
-        if (ui.getSession() != null) {
-            afterProgrammaticNavigationListenerRegistration = ui
-                    .addAfterNavigationListener(event -> {
-                        if (event.getLocationChangeEvent()
-                                .getTrigger() == NavigationTrigger.PROGRAMMATIC) {
-                            addToUiRegistration.remove();
-                            afterProgrammaticNavigationListenerRegistration
-                                    .remove();
-                        }
-                    });
-        }
     }
 
     /**

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -71,6 +71,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     private Component target;
     private Registration targetAttachRegistration;
+    private Registration targetDetachRegistration;
     private boolean autoAddedToTheUi;
 
     private boolean openOnClick = true;
@@ -683,6 +684,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
         if (this.target != null) {
             targetAttachRegistration.remove();
+            targetDetachRegistration.remove();
         }
 
         this.target = target;
@@ -702,7 +704,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         target.getUI().ifPresent(this::onTargetAttach);
         targetAttachRegistration = target
                 .addAttachListener(e -> onTargetAttach(e.getUI()));
-        target.addDetachListener(e -> {
+        targetDetachRegistration = target.addDetachListener(e -> {
             if (autoAddedToTheUi) {
                 getElement().removeFromParent();
                 autoAddedToTheUi = false;

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -45,21 +46,39 @@ public class PopoverAutoAddTest {
     }
 
     @Test
-    public void open_autoAttachedInBeforeClientResponse() {
+    public void setTarget_autoAttachedInBeforeClientResponse() {
         Popover popover = new Popover();
-        popover.open();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
 
         fakeClientResponse();
         Assert.assertNotNull(popover.getElement().getParent());
     }
 
     @Test
-    public void open_close_notAutoAttachedInBeforeClientResponse() {
+    public void setTarget_clearTarget_notAutoAttachedInBeforeClientResponse() {
         Popover popover = new Popover();
-        popover.open();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
         fakeClientResponse();
 
-        popover.close();
+        popover.setTarget(null);
+
+        fakeClientResponse();
+        Assert.assertNull(popover.getElement().getParent());
+    }
+
+    @Test
+    public void setTarget_detachTarget_notAutoAttachedInBeforeClientResponse() {
+        Popover popover = new Popover();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
+        fakeClientResponse();
+
+        ui.remove(target);
 
         fakeClientResponse();
         Assert.assertNull(popover.getElement().getParent());

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -85,6 +85,22 @@ public class PopoverAutoAddTest {
     }
 
     @Test
+    public void setTarget_changeTarget_notAutoRemoved() {
+        Popover popover = new Popover();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
+        fakeClientResponse();
+
+        Div other = new Div();
+        ui.add(other);
+        popover.setTarget(other);
+        fakeClientResponse();
+
+        Assert.assertEquals(ui.getElement(), popover.getElement().getParent());
+    }
+
+    @Test
     public void setTarget_changeTarget_detachOldTarget_notAutoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
@@ -100,6 +116,21 @@ public class PopoverAutoAddTest {
         ui.remove(target);
         fakeClientResponse();
         Assert.assertEquals(ui.getElement(), popover.getElement().getParent());
+    }
+
+    @Test
+    public void setTarget_changeToDetachedTarget_autoRemoved() {
+        Popover popover = new Popover();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
+        fakeClientResponse();
+
+        Div other = new Div();
+        popover.setTarget(other);
+        fakeClientResponse();
+
+        Assert.assertNull(popover.getElement().getParent());
     }
 
     private void fakeClientResponse() {

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.popover;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * @author Vaadin Ltd.
+ */
+public class PopoverAutoAddTest {
+    private UI ui = new UI();
+
+    @Before
+    public void setup() {
+        UI.setCurrent(ui);
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
+    @Test
+    public void open_autoAttachedInBeforeClientResponse() {
+        Popover popover = new Popover();
+        popover.open();
+
+        fakeClientResponse();
+        Assert.assertNotNull(popover.getElement().getParent());
+    }
+
+    @Test
+    public void open_close_notAutoAttachedInBeforeClientResponse() {
+        Popover popover = new Popover();
+        popover.open();
+        fakeClientResponse();
+
+        popover.close();
+
+        fakeClientResponse();
+        Assert.assertNull(popover.getElement().getParent());
+    }
+
+    private void fakeClientResponse() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+}

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -46,18 +46,18 @@ public class PopoverAutoAddTest {
     }
 
     @Test
-    public void setTarget_autoAttachedInBeforeClientResponse() {
+    public void setTarget_autoAdded() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
         ui.add(target);
 
         fakeClientResponse();
-        Assert.assertNotNull(popover.getElement().getParent());
+        Assert.assertEquals(ui.getElement(), popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_clearTarget_notAutoAttachedInBeforeClientResponse() {
+    public void setTarget_clearTarget_autoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -71,7 +71,7 @@ public class PopoverAutoAddTest {
     }
 
     @Test
-    public void setTarget_detachTarget_notAutoAttachedInBeforeClientResponse() {
+    public void setTarget_detachTarget_autoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -84,6 +84,24 @@ public class PopoverAutoAddTest {
         Assert.assertNull(popover.getElement().getParent());
     }
 
+    @Test
+    public void setTarget_changeTarget_detachOldTarget_notAutoRemoved() {
+        Popover popover = new Popover();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
+        fakeClientResponse();
+
+        Div other = new Div();
+        ui.add(other);
+        popover.setTarget(other);
+        fakeClientResponse();
+
+        ui.remove(target);
+        fakeClientResponse();
+        Assert.assertEquals(ui.getElement(), popover.getElement().getParent());
+    }
+
     private void fakeClientResponse() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {


### PR DESCRIPTION
## Description

Based on DX tests findings, we decided to introduce auto-adding logic as all the participants were confused with `popover.open()` not working with no warnings when `Popover` is not manually added to the UI. 

**UPD**: the logic has been changed to auto-add when calling `setTarget()` instead of `open()` (and also remove the auto-attached Popover if the target is either detached or reset to `null`).

## Type of change

- Feature