### PR TITLE
feat: add dashboard widget colspan support

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -83,7 +83,20 @@ public class DashboardPage extends Div {
                 click -> dashboard.setMaximumColumnCount(null));
         setMaximumColumnCountNull.setId("set-maximum-column-count-null");
 
+        NativeButton increaseAllColspansBy1 = new NativeButton(
+                "Increase all colspans by 1");
+        increaseAllColspansBy1.addClickListener(click -> dashboard.getWidgets()
+                .forEach(widget -> widget.setColspan(widget.getColspan() + 1)));
+        increaseAllColspansBy1.setId("increase-all-colspans-by-1");
+
+        NativeButton decreaseAllColspansBy1 = new NativeButton(
+                "Decrease all colspans by 1");
+        decreaseAllColspansBy1.addClickListener(click -> dashboard.getWidgets()
+                .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
+        decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
+
         add(addWidgetAtIndex1, removeFirstAndLastWidgets, removeAllWidgets,
-                setMaximumColumnCount1, setMaximumColumnCountNull, dashboard);
+                setMaximumColumnCount1, setMaximumColumnCountNull,
+                increaseAllColspansBy1, decreaseAllColspansBy1, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -85,6 +85,24 @@ public class DashboardIT extends AbstractComponentIT {
         Assert.assertEquals(yOfWidget1, widgets.get(1).getLocation().getY());
     }
 
+    @Test
+    public void defaultWidgetColspanIsCorrect() {
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(1),
+                widget.getColspan()));
+    }
+
+    @Test
+    public void updateColspans_colspansForAllWidgetsUpdated() {
+        clickElementWithJs("increase-all-colspans-by-1");
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(2),
+                widget.getColspan()));
+        clickElementWithJs("decrease-all-colspans-by-1");
+        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(1),
+                widget.getColspan()));
+    }
+
     private void assertWidgetsByTitle(String... expectedWidgetTitles) {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         List<String> widgetTitles = widgets.stream()

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -159,7 +159,7 @@ public class Dashboard extends Component {
     /**
      * Sets the maximum column count of the dashboard.
      *
-     * @param maxCount
+     * @param maxColCount
      *            the new maximum column count. Pass in {@code null} to set the
      *            maximum column count back to the default value.
      */
@@ -178,6 +178,18 @@ public class Dashboard extends Component {
         super.onAttach(attachEvent);
         attachRenderer();
         doUpdateClient();
+    }
+
+    void updateClient() {
+        if (pendingUpdate) {
+            return;
+        }
+        pendingUpdate = true;
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this, ctx -> {
+                    doUpdateClient();
+                    pendingUpdate = false;
+                }));
     }
 
     private final Map<Element, Registration> childDetachListenerMap = new HashMap<>();
@@ -206,18 +218,6 @@ public class Dashboard extends Component {
         }
     };
 
-    private void updateClient() {
-        if (pendingUpdate) {
-            return;
-        }
-        pendingUpdate = true;
-        getElement().getNode()
-                .runWhenAttached(ui -> ui.beforeClientResponse(this, ctx -> {
-                    doUpdateClient();
-                    pendingUpdate = false;
-                }));
-    }
-
     private void doUpdateClient() {
         widgets.forEach(widget -> {
             Element childWidgetElement = widget.getElement();
@@ -244,6 +244,7 @@ public class Dashboard extends Component {
         for (DashboardWidget widget : widgets) {
             JsonObject jsonItem = Json.createObject();
             jsonItem.put("nodeid", getWidgetNodeId(widget));
+            jsonItem.put("colspan", widget.getColspan());
             jsonItems.set(jsonItems.length(), jsonItem);
         }
         return jsonItems;

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -23,6 +23,8 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 // @NpmPackage(value = "@vaadin/dashboard", version = "24.6.0-alpha0")
 public class DashboardWidget extends Component {
 
+    private int colspan = 1;
+
     /**
      * Returns the title of the widget.
      *
@@ -40,5 +42,40 @@ public class DashboardWidget extends Component {
      */
     public void setTitle(String title) {
         getElement().setProperty("widgetTitle", title == null ? "" : title);
+    }
+
+    /**
+     * Returns the colspan of the widget. The default is 1.
+     *
+     * @return the colspan of the widget
+     */
+    public int getColspan() {
+        return colspan;
+    }
+
+    /**
+     * Sets the colspan of the widget. Cannot be lower than 1.
+     *
+     * @param colspan
+     *            the colspan to set
+     */
+    public void setColspan(int colspan) {
+        if (colspan < 1) {
+            throw new IllegalArgumentException(
+                    "Cannot set a colspan lower than 1.");
+        }
+        if (this.colspan == colspan) {
+            return;
+        }
+        this.colspan = colspan;
+        notifyParentDashboard();
+    }
+
+    private void notifyParentDashboard() {
+        getParent().ifPresent(parent -> {
+            if (parent instanceof Dashboard dashboard) {
+                dashboard.updateClient();
+            }
+        });
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -85,6 +85,27 @@ public class DashboardWidgetTest {
         Assert.assertTrue(newParent.getChildren().anyMatch(widget::equals));
     }
 
+    @Test
+    public void assertDefaultColspan() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertEquals(1, widget.getColspan());
+    }
+
+    @Test
+    public void setValidColspan_returnsCorrectColspan() {
+        int valueToSet = 2;
+        DashboardWidget widget = new DashboardWidget();
+        widget.setColspan(valueToSet);
+        Assert.assertEquals(valueToSet, widget.getColspan());
+    }
+
+    @Test
+    public void setInvalidColspan_throwsIllegalArgumentException() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> widget.setColspan(0));
+    }
+
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -29,8 +29,8 @@ public class DashboardWidgetElement extends TestBenchElement {
     /**
      * Returns the colspan of the widget.
      *
-     * @return the {@code --vaadin-dashboard-item-colspan} style from the
-     *         wrapper of the web component
+     * @return the {@code --vaadin-dashboard-item-colspan} computed style from
+     *         the web component
      */
     public Integer getColspan() {
         var colspanStr = getComputedCssValue("--vaadin-dashboard-item-colspan");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -8,6 +8,11 @@
  */
 package com.vaadin.flow.component.dashboard.testbench;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openqa.selenium.By;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -24,5 +29,41 @@ public class DashboardWidgetElement extends TestBenchElement {
      */
     public String getTitle() {
         return getPropertyString("widgetTitle");
+    }
+
+    /**
+     * Returns the colspan of the widget.
+     *
+     * @return the {@code --vaadin-dashboard-item-colspan} style from the
+     *         wrapper of the web component
+     */
+    public Integer getColspan() {
+        TestBenchElement wrapper = getWrapper();
+        if (wrapper == null) {
+            return null;
+        }
+        String colspanStr = getStyle(wrapper,
+                "--vaadin-dashboard-item-colspan");
+        if (colspanStr == null) {
+            return null;
+        }
+        return Integer.valueOf(colspanStr);
+    }
+
+    private TestBenchElement getWrapper() {
+        return findElement(By.xpath(".."));
+    }
+
+    private static String getStyle(TestBenchElement element, String name) {
+        String style = element.getAttribute("style");
+        if (style == null) {
+            return null;
+        }
+        Pattern pattern = Pattern.compile(name + ": (.*?);");
+        Matcher matcher = pattern.matcher(style);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -8,11 +8,6 @@
  */
 package com.vaadin.flow.component.dashboard.testbench;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.openqa.selenium.By;
-
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -38,32 +33,13 @@ public class DashboardWidgetElement extends TestBenchElement {
      *         wrapper of the web component
      */
     public Integer getColspan() {
-        TestBenchElement wrapper = getWrapper();
-        if (wrapper == null) {
-            return null;
-        }
-        String colspanStr = getStyle(wrapper,
-                "--vaadin-dashboard-item-colspan");
-        if (colspanStr == null) {
-            return null;
-        }
-        return Integer.valueOf(colspanStr);
+        var colspanStr = getComputedCssValue("--vaadin-dashboard-item-colspan");
+        return colspanStr.isEmpty() ? null : Integer.valueOf(colspanStr);
     }
 
-    private TestBenchElement getWrapper() {
-        return findElement(By.xpath(".."));
-    }
-
-    private static String getStyle(TestBenchElement element, String name) {
-        String style = element.getAttribute("style");
-        if (style == null) {
-            return null;
-        }
-        Pattern pattern = Pattern.compile(name + ": (.*?);");
-        Matcher matcher = pattern.matcher(style);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-        return null;
+    private String getComputedCssValue(String propertyName) {
+        return (String) executeScript(
+                "return getComputedStyle(arguments[0]).getPropertyValue(arguments[1]);",
+                this, propertyName);
     }
 }


### PR DESCRIPTION
## Description

Adds colspan support to dashboard widget.

Added API:
- `int getColspan()`: Returns the colspan of the widget
- `void setColspan(int colspan)`: Sets the colspan of the widget

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=76144368

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature