### PR TITLE
chore: upgrade commons-lang3 to 3.14.0 (14.12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
after the `commons-compress` upgrade vaadin/flow#19840 , the `commons-lang3` should be upgraded to avoid the dependency convergence failure