### PR TITLE
feat: add min row height support to dashboard

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -209,6 +209,26 @@ public class Dashboard extends Component {
     }
 
     /**
+     * Returns the minimum row height of the dashboard.
+     *
+     * @return the minimum row height of the dashboard
+     */
+    public String getMinimumRowHeight() {
+        return getStyle().get("--vaadin-dashboard-row-min-height");
+    }
+
+    /**
+     * Sets the minimum row height of the dashboard.
+     *
+     * @param minRowHeight
+     *            the new minimum row height. Pass in {@code null} to set the
+     *            minimum row height back to the default value.
+     */
+    public void setMinimumRowHeight(String minRowHeight) {
+        getStyle().set("--vaadin-dashboard-row-min-height", minRowHeight);
+    }
+
+    /**
      * Returns the gap between the cells of the dashboard.
      *
      * @return the gap between the cells of the dashboard

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -352,6 +352,44 @@ public class DashboardTest {
     }
 
     @Test
+    public void setMinimumRowHeight_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-row-min-height";
+        String valueToSet = "200px";
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+        dashboard.setMinimumRowHeight(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
+        dashboard.setMinimumRowHeight(null);
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    public void setMinimumRowHeightNull_propertyIsRemoved() {
+        dashboard.setMinimumRowHeight("200px");
+        dashboard.setMinimumRowHeight(null);
+        Assert.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-row-min-height"));
+    }
+
+    @Test
+    public void defaultMinimumRowHeightValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getMinimumRowHeight());
+    }
+
+    @Test
+    public void setMinimumRowHeight_valueIsCorrectlyRetrieved() {
+        String valueToSet = "200px";
+        dashboard.setMinimumRowHeight(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getMinimumRowHeight());
+    }
+
+    @Test
+    public void setMinimumRowHeightNull_valueIsCorrectlyRetrieved() {
+        dashboard.setMinimumRowHeight("200px");
+        dashboard.setMinimumRowHeight(null);
+        Assert.assertNull(dashboard.getMinimumRowHeight());
+    }
+
+    @Test
     public void setGap_valueIsCorrectlySet() {
         String propertyName = "--vaadin-dashboard-gap";
         String valueToSet = "10px";


### PR DESCRIPTION
## Description

Adds minimum row height support to dashboard.

Added API:
- `String getMinimumRowHeight()`: Returns the minimum row height of the dashboard
- `void setMinimumRowHeight(String minRowHeight)`: Sets the minimum row height of the dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=78740444

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature