### PR TITLE
feat: introduce add and remove widget functionality to dashboard

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -8,6 +8,8 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.List;
+
 import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
@@ -46,16 +48,28 @@ public class DashboardPage extends Div {
         });
         addWidgetAtIndex1.setId("add-widget-at-index-1");
 
-        NativeButton removeWidgets1And3 = new NativeButton(
-                "Remove widgets 1 and 3");
-        removeWidgets1And3
-                .addClickListener(click -> dashboard.remove(widget1, widget3));
-        removeWidgets1And3.setId("remove-widgets-1-and-3");
+        NativeButton removeFirstAndLastWidgets = new NativeButton(
+                "Remove first and last widgets");
+        removeFirstAndLastWidgets.addClickListener(click -> {
+            List<DashboardWidget> currentWidgets = dashboard.getWidgets();
+            if (currentWidgets.isEmpty()) {
+                return;
+            }
+            int currentWidgetCount = currentWidgets.size();
+            if (currentWidgetCount == 1) {
+                dashboard.remove(dashboard.getWidgets().get(0));
+            } else {
+                dashboard.remove(dashboard.getWidgets().get(0),
+                        dashboard.getWidgets().get(currentWidgetCount - 1));
+            }
+        });
+        removeFirstAndLastWidgets.setId("remove-first-and-last-widgets");
 
         NativeButton removeAllWidgets = new NativeButton("Remove all widgets");
         removeAllWidgets.addClickListener(click -> dashboard.removeAll());
         removeAllWidgets.setId("remove-all-widgets");
 
-        add(addWidgetAtIndex1, removeWidgets1And3, removeAllWidgets, dashboard);
+        add(addWidgetAtIndex1, removeFirstAndLastWidgets, removeAllWidgets,
+                dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -36,7 +36,8 @@ public class DashboardPage extends Div {
         Dashboard dashboard = new Dashboard();
         dashboard.add(widget1, widget2, widget3);
 
-        NativeButton addWidgetAtIndex1 = new NativeButton("Add widget at index 1");
+        NativeButton addWidgetAtIndex1 = new NativeButton(
+                "Add widget at index 1");
         addWidgetAtIndex1.addClickListener(click -> {
             DashboardWidget widgetAtIndex1 = new DashboardWidget();
             widgetAtIndex1.setTitle("Widget at index 1");
@@ -45,8 +46,10 @@ public class DashboardPage extends Div {
         });
         addWidgetAtIndex1.setId("add-widget-at-index-1");
 
-        NativeButton removeWidgets1And3 = new NativeButton("Remove widgets 1 and 3");
-        removeWidgets1And3.addClickListener(click -> dashboard.remove(widget1, widget3));
+        NativeButton removeWidgets1And3 = new NativeButton(
+                "Remove widgets 1 and 3");
+        removeWidgets1And3
+                .addClickListener(click -> dashboard.remove(widget1, widget3));
         removeWidgets1And3.setId("remove-widgets-1-and-3");
 
         NativeButton removeAllWidgets = new NativeButton("Remove all widgets");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.
@@ -8,7 +8,10 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -16,4 +19,40 @@ import com.vaadin.flow.router.Route;
  */
 @Route("vaadin-dashboard")
 public class DashboardPage extends Div {
+
+    public DashboardPage() {
+        DashboardWidget widget1 = new DashboardWidget();
+        widget1.setTitle("Widget 1");
+        widget1.setId("widget-1");
+
+        DashboardWidget widget2 = new DashboardWidget();
+        widget2.setTitle("Widget 2");
+        widget2.setId("widget-2");
+
+        DashboardWidget widget3 = new DashboardWidget();
+        widget3.setTitle("Widget 3");
+        widget3.setId("widget-3");
+
+        Dashboard dashboard = new Dashboard();
+        dashboard.add(widget1, widget2, widget3);
+
+        NativeButton addWidgetAtIndex1 = new NativeButton("Add widget at index 1");
+        addWidgetAtIndex1.addClickListener(click -> {
+            DashboardWidget widgetAtIndex1 = new DashboardWidget();
+            widgetAtIndex1.setTitle("Widget at index 1");
+            widgetAtIndex1.setId("widget-at-index-1");
+            dashboard.addWidgetAtIndex(1, widgetAtIndex1);
+        });
+        addWidgetAtIndex1.setId("add-widget-at-index-1");
+
+        NativeButton removeWidgets1And3 = new NativeButton("Remove widgets 1 and 3");
+        removeWidgets1And3.addClickListener(click -> dashboard.remove(widget1, widget3));
+        removeWidgets1And3.setId("remove-widgets-1-and-3");
+
+        NativeButton removeAllWidgets = new NativeButton("Remove all widgets");
+        removeAllWidgets.addClickListener(click -> dashboard.removeAll());
+        removeAllWidgets.setId("remove-all-widgets");
+
+        add(addWidgetAtIndex1, removeWidgets1And3, removeAllWidgets, dashboard);
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -42,7 +42,8 @@ public class DashboardIT extends AbstractComponentIT {
     @Test
     public void addWidgetsAtIndex1_widgetIsAddedIntoTheCorrectPlace() {
         $("button").id("add-widget-at-index-1").click();
-        assertWidgetsByTitle("Widget 1", "Widget at index 1", "Widget 2", "Widget 3");
+        assertWidgetsByTitle("Widget 1", "Widget at index 1", "Widget 2",
+                "Widget 3");
     }
 
     @Test
@@ -61,7 +62,6 @@ public class DashboardIT extends AbstractComponentIT {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         List<String> widgetTitles = widgets.stream()
                 .map(DashboardWidgetElement::getTitle).toList();
-        Assert.assertEquals(Arrays.asList(expectedWidgetTitles),
-                widgetTitles);
+        Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.
@@ -8,6 +8,15 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
+import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
@@ -16,4 +25,43 @@ import com.vaadin.tests.AbstractComponentIT;
  */
 @TestPath("vaadin-dashboard")
 public class DashboardIT extends AbstractComponentIT {
+
+    private DashboardElement dashboardElement;
+
+    @Before
+    public void init() {
+        open();
+        dashboardElement = $(DashboardElement.class).waitForFirst();
+    }
+
+    @Test
+    public void addWidgets_widgetsAreCorrectlyAdded() {
+        assertWidgetsByTitle("Widget 1", "Widget 2", "Widget 3");
+    }
+
+    @Test
+    public void addWidgetsAtIndex1_widgetIsAddedIntoTheCorrectPlace() {
+        $("button").id("add-widget-at-index-1").click();
+        assertWidgetsByTitle("Widget 1", "Widget at index 1", "Widget 2", "Widget 3");
+    }
+
+    @Test
+    public void removeWidgets1And3_widgetsAreCorrectlyRemoved() {
+        $("button").id("remove-widgets-1-and-3").click();
+        assertWidgetsByTitle("Widget 2");
+    }
+
+    @Test
+    public void removeAllWidgets_widgetsAreCorrectlyRemoved() {
+        $("button").id("remove-all-widgets").click();
+        assertWidgetsByTitle();
+    }
+
+    private void assertWidgetsByTitle(String... expectedWidgetTitles) {
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        List<String> widgetTitles = widgets.stream()
+                .map(DashboardWidgetElement::getTitle).toList();
+        Assert.assertEquals(Arrays.asList(expectedWidgetTitles),
+                widgetTitles);
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -14,7 +14,6 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
 import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
@@ -42,20 +41,20 @@ public class DashboardIT extends AbstractComponentIT {
 
     @Test
     public void addWidgetsAtIndex1_widgetIsAddedIntoTheCorrectPlace() {
-        clickElementWithJs(findElement(By.id("add-widget-at-index-1")));
+        clickElementWithJs("add-widget-at-index-1");
         assertWidgetsByTitle("Widget 1", "Widget at index 1", "Widget 2",
                 "Widget 3");
     }
 
     @Test
     public void removeFirstAndLastWidgets_widgetsAreCorrectlyRemoved() {
-        clickElementWithJs(findElement(By.id("remove-first-and-last-widgets")));
+        clickElementWithJs("remove-first-and-last-widgets");
         assertWidgetsByTitle("Widget 2");
     }
 
     @Test
     public void removeAllWidgets_widgetsAreCorrectlyRemoved() {
-        clickElementWithJs(findElement(By.id("remove-all-widgets")));
+        clickElementWithJs("remove-all-widgets");
         assertWidgetsByTitle();
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
 import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
@@ -41,20 +42,20 @@ public class DashboardIT extends AbstractComponentIT {
 
     @Test
     public void addWidgetsAtIndex1_widgetIsAddedIntoTheCorrectPlace() {
-        $("button").id("add-widget-at-index-1").click();
+        clickElementWithJs(findElement(By.id("add-widget-at-index-1")));
         assertWidgetsByTitle("Widget 1", "Widget at index 1", "Widget 2",
                 "Widget 3");
     }
 
     @Test
-    public void removeWidgets1And3_widgetsAreCorrectlyRemoved() {
-        $("button").id("remove-widgets-1-and-3").click();
+    public void removeFirstAndLastWidgets_widgetsAreCorrectlyRemoved() {
+        clickElementWithJs(findElement(By.id("remove-first-and-last-widgets")));
         assertWidgetsByTitle("Widget 2");
     }
 
     @Test
     public void removeAllWidgets_widgetsAreCorrectlyRemoved() {
-        $("button").id("remove-all-widgets").click();
+        clickElementWithJs(findElement(By.id("remove-all-widgets")));
         assertWidgetsByTitle();
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/pom.xml
@@ -54,6 +54,11 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-renderer-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -143,6 +143,10 @@ public class Dashboard extends Component {
         updateClient();
     }
 
+    @Override
+    public Stream<Component> getChildren() {
+        return getWidgets().stream().map(Component.class::cast);
+    }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -225,10 +225,7 @@ public class Dashboard extends Component {
     }
 
     private void doRemoveAllWidgets() {
-        List<Element> elementsToRemove = widgets.stream()
-                .map(Component::getElement).toList();
-        elementsToRemove.forEach(getElement()::removeChild);
-        widgets.clear();
+        new ArrayList<>(widgets).forEach(this::doRemoveWidget);
     }
 
     private void doRemoveWidget(DashboardWidget widget) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.
@@ -8,10 +8,27 @@
  */
 package com.vaadin.flow.component.dashboard;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.ElementDetachEvent;
+import com.vaadin.flow.dom.ElementDetachListener;
+import com.vaadin.flow.shared.Registration;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
 
 /**
  * @author Vaadin Ltd
@@ -22,4 +39,203 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @JsModule("@vaadin/dashboard/src/vaadin-dashboard.js")
 // @NpmPackage(value = "@vaadin/dashboard", version = "24.6.0-alpha0")
 public class Dashboard extends Component {
+
+    private final List<DashboardWidget> widgets = new ArrayList<>();
+
+    private boolean pendingUpdate = false;
+
+    /**
+     * Creates an empty dashboard.
+     */
+    public Dashboard() {
+        getElement().getNode().addAttachListener(this::attachRenderer);
+    }
+
+    /**
+     * Returns the widgets in the dashboard.
+     *
+     * @return The widgets in the dashboard
+     */
+    public List<DashboardWidget> getWidgets() {
+        return Collections.unmodifiableList(widgets);
+    }
+
+    /**
+     * Adds the given widgets to the dashboard.
+     *
+     * @param widgets
+     *            the widgets to add, not {@code null}
+     */
+    public void add(DashboardWidget... widgets) {
+        Objects.requireNonNull(widgets, "Widgets to add cannot be null.");
+        List<DashboardWidget> toAdd = new ArrayList<>(widgets.length);
+        for (DashboardWidget widget : widgets) {
+            Objects.requireNonNull(widget, "Widget to add cannot be null.");
+            toAdd.add(widget);
+        }
+        toAdd.forEach(this::doAddWidget);
+        updateClient();
+    }
+
+    /**
+     * Adds the given widget as child of this dashboard at the specific index.
+     * <p>
+     * In case the specified widget has already been added to another parent, it
+     * will be removed from there and added to this one.
+     *
+     * @param index
+     *            the index, where the widget will be added. The index must be
+     *            non-negative and may not exceed the children count
+     * @param widget
+     *            the widget to add, not {@code null}
+     */
+    public void addWidgetAtIndex(int index, DashboardWidget widget) {
+        Objects.requireNonNull(widget, "Widget to add cannot be null.");
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Cannot add a widget with a negative index.");
+        }
+        // The case when the index is bigger than the children count is handled
+        // inside the method below
+        doAddWidget(index, widget);
+        updateClient();
+    }
+
+    /**
+     * Removes the given widgets from this dashboard.
+     *
+     * @param widgets
+     *            the widgets to remove, not {@code null}
+     * @throws IllegalArgumentException
+     *             if there is a widget whose non {@code null} parent is not
+     *             this dashboard
+     */
+    public void remove(DashboardWidget... widgets) {
+        Objects.requireNonNull(widgets, "Widgets to remove cannot be null.");
+        List<DashboardWidget> toRemove = new ArrayList<>(widgets.length);
+        for (DashboardWidget widget : widgets) {
+            Objects.requireNonNull(widget, "Widget to remove cannot be null.");
+            Element parent = widget.getElement().getParent();
+            if (parent == null) {
+                LoggerFactory.getLogger(getClass()).debug(
+                        "Removal of a widget with no parent does nothing.");
+                continue;
+            }
+            if (getElement().equals(parent)) {
+                toRemove.add(widget);
+            } else {
+                throw new IllegalArgumentException("The given widget (" + widget
+                        + ") is not a child of this dashboard");
+            }
+        }
+        toRemove.forEach(this::doRemoveWidget);
+        updateClient();
+    }
+
+    /**
+     * Removes all widgets from this dashboard.
+     */
+    public void removeAll() {
+        doRemoveAllWidgets();
+        updateClient();
+     */
+
+    private final Map<Element, Registration> childDetachListenerMap = new HashMap<>();
+
+    // Must not use lambda here as that would break serialization. See
+    // https://github.com/vaadin/flow-components/issues/5597
+    private final ElementDetachListener childDetachListener = new ElementDetachListener() {
+        @Override
+        public void onDetach(ElementDetachEvent e) {
+            var detachedElement = e.getSource();
+            getWidgets().stream()
+                    .filter(widget -> Objects.equals(detachedElement,
+                            widget.getElement()))
+                    .findAny().ifPresent(detachedWidget -> {
+                        // The child was removed from the dashboard
+
+                        // Remove the registration for the child detach listener
+                        childDetachListenerMap.get(detachedWidget.getElement())
+                                .remove();
+                        childDetachListenerMap
+                                .remove(detachedWidget.getElement());
+
+                        doRemoveWidget(detachedWidget);
+                        updateClient();
+                    });
+        }
+    };
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        updateClient();
+    }
+
+    private void updateClient() {
+        if (pendingUpdate) {
+            return;
+        }
+        pendingUpdate = true;
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this, ctx -> {
+                    doUpdateClient();
+                    pendingUpdate = false;
+                }));
+    }
+
+    private void doUpdateClient() {
+        getElement().getChildren().forEach(child -> {
+            if (!childDetachListenerMap.containsKey(child)) {
+                childDetachListenerMap.put(child,
+                        child.addDetachListener(childDetachListener));
+            }
+        });
+        List<Integer> widgetNodeIds = getWidgets().stream()
+                .map(this::getWidgetNodeId).toList();
+        getElement().setPropertyList("virtualChildNodeIds", widgetNodeIds);
+        getElement().setPropertyJson("items", createItemsJsonArray());
+    }
+
+    private void attachRenderer() {
+        getElement().executeJs(
+                "Vaadin.FlowComponentHost.patchVirtualContainer(this);");
+        String appId = UI.getCurrent().getInternals().getAppId();
+        getElement().executeJs(
+                "this.renderer = (root, _, model) => Vaadin.FlowComponentHost.setChildNodes($0, [model.item.nodeid], root);",
+                appId);
+    }
+
+    private JsonArray createItemsJsonArray() {
+        JsonArray jsonItems = Json.createArray();
+        for (DashboardWidget widget : widgets) {
+            JsonObject jsonItem = Json.createObject();
+             */
+            jsonItems.set(jsonItems.length(), jsonItem);
+        }
+        return jsonItems;
+    }
+
+    private int getWidgetNodeId(DashboardWidget widget) {
+        return widget.getElement().getNode().getId();
+    }
+
+    private void doRemoveAllWidgets() {
+        widgets.clear();
+        getElement().removeAllChildren();
+    }
+
+    private void doRemoveWidget(DashboardWidget widget) {
+        widgets.remove(widget);
+        getElement().removeChild(widget.getElement());
+    }
+
+    private void doAddWidget(int index, DashboardWidget widget) {
+        widgets.add(index, widget);
+        getElement().insertChild(index, widget.getElement());
+    }
+
+    private void doAddWidget(DashboardWidget widget) {
+        widgets.add(widget);
+        getElement().appendChild(widget.getElement());
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -10,9 +10,7 @@ package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.slf4j.LoggerFactory;
@@ -24,9 +22,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.dom.ElementDetachEvent;
-import com.vaadin.flow.dom.ElementDetachListener;
-import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -142,31 +137,6 @@ public class Dashboard extends Component {
         updateClient();
     }
 
-    private final Map<Element, Registration> childDetachListenerMap = new HashMap<>();
-
-    // Must not use lambda here as that would break serialization. See
-    // https://github.com/vaadin/flow-components/issues/5597
-    private final ElementDetachListener childDetachListener = new ElementDetachListener() {
-        @Override
-        public void onDetach(ElementDetachEvent e) {
-            var detachedElement = e.getSource();
-            getWidgets().stream()
-                    .filter(widget -> Objects.equals(detachedElement,
-                            widget.getElement()))
-                    .findAny().ifPresent(detachedWidget -> {
-                        // The child was removed from the dashboard
-
-                        // Remove the registration for the child detach listener
-                        childDetachListenerMap.get(detachedWidget.getElement())
-                                .remove();
-                        childDetachListenerMap
-                                .remove(detachedWidget.getElement());
-
-                        widgets.remove(detachedWidget);
-                        updateClient();
-                    });
-        }
-    };
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
@@ -188,14 +158,6 @@ public class Dashboard extends Component {
     }
 
     private void doUpdateClient() {
-        widgets.forEach(widget -> {
-            Element childWidgetElement = widget.getElement();
-            if (!childDetachListenerMap.containsKey(childWidgetElement)) {
-                childDetachListenerMap.put(childWidgetElement,
-                        childWidgetElement
-                                .addDetachListener(childDetachListener));
-            }
-        });
         getElement().setPropertyJson("items", createItemsJsonArray());
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -194,9 +194,6 @@ public class Dashboard extends Component {
                         child.addDetachListener(childDetachListener));
             }
         });
-        List<Integer> widgetNodeIds = getWidgets().stream()
-                .map(this::getWidgetNodeId).toList();
-        getElement().setPropertyList("virtualChildNodeIds", widgetNodeIds);
         getElement().setPropertyJson("items", createItemsJsonArray());
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -141,7 +141,7 @@ public class Dashboard extends Component {
     public void removeAll() {
         doRemoveAllWidgets();
         updateClient();
-     */
+    }
 
     private final Map<Element, Registration> childDetachListenerMap = new HashMap<>();
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -51,7 +51,6 @@ public class Dashboard extends Component {
      * Creates an empty dashboard.
      */
     public Dashboard() {
-        getElement().getNode().addAttachListener(this::attachRenderer);
     }
 
     /**
@@ -172,7 +171,8 @@ public class Dashboard extends Component {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        updateClient();
+        attachRenderer();
+        doUpdateClient();
     }
 
     private void updateClient() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -224,22 +224,30 @@ public class Dashboard extends Component {
     }
 
     private void doRemoveAllWidgets() {
+        List<Element> elementsToRemove = widgets.stream()
+                .map(Component::getElement).toList();
+        elementsToRemove.forEach(getElement()::removeVirtualChild);
         widgets.clear();
-        getElement().removeAllChildren();
     }
 
     private void doRemoveWidget(DashboardWidget widget) {
+        getElement().removeVirtualChild(widget.getElement());
         widgets.remove(widget);
-        getElement().removeChild(widget.getElement());
     }
 
     private void doAddWidget(int index, DashboardWidget widget) {
+        if (widget.getParent().isPresent()) {
+            widget.removeFromParent();
+        }
+        getElement().appendVirtualChild(widget.getElement());
         widgets.add(index, widget);
-        getElement().insertChild(index, widget.getElement());
     }
 
     private void doAddWidget(DashboardWidget widget) {
+        if (widget.getParent().isPresent()) {
+            widget.removeFromParent();
+        }
+        getElement().appendVirtualChild(widget.getElement());
         widgets.add(widget);
-        getElement().appendChild(widget.getElement());
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -20,8 +20,10 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementDetachEvent;
 import com.vaadin.flow.dom.ElementDetachListener;
 import com.vaadin.flow.shared.Registration;
@@ -37,6 +39,7 @@ import elemental.json.JsonObject;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.5.0-alpha8")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/dashboard/src/vaadin-dashboard.js")
+@JsModule("./flow-component-renderer.js")
 // @NpmPackage(value = "@vaadin/dashboard", version = "24.6.0-alpha0")
 public class Dashboard extends Component {
 
@@ -210,7 +213,7 @@ public class Dashboard extends Component {
         JsonArray jsonItems = Json.createArray();
         for (DashboardWidget widget : widgets) {
             JsonObject jsonItem = Json.createObject();
-             */
+            jsonItem.put("nodeid", getWidgetNodeId(widget));
             jsonItems.set(jsonItems.length(), jsonItem);
         }
         return jsonItems;
@@ -238,4 +241,5 @@ public class Dashboard extends Component {
     private void doAddWidget(DashboardWidget widget) {
         widgets.add(widget);
         getElement().appendChild(widget.getElement());
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -162,7 +162,7 @@ public class Dashboard extends Component {
                         childDetachListenerMap
                                 .remove(detachedWidget.getElement());
 
-                        doRemoveWidget(detachedWidget);
+                        widgets.remove(detachedWidget);
                         updateClient();
                     });
         }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -188,10 +188,12 @@ public class Dashboard extends Component {
     }
 
     private void doUpdateClient() {
-        getElement().getChildren().forEach(child -> {
-            if (!childDetachListenerMap.containsKey(child)) {
-                childDetachListenerMap.put(child,
-                        child.addDetachListener(childDetachListener));
+        widgets.forEach(widget -> {
+            Element childWidgetElement = widget.getElement();
+            if (!childDetachListenerMap.containsKey(childWidgetElement)) {
+                childDetachListenerMap.put(childWidgetElement,
+                        childWidgetElement
+                                .addDetachListener(childDetachListener));
             }
         });
         getElement().setPropertyJson("items", createItemsJsonArray());

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -14,7 +14,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.dom.Node;
 
 /**
  * @author Vaadin Ltd
@@ -49,11 +48,8 @@ public class DashboardWidget extends Component {
     public void removeFromParent() {
         Optional<Component> optionalParent = getParent();
         if (optionalParent.isPresent()
-                && optionalParent.get() instanceof Dashboard) {
-            Node<?> parent = getElement().getParentNode();
-            if (parent != null) {
-                parent.removeVirtualChild(getElement());
-            }
+                && optionalParent.get() instanceof Dashboard dashboard) {
+            dashboard.remove(this);
         } else {
             super.removeFromParent();
         }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -8,8 +8,6 @@
  */
 package com.vaadin.flow.component.dashboard;
 
-import java.util.Optional;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -42,16 +40,5 @@ public class DashboardWidget extends Component {
      */
     public void setTitle(String title) {
         getElement().setProperty("widgetTitle", title == null ? "" : title);
-    }
-
-    @Override
-    public void removeFromParent() {
-        Optional<Component> optionalParent = getParent();
-        if (optionalParent.isPresent()
-                && optionalParent.get() instanceof Dashboard dashboard) {
-            dashboard.remove(this);
-        } else {
-            super.removeFromParent();
-        }
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -8,10 +8,13 @@
  */
 package com.vaadin.flow.component.dashboard;
 
+import java.util.Optional;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Node;
 
 /**
  * @author Vaadin Ltd
@@ -40,5 +43,19 @@ public class DashboardWidget extends Component {
      */
     public void setTitle(String title) {
         getElement().setProperty("widgetTitle", title == null ? "" : title);
+    }
+
+    @Override
+    public void removeFromParent() {
+        Optional<Component> optionalParent = getParent();
+        if (optionalParent.isPresent()
+                && optionalParent.get() instanceof Dashboard) {
+            Node<?> parent = getElement().getParentNode();
+            if (parent != null) {
+                parent.removeVirtualChild(getElement());
+            }
+        } else {
+            super.removeFromParent();
+        }
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -32,7 +32,8 @@ public class DashboardTest {
     @Test
     public void addNullWidget_exceptionIsThrown() {
         Dashboard dashboard = new Dashboard();
-        Assert.assertThrows(NullPointerException.class, () -> dashboard.add((DashboardWidget) null));
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.add((DashboardWidget) null));
     }
 
     @Test
@@ -63,7 +64,8 @@ public class DashboardTest {
     @Test
     public void addNullWidgetAtIndex_exceptionIsThrown() {
         Dashboard dashboard = new Dashboard();
-        Assert.assertThrows(NullPointerException.class, () -> dashboard.addWidgetAtIndex(0, null));
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.addWidgetAtIndex(0, null));
     }
 
     @Test
@@ -80,7 +82,8 @@ public class DashboardTest {
     @Test
     public void removeNullWidget_exceptionIsThrown() {
         Dashboard dashboard = new Dashboard();
-        Assert.assertThrows(NullPointerException.class, () -> dashboard.remove((DashboardWidget) null));
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.remove((DashboardWidget) null));
 
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -8,20 +8,48 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.server.VaadinSession;
+
+import elemental.json.JsonArray;
 
 public class DashboardTest {
 
+    private final UI ui = new UI();
+    private Dashboard dashboard;
+
+    @Before
+    public void setup() {
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+        dashboard = new Dashboard();
+        ui.add(dashboard);
+        fakeClientCommunication();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
     @Test
     public void addWidget_widgetIsAdded() {
-        Dashboard dashboard = new Dashboard();
         DashboardWidget widget1 = new DashboardWidget();
         DashboardWidget widget2 = new DashboardWidget();
         dashboard.add(widget1, widget2);
@@ -31,14 +59,12 @@ public class DashboardTest {
 
     @Test
     public void addNullWidget_exceptionIsThrown() {
-        Dashboard dashboard = new Dashboard();
         Assert.assertThrows(NullPointerException.class,
                 () -> dashboard.add((DashboardWidget) null));
     }
 
     @Test
     public void addNullWidgetInArray_noWidgetIsAdded() {
-        Dashboard dashboard = new Dashboard();
         DashboardWidget widget = new DashboardWidget();
         try {
             dashboard.add(widget, null);
@@ -50,7 +76,6 @@ public class DashboardTest {
 
     @Test
     public void addWidgetAtIndex_widgetIsCorrectlyAdded() {
-        Dashboard dashboard = new Dashboard();
         DashboardWidget widget1 = new DashboardWidget();
         DashboardWidget widget2 = new DashboardWidget();
         DashboardWidget widget3 = new DashboardWidget();
@@ -63,14 +88,12 @@ public class DashboardTest {
 
     @Test
     public void addNullWidgetAtIndex_exceptionIsThrown() {
-        Dashboard dashboard = new Dashboard();
         Assert.assertThrows(NullPointerException.class,
                 () -> dashboard.addWidgetAtIndex(0, null));
     }
 
     @Test
     public void removeWidget_widgetIsRemoved() {
-        Dashboard dashboard = new Dashboard();
         DashboardWidget widget1 = new DashboardWidget();
         DashboardWidget widget2 = new DashboardWidget();
         dashboard.add(widget1, widget2);
@@ -81,7 +104,6 @@ public class DashboardTest {
 
     @Test
     public void removeNullWidget_exceptionIsThrown() {
-        Dashboard dashboard = new Dashboard();
         Assert.assertThrows(NullPointerException.class,
                 () -> dashboard.remove((DashboardWidget) null));
 
@@ -89,12 +111,101 @@ public class DashboardTest {
 
     @Test
     public void removeAllWidgets_widgetsAreRemoved() {
-        Dashboard dashboard = new Dashboard();
         DashboardWidget widget1 = new DashboardWidget();
         DashboardWidget widget2 = new DashboardWidget();
         dashboard.add(widget1, widget2);
         dashboard.removeAll();
 
         Assert.assertEquals(Collections.emptyList(), dashboard.getWidgets());
+    }
+
+    @Test
+    public void removeWidgetFromParent_widgetIsRemoved() {
+        DashboardWidget widget1 = new DashboardWidget();
+        dashboard.add(widget1);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        Assert.assertEquals(Collections.emptyList(), dashboard.getWidgets());
+    }
+
+    @Test
+    public void addWidget_virtualNodeIdsInSync() {
+        DashboardWidget widget1 = new DashboardWidget();
+        dashboard.add(widget1);
+        fakeClientCommunication();
+        assertVirtualChildren(dashboard, widget1);
+    }
+
+    @Test
+    public void removeWidget_virtualNodeIdsInSync() {
+        DashboardWidget widget1 = new DashboardWidget();
+        dashboard.add(widget1);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        fakeClientCommunication();
+        assertVirtualChildren(dashboard);
+    }
+
+    @Test
+    public void selfRemoveChild_virtualNodeIdsInSync() {
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        dashboard.add(widget1, widget2);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        fakeClientCommunication();
+        assertVirtualChildren(dashboard, widget2);
+    }
+
+    @Test
+    public void addSeparately_selfRemoveChild_doesNotThrow() {
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        dashboard.add(widget1);
+        dashboard.add(widget2);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        fakeClientCommunication();
+        assertVirtualChildren(dashboard, widget2);
+    }
+
+    @Test
+    public void addWidgetToAnotherDashboard_widgetIsAdded() {
+        DashboardWidget widget1 = new DashboardWidget();
+        dashboard.add(widget1);
+        fakeClientCommunication();
+
+        Dashboard newDashboard = new Dashboard();
+        ui.add(newDashboard);
+        newDashboard.add(widget1);
+        fakeClientCommunication();
+
+        assertVirtualChildren(dashboard);
+        assertVirtualChildren(newDashboard, widget1);
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    private static void assertVirtualChildren(Dashboard dashboard,
+            Component... components) {
+        // Get a List of the node ids
+        List<Integer> expectedChildNodeIds = Arrays.stream(components)
+                .map(component -> component.getElement().getNode().getId())
+                .toList();
+        // Get the node ids from the items property of the dashboard
+        List<Integer> actualChildNodeIds = getChildNodeIds(dashboard);
+        Assert.assertEquals(expectedChildNodeIds, actualChildNodeIds);
+    }
+
+    private static List<Integer> getChildNodeIds(Dashboard dashboard) {
+        JsonArray jsonArrayOfIds = (JsonArray) dashboard.getElement()
+                .getPropertyRaw("items");
+        return JsonUtils.objectStream(jsonArrayOfIds)
+                .mapToInt(obj -> (int) obj.getNumber("nodeid")).boxed()
+                .toList();
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.
@@ -8,5 +8,90 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+
 public class DashboardTest {
+
+    @Test
+    public void addWidget_widgetIsAdded() {
+        Dashboard dashboard = new Dashboard();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        dashboard.add(widget1, widget2);
+
+        Assert.assertEquals(List.of(widget1, widget2), dashboard.getWidgets());
+    }
+
+    @Test
+    public void addNullWidget_exceptionIsThrown() {
+        Dashboard dashboard = new Dashboard();
+        Assert.assertThrows(NullPointerException.class, () -> dashboard.add((DashboardWidget) null));
+    }
+
+    @Test
+    public void addNullWidgetInArray_noWidgetIsAdded() {
+        Dashboard dashboard = new Dashboard();
+        DashboardWidget widget = new DashboardWidget();
+        try {
+            dashboard.add(widget, null);
+        } catch (NullPointerException e) {
+            // Do nothing
+        }
+        Assert.assertEquals(Collections.emptyList(), dashboard.getWidgets());
+    }
+
+    @Test
+    public void addWidgetAtIndex_widgetIsCorrectlyAdded() {
+        Dashboard dashboard = new Dashboard();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        DashboardWidget widget3 = new DashboardWidget();
+        dashboard.add(widget1, widget2);
+        dashboard.addWidgetAtIndex(1, widget3);
+
+        Assert.assertEquals(List.of(widget1, widget3, widget2),
+                dashboard.getWidgets());
+    }
+
+    @Test
+    public void addNullWidgetAtIndex_exceptionIsThrown() {
+        Dashboard dashboard = new Dashboard();
+        Assert.assertThrows(NullPointerException.class, () -> dashboard.addWidgetAtIndex(0, null));
+    }
+
+    @Test
+    public void removeWidget_widgetIsRemoved() {
+        Dashboard dashboard = new Dashboard();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        dashboard.add(widget1, widget2);
+        dashboard.remove(widget1);
+
+        Assert.assertEquals(List.of(widget2), dashboard.getWidgets());
+    }
+
+    @Test
+    public void removeNullWidget_exceptionIsThrown() {
+        Dashboard dashboard = new Dashboard();
+        Assert.assertThrows(NullPointerException.class, () -> dashboard.remove((DashboardWidget) null));
+
+    }
+
+    @Test
+    public void removeAllWidgets_widgetsAreRemoved() {
+        Dashboard dashboard = new Dashboard();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        dashboard.add(widget1, widget2);
+        dashboard.removeAll();
+
+        Assert.assertEquals(Collections.emptyList(), dashboard.getWidgets());
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -8,5 +8,86 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.server.VaadinSession;
+
 public class DashboardWidgetTest {
+
+    private final UI ui = new UI();
+
+    @Before
+    public void setup() {
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
+    @Test
+    public void addWidgetToLayout_widgetIsAdded() {
+        Div layout = new Div();
+        ui.add(layout);
+        DashboardWidget widget = new DashboardWidget();
+        layout.add(widget);
+        fakeClientCommunication();
+        Assert.assertTrue(layout.getChildren().anyMatch(widget::equals));
+    }
+
+    @Test
+    public void removeWidgetFromLayout_widgetIsRemoved() {
+        Div layout = new Div();
+        ui.add(layout);
+        DashboardWidget widget = new DashboardWidget();
+        layout.add(widget);
+        fakeClientCommunication();
+        layout.remove(widget);
+        fakeClientCommunication();
+        Assert.assertTrue(layout.getChildren().noneMatch(widget::equals));
+    }
+
+    @Test
+    public void addWidgetToLayout_removeFromParent_widgetIsRemoved() {
+        Div layout = new Div();
+        ui.add(layout);
+        DashboardWidget widget = new DashboardWidget();
+        layout.add(widget);
+        fakeClientCommunication();
+        widget.removeFromParent();
+        fakeClientCommunication();
+        Assert.assertTrue(layout.getChildren().noneMatch(widget::equals));
+    }
+
+    @Test
+    public void addWidgetFromLayoutToAnotherLayout_widgetIsMoved() {
+        Div parent = new Div();
+        ui.add(parent);
+        DashboardWidget widget = new DashboardWidget();
+        parent.add(widget);
+        fakeClientCommunication();
+        Div newParent = new Div();
+        ui.add(newParent);
+        newParent.add(widget);
+        fakeClientCommunication();
+        Assert.assertTrue(parent.getChildren().noneMatch(widget::equals));
+        Assert.assertTrue(newParent.getChildren().anyMatch(widget::equals));
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2000-2024 Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.
@@ -8,6 +8,8 @@
  */
 package com.vaadin.flow.component.dashboard.testbench;
 
+import java.util.List;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -16,4 +18,13 @@ import com.vaadin.testbench.elementsbase.Element;
  */
 @Element("vaadin-dashboard")
 public class DashboardElement extends TestBenchElement {
+
+    /**
+     * Returns the widgets in the dashboard.
+     *
+     * @return The widgets in the dashboard
+     */
+    public List<DashboardWidgetElement> getWidgets() {
+        return $(DashboardWidgetElement.class).all();
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
@@ -1,17 +1,10 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
  */
 package com.vaadin.flow.component.dashboard.testbench;
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
@@ -1,10 +1,17 @@
 /*
  * Copyright 2000-2024 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
- * license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.flow.component.dashboard.testbench;
 


### PR DESCRIPTION
## Description

Adds add/remove widget functionality to dashboard.

Added API:
- `List<DashboardWidget> getWidgets()`: Returns the widgets in the dashboard
- `void add(DashboardWidget... widgets)`: Adds the given widgets to the dashboard
- `void addWidgetAtIndex(int index, DashboardWidget widget)`: Adds the given widget to the dashboard at the specific index
- `remove(DashboardWidget... widgets)`: Removes the given widgets from the dashboard
- `void removeAll()`: Removes all widgets from the dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=74589970

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature