### PR TITLE
test: improve flaky charts test

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/DynamicChangingChartIT.java
@@ -10,11 +10,9 @@ package com.vaadin.flow.component.charts.tests;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.charts.examples.AbstractChartExample;
 import com.vaadin.flow.component.charts.examples.other.DynamicChangingChart;
-import com.vaadin.flow.component.charts.testbench.ChartElement;
 
 public class DynamicChangingChartIT extends AbstractTBTest {
     @Override
@@ -24,18 +22,17 @@ public class DynamicChangingChartIT extends AbstractTBTest {
 
     @Test
     public void setConfiguration_changes_chart() {
-        ChartElement chart = getChartElement();
         findElement(By.id("set_funnel_button")).click();
-        assertTitle(chart, "Sales funnel");
+        assertTitle("Sales funnel");
         findElement(By.id("set_polar_button")).click();
-        assertTitle(chart, "Polar Chart");
+        assertTitle("Polar Chart");
         findElement(By.id("set_line_button")).click();
-        assertTitle(chart, "Solar Employment Growth by Sector, 2010-2016");
+        assertTitle("Solar Employment Growth by Sector, 2010-2016");
     }
 
-    private void assertTitle(ChartElement chart, String expectedTitle) {
-        WebElement title = chart.$("*")
-                .attributeContains("class", "highcharts-title").first();
-        waitUntil(e -> expectedTitle.equals(title.getText()), 2);
+    private void assertTitle(String expectedTitle) {
+        waitUntil(e -> getChartElement().$("*")
+                .withAttributeContaining("class", "highcharts-title")
+                .withText(expectedTitle).exists(), 2);
     }
 }


### PR DESCRIPTION
Could reproduce [this test failure](https://bender.vaadin.com/buildConfiguration/FlowComponents_Snapshot/578590?buildTab=log&logView=flowAware&focusLine=25389&linesState=101.16335.25347) locally, sometimes the assertion failed with a stale element reference. Aquiring fresh references within the wait loop seems to fix it.