### PR TITLE
fix: Do not show error with theme property

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
@@ -299,6 +299,7 @@ export class VaadinSpreadsheet extends LitElement {
       } else if ('resources' == name) {
         this.api.setResources(this, newVal);
       } else if ('api' == name) {
+      } else if ('theme' == name) {
       } else {
         console.error('<vaadin-spreadsheet> unsupported property received from server: property=' + name);
       }


### PR DESCRIPTION
This was a tiny error left behind in Spreadsheet Lumo theme