### PR TITLE
feat: allow matching navigation hierarchies with side nav item

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -395,6 +395,34 @@ public class SideNavItem extends SideNavItemContainer
     }
 
     /**
+     * Gets whether this item also matches nested paths / routes.
+     *
+     * @return true if this item also matches nested paths / routes, false
+     *         otherwise
+     */
+    public boolean isMatchNested() {
+        return getElement().getProperty("matchNested", false);
+    }
+
+    /**
+     * Sets whether to also match nested paths / routes. {@code false} by
+     * default.
+     * <p>
+     * When enabled, an item with the path {@code /path} is considered current
+     * when the browser URL is {@code /path}, {@code /path/child},
+     * {@code /path/child/grandchild}, etc.
+     * <p>
+     * Note that this only affects matching of the URLs path, not the base
+     * origin or query parameters.
+     *
+     * @param value
+     *            true to also match nested paths / routes, false otherwise
+     */
+    public void setMatchNested(boolean value) {
+        getElement().setProperty("matchNested", value);
+    }
+
+    /**
      * @return true if this item should be ignored by the Vaadin router and
      *         behave like a regular anchor.
      */

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -622,6 +622,24 @@ public class SideNavItemTest {
     }
 
     @Test
+    public void isMatchNested_falseByDefault() {
+        Assert.assertFalse(sideNavItem.isMatchNested());
+    }
+
+    @Test
+    public void setMatchNested_isMatchNested() {
+        sideNavItem.setMatchNested(true);
+        Assert.assertTrue(
+                sideNavItem.getElement().getProperty("matchNested", false));
+        Assert.assertTrue(sideNavItem.isMatchNested());
+
+        sideNavItem.setMatchNested(false);
+        Assert.assertFalse(
+                sideNavItem.getElement().getProperty("matchNested", false));
+        Assert.assertFalse(sideNavItem.isMatchNested());
+    }
+
+    @Test
     public void isRouterIgnore_falseByDefault() {
         Assert.assertFalse(sideNavItem.isRouterIgnore());
     }


### PR DESCRIPTION
Adds a `matchNested` property to `vaadin-side-nav-item` that allows an item to match nested paths. When enabled, then an item with the path `/users` does not only match `/users`, but also `/users/1`, `/users/1/permissions`, etc.

WC PR: https://github.com/vaadin/web-components/pull/7693

Closes https://github.com/vaadin/flow-components/issues/5227