### PR TITLE
feat: add gap support to dashboard

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -208,6 +208,26 @@ public class Dashboard extends Component {
         getStyle().set("--vaadin-dashboard-col-max-width", maxColWidth);
     }
 
+    /**
+     * Returns the gap between the cells of the dashboard.
+     *
+     * @return the gap between the cells of the dashboard
+     */
+    public String getGap() {
+        return getStyle().get("--vaadin-dashboard-gap");
+    }
+
+    /**
+     * Sets the gap between the cells of the dashboard.
+     *
+     * @param gap
+     *            the new gap. Pass in {@code null} to set the gap back to the
+     *            default value.
+     */
+    public void setGap(String gap) {
+        getStyle().set("--vaadin-dashboard-gap", gap);
+    }
+
     @Override
     public Stream<Component> getChildren() {
         return getWidgets().stream().map(Component.class::cast);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -351,6 +351,43 @@ public class DashboardTest {
         Assert.assertNull(dashboard.getMinimumColumnWidth());
     }
 
+    @Test
+    public void setGap_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-gap";
+        String valueToSet = "10px";
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+        dashboard.setGap(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
+        dashboard.setGap(null);
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    public void setGapNull_propertyIsRemoved() {
+        dashboard.setGap("10px");
+        dashboard.setGap(null);
+        Assert.assertNull(dashboard.getStyle().get("--vaadin-dashboard-gap"));
+    }
+
+    @Test
+    public void defaultGapValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getGap());
+    }
+
+    @Test
+    public void setGap_valueIsCorrectlyRetrieved() {
+        String valueToSet = "10px";
+        dashboard.setGap(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getGap());
+    }
+
+    @Test
+    public void setGapNull_valueIsCorrectlyRetrieved() {
+        dashboard.setGap("10px");
+        dashboard.setGap(null);
+        Assert.assertNull(dashboard.getGap());
+    }
+
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {


### PR DESCRIPTION
## Description

Adds gap support to dashboard.

Added API:
- `String getGap()`: Returns the gap between the cells of the dashboard
- `void setGap(String gap)`: Sets the gap between the cells of the dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=76144419

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature