### PR TITLE
feat: add dashboard sections support

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.dashboard.tests;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardSection;
@@ -59,15 +60,18 @@ public class DashboardPage extends Div {
         DashboardSection section2 = dashboard.addSection("Section 2");
         section2.add(widget1InSection2);
 
-        NativeButton addWidgetAtIndex1 = new NativeButton(
-                "Add widget at index 1");
-        addWidgetAtIndex1.addClickListener(click -> {
-            DashboardWidget widgetAtIndex1 = new DashboardWidget();
-            widgetAtIndex1.setTitle("Widget at index 1");
-            widgetAtIndex1.setId("widget-at-index-1");
-            dashboard.addWidgetAtIndex(1, widgetAtIndex1);
+        NativeButton addMultipleWidgets = new NativeButton(
+                "Add multiple widgets");
+        addMultipleWidgets.addClickListener(click -> {
+            DashboardWidget newWidget1 = new DashboardWidget();
+            newWidget1.setTitle("New widget 1");
+            DashboardWidget newWidget2 = new DashboardWidget();
+            newWidget2.setTitle("New widget 2");
+            dashboard.add(newWidget2);
+            dashboard.addWidgetAtIndex(
+                    (int) (dashboard.getChildren().count() - 1), newWidget1);
         });
-        addWidgetAtIndex1.setId("add-widget-at-index-1");
+        addMultipleWidgets.setId("add-multiple-widgets");
 
         NativeButton removeFirstAndLastWidgets = new NativeButton(
                 "Remove first and last widgets");
@@ -87,9 +91,60 @@ public class DashboardPage extends Div {
         });
         removeFirstAndLastWidgets.setId("remove-first-and-last-widgets");
 
-        NativeButton removeAllWidgets = new NativeButton("Remove all widgets");
-        removeAllWidgets.addClickListener(click -> dashboard.removeAll());
-        removeAllWidgets.setId("remove-all-widgets");
+        NativeButton removeAll = new NativeButton("Remove all");
+        removeAll.addClickListener(click -> dashboard.removeAll());
+        removeAll.setId("remove-all");
+
+        NativeButton addSectionWithMultipleWidgets = new NativeButton(
+                "Add section with multiple widgets");
+        addSectionWithMultipleWidgets.addClickListener(click -> {
+            DashboardSection section = dashboard
+                    .addSection("New section with multiple widgets");
+            DashboardWidget newWidget1 = new DashboardWidget();
+            newWidget1.setTitle("New widget 1");
+            DashboardWidget newWidget2 = new DashboardWidget();
+            newWidget2.setTitle("New widget 2");
+            section.add(newWidget2);
+            section.addWidgetAtIndex(0, newWidget1);
+        });
+        addSectionWithMultipleWidgets
+                .setId("add-section-with-multiple-widgets");
+
+        NativeButton removeFirstSection = new NativeButton(
+                "Remove first section");
+        removeFirstSection.addClickListener(click -> getFirstSection(dashboard)
+                .ifPresent(dashboard::remove));
+        removeFirstSection.setId("remove-first-section");
+
+        NativeButton addWidgetToFirstSection = new NativeButton(
+                "Add widget to first section");
+        addWidgetToFirstSection.addClickListener(
+                click -> getFirstSection(dashboard).ifPresent(section -> {
+                    DashboardWidget newWidget = new DashboardWidget();
+                    newWidget.setTitle("New widget");
+                    section.add(newWidget);
+                }));
+        addWidgetToFirstSection.setId("add-widget-to-first-section");
+
+        NativeButton removeFirstWidgetFromFirstSection = new NativeButton(
+                "Remove first widget from first section");
+        removeFirstWidgetFromFirstSection.addClickListener(
+                click -> getFirstSection(dashboard).ifPresent(section -> {
+                    List<DashboardWidget> currentWidgets = section.getWidgets();
+                    if (currentWidgets.isEmpty()) {
+                        return;
+                    }
+                    section.remove(currentWidgets.get(0));
+                }));
+        removeFirstWidgetFromFirstSection
+                .setId("remove-first-widget-from-first-section");
+
+        NativeButton removeAllFromFirstSection = new NativeButton(
+                "Remove all from first section");
+        removeAllFromFirstSection
+                .addClickListener(click -> getFirstSection(dashboard)
+                        .ifPresent(DashboardSection::removeAll));
+        removeAllFromFirstSection.setId("remove-all-from-first-section");
 
         NativeButton setMaximumColumnCount1 = new NativeButton(
                 "Set maximum column count 1");
@@ -115,8 +170,18 @@ public class DashboardPage extends Div {
                 .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
         decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
 
-        add(addWidgetAtIndex1, removeFirstAndLastWidgets, removeAllWidgets,
-                setMaximumColumnCount1, setMaximumColumnCountNull,
-                increaseAllColspansBy1, decreaseAllColspansBy1, dashboard);
+        add(addMultipleWidgets, removeFirstAndLastWidgets, removeAll,
+                addSectionWithMultipleWidgets, removeFirstSection,
+                addWidgetToFirstSection, removeFirstWidgetFromFirstSection,
+                removeAllFromFirstSection, setMaximumColumnCount1,
+                setMaximumColumnCountNull, increaseAllColspansBy1,
+                decreaseAllColspansBy1, dashboard);
+    }
+
+    private static Optional<DashboardSection> getFirstSection(
+            Dashboard dashboard) {
+        return dashboard.getChildren()
+                .filter(DashboardSection.class::isInstance)
+                .map(DashboardSection.class::cast).findFirst();
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.dashboard.tests;
 import java.util.List;
 
 import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
@@ -23,6 +24,8 @@ import com.vaadin.flow.router.Route;
 public class DashboardPage extends Div {
 
     public DashboardPage() {
+        Dashboard dashboard = new Dashboard();
+
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
         widget1.setId("widget-1");
@@ -35,8 +38,26 @@ public class DashboardPage extends Div {
         widget3.setTitle("Widget 3");
         widget3.setId("widget-3");
 
-        Dashboard dashboard = new Dashboard();
+        DashboardWidget widget1InSection1 = new DashboardWidget();
+        widget1InSection1.setTitle("Widget 1 in Section 1");
+        widget1InSection1.setId("widget-1-in-section-1");
+
+        DashboardWidget widget2InSection1 = new DashboardWidget();
+        widget2InSection1.setTitle("Widget 2 in Section 1");
+        widget2InSection1.setId("widget-2-in-section-1");
+
+        DashboardWidget widget1InSection2 = new DashboardWidget();
+        widget1InSection2.setTitle("Widget 1 in Section 2");
+        widget1InSection2.setId("widget-1-in-section-2");
+
         dashboard.add(widget1, widget2, widget3);
+
+        DashboardSection section1 = new DashboardSection("Section 1");
+        section1.add(widget1InSection1, widget2InSection1);
+        dashboard.addSection(section1);
+
+        DashboardSection section2 = dashboard.addSection("Section 2");
+        section2.add(widget1InSection2);
 
         NativeButton addWidgetAtIndex1 = new NativeButton(
                 "Add widget at index 1");
@@ -57,10 +78,11 @@ public class DashboardPage extends Div {
             }
             int currentWidgetCount = currentWidgets.size();
             if (currentWidgetCount == 1) {
-                dashboard.remove(dashboard.getWidgets().get(0));
+                dashboard.getWidgets().get(0).removeFromParent();
             } else {
-                dashboard.remove(dashboard.getWidgets().get(0),
-                        dashboard.getWidgets().get(currentWidgetCount - 1));
+                dashboard.getWidgets().get(currentWidgetCount - 1)
+                        .removeFromParent();
+                dashboard.getWidgets().get(0).removeFromParent();
             }
         });
         removeFirstAndLastWidgets.setId("remove-first-and-last-widgets");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -36,35 +36,36 @@ public class DashboardIT extends AbstractComponentIT {
     }
 
     @Test
-    public void addWidgets_widgetsAreCorrectlyAdded() {
+    public void addInitialWidgetsToDashboard_widgetsAreCorrectlyAdded() {
         assertDashboardWidgetsByTitle("Widget 1", "Widget 2", "Widget 3",
                 "Widget 1 in Section 1", "Widget 2 in Section 1",
                 "Widget 1 in Section 2");
     }
 
     @Test
-    public void addWidgetsAtIndex1_widgetIsAddedIntoTheCorrectPlace() {
-        clickElementWithJs("add-widget-at-index-1");
-        assertDashboardWidgetsByTitle("Widget 1", "Widget at index 1",
-                "Widget 2", "Widget 3", "Widget 1 in Section 1",
-                "Widget 2 in Section 1", "Widget 1 in Section 2");
+    public void addWidgetsToDashboard_widgetsAreCorrectlyAdded() {
+        clickElementWithJs("add-multiple-widgets");
+        assertDashboardWidgetsByTitle("Widget 1", "Widget 2", "Widget 3",
+                "Widget 1 in Section 1", "Widget 2 in Section 1",
+                "Widget 1 in Section 2", "New widget 1", "New widget 2");
     }
 
     @Test
-    public void removeFirstAndLastWidgets_widgetsAreCorrectlyRemoved() {
+    public void removeFirstAndLastWidgetsFromDashboard_widgetsAreCorrectlyRemoved() {
         clickElementWithJs("remove-first-and-last-widgets");
         assertDashboardWidgetsByTitle("Widget 2", "Widget 3",
                 "Widget 1 in Section 1", "Widget 2 in Section 1");
     }
 
     @Test
-    public void removeAllWidgets_widgetsAreCorrectlyRemoved() {
-        clickElementWithJs("remove-all-widgets");
+    public void removeAllFromDashboard_widgetsAnsSectionsAreCorrectlyRemoved() {
+        clickElementWithJs("remove-all");
         assertDashboardWidgetsByTitle();
+        Assert.assertTrue(dashboardElement.getSections().isEmpty());
     }
 
     @Test
-    public void addSectionsWithWidgets_widgetsAreCorrectlyAdded() {
+    public void addInitialSectionsWithWidgetsToDashboard_widgetsAreCorrectlyAdded() {
         List<DashboardSectionElement> sections = dashboardElement.getSections();
         Assert.assertEquals(2, sections.size());
 
@@ -76,6 +77,55 @@ public class DashboardIT extends AbstractComponentIT {
         DashboardSectionElement section2 = sections.get(1);
         Assert.assertEquals("Section 2", section2.getTitle());
         assertSectionWidgetsByTitle(section2, "Widget 1 in Section 2");
+    }
+
+    @Test
+    public void addSectionWithWidgets_sectionAndWidgetsAreCorrectlyAdded() {
+        clickElementWithJs("add-section-with-multiple-widgets");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        Assert.assertEquals(3, sections.size());
+        DashboardSectionElement newSection = sections.get(2);
+        Assert.assertEquals("New section with multiple widgets",
+                newSection.getTitle());
+        assertSectionWidgetsByTitle(newSection, "New widget 1", "New widget 2");
+    }
+
+    @Test
+    public void removeFirstSection_sectionIsRemoved() {
+        clickElementWithJs("remove-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        Assert.assertEquals(1, sections.size());
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 2", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection, "Widget 1 in Section 2");
+    }
+
+    @Test
+    public void addWidgetToFirstSection_widgetsAreAdded() {
+        clickElementWithJs("add-widget-to-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 1", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection, "Widget 1 in Section 1",
+                "Widget 2 in Section 1", "New widget");
+    }
+
+    @Test
+    public void removeFirstWidgetFromFirstSection_widgetIsRemoved() {
+        clickElementWithJs("remove-first-widget-from-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 1", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection, "Widget 2 in Section 1");
+    }
+
+    @Test
+    public void removeAllFromFirstSection_widgetsAreRemoved() {
+        clickElementWithJs("remove-all-from-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 1", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection);
     }
 
     @Test

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
+import com.vaadin.flow.component.dashboard.testbench.DashboardSectionElement;
 import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
@@ -36,26 +37,45 @@ public class DashboardIT extends AbstractComponentIT {
 
     @Test
     public void addWidgets_widgetsAreCorrectlyAdded() {
-        assertWidgetsByTitle("Widget 1", "Widget 2", "Widget 3");
+        assertDashboardWidgetsByTitle("Widget 1", "Widget 2", "Widget 3",
+                "Widget 1 in Section 1", "Widget 2 in Section 1",
+                "Widget 1 in Section 2");
     }
 
     @Test
     public void addWidgetsAtIndex1_widgetIsAddedIntoTheCorrectPlace() {
         clickElementWithJs("add-widget-at-index-1");
-        assertWidgetsByTitle("Widget 1", "Widget at index 1", "Widget 2",
-                "Widget 3");
+        assertDashboardWidgetsByTitle("Widget 1", "Widget at index 1",
+                "Widget 2", "Widget 3", "Widget 1 in Section 1",
+                "Widget 2 in Section 1", "Widget 1 in Section 2");
     }
 
     @Test
     public void removeFirstAndLastWidgets_widgetsAreCorrectlyRemoved() {
         clickElementWithJs("remove-first-and-last-widgets");
-        assertWidgetsByTitle("Widget 2");
+        assertDashboardWidgetsByTitle("Widget 2", "Widget 3",
+                "Widget 1 in Section 1", "Widget 2 in Section 1");
     }
 
     @Test
     public void removeAllWidgets_widgetsAreCorrectlyRemoved() {
         clickElementWithJs("remove-all-widgets");
-        assertWidgetsByTitle();
+        assertDashboardWidgetsByTitle();
+    }
+
+    @Test
+    public void addSectionsWithWidgets_widgetsAreCorrectlyAdded() {
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        Assert.assertEquals(2, sections.size());
+
+        DashboardSectionElement section1 = sections.get(0);
+        Assert.assertEquals("Section 1", section1.getTitle());
+        assertSectionWidgetsByTitle(section1, "Widget 1 in Section 1",
+                "Widget 2 in Section 1");
+
+        DashboardSectionElement section2 = sections.get(1);
+        Assert.assertEquals("Section 2", section2.getTitle());
+        assertSectionWidgetsByTitle(section2, "Widget 1 in Section 2");
     }
 
     @Test
@@ -103,9 +123,20 @@ public class DashboardIT extends AbstractComponentIT {
                 widget.getColspan()));
     }
 
-    private void assertWidgetsByTitle(String... expectedWidgetTitles) {
-        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
-        List<String> widgetTitles = widgets.stream()
+    private void assertDashboardWidgetsByTitle(String... expectedWidgetTitles) {
+        assertWidgetsByTitle(dashboardElement.getWidgets(),
+                expectedWidgetTitles);
+    }
+
+    private static void assertSectionWidgetsByTitle(
+            DashboardSectionElement section, String... expectedWidgetTitles) {
+        assertWidgetsByTitle(section.getWidgets(), expectedWidgetTitles);
+    }
+
+    private static void assertWidgetsByTitle(
+            List<DashboardWidgetElement> actualWidgets,
+            String... expectedWidgetTitles) {
+        List<String> widgetTitles = actualWidgets.stream()
                 .map(DashboardWidgetElement::getTitle).toList();
         Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -263,6 +263,8 @@ public class Dashboard extends Component implements HasWidgets {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
+        getElement().executeJs(
+                "Vaadin.FlowComponentHost.patchVirtualContainer(this);");
         doUpdateClient();
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardChildDetachHandler.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardChildDetachHandler.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementDetachEvent;
+import com.vaadin.flow.dom.ElementDetachListener;
+import com.vaadin.flow.shared.Registration;
+
+public abstract class DashboardChildDetachHandler implements Serializable {
+
+    private final Map<Element, Registration> childDetachListenerMap = new HashMap<>();
+
+    // Must not use lambda here as that would break serialization. See
+    // https://github.com/vaadin/flow-components/issues/5597
+    private final ElementDetachListener childDetachListener = new ElementDetachListener() {
+        @Override
+        public void onDetach(ElementDetachEvent e) {
+            var detachedElement = e.getSource();
+            getDirectChildren().stream()
+                    .filter(childComponent -> Objects.equals(detachedElement,
+                            childComponent.getElement()))
+                    .findAny().ifPresent(detachedChild -> {
+                        // The child was removed from the component
+
+                        // Remove the registration for the child detach listener
+                        childDetachListenerMap.get(detachedChild.getElement())
+                                .remove();
+                        childDetachListenerMap
+                                .remove(detachedChild.getElement());
+
+                        removeChild(detachedChild);
+                    });
+        }
+    };
+
+    void refreshListeners() {
+        getDirectChildren().forEach(child -> {
+            Element childElement = child.getElement();
+            if (!childDetachListenerMap.containsKey(childElement)) {
+                childDetachListenerMap.put(childElement,
+                        childElement.addDetachListener(childDetachListener));
+            }
+        });
+    }
+
+    abstract void removeChild(Component child);
+
+    abstract Collection<Component> getDirectChildren();
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * @author Vaadin Ltd
+ */
+@Tag("vaadin-dashboard-section")
+@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.5.0-alpha8")
+@JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
+@JsModule("@vaadin/dashboard/src/vaadin-dashboard-section.js")
+// @NpmPackage(value = "@vaadin/dashboard", version = "24.6.0-alpha0")
+public class DashboardSection extends Component implements HasWidgets {
+
+    private final List<DashboardWidget> widgets = new ArrayList<>();
+
+    private final DashboardChildDetachHandler childDetachHandler;
+
+    private String title;
+
+    /**
+     * Creates an empty section.
+     */
+    public DashboardSection() {
+        this(null);
+    }
+
+    /**
+     * Creates an empty section with title.
+     *
+     * @param title
+     *            the title to set
+     */
+    public DashboardSection(String title) {
+        super();
+        childDetachHandler = getChildDetachHandler();
+        setTitle(title);
+    }
+
+    /**
+     * Returns the title of the section.
+     *
+     * @return the {@code sectionTitle} property from the web component
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Sets the title of the section.
+     *
+     * @param title
+     *            the title to set
+     */
+    public void setTitle(String title) {
+        this.title = title;
+        updateClient();
+    }
+
+    @Override
+    public List<DashboardWidget> getWidgets() {
+        return Collections.unmodifiableList(widgets);
+    }
+
+    @Override
+    public Stream<Component> getChildren() {
+        return widgets.stream().map(Component.class::cast);
+    }
+
+    @Override
+    public void add(DashboardWidget... widgets) {
+        Objects.requireNonNull(widgets, "Widgets to add cannot be null.");
+        List<DashboardWidget> toAdd = new ArrayList<>(widgets.length);
+        for (DashboardWidget widget : widgets) {
+            Objects.requireNonNull(widget, "Widget to add cannot be null.");
+            toAdd.add(widget);
+        }
+        toAdd.forEach(this::doAddWidget);
+        updateClient();
+    }
+
+    @Override
+    public void addWidgetAtIndex(int index, DashboardWidget widget) {
+        Objects.requireNonNull(widget, "Widget to add cannot be null.");
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Cannot add a widget with a negative index.");
+        }
+        if (index > getWidgets().size()) {
+            throw new IllegalArgumentException(String.format(
+                    "Cannot add a widget with index %d when there are %d widgets",
+                    index, getWidgets().size()));
+        }
+        doAddWidgetAtIndex(index, widget);
+        updateClient();
+    }
+
+    @Override
+    public void remove(DashboardWidget... widgets) {
+        Objects.requireNonNull(widgets, "Widgets to remove cannot be null.");
+        List<DashboardWidget> toRemove = new ArrayList<>(widgets.length);
+        for (DashboardWidget widget : widgets) {
+            Objects.requireNonNull(widget, "Widget to remove cannot be null.");
+            Element parent = widget.getElement().getParent();
+            if (parent == null) {
+                LoggerFactory.getLogger(getClass()).debug(
+                        "Removal of a widget with no parent does nothing.");
+                continue;
+            }
+            if (getElement().equals(parent)) {
+                toRemove.add(widget);
+            } else {
+                throw new IllegalArgumentException("The given widget (" + widget
+                        + ") is not a child of this section");
+            }
+        }
+        if (!toRemove.isEmpty()) {
+            toRemove.forEach(this::doRemoveWidget);
+            updateClient();
+        }
+    }
+
+    @Override
+    public void removeAll() {
+        if (getWidgets().isEmpty()) {
+            return;
+        }
+        doRemoveAll();
+        updateClient();
+    }
+
+    @Override
+    public void removeFromParent() {
+        getParent().ifPresent(parent -> ((Dashboard) parent).remove(this));
+    }
+
+    private void doRemoveAll() {
+        new ArrayList<>(widgets).forEach(this::doRemoveWidget);
+    }
+
+    private void doRemoveWidget(DashboardWidget widget) {
+        getElement().removeChild(widget.getElement());
+        widgets.remove(widget);
+    }
+
+    private void doAddWidgetAtIndex(int index, DashboardWidget widget) {
+        getElement().appendChild(widget.getElement());
+        widgets.add(index, widget);
+    }
+
+    private void doAddWidget(DashboardWidget widget) {
+        getElement().appendChild(widget.getElement());
+        widgets.add(widget);
+    }
+
+    void updateClient() {
+        childDetachHandler.refreshListeners();
+        getParent().ifPresent(parent -> ((Dashboard) parent).updateClient());
+    }
+
+    private DashboardChildDetachHandler getChildDetachHandler() {
+        return new DashboardChildDetachHandler() {
+            @Override
+            void removeChild(Component child) {
+                widgets.remove(child);
+                updateClient();
+            }
+
+            @Override
+            Collection<Component> getDirectChildren() {
+                return DashboardSection.this.getChildren().toList();
+            }
+        };
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -37,8 +37,6 @@ public class DashboardSection extends Component implements HasWidgets {
 
     private final DashboardChildDetachHandler childDetachHandler;
 
-    private String title;
-
     /**
      * Creates an empty section.
      */
@@ -64,7 +62,7 @@ public class DashboardSection extends Component implements HasWidgets {
      * @return the {@code sectionTitle} property from the web component
      */
     public String getTitle() {
-        return title;
+        return getElement().getProperty("sectionTitle");
     }
 
     /**
@@ -74,8 +72,7 @@ public class DashboardSection extends Component implements HasWidgets {
      *            the title to set
      */
     public void setTitle(String title) {
-        this.title = title;
-        updateClient();
+        getElement().setProperty("sectionTitle", title);
     }
 
     @Override

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -68,13 +68,15 @@ public class DashboardWidget extends Component {
             return;
         }
         this.colspan = colspan;
-        notifyParentDashboard();
+        notifyParentDashboardOrSection();
     }
 
-    private void notifyParentDashboard() {
+    private void notifyParentDashboardOrSection() {
         getParent().ifPresent(parent -> {
             if (parent instanceof Dashboard dashboard) {
                 dashboard.updateClient();
+            } else if (parent instanceof DashboardSection section) {
+                section.updateClient();
             }
         });
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/HasWidgets.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/HasWidgets.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.io.Serializable;
+import java.util.List;
+
+public interface HasWidgets extends Serializable {
+
+    /**
+     * Returns the widgets in this component.
+     *
+     * @return The widgets in this component
+     */
+    List<DashboardWidget> getWidgets();
+
+    /**
+     * Adds the given widgets to this component.
+     *
+     * @param widgets
+     *            the widgets to add, not {@code null}
+     */
+    void add(DashboardWidget... widgets);
+
+    /**
+     * Adds the given widget as child of this component at the specific index.
+     * <p>
+     * In case the specified widget has already been added to another parent, it
+     * will be removed from there and added to this one.
+     *
+     * @param index
+     *            the index, where the widget will be added. The index must be
+     *            non-negative and may not exceed the children count
+     * @param widget
+     *            the widget to add, not {@code null}
+     */
+    void addWidgetAtIndex(int index, DashboardWidget widget);
+
+    /**
+     * Removes the given widgets from this component.
+     *
+     * @param widgets
+     *            the widgets to remove, not {@code null}
+     * @throws IllegalArgumentException
+     *             if there is a widget whose non {@code null} parent is not
+     *             this component
+     */
+    void remove(DashboardWidget... widgets);
+
+    /**
+     * Removes all widgets from this component.
+     */
+    void removeAll();
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -11,7 +11,6 @@ package com.vaadin.flow.component.dashboard.tests;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -25,11 +24,7 @@ import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.server.VaadinSession;
-
-import elemental.json.JsonArray;
-import elemental.json.JsonObject;
 
 public class DashboardTest {
     private final UI ui = new UI();
@@ -773,57 +768,8 @@ public class DashboardTest {
         List<DashboardWidget> expectedWidgets = getExpectedWidgets(
                 expectedChildren);
         Assert.assertEquals(expectedWidgets, dashboard.getWidgets());
-
-        List<JsonObject> dashboardItems = getItemsStream(dashboard).toList();
-        assertDashboardItems(dashboardItems, expectedChildren);
-    }
-
-    private static void assertDashboardItems(List<JsonObject> dashboardItems,
-            Component... expectedChildren) {
-        Assert.assertEquals(expectedChildren.length, dashboardItems.size());
-        for (int i = 0; i < expectedChildren.length; i++) {
-            JsonObject actualChild = dashboardItems.get(i);
-            Component expectedChild = expectedChildren[i];
-            if (expectedChild instanceof DashboardSection section) {
-                assertSectionItem(section, actualChild);
-            } else if (expectedChild instanceof DashboardWidget widget) {
-                assertWidgetItem(widget, actualChild);
-            } else {
-                throw new IllegalArgumentException(
-                        "A dashboard can only contain widgets or sections.");
-            }
-        }
-    }
-
-    private static void assertSectionItem(DashboardSection expectedSection,
-            JsonObject actualSection) {
-        if (expectedSection.getTitle() == null) {
-            Assert.assertNull(actualSection.get("title"));
-        } else {
-            Assert.assertEquals(expectedSection.getTitle(),
-                    actualSection.getString("title"));
-        }
-        JsonArray sectionItems = actualSection.getArray("items");
-        List<DashboardWidget> expectedSectionWidgets = expectedSection
-                .getWidgets();
-        Assert.assertEquals(expectedSectionWidgets.size(),
-                sectionItems.length());
-        for (int i = 0; i < expectedSectionWidgets.size(); i++) {
-            DashboardWidget expectedWidget = expectedSectionWidgets.get(i);
-            JsonObject actualWidget = sectionItems.getObject(i);
-            assertWidgetItem(expectedWidget, actualWidget);
-        }
-    }
-
-    private static void assertWidgetItem(DashboardWidget expectedWidget,
-            JsonObject actualWidget) {
-        int expectedNodeId = expectedWidget.getElement().getNode().getId();
-        int actualNodeId = (int) actualWidget.getNumber("nodeid");
-        Assert.assertEquals(expectedNodeId, actualNodeId);
-
-        int expectedColspan = expectedWidget.getColspan();
-        int actualColspan = (int) actualWidget.getNumber("colspan");
-        Assert.assertEquals(expectedColspan, actualColspan);
+        Assert.assertEquals(Arrays.asList(expectedChildren),
+                dashboard.getChildren().toList());
     }
 
     private static List<DashboardWidget> getExpectedWidgets(
@@ -840,12 +786,6 @@ public class DashboardTest {
             }
         }
         return expectedWidgets;
-    }
-
-    private static Stream<JsonObject> getItemsStream(Dashboard dashboard) {
-        JsonArray jsonArrayOfIds = (JsonArray) dashboard.getElement()
-                .getPropertyRaw("items");
-        return JsonUtils.objectStream(jsonArrayOfIds);
     }
 
     private static void assertSectionWidgets(DashboardSection section,

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -21,6 +22,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.internal.JsonUtils;
@@ -30,7 +32,6 @@ import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
 public class DashboardTest {
-
     private final UI ui = new UI();
     private Dashboard dashboard;
 
@@ -56,7 +57,7 @@ public class DashboardTest {
         DashboardWidget widget2 = new DashboardWidget();
         dashboard.add(widget1, widget2);
         fakeClientCommunication();
-        assertWidgets(dashboard, widget1, widget2);
+        assertChildComponents(dashboard, widget1, widget2);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class DashboardTest {
             // Do nothing
         }
         fakeClientCommunication();
-        assertWidgets(dashboard);
+        assertChildComponents(dashboard);
     }
 
     @Test
@@ -86,7 +87,7 @@ public class DashboardTest {
         fakeClientCommunication();
         dashboard.addWidgetAtIndex(1, widget3);
         fakeClientCommunication();
-        assertWidgets(dashboard, widget1, widget3, widget2);
+        assertChildComponents(dashboard, widget1, widget3, widget2);
     }
 
     @Test
@@ -98,7 +99,7 @@ public class DashboardTest {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> dashboard.addWidgetAtIndex(2, widget2));
         fakeClientCommunication();
-        assertWidgets(dashboard, widget1);
+        assertChildComponents(dashboard, widget1);
     }
 
     @Test
@@ -107,7 +108,7 @@ public class DashboardTest {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> dashboard.addWidgetAtIndex(-1, widget));
         fakeClientCommunication();
-        assertWidgets(dashboard);
+        assertChildComponents(dashboard);
     }
 
     @Test
@@ -124,7 +125,7 @@ public class DashboardTest {
         fakeClientCommunication();
         dashboard.remove(widget1);
         fakeClientCommunication();
-        assertWidgets(dashboard, widget2);
+        assertChildComponents(dashboard, widget2);
     }
 
     @Test
@@ -141,7 +142,7 @@ public class DashboardTest {
         fakeClientCommunication();
         dashboard.removeAll();
         fakeClientCommunication();
-        assertWidgets(dashboard);
+        assertChildComponents(dashboard);
     }
 
     @Test
@@ -151,7 +152,7 @@ public class DashboardTest {
         fakeClientCommunication();
         widget1.removeFromParent();
         fakeClientCommunication();
-        assertWidgets(dashboard);
+        assertChildComponents(dashboard);
     }
 
     @Test
@@ -162,11 +163,11 @@ public class DashboardTest {
         fakeClientCommunication();
         widget1.removeFromParent();
         fakeClientCommunication();
-        assertWidgets(dashboard, widget2);
+        assertChildComponents(dashboard, widget2);
     }
 
     @Test
-    public void addSeparately_removeOneFromParent_widgetIsRemoved() {
+    public void addWidgetsSeparately_removeOneFromParent_widgetIsRemoved() {
         DashboardWidget widget1 = new DashboardWidget();
         DashboardWidget widget2 = new DashboardWidget();
         dashboard.add(widget1);
@@ -174,7 +175,7 @@ public class DashboardTest {
         fakeClientCommunication();
         widget1.removeFromParent();
         fakeClientCommunication();
-        assertWidgets(dashboard, widget2);
+        assertChildComponents(dashboard, widget2);
     }
 
     @Test
@@ -187,7 +188,7 @@ public class DashboardTest {
         dashboard.add(widget);
         fakeClientCommunication();
         Assert.assertTrue(parent.getChildren().noneMatch(widget::equals));
-        assertWidgets(dashboard, widget);
+        assertChildComponents(dashboard, widget);
     }
 
     @Test
@@ -199,7 +200,7 @@ public class DashboardTest {
         ui.add(parent);
         parent.add(widget);
         fakeClientCommunication();
-        assertWidgets(dashboard);
+        assertChildComponents(dashboard);
         Assert.assertTrue(parent.getChildren().anyMatch(widget::equals));
     }
 
@@ -212,8 +213,381 @@ public class DashboardTest {
         ui.add(newDashboard);
         newDashboard.add(widget);
         fakeClientCommunication();
-        assertWidgets(dashboard);
-        assertWidgets(newDashboard, widget);
+        assertChildComponents(dashboard);
+        assertChildComponents(newDashboard, widget);
+    }
+
+    @Test
+    public void addSectionWithoutTitle_sectionIsAdded() {
+        DashboardSection section1 = dashboard.addSection();
+        DashboardSection section2 = dashboard.addSection();
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section1, section2);
+    }
+
+    @Test
+    public void addSectionWithNullTitle_sectionIsAdded() {
+        DashboardSection section1 = dashboard.addSection((String) null);
+        DashboardSection section2 = dashboard.addSection((String) null);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section1, section2);
+    }
+
+    @Test
+    public void addSectionWithTitle_sectionIsAdded() {
+        DashboardSection section1 = dashboard.addSection("Section 1");
+        DashboardSection section2 = dashboard.addSection("Section 2");
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section1, section2);
+    }
+
+    @Test
+    public void createAndAddSectionWithoutTitle_sectionIsAdded() {
+        DashboardSection section1 = new DashboardSection();
+        DashboardSection section2 = new DashboardSection();
+        dashboard.addSection(section1);
+        dashboard.addSection(section2);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section1, section2);
+    }
+
+    @Test
+    public void createAndAddSectionWithNullTitle_sectionIsAdded() {
+        DashboardSection section1 = new DashboardSection(null);
+        DashboardSection section2 = new DashboardSection(null);
+        dashboard.addSection(section1);
+        dashboard.addSection(section2);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section1, section2);
+    }
+
+    @Test
+    public void createAndAddSectionWithTitle_sectionIsAdded() {
+        DashboardSection section1 = new DashboardSection("Section 1");
+        DashboardSection section2 = new DashboardSection("Section 2");
+        dashboard.addSection(section1);
+        dashboard.addSection(section2);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section1, section2);
+    }
+
+    @Test
+    public void addNullSection_exceptionIsThrown() {
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.addSection((DashboardSection) null));
+    }
+
+    @Test
+    public void removeSection_sectionIsRemoved() {
+        DashboardSection section1 = dashboard.addSection();
+        DashboardSection section2 = dashboard.addSection();
+        fakeClientCommunication();
+        dashboard.remove(section1);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section2);
+    }
+
+    @Test
+    public void removeNullSection_exceptionIsThrown() {
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.remove((DashboardSection) null));
+    }
+
+    @Test
+    public void removeAllSections_sectionsAreRemoved() {
+        dashboard.addSection();
+        dashboard.addSection();
+        fakeClientCommunication();
+        dashboard.removeAll();
+        fakeClientCommunication();
+        assertChildComponents(dashboard);
+    }
+
+    @Test
+    public void removeSectionFromParent_sectionIsRemoved() {
+        DashboardSection section = dashboard.addSection();
+        fakeClientCommunication();
+        section.removeFromParent();
+        fakeClientCommunication();
+        assertChildComponents(dashboard);
+    }
+
+    @Test
+    public void addMultipleSections_removeOneFromParent_sectionIsRemoved() {
+        DashboardSection section1 = dashboard.addSection();
+        DashboardSection section2 = dashboard.addSection();
+        fakeClientCommunication();
+        section1.removeFromParent();
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section2);
+    }
+
+    @Test
+    public void setTitleOnExistingSection_itemsAreUpdatedWithCorrectTitles() {
+        DashboardSection section = dashboard.addSection("Section");
+        fakeClientCommunication();
+        section.setTitle("New title");
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addSectionWithWidget_removeWidgetFromDashboard_throwsException() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget = new DashboardWidget();
+        section.add(widget);
+        fakeClientCommunication();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> dashboard.remove(widget));
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addSection_addWidgetToSection_widgetIsAdded() {
+        DashboardSection section = dashboard.addSection();
+        fakeClientCommunication();
+        DashboardWidget widget = new DashboardWidget();
+        section.add(widget);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addSectionAndWidget_removeWidget_widgetRemoved() {
+        DashboardSection section = dashboard.addSection();
+        section.add(new DashboardWidget());
+        DashboardWidget widget = new DashboardWidget();
+        dashboard.add(widget);
+        fakeClientCommunication();
+        dashboard.remove(widget);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addSectionAndWidget_removeSection_sectionRemoved() {
+        DashboardSection section = dashboard.addSection();
+        section.add(new DashboardWidget());
+        DashboardWidget widget = new DashboardWidget();
+        dashboard.add(widget);
+        fakeClientCommunication();
+        dashboard.remove(section);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, widget);
+    }
+
+    @Test
+    public void addSectionAndWidget_removeAll_widgetAndSectionRemoved() {
+        DashboardSection section = dashboard.addSection();
+        section.add(new DashboardWidget());
+        DashboardWidget widget = new DashboardWidget();
+        dashboard.add(widget);
+        fakeClientCommunication();
+        dashboard.removeAll();
+        fakeClientCommunication();
+        assertChildComponents(dashboard);
+    }
+
+    @Test
+    public void addWidgetToSection_widgetIsAdded() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        section.add(widget1, widget2);
+        fakeClientCommunication();
+        assertSectionWidgets(section, widget1, widget2);
+        assertChildComponents(dashboard, section);
+
+    }
+
+    @Test
+    public void addNullWidgetToSection_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        Assert.assertThrows(NullPointerException.class,
+                () -> section.add((DashboardWidget) null));
+        fakeClientCommunication();
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addNullWidgetInArrayToSection_noWidgetIsAdded() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget = new DashboardWidget();
+        try {
+            section.add(widget, null);
+        } catch (NullPointerException e) {
+            // Do nothing
+        }
+        fakeClientCommunication();
+        assertSectionWidgets(section);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetAtIndexToSection_widgetIsCorrectlyAdded() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        DashboardWidget widget3 = new DashboardWidget();
+        section.add(widget1, widget2);
+        fakeClientCommunication();
+        section.addWidgetAtIndex(1, widget3);
+        fakeClientCommunication();
+        assertSectionWidgets(section, widget1, widget3, widget2);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetAtInvalidIndexToSection_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        section.add(widget1);
+        fakeClientCommunication();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> section.addWidgetAtIndex(2, widget2));
+        fakeClientCommunication();
+        assertSectionWidgets(section, widget1);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetAtNegativeIndexToSection_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> section.addWidgetAtIndex(-1, widget));
+        fakeClientCommunication();
+        assertSectionWidgets(section);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addNullWidgetAtIndexToSection_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        fakeClientCommunication();
+        Assert.assertThrows(NullPointerException.class,
+                () -> section.addWidgetAtIndex(0, null));
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void removeWidgetFromSection_widgetIsRemoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        section.add(widget1, widget2);
+        fakeClientCommunication();
+        section.remove(widget1);
+        fakeClientCommunication();
+        assertSectionWidgets(section, widget2);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void removeNullWidgetFromSection_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        fakeClientCommunication();
+        Assert.assertThrows(NullPointerException.class,
+                () -> section.remove((DashboardWidget) null));
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void removeAllWidgetsFromSection_widgetsAreRemoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        section.add(widget1, widget2);
+        fakeClientCommunication();
+        section.removeAll();
+        fakeClientCommunication();
+        assertSectionWidgets(section);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void removeWidgetInSectionFromParent_widgetIsRemoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        section.add(widget1);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        fakeClientCommunication();
+        assertSectionWidgets(section);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addMultipleWidgetsToSection_removeOneFromParent_widgetIsRemoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        section.add(widget1, widget2);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        fakeClientCommunication();
+        assertSectionWidgets(section, widget2);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetsSeparatelyToSection_removeOneFromParent_widgetIsRemoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget1 = new DashboardWidget();
+        DashboardWidget widget2 = new DashboardWidget();
+        section.add(widget1);
+        section.add(widget2);
+        fakeClientCommunication();
+        widget1.removeFromParent();
+        fakeClientCommunication();
+        assertSectionWidgets(section, widget2);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetFromLayoutToSection_widgetIsMoved() {
+        DashboardSection section = dashboard.addSection();
+        Div parent = new Div();
+        ui.add(parent);
+        DashboardWidget widget = new DashboardWidget();
+        parent.add(widget);
+        fakeClientCommunication();
+        section.add(widget);
+        fakeClientCommunication();
+        Assert.assertTrue(parent.getChildren().noneMatch(widget::equals));
+        assertSectionWidgets(section, widget);
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetFromSectionToLayout_widgetIsMoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget = new DashboardWidget();
+        section.add(widget);
+        fakeClientCommunication();
+        Div parent = new Div();
+        ui.add(parent);
+        parent.add(widget);
+        fakeClientCommunication();
+        assertSectionWidgets(section);
+        Assert.assertTrue(parent.getChildren().anyMatch(widget::equals));
+        assertChildComponents(dashboard, section);
+    }
+
+    @Test
+    public void addWidgetToAnotherSection_widgetIsMoved() {
+        DashboardSection section = dashboard.addSection();
+        DashboardWidget widget = new DashboardWidget();
+        section.add(widget);
+        fakeClientCommunication();
+        DashboardSection newSection = dashboard.addSection();
+        newSection.add(widget);
+        fakeClientCommunication();
+        assertSectionWidgets(section);
+        assertSectionWidgets(newSection, widget);
+        assertChildComponents(dashboard, section, newSection);
     }
 
     @Test
@@ -262,7 +636,7 @@ public class DashboardTest {
         widget2.setColspan(2);
         dashboard.add(widget1, widget2);
         fakeClientCommunication();
-        assertWidgetColspans(dashboard, widget1, widget2);
+        assertChildComponents(dashboard, widget1, widget2);
     }
 
     @Test
@@ -272,7 +646,7 @@ public class DashboardTest {
         fakeClientCommunication();
         widget.setColspan(2);
         fakeClientCommunication();
-        assertWidgetColspans(dashboard, widget);
+        assertChildComponents(dashboard, widget);
     }
 
     @Test
@@ -394,49 +768,89 @@ public class DashboardTest {
         });
     }
 
-    private static void assertWidgets(Dashboard dashboard,
-            DashboardWidget... expectedWidgets) {
-        assertVirtualChildren(dashboard, expectedWidgets);
-        Assert.assertEquals(Arrays.asList(expectedWidgets),
-                dashboard.getWidgets());
+    private static void assertChildComponents(Dashboard dashboard,
+            Component... expectedChildren) {
+        List<DashboardWidget> expectedWidgets = getExpectedWidgets(
+                expectedChildren);
+        Assert.assertEquals(expectedWidgets, dashboard.getWidgets());
+
+        List<JsonObject> dashboardItems = getItemsStream(dashboard).toList();
+        assertDashboardItems(dashboardItems, expectedChildren);
     }
 
-    private static void assertVirtualChildren(Dashboard dashboard,
-            Component... components) {
-        // Get a List of the node ids
-        List<Integer> expectedChildNodeIds = Arrays.stream(components)
-                .map(component -> component.getElement().getNode().getId())
-                .toList();
-        // Get the node ids from the items property of the dashboard
-        List<Integer> actualChildNodeIds = getChildNodeIds(dashboard);
-        Assert.assertEquals(expectedChildNodeIds, actualChildNodeIds);
+    private static void assertDashboardItems(List<JsonObject> dashboardItems,
+            Component... expectedChildren) {
+        Assert.assertEquals(expectedChildren.length, dashboardItems.size());
+        for (int i = 0; i < expectedChildren.length; i++) {
+            JsonObject actualChild = dashboardItems.get(i);
+            Component expectedChild = expectedChildren[i];
+            if (expectedChild instanceof DashboardSection section) {
+                assertSectionItem(section, actualChild);
+            } else if (expectedChild instanceof DashboardWidget widget) {
+                assertWidgetItem(widget, actualChild);
+            } else {
+                throw new IllegalArgumentException(
+                        "A dashboard can only contain widgets or sections.");
+            }
+        }
     }
 
-    private static List<Integer> getChildNodeIds(Dashboard dashboard) {
-        return getItemsStream(dashboard)
-                .mapToInt(obj -> (int) obj.getNumber("nodeid")).boxed()
-                .toList();
+    private static void assertSectionItem(DashboardSection expectedSection,
+            JsonObject actualSection) {
+        if (expectedSection.getTitle() == null) {
+            Assert.assertNull(actualSection.get("title"));
+        } else {
+            Assert.assertEquals(expectedSection.getTitle(),
+                    actualSection.getString("title"));
+        }
+        JsonArray sectionItems = actualSection.getArray("items");
+        List<DashboardWidget> expectedSectionWidgets = expectedSection
+                .getWidgets();
+        Assert.assertEquals(expectedSectionWidgets.size(),
+                sectionItems.length());
+        for (int i = 0; i < expectedSectionWidgets.size(); i++) {
+            DashboardWidget expectedWidget = expectedSectionWidgets.get(i);
+            JsonObject actualWidget = sectionItems.getObject(i);
+            assertWidgetItem(expectedWidget, actualWidget);
+        }
     }
 
-    private static void assertWidgetColspans(Dashboard dashboard,
-            DashboardWidget... widgets) {
-        // Get a List of the widget colspans
-        List<Integer> expectedColspans = Arrays.stream(widgets)
-                .map(DashboardWidget::getColspan).toList();
-        // Get the colspans from the items property of the dashboard
-        List<Integer> actualColspans = getWidgetColspans(dashboard);
-        Assert.assertEquals(expectedColspans, actualColspans);
+    private static void assertWidgetItem(DashboardWidget expectedWidget,
+            JsonObject actualWidget) {
+        int expectedNodeId = expectedWidget.getElement().getNode().getId();
+        int actualNodeId = (int) actualWidget.getNumber("nodeid");
+        Assert.assertEquals(expectedNodeId, actualNodeId);
+
+        int expectedColspan = expectedWidget.getColspan();
+        int actualColspan = (int) actualWidget.getNumber("colspan");
+        Assert.assertEquals(expectedColspan, actualColspan);
     }
 
-    private static List<Integer> getWidgetColspans(Dashboard dashboard) {
-        return getItemsStream(dashboard)
-                .mapToInt(obj -> (int) obj.getNumber("colspan")).boxed()
-                .toList();
+    private static List<DashboardWidget> getExpectedWidgets(
+            Component... expectedChildren) {
+        List<DashboardWidget> expectedWidgets = new ArrayList<>();
+        for (Component child : expectedChildren) {
+            if (child instanceof DashboardSection section) {
+                expectedWidgets.addAll(section.getWidgets());
+            } else if (child instanceof DashboardWidget widget) {
+                expectedWidgets.add(widget);
+            } else {
+                throw new IllegalArgumentException(
+                        "A dashboard can only contain widgets or sections.");
+            }
+        }
+        return expectedWidgets;
     }
 
     private static Stream<JsonObject> getItemsStream(Dashboard dashboard) {
         JsonArray jsonArrayOfIds = (JsonArray) dashboard.getElement()
                 .getPropertyRaw("items");
         return JsonUtils.objectStream(jsonArrayOfIds);
+    }
+
+    private static void assertSectionWidgets(DashboardSection section,
+            DashboardWidget... expectedWidgets) {
+        Assert.assertEquals(Arrays.asList(expectedWidgets),
+                section.getWidgets());
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardSectionElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardSectionElement.java
@@ -16,24 +16,24 @@ import com.vaadin.testbench.elementsbase.Element;
 /**
  * @author Vaadin Ltd
  */
-@Element("vaadin-dashboard")
-public class DashboardElement extends TestBenchElement {
+@Element("vaadin-dashboard-section")
+public class DashboardSectionElement extends TestBenchElement {
 
     /**
-     * Returns the widgets in the dashboard.
+     * Returns the title of the section.
      *
-     * @return The widgets in the dashboard
+     * @return the {@code sectionTitle} property from the web component
      */
-    public List<DashboardWidgetElement> getWidgets() {
-        return $(DashboardWidgetElement.class).all();
+    public String getTitle() {
+        return getPropertyString("sectionTitle");
     }
 
     /**
-     * Returns the sections in the dashboard.
+     * Returns the widgets in the section.
      *
-     * @return The sections in the dashboard
+     * @return The widgets in the section
      */
-    public List<DashboardSectionElement> getSections() {
-        return $(DashboardSectionElement.class).all();
+    public List<DashboardWidgetElement> getWidgets() {
+        return $(DashboardWidgetElement.class).all();
     }
 }


### PR DESCRIPTION
## Description

Adds sections support to dashboard.

Added APIs for `HasWidgets` interface:
- `List<DashboardWidget> getWidgets()`: Returns the widgets in the component.
- `void add(DashboardWidget... widgets)`: Adds the given widgets to the component.
- `void addWidgetAtIndex(int index, DashboardWidget widget)`: Adds the given widget as child of the component at the specific index.
- `void remove(DashboardWidget... widgets)`: Removes the given widgets from the component.
- `void removeAll()`: Removes all widgets from the component.

Added APIs for `Dashboard`:
- `DashboardSection addSection()`: Adds an empty section to the dashboard.
- `DashboardSection addSection(String title)`: Adds an empty section with the provided title to the dashboard.
- `void addSection(DashboardSection section)`: Adds the given section to the dashboard.
- `void remove(DashboardSection section)`: Removes the given section from the dashboard.

Added APIs for `DashboardSection`:
- `String getTitle()`: Returns the title of the section.
- `void setTitle(String title)`: Sets the title of the section.
- All the APIs from `HasWidgets` interface

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=76144303

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature