### PR TITLE
feat: add max min column width support

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -93,28 +93,8 @@ public class DashboardPage extends Div {
                 .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
         decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
 
-        NativeButton setColumnWidthRangeTo40Px50Px = new NativeButton(
-                "Set column width range to 40px-50px");
-        setColumnWidthRangeTo40Px50Px.addClickListener(click -> {
-            dashboard.setMinimumColumnWidth("40px");
-            dashboard.setMaximumColumnWidth("50px");
-        });
-        setColumnWidthRangeTo40Px50Px
-                .setId("set-column-width-range-to-40px-50px");
-
-        NativeButton setMaxAndMinColumnWidthsNull = new NativeButton(
-                "Set max and min column widths null");
-        setMaxAndMinColumnWidthsNull.addClickListener(click -> {
-            dashboard.setMinimumColumnWidth(null);
-            dashboard.setMaximumColumnWidth(null);
-        });
-        setMaxAndMinColumnWidthsNull
-                .setId("set-max-and-min-column-widths-null");
-
         add(addWidgetAtIndex1, removeFirstAndLastWidgets, removeAllWidgets,
                 setMaximumColumnCount1, setMaximumColumnCountNull,
-                increaseAllColspansBy1, decreaseAllColspansBy1,
-                setColumnWidthRangeTo40Px50Px, setMaxAndMinColumnWidthsNull,
-                dashboard);
+                increaseAllColspansBy1, decreaseAllColspansBy1, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -38,8 +38,6 @@ public class DashboardPage extends Div {
         Dashboard dashboard = new Dashboard();
         dashboard.add(widget1, widget2, widget3);
 
-        dashboard.setMaximumColumnCount(3);
-
         NativeButton addWidgetAtIndex1 = new NativeButton(
                 "Add widget at index 1");
         addWidgetAtIndex1.addClickListener(click -> {
@@ -95,8 +93,28 @@ public class DashboardPage extends Div {
                 .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
         decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
 
+        NativeButton setColumnWidthRangeTo40Px50Px = new NativeButton(
+                "Set column width range to 40px-50px");
+        setColumnWidthRangeTo40Px50Px.addClickListener(click -> {
+            dashboard.setMinimumColumnWidth("40px");
+            dashboard.setMaximumColumnWidth("50px");
+        });
+        setColumnWidthRangeTo40Px50Px
+                .setId("set-column-width-range-to-40px-50px");
+
+        NativeButton setMaxAndMinColumnWidthsNull = new NativeButton(
+                "Set max and min column widths null");
+        setMaxAndMinColumnWidthsNull.addClickListener(click -> {
+            dashboard.setMinimumColumnWidth(null);
+            dashboard.setMaximumColumnWidth(null);
+        });
+        setMaxAndMinColumnWidthsNull
+                .setId("set-max-and-min-column-widths-null");
+
         add(addWidgetAtIndex1, removeFirstAndLastWidgets, removeAllWidgets,
                 setMaximumColumnCount1, setMaximumColumnCountNull,
-                increaseAllColspansBy1, decreaseAllColspansBy1, dashboard);
+                increaseAllColspansBy1, decreaseAllColspansBy1,
+                setColumnWidthRangeTo40Px50Px, setMaxAndMinColumnWidthsNull,
+                dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -103,32 +103,6 @@ public class DashboardIT extends AbstractComponentIT {
                 widget.getColspan()));
     }
 
-    @Test
-    public void setMinAndMaxColumnWidths_columnWidthIsInTheRange() {
-        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
-        int initialWidth = widgets.get(0).getSize().getWidth();
-        Assert.assertTrue(initialWidth > 50);
-        clickElementWithJs("set-column-width-range-to-40px-50px");
-        waitUntil(
-                driver -> initialWidth != widgets.get(0).getSize().getWidth());
-        int updatedWidth = widgets.get(0).getSize().getWidth();
-        Assert.assertTrue(updatedWidth >= 40 && updatedWidth <= 50);
-    }
-
-    @Test
-    public void setMinAndMaxColumnWidths_setMinAndMaxColumnWidthsNull_columnWidthReturnsToInitialState() {
-        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
-        int initialWidth = widgets.get(0).getSize().getWidth();
-        clickElementWithJs("set-column-width-range-to-40px-50px");
-        waitUntil(
-                driver -> initialWidth != widgets.get(0).getSize().getWidth());
-        int updatedWidth = widgets.get(0).getSize().getWidth();
-        clickElementWithJs("set-max-and-min-column-widths-null");
-        waitUntil(
-                driver -> updatedWidth != widgets.get(0).getSize().getWidth());
-        Assert.assertEquals(initialWidth, widgets.get(0).getSize().getWidth());
-    }
-
     private void assertWidgetsByTitle(String... expectedWidgetTitles) {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         List<String> widgetTitles = widgets.stream()

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -103,6 +103,32 @@ public class DashboardIT extends AbstractComponentIT {
                 widget.getColspan()));
     }
 
+    @Test
+    public void setMinAndMaxColumnWidths_columnWidthIsInTheRange() {
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        int initialWidth = widgets.get(0).getSize().getWidth();
+        Assert.assertTrue(initialWidth > 50);
+        clickElementWithJs("set-column-width-range-to-40px-50px");
+        waitUntil(
+                driver -> initialWidth != widgets.get(0).getSize().getWidth());
+        int updatedWidth = widgets.get(0).getSize().getWidth();
+        Assert.assertTrue(updatedWidth >= 40 && updatedWidth <= 50);
+    }
+
+    @Test
+    public void setMinAndMaxColumnWidths_setMinAndMaxColumnWidthsNull_columnWidthReturnsToInitialState() {
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        int initialWidth = widgets.get(0).getSize().getWidth();
+        clickElementWithJs("set-column-width-range-to-40px-50px");
+        waitUntil(
+                driver -> initialWidth != widgets.get(0).getSize().getWidth());
+        int updatedWidth = widgets.get(0).getSize().getWidth();
+        clickElementWithJs("set-max-and-min-column-widths-null");
+        waitUntil(
+                driver -> updatedWidth != widgets.get(0).getSize().getWidth());
+        Assert.assertEquals(initialWidth, widgets.get(0).getSize().getWidth());
+    }
+
     private void assertWidgetsByTitle(String... expectedWidgetTitles) {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         List<String> widgetTitles = widgets.stream()

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -168,6 +168,46 @@ public class Dashboard extends Component {
                 maxColCount == null ? null : String.valueOf(maxColCount));
     }
 
+    /**
+     * Returns the minimum column width of the dashboard.
+     *
+     * @return the minimum column width of the dashboard
+     */
+    public String getMinimumColumnWidth() {
+        return getStyle().get("--vaadin-dashboard-col-min-width");
+    }
+
+    /**
+     * Sets the minimum column width of the dashboard.
+     *
+     * @param minColWidth
+     *            the new minimum column width. Pass in {@code null} to set the
+     *            minimum column width back to the default value.
+     */
+    public void setMinimumColumnWidth(String minColWidth) {
+        getStyle().set("--vaadin-dashboard-col-min-width", minColWidth);
+    }
+
+    /**
+     * Returns the maximum column width of the dashboard.
+     *
+     * @return the maximum column width of the dashboard
+     */
+    public String getMaximumColumnWidth() {
+        return getStyle().get("--vaadin-dashboard-col-max-width");
+    }
+
+    /**
+     * Sets the maximum column width of the dashboard.
+     *
+     * @param maxColWidth
+     *            the new maximum column width. Pass in {@code null} to set the
+     *            maximum column width back to the default value.
+     */
+    public void setMaximumColumnWidth(String maxColWidth) {
+        getStyle().set("--vaadin-dashboard-col-max-width", maxColWidth);
+    }
+
     @Override
     public Stream<Component> getChildren() {
         return getWidgets().stream().map(Component.class::cast);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -275,6 +275,82 @@ public class DashboardTest {
         assertWidgetColspans(dashboard, widget);
     }
 
+    @Test
+    public void setMaximumColumnWidth_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-col-max-width";
+        String valueToSet = "50px";
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+        dashboard.setMaximumColumnWidth(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
+        dashboard.setMaximumColumnWidth(null);
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    public void setMaximumColumnWidthNull_propertyIsRemoved() {
+        dashboard.setMaximumColumnWidth("50px");
+        dashboard.setMaximumColumnWidth(null);
+        Assert.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-col-max-width"));
+    }
+
+    @Test
+    public void defaultMaximumColumnWidthValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getMaximumColumnWidth());
+    }
+
+    @Test
+    public void setMaximumColumnWidth_valueIsCorrectlyRetrieved() {
+        String valueToSet = "50px";
+        dashboard.setMaximumColumnWidth(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getMaximumColumnWidth());
+    }
+
+    @Test
+    public void setMaximumColumnWidthNull_valueIsCorrectlyRetrieved() {
+        dashboard.setMaximumColumnWidth("50px");
+        dashboard.setMaximumColumnWidth(null);
+        Assert.assertNull(dashboard.getMaximumColumnWidth());
+    }
+
+    @Test
+    public void setMinimumColumnWidth_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-col-min-width";
+        String valueToSet = "50px";
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+        dashboard.setMinimumColumnWidth(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
+        dashboard.setMinimumColumnWidth(null);
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    public void setMinimumColumnWidthNull_propertyIsRemoved() {
+        dashboard.setMinimumColumnWidth("50px");
+        dashboard.setMinimumColumnWidth(null);
+        Assert.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-col-min-width"));
+    }
+
+    @Test
+    public void defaultMinimumColumnWidthValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getMinimumColumnWidth());
+    }
+
+    @Test
+    public void setMinimumColumnWidth_valueIsCorrectlyRetrieved() {
+        String valueToSet = "50px";
+        dashboard.setMinimumColumnWidth(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getMinimumColumnWidth());
+    }
+
+    @Test
+    public void setMinimumColumnWidthNull_valueIsCorrectlyRetrieved() {
+        dashboard.setMinimumColumnWidth("50px");
+        dashboard.setMinimumColumnWidth(null);
+        Assert.assertNull(dashboard.getMinimumColumnWidth());
+    }
+
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {


### PR DESCRIPTION
## Description

Adds maximum and minimum column width support to dashboard.

Added API:
- `String getMinimumColumnWidth()`: Returns the minimum column width of the dashboard
- `void setMinimumColumnWidth(String minColWidth)`: Sets the minimum column width of the dashboard
- `String getMaximumColumnWidth()`: Returns the maximum column width of the dashboard
- `void setMaximumColumnWidth(String maxColWidth)`: Sets the maximum column width of the dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=76144368

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature