### PR TITLE
feat: implement max col count feature

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -38,6 +38,8 @@ public class DashboardPage extends Div {
         Dashboard dashboard = new Dashboard();
         dashboard.add(widget1, widget2, widget3);
 
+        dashboard.setMaximumColumnCount(3);
+
         NativeButton addWidgetAtIndex1 = new NativeButton(
                 "Add widget at index 1");
         addWidgetAtIndex1.addClickListener(click -> {
@@ -69,7 +71,19 @@ public class DashboardPage extends Div {
         removeAllWidgets.addClickListener(click -> dashboard.removeAll());
         removeAllWidgets.setId("remove-all-widgets");
 
+        NativeButton setMaximumColumnCount1 = new NativeButton(
+                "Set maximum column count 1");
+        setMaximumColumnCount1
+                .addClickListener(click -> dashboard.setMaximumColumnCount(1));
+        setMaximumColumnCount1.setId("set-maximum-column-count-1");
+
+        NativeButton setMaximumColumnCountNull = new NativeButton(
+                "Set maximum column count null");
+        setMaximumColumnCountNull.addClickListener(
+                click -> dashboard.setMaximumColumnCount(null));
+        setMaximumColumnCountNull.setId("set-maximum-column-count-null");
+
         add(addWidgetAtIndex1, removeFirstAndLastWidgets, removeAllWidgets,
-                dashboard);
+                setMaximumColumnCount1, setMaximumColumnCountNull, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -58,6 +58,33 @@ public class DashboardIT extends AbstractComponentIT {
         assertWidgetsByTitle();
     }
 
+    @Test
+    public void changeMaximumColumnCountTo1_widgetsShouldBeOnTheSameColumn() {
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        // The first two widgets should initially be on the same horizontal line
+        int yOfWidget1 = widgets.get(0).getLocation().getY();
+        Assert.assertEquals(yOfWidget1, widgets.get(1).getLocation().getY());
+
+        clickElementWithJs("set-maximum-column-count-1");
+        // The first two widgets should be on the same vertical line
+        int xOfWidget1 = widgets.get(0).getLocation().getX();
+        Assert.assertEquals(xOfWidget1, widgets.get(1).getLocation().getX());
+    }
+
+    @Test
+    public void changeMaximumColumnCountToNull_widgetsShouldBeOnTheSameRow() {
+        clickElementWithJs("set-maximum-column-count-1");
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        // The first two widgets should be on the same vertical line
+        int xOfWidget1 = widgets.get(0).getLocation().getX();
+        Assert.assertEquals(xOfWidget1, widgets.get(1).getLocation().getX());
+
+        clickElementWithJs("set-maximum-column-count-null");
+        // The widgets should be on the same horizontal line
+        int yOfWidget1 = widgets.get(0).getLocation().getY();
+        Assert.assertEquals(yOfWidget1, widgets.get(1).getLocation().getY());
+    }
+
     private void assertWidgetsByTitle(String... expectedWidgetTitles) {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         List<String> widgetTitles = widgets.stream()

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -144,6 +144,16 @@ public class Dashboard extends Component {
     }
 
     /**
+     * Returns maximum column count of the dashboard.
+     *
+     * @return the maximum column count of the dashboard
+     */
+    public Integer getMaximumColumnCount() {
+        String maxColCount = getStyle().get("--vaadin-dashboard-col-max-count");
+        return maxColCount == null ? null : Integer.valueOf(maxColCount);
+    }
+
+    /**
      * Sets the maximum column count of the dashboard.
      *
      * @param maxCount

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -160,9 +160,9 @@ public class Dashboard extends Component {
      *            the new maximum column count. Pass in {@code null} to set the
      *            maximum column count back to the default value.
      */
-    public void setMaximumColumnCount(Integer maxCount) {
+    public void setMaximumColumnCount(Integer maxColCount) {
         getStyle().set("--vaadin-dashboard-col-max-count",
-                maxCount == null ? null : String.valueOf(maxCount));
+                maxColCount == null ? null : String.valueOf(maxColCount));
     }
 
     @Override

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -143,6 +143,18 @@ public class Dashboard extends Component {
         updateClient();
     }
 
+    /**
+     * Sets the maximum column count of the dashboard.
+     *
+     * @param maxCount
+     *            the new maximum column count. Pass in {@code null} to set the
+     *            maximum column count back to the default value.
+     */
+    public void setMaximumColumnCount(Integer maxCount) {
+        getStyle().set("--vaadin-dashboard-col-max-count",
+                maxCount == null ? null : String.valueOf(maxCount));
+    }
+
     @Override
     public Stream<Component> getChildren() {
         return getWidgets().stream().map(Component.class::cast);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -144,7 +144,7 @@ public class Dashboard extends Component {
     }
 
     /**
-     * Returns maximum column count of the dashboard.
+     * Returns the maximum column count of the dashboard.
      *
      * @return the maximum column count of the dashboard
      */

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -211,6 +211,30 @@ public class DashboardTest {
         assertWidgets(newDashboard, widget);
     }
 
+    @Test
+    public void setMaximumColumnCount_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-col-max-count";
+        int valueToSet = 5;
+
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+
+        dashboard.setMaximumColumnCount(valueToSet);
+        Assert.assertEquals(String.valueOf(valueToSet),
+                dashboard.getStyle().get(propertyName));
+
+        dashboard.setMaximumColumnCount(null);
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    public void setMaximumColumnCountNull_propertyIsRemoved() {
+        dashboard.setMaximumColumnCount(5);
+
+        dashboard.setMaximumColumnCount(null);
+        Assert.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-col-max-count"));
+    }
+
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -215,13 +215,10 @@ public class DashboardTest {
     public void setMaximumColumnCount_valueIsCorrectlySet() {
         String propertyName = "--vaadin-dashboard-col-max-count";
         int valueToSet = 5;
-
         Assert.assertNull(dashboard.getStyle().get(propertyName));
-
         dashboard.setMaximumColumnCount(valueToSet);
         Assert.assertEquals(String.valueOf(valueToSet),
                 dashboard.getStyle().get(propertyName));
-
         dashboard.setMaximumColumnCount(null);
         Assert.assertNull(dashboard.getStyle().get(propertyName));
     }
@@ -229,10 +226,28 @@ public class DashboardTest {
     @Test
     public void setMaximumColumnCountNull_propertyIsRemoved() {
         dashboard.setMaximumColumnCount(5);
-
         dashboard.setMaximumColumnCount(null);
         Assert.assertNull(
                 dashboard.getStyle().get("--vaadin-dashboard-col-max-count"));
+    }
+
+    @Test
+    public void defaultMaximumColumnCountValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getMaximumColumnCount());
+    }
+
+    @Test
+    public void setMaximumColumnCount_valueIsCorrectlyRetrieved() {
+        Integer valueToSet = 5;
+        dashboard.setMaximumColumnCount(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getMaximumColumnCount());
+    }
+
+    @Test
+    public void setMaximumColumnCountNull_valueIsCorrectlyRetrieved() {
+        dashboard.setMaximumColumnCount(5);
+        dashboard.setMaximumColumnCount(null);
+        Assert.assertNull(dashboard.getMaximumColumnCount());
     }
 
     private void fakeClientCommunication() {


### PR DESCRIPTION
## Description

Adds maximum column count functionality to dashboard.

Added API:
- `Integer getMaximumColumnCount()`: Returns the maximum column count of the dashboard
- `void setMaximumColumnCount(Integer maxCount)`: Sets the maximum column count of the dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=76144538

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature