### PR TITLE
feat: add header support to dashboard widget

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -16,7 +16,6 @@ import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -30,8 +29,6 @@ public class DashboardPage extends Div {
 
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
-        widget1.setContent(new Div("Some content"));
-        widget1.setHeader(new Span("Some header"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -31,6 +31,7 @@ public class DashboardPage extends Div {
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
         widget1.setContent(new Div("Some content"));
+        widget1.setHeader(new Span("Some header"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -29,6 +30,7 @@ public class DashboardPage extends Div {
 
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
+        widget1.setContent(new Div("Some content"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
@@ -29,6 +29,7 @@ public class DashboardWidgetPage extends Div {
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
         widget1.setContent(new Div("Some content"));
+        widget1.setHeader(new Span("Some header"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
@@ -84,7 +84,28 @@ public class DashboardWidgetPage extends Div {
         removeContentOfTheFirstWidget
                 .setId("remove-content-of-the-first-widget");
 
+        NativeButton updateHeaderOfTheFirstWidget = new NativeButton(
+                "Update header of the first widget");
+        updateHeaderOfTheFirstWidget.addClickListener(click -> {
+            List<DashboardWidget> widgets = dashboard.getWidgets();
+            if (!widgets.isEmpty()) {
+                widgets.get(0).setHeader(new Span("Updated header"));
+            }
+        });
+        updateHeaderOfTheFirstWidget.setId("update-header-of-the-first-widget");
+
+        NativeButton removeHeaderOfTheFirstWidget = new NativeButton(
+                "Remove header of the first widget");
+        removeHeaderOfTheFirstWidget.addClickListener(click -> {
+            List<DashboardWidget> widgets = dashboard.getWidgets();
+            if (!widgets.isEmpty()) {
+                widgets.get(0).setHeader(null);
+            }
+        });
+        removeHeaderOfTheFirstWidget.setId("remove-header-of-the-first-widget");
+
         add(updateContentOfTheFirstWidget, removeContentOfTheFirstWidget,
+                updateHeaderOfTheFirstWidget, removeHeaderOfTheFirstWidget,
                 increaseAllColspansBy1, decreaseAllColspansBy1,
                 increaseAllRowspansBy1, decreaseAllRowspansBy1, dashboard);
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetIT.java
@@ -104,4 +104,34 @@ public class DashboardWidgetIT extends AbstractComponentIT {
         Assert.assertFalse(firstWidget.getText().contains("Some content"));
         Assert.assertNull(firstWidget.getContent());
     }
+
+    @Test
+    public void widgetWithInitialHeader_headerIsCorrectlySet() {
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertNotNull(firstWidget.getHeader());
+        Assert.assertTrue(
+                firstWidget.getHeader().getText().contains("Some header"));
+    }
+
+    @Test
+    public void updateWidgetHeader_headerIsCorrectlyUpdated() {
+        clickElementWithJs("update-header-of-the-first-widget");
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertNotNull(firstWidget.getHeader());
+        Assert.assertFalse(
+                firstWidget.getHeader().getText().contains("Some header"));
+        Assert.assertTrue(
+                firstWidget.getHeader().getText().contains("Updated header"));
+    }
+
+    @Test
+    public void removeWidgetHeader_headerIsCorrectlyRemoved() {
+        clickElementWithJs("remove-header-of-the-first-widget");
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertFalse(firstWidget.getText().contains("Some header"));
+        Assert.assertNull(firstWidget.getHeader());
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -12,6 +12,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.SlotUtils;
 
 /**
  * @author Vaadin Ltd
@@ -130,6 +131,28 @@ public class DashboardWidget extends Component {
         if (content != null) {
             getElement().appendChild(content.getElement());
         }
+    }
+
+    /**
+     * Gets the component in the header slot of this widget.
+     *
+     * @return the header component of this widget, or {@code null} if no header
+     *         component has been set
+     */
+    public Component getHeader() {
+        return SlotUtils.getChildInSlot(this, "header");
+    }
+
+    /**
+     * Sets the component in the header slot of this widget, replacing any
+     * existing header component.
+     *
+     * @param header
+     *            the component to set, can be {@code null} to remove existing
+     *            header component
+     */
+    public void setHeader(Component header) {
+        SlotUtils.setSlot(this, "header", header);
     }
 
     private void notifyParentDashboardOrSection() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -168,6 +168,86 @@ public class DashboardWidgetTest {
         Assert.assertNull(widget.getContent());
     }
 
+    @Test
+    public void defaultHeaderIsNull() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertNull(widget.getHeader());
+    }
+
+    @Test
+    public void setHeaderToEmptyWidget_correctHeaderIsSet() {
+        Div header = new Div();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setHeader(header);
+        Assert.assertEquals(header, widget.getHeader());
+    }
+
+    @Test
+    public void setAnotherHeaderToNonEmptyWidget_correctHeaderIsSet() {
+        DashboardWidget widget = new DashboardWidget();
+        widget.setHeader(new Div());
+        Span newHeader = new Span();
+        widget.setHeader(newHeader);
+        Assert.assertEquals(newHeader, widget.getHeader());
+    }
+
+    @Test
+    public void setTheSameHeaderToNonEmptyWidget_correctHeaderIsSet() {
+        Div header = new Div();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setHeader(header);
+        widget.setHeader(header);
+        Assert.assertEquals(header, widget.getHeader());
+    }
+
+    @Test
+    public void setNullHeaderToNonEmptyWidget_headerIsRemoved() {
+        DashboardWidget widget = new DashboardWidget();
+        widget.setHeader(new Div());
+        widget.setHeader(null);
+        Assert.assertNull(widget.getHeader());
+    }
+
+    @Test
+    public void setNullHeaderToWidgetWithContent_contentIsNotRemoved() {
+        Div content = new Div();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setContent(content);
+        widget.setHeader(null);
+        Assert.assertEquals(content, widget.getContent());
+    }
+
+    @Test
+    public void setNullContentToWidgetWithHeader_headerIsNotRemoved() {
+        Div header = new Div();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setHeader(header);
+        widget.setContent(null);
+        Assert.assertEquals(header, widget.getHeader());
+    }
+
+    @Test
+    public void setHeaderToWidgetWithContent_contentAndHeaderCorrectlyRetrieved() {
+        Div content = new Div();
+        Span header = new Span();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setContent(content);
+        widget.setHeader(header);
+        Assert.assertEquals(content, widget.getContent());
+        Assert.assertEquals(header, widget.getHeader());
+    }
+
+    @Test
+    public void setContentToWidgetWithHeader_contentAndHeaderCorrectlyRetrieved() {
+        Div content = new Div();
+        Span header = new Span();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setHeader(header);
+        widget.setContent(content);
+        Assert.assertEquals(content, widget.getContent());
+        Assert.assertEquals(header, widget.getHeader());
+    }
+
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -60,6 +60,18 @@ public class DashboardWidgetElement extends TestBenchElement {
         return content == null ? null : (TestBenchElement) content;
     }
 
+    /**
+     * Returns the header of the widget.
+     *
+     * @return the header element set to the widget
+     */
+    public TestBenchElement getHeader() {
+        Object header = executeScript(
+                "return Array.from(arguments[0].children).filter(child => child.slot === 'header')[0]",
+                this);
+        return header == null ? null : (TestBenchElement) header;
+    }
+
     private String getComputedCssValue(String propertyName) {
         return (String) executeScript(
                 "return getComputedStyle(arguments[0]).getPropertyValue(arguments[1]);",


### PR DESCRIPTION
## Description

Adds APIs for getting and setting widget header.

Added API:
- `Component getHeader()`: Returns the header of the widget
- `void setHeader(Component header)`:  Sets the header of the widget (`null` to remove header)

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=78854087

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature