### PR TITLE
fix: handle invalid widget index

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -98,8 +98,11 @@ public class Dashboard extends Component {
             throw new IllegalArgumentException(
                     "Cannot add a widget with a negative index.");
         }
-        // The case when the index is bigger than the children count is handled
-        // inside the method below
+        if (index > widgets.size()) {
+            throw new IllegalArgumentException(String.format(
+                    "Cannot add a widget with index %d when there are %d widgets",
+                    index, widgets.size()));
+        }
         doAddWidget(index, widget);
         updateClient();
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -88,6 +88,27 @@ public class DashboardTest {
     }
 
     @Test
+    public void addWidgetAtInvalidIndex_exceptionIsThrown() {
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        dashboard.add(widget1);
+        fakeClientCommunication();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> dashboard.addWidgetAtIndex(2, widget2));
+        fakeClientCommunication();
+        assertWidgets(dashboard, widget1);
+    }
+
+    @Test
+    public void addWidgetAtNegativeIndex_exceptionIsThrown() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> dashboard.addWidgetAtIndex(-1, widget));
+        fakeClientCommunication();
+        assertWidgets(dashboard);
+    }
+
+    @Test
     public void addNullWidgetAtIndex_exceptionIsThrown() {
         Assert.assertThrows(NullPointerException.class,
                 () -> dashboard.addWidgetAtIndex(0, null));


### PR DESCRIPTION
## Description

This PR adds a check for an index larger than the widget count to `Dashboard.addWidgetAtIndex`. An `InvalidArgumentException` is thrown if this is the case.

This case was previously handled in the implementation internally. However during a refactoring, the implementation changed to one without this check.

No related issue.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.