### PR TITLE
feat: add content support to dashboard widget

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -197,7 +197,8 @@ public class DashboardPage extends Div {
         add(addMultipleWidgets, removeFirstAndLastWidgets, removeAll,
                 addSectionWithMultipleWidgets, removeFirstSection,
                 addWidgetToFirstSection, removeFirstWidgetFromFirstSection,
-                removeAllFromFirstSection, updateContentOfTheFirstWidget, removeContentOfTheFirstWidget, setMaximumColumnCount1,
+                removeAllFromFirstSection, updateContentOfTheFirstWidget,
+                removeContentOfTheFirstWidget, setMaximumColumnCount1,
                 setMaximumColumnCountNull, increaseAllColspansBy1,
                 decreaseAllColspansBy1, dashboard);
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -29,6 +30,7 @@ public class DashboardPage extends Div {
 
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
+        widget1.setContent(new Div("Some content"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();
@@ -170,10 +172,32 @@ public class DashboardPage extends Div {
                 .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
         decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
 
+        NativeButton updateContentOfTheFirstWidget = new NativeButton(
+                "Update content of the first widget");
+        updateContentOfTheFirstWidget.addClickListener(click -> {
+            List<DashboardWidget> widgets = dashboard.getWidgets();
+            if (!widgets.isEmpty()) {
+                widgets.get(0).setContent(new Span("Updated content"));
+            }
+        });
+        updateContentOfTheFirstWidget
+                .setId("update-content-of-the-first-widget");
+
+        NativeButton removeContentOfTheFirstWidget = new NativeButton(
+                "Remove content of the first widget");
+        removeContentOfTheFirstWidget.addClickListener(click -> {
+            List<DashboardWidget> widgets = dashboard.getWidgets();
+            if (!widgets.isEmpty()) {
+                widgets.get(0).setContent(null);
+            }
+        });
+        removeContentOfTheFirstWidget
+                .setId("remove-content-of-the-first-widget");
+
         add(addMultipleWidgets, removeFirstAndLastWidgets, removeAll,
                 addSectionWithMultipleWidgets, removeFirstSection,
                 addWidgetToFirstSection, removeFirstWidgetFromFirstSection,
-                removeAllFromFirstSection, setMaximumColumnCount1,
+                removeAllFromFirstSection, updateContentOfTheFirstWidget, removeContentOfTheFirstWidget, setMaximumColumnCount1,
                 setMaximumColumnCountNull, increaseAllColspansBy1,
                 decreaseAllColspansBy1, dashboard);
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -16,7 +16,6 @@ import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -30,7 +29,6 @@ public class DashboardPage extends Div {
 
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
-        widget1.setContent(new Div("Some content"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();
@@ -118,36 +116,6 @@ public class DashboardPage extends Div {
                 .ifPresent(dashboard::remove));
         removeFirstSection.setId("remove-first-section");
 
-        NativeButton addWidgetToFirstSection = new NativeButton(
-                "Add widget to first section");
-        addWidgetToFirstSection.addClickListener(
-                click -> getFirstSection(dashboard).ifPresent(section -> {
-                    DashboardWidget newWidget = new DashboardWidget();
-                    newWidget.setTitle("New widget");
-                    section.add(newWidget);
-                }));
-        addWidgetToFirstSection.setId("add-widget-to-first-section");
-
-        NativeButton removeFirstWidgetFromFirstSection = new NativeButton(
-                "Remove first widget from first section");
-        removeFirstWidgetFromFirstSection.addClickListener(
-                click -> getFirstSection(dashboard).ifPresent(section -> {
-                    List<DashboardWidget> currentWidgets = section.getWidgets();
-                    if (currentWidgets.isEmpty()) {
-                        return;
-                    }
-                    section.remove(currentWidgets.get(0));
-                }));
-        removeFirstWidgetFromFirstSection
-                .setId("remove-first-widget-from-first-section");
-
-        NativeButton removeAllFromFirstSection = new NativeButton(
-                "Remove all from first section");
-        removeAllFromFirstSection
-                .addClickListener(click -> getFirstSection(dashboard)
-                        .ifPresent(DashboardSection::removeAll));
-        removeAllFromFirstSection.setId("remove-all-from-first-section");
-
         NativeButton setMaximumColumnCount1 = new NativeButton(
                 "Set maximum column count 1");
         setMaximumColumnCount1
@@ -160,47 +128,9 @@ public class DashboardPage extends Div {
                 click -> dashboard.setMaximumColumnCount(null));
         setMaximumColumnCountNull.setId("set-maximum-column-count-null");
 
-        NativeButton increaseAllColspansBy1 = new NativeButton(
-                "Increase all colspans by 1");
-        increaseAllColspansBy1.addClickListener(click -> dashboard.getWidgets()
-                .forEach(widget -> widget.setColspan(widget.getColspan() + 1)));
-        increaseAllColspansBy1.setId("increase-all-colspans-by-1");
-
-        NativeButton decreaseAllColspansBy1 = new NativeButton(
-                "Decrease all colspans by 1");
-        decreaseAllColspansBy1.addClickListener(click -> dashboard.getWidgets()
-                .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
-        decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
-
-        NativeButton updateContentOfTheFirstWidget = new NativeButton(
-                "Update content of the first widget");
-        updateContentOfTheFirstWidget.addClickListener(click -> {
-            List<DashboardWidget> widgets = dashboard.getWidgets();
-            if (!widgets.isEmpty()) {
-                widgets.get(0).setContent(new Span("Updated content"));
-            }
-        });
-        updateContentOfTheFirstWidget
-                .setId("update-content-of-the-first-widget");
-
-        NativeButton removeContentOfTheFirstWidget = new NativeButton(
-                "Remove content of the first widget");
-        removeContentOfTheFirstWidget.addClickListener(click -> {
-            List<DashboardWidget> widgets = dashboard.getWidgets();
-            if (!widgets.isEmpty()) {
-                widgets.get(0).setContent(null);
-            }
-        });
-        removeContentOfTheFirstWidget
-                .setId("remove-content-of-the-first-widget");
-
         add(addMultipleWidgets, removeFirstAndLastWidgets, removeAll,
                 addSectionWithMultipleWidgets, removeFirstSection,
-                addWidgetToFirstSection, removeFirstWidgetFromFirstSection,
-                removeAllFromFirstSection, updateContentOfTheFirstWidget,
-                removeContentOfTheFirstWidget, setMaximumColumnCount1,
-                setMaximumColumnCountNull, increaseAllColspansBy1,
-                decreaseAllColspansBy1, dashboard);
+                setMaximumColumnCount1, setMaximumColumnCountNull, dashboard);
     }
 
     private static Optional<DashboardSection> getFirstSection(

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionPage.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardSection;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+/**
+ * @author Vaadin Ltd
+ */
+@Route("vaadin-dashboard-section")
+public class DashboardSectionPage extends Div {
+
+    public DashboardSectionPage() {
+        Dashboard dashboard = new Dashboard();
+
+        DashboardWidget widget1InSection1 = new DashboardWidget();
+        widget1InSection1.setTitle("Widget 1 in Section 1");
+        widget1InSection1.setId("widget-1-in-section-1");
+
+        DashboardWidget widget2InSection1 = new DashboardWidget();
+        widget2InSection1.setTitle("Widget 2 in Section 1");
+        widget2InSection1.setId("widget-2-in-section-1");
+
+        DashboardWidget widget1InSection2 = new DashboardWidget();
+        widget1InSection2.setTitle("Widget 1 in Section 2");
+        widget1InSection2.setId("widget-1-in-section-2");
+
+        DashboardSection section1 = new DashboardSection("Section 1");
+        section1.add(widget1InSection1, widget2InSection1);
+        dashboard.addSection(section1);
+
+        DashboardSection section2 = dashboard.addSection("Section 2");
+        section2.add(widget1InSection2);
+
+        NativeButton addWidgetToFirstSection = new NativeButton(
+                "Add widget to first section");
+        addWidgetToFirstSection.addClickListener(
+                click -> getFirstSection(dashboard).ifPresent(section -> {
+                    DashboardWidget newWidget = new DashboardWidget();
+                    newWidget.setTitle("New widget");
+                    section.add(newWidget);
+                }));
+        addWidgetToFirstSection.setId("add-widget-to-first-section");
+
+        NativeButton removeFirstWidgetFromFirstSection = new NativeButton(
+                "Remove first widget from first section");
+        removeFirstWidgetFromFirstSection.addClickListener(
+                click -> getFirstSection(dashboard).ifPresent(section -> {
+                    List<DashboardWidget> currentWidgets = section.getWidgets();
+                    if (currentWidgets.isEmpty()) {
+                        return;
+                    }
+                    section.remove(currentWidgets.get(0));
+                }));
+        removeFirstWidgetFromFirstSection
+                .setId("remove-first-widget-from-first-section");
+
+        NativeButton removeAllFromFirstSection = new NativeButton(
+                "Remove all from first section");
+        removeAllFromFirstSection
+                .addClickListener(click -> getFirstSection(dashboard)
+                        .ifPresent(DashboardSection::removeAll));
+        removeAllFromFirstSection.setId("remove-all-from-first-section");
+
+        add(addWidgetToFirstSection, removeFirstWidgetFromFirstSection,
+                removeAllFromFirstSection, dashboard);
+    }
+
+    private static Optional<DashboardSection> getFirstSection(
+            Dashboard dashboard) {
+        return dashboard.getChildren()
+                .filter(DashboardSection.class::isInstance)
+                .map(DashboardSection.class::cast).findFirst();
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
@@ -8,8 +8,13 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.List;
+
+import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -19,8 +24,54 @@ import com.vaadin.flow.router.Route;
 public class DashboardWidgetPage extends Div {
 
     public DashboardWidgetPage() {
-        DashboardWidget widget = new DashboardWidget();
-        widget.setTitle("Widget");
-        add(widget);
+        Dashboard dashboard = new Dashboard();
+
+        DashboardWidget widget1 = new DashboardWidget();
+        widget1.setTitle("Widget 1");
+        widget1.setContent(new Div("Some content"));
+        widget1.setId("widget-1");
+
+        DashboardWidget widget2 = new DashboardWidget();
+        widget2.setTitle("Widget 2");
+        widget2.setId("widget-2");
+
+        dashboard.add(widget1, widget2);
+
+        NativeButton increaseAllColspansBy1 = new NativeButton(
+                "Increase all colspans by 1");
+        increaseAllColspansBy1.addClickListener(click -> dashboard.getWidgets()
+                .forEach(widget -> widget.setColspan(widget.getColspan() + 1)));
+        increaseAllColspansBy1.setId("increase-all-colspans-by-1");
+
+        NativeButton decreaseAllColspansBy1 = new NativeButton(
+                "Decrease all colspans by 1");
+        decreaseAllColspansBy1.addClickListener(click -> dashboard.getWidgets()
+                .forEach(widget -> widget.setColspan(widget.getColspan() - 1)));
+        decreaseAllColspansBy1.setId("decrease-all-colspans-by-1");
+
+        NativeButton updateContentOfTheFirstWidget = new NativeButton(
+                "Update content of the first widget");
+        updateContentOfTheFirstWidget.addClickListener(click -> {
+            List<DashboardWidget> widgets = dashboard.getWidgets();
+            if (!widgets.isEmpty()) {
+                widgets.get(0).setContent(new Span("Updated content"));
+            }
+        });
+        updateContentOfTheFirstWidget
+                .setId("update-content-of-the-first-widget");
+
+        NativeButton removeContentOfTheFirstWidget = new NativeButton(
+                "Remove content of the first widget");
+        removeContentOfTheFirstWidget.addClickListener(click -> {
+            List<DashboardWidget> widgets = dashboard.getWidgets();
+            if (!widgets.isEmpty()) {
+                widgets.get(0).setContent(null);
+            }
+        });
+        removeContentOfTheFirstWidget
+                .setId("remove-content-of-the-first-widget");
+
+        add(updateContentOfTheFirstWidget, removeContentOfTheFirstWidget,
+                increaseAllColspansBy1, decreaseAllColspansBy1, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -216,7 +216,8 @@ public class DashboardIT extends AbstractComponentIT {
     private static void assertWidgetsByTitle(
             List<DashboardWidgetElement> actualWidgets,
             String... expectedWidgetTitles) {
-        List<String> widgetTitles = actualWidgets.stream().map(DashboardWidgetElement::getTitle).toList();
+        List<String> widgetTitles = actualWidgets.stream()
+                .map(DashboardWidgetElement::getTitle).toList();
         Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -173,6 +173,36 @@ public class DashboardIT extends AbstractComponentIT {
                 widget.getColspan()));
     }
 
+    @Test
+    public void widgetWithInitialContent_contentIsCorrectlySet() {
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertNotNull(firstWidget.getContent());
+        Assert.assertTrue(
+                firstWidget.getContent().getText().contains("Some content"));
+    }
+
+    @Test
+    public void updateWidgetContent_contentIsCorrectlyUpdated() {
+        clickElementWithJs("update-content-of-the-first-widget");
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertNotNull(firstWidget.getContent());
+        Assert.assertFalse(
+                firstWidget.getContent().getText().contains("Some content"));
+        Assert.assertTrue(
+                firstWidget.getContent().getText().contains("Updated content"));
+    }
+
+    @Test
+    public void removeWidgetContent_contentIsCorrectlyRemoved() {
+        clickElementWithJs("remove-content-of-the-first-widget");
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertFalse(firstWidget.getText().contains("Some content"));
+        Assert.assertNull(firstWidget.getContent());
+    }
+
     private void assertDashboardWidgetsByTitle(String... expectedWidgetTitles) {
         assertWidgetsByTitle(dashboardElement.getWidgets(),
                 expectedWidgetTitles);
@@ -186,8 +216,7 @@ public class DashboardIT extends AbstractComponentIT {
     private static void assertWidgetsByTitle(
             List<DashboardWidgetElement> actualWidgets,
             String... expectedWidgetTitles) {
-        List<String> widgetTitles = actualWidgets.stream()
-                .map(DashboardWidgetElement::getTitle).toList();
+        List<String> widgetTitles = actualWidgets.stream().map(DashboardWidgetElement::getTitle).toList();
         Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -101,34 +101,6 @@ public class DashboardIT extends AbstractComponentIT {
     }
 
     @Test
-    public void addWidgetToFirstSection_widgetsAreAdded() {
-        clickElementWithJs("add-widget-to-first-section");
-        List<DashboardSectionElement> sections = dashboardElement.getSections();
-        DashboardSectionElement firstSection = sections.get(0);
-        Assert.assertEquals("Section 1", firstSection.getTitle());
-        assertSectionWidgetsByTitle(firstSection, "Widget 1 in Section 1",
-                "Widget 2 in Section 1", "New widget");
-    }
-
-    @Test
-    public void removeFirstWidgetFromFirstSection_widgetIsRemoved() {
-        clickElementWithJs("remove-first-widget-from-first-section");
-        List<DashboardSectionElement> sections = dashboardElement.getSections();
-        DashboardSectionElement firstSection = sections.get(0);
-        Assert.assertEquals("Section 1", firstSection.getTitle());
-        assertSectionWidgetsByTitle(firstSection, "Widget 2 in Section 1");
-    }
-
-    @Test
-    public void removeAllFromFirstSection_widgetsAreRemoved() {
-        clickElementWithJs("remove-all-from-first-section");
-        List<DashboardSectionElement> sections = dashboardElement.getSections();
-        DashboardSectionElement firstSection = sections.get(0);
-        Assert.assertEquals("Section 1", firstSection.getTitle());
-        assertSectionWidgetsByTitle(firstSection);
-    }
-
-    @Test
     public void changeMaximumColumnCountTo1_widgetsShouldBeOnTheSameColumn() {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         // The first two widgets should initially be on the same horizontal line
@@ -153,54 +125,6 @@ public class DashboardIT extends AbstractComponentIT {
         // The widgets should be on the same horizontal line
         int yOfWidget1 = widgets.get(0).getLocation().getY();
         Assert.assertEquals(yOfWidget1, widgets.get(1).getLocation().getY());
-    }
-
-    @Test
-    public void defaultWidgetColspanIsCorrect() {
-        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
-        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(1),
-                widget.getColspan()));
-    }
-
-    @Test
-    public void updateColspans_colspansForAllWidgetsUpdated() {
-        clickElementWithJs("increase-all-colspans-by-1");
-        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
-        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(2),
-                widget.getColspan()));
-        clickElementWithJs("decrease-all-colspans-by-1");
-        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(1),
-                widget.getColspan()));
-    }
-
-    @Test
-    public void widgetWithInitialContent_contentIsCorrectlySet() {
-        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
-                .get(0);
-        Assert.assertNotNull(firstWidget.getContent());
-        Assert.assertTrue(
-                firstWidget.getContent().getText().contains("Some content"));
-    }
-
-    @Test
-    public void updateWidgetContent_contentIsCorrectlyUpdated() {
-        clickElementWithJs("update-content-of-the-first-widget");
-        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
-                .get(0);
-        Assert.assertNotNull(firstWidget.getContent());
-        Assert.assertFalse(
-                firstWidget.getContent().getText().contains("Some content"));
-        Assert.assertTrue(
-                firstWidget.getContent().getText().contains("Updated content"));
-    }
-
-    @Test
-    public void removeWidgetContent_contentIsCorrectlyRemoved() {
-        clickElementWithJs("remove-content-of-the-first-widget");
-        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
-                .get(0);
-        Assert.assertFalse(firstWidget.getText().contains("Some content"));
-        Assert.assertNull(firstWidget.getContent());
     }
 
     private void assertDashboardWidgetsByTitle(String... expectedWidgetTitles) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionIT.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
+import com.vaadin.flow.component.dashboard.testbench.DashboardSectionElement;
+import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * @author Vaadin Ltd
+ */
+@TestPath("vaadin-dashboard-section")
+public class DashboardSectionIT extends AbstractComponentIT {
+
+    private DashboardElement dashboardElement;
+
+    @Before
+    public void init() {
+        open();
+        dashboardElement = $(DashboardElement.class).waitForFirst();
+    }
+
+    @Test
+    public void addWidgetToFirstSection_widgetsAreAdded() {
+        clickElementWithJs("add-widget-to-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 1", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection, "Widget 1 in Section 1",
+                "Widget 2 in Section 1", "New widget");
+    }
+
+    @Test
+    public void removeFirstWidgetFromFirstSection_widgetIsRemoved() {
+        clickElementWithJs("remove-first-widget-from-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 1", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection, "Widget 2 in Section 1");
+    }
+
+    @Test
+    public void removeAllFromFirstSection_widgetsAreRemoved() {
+        clickElementWithJs("remove-all-from-first-section");
+        List<DashboardSectionElement> sections = dashboardElement.getSections();
+        DashboardSectionElement firstSection = sections.get(0);
+        Assert.assertEquals("Section 1", firstSection.getTitle());
+        assertSectionWidgetsByTitle(firstSection);
+    }
+
+    private static void assertSectionWidgetsByTitle(
+            DashboardSectionElement section, String... expectedWidgetTitles) {
+        assertWidgetsByTitle(section.getWidgets(), expectedWidgetTitles);
+    }
+
+    private static void assertWidgetsByTitle(
+            List<DashboardWidgetElement> actualWidgets,
+            String... expectedWidgetTitles) {
+        List<String> widgetTitles = actualWidgets.stream()
+                .map(DashboardWidgetElement::getTitle).toList();
+        Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetIT.java
@@ -8,10 +8,13 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
 import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
@@ -22,16 +25,65 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-dashboard-widget")
 public class DashboardWidgetIT extends AbstractComponentIT {
 
-    private DashboardWidgetElement widget;
+    private DashboardElement dashboardElement;
 
     @Before
     public void init() {
         open();
-        widget = $(DashboardWidgetElement.class).waitForFirst();
+        dashboardElement = $(DashboardElement.class).waitForFirst();
     }
 
     @Test
     public void titleIsSetCorrectly() {
-        Assert.assertEquals("Widget", widget.getTitle());
+        Assert.assertEquals("Widget 1",
+                dashboardElement.getWidgets().get(0).getTitle());
+    }
+
+    @Test
+    public void defaultWidgetColspanIsCorrect() {
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(1),
+                widget.getColspan()));
+    }
+
+    @Test
+    public void updateColspans_colspansForAllWidgetsUpdated() {
+        clickElementWithJs("increase-all-colspans-by-1");
+        List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
+        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(2),
+                widget.getColspan()));
+        clickElementWithJs("decrease-all-colspans-by-1");
+        widgets.forEach(widget -> Assert.assertEquals(Integer.valueOf(1),
+                widget.getColspan()));
+    }
+
+    @Test
+    public void widgetWithInitialContent_contentIsCorrectlySet() {
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertNotNull(firstWidget.getContent());
+        Assert.assertTrue(
+                firstWidget.getContent().getText().contains("Some content"));
+    }
+
+    @Test
+    public void updateWidgetContent_contentIsCorrectlyUpdated() {
+        clickElementWithJs("update-content-of-the-first-widget");
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertNotNull(firstWidget.getContent());
+        Assert.assertFalse(
+                firstWidget.getContent().getText().contains("Some content"));
+        Assert.assertTrue(
+                firstWidget.getContent().getText().contains("Updated content"));
+    }
+
+    @Test
+    public void removeWidgetContent_contentIsCorrectlyRemoved() {
+        clickElementWithJs("remove-content-of-the-first-widget");
+        DashboardWidgetElement firstWidget = dashboardElement.getWidgets()
+                .get(0);
+        Assert.assertFalse(firstWidget.getText().contains("Some content"));
+        Assert.assertNull(firstWidget.getContent());
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -78,7 +78,9 @@ public class DashboardWidget extends Component {
      * @return the content of the widget
      */
     public Component getContent() {
-        return getChildren().findFirst().orElse(null);
+        return getChildren().filter(
+                component -> !component.getElement().hasAttribute("slot"))
+                .findAny().orElse(null);
     }
 
     /**
@@ -89,12 +91,14 @@ public class DashboardWidget extends Component {
      *            the content to set
      */
     public void setContent(Component content) {
-        if (content == null) {
-            getElement().removeAllChildren();
+        Component initialContent = getContent();
+        if (initialContent == content) {
             return;
         }
-        if (!content.equals(getContent())) {
-            getElement().removeAllChildren();
+        if (initialContent != null) {
+            getElement().removeChild(initialContent.getElement());
+        }
+        if (content != null) {
             getElement().appendChild(content.getElement());
         }
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -71,6 +71,34 @@ public class DashboardWidget extends Component {
         notifyParentDashboardOrSection();
     }
 
+    /**
+     * Returns the content of the widget. Returns {@code null} if the widget has
+     * no content.
+     *
+     * @return the content of the widget
+     */
+    public Component getContent() {
+        return getChildren().findFirst().orElse(null);
+    }
+
+    /**
+     * Sets the content to the widget. Set {@code null} to remove the current
+     * content.
+     *
+     * @param content
+     *            the content to set
+     */
+    public void setContent(Component content) {
+        if (content == null) {
+            getElement().removeAllChildren();
+            return;
+        }
+        if (!content.equals(getContent())) {
+            getElement().removeAllChildren();
+            getElement().appendChild(content.getElement());
+        }
+    }
+
     private void notifyParentDashboardOrSection() {
         getParent().ifPresent(parent -> {
             if (parent instanceof Dashboard dashboard) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.server.VaadinSession;
 
 public class DashboardWidgetTest {
@@ -104,6 +105,46 @@ public class DashboardWidgetTest {
         DashboardWidget widget = new DashboardWidget();
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> widget.setColspan(0));
+    }
+
+    @Test
+    public void defaultContentIsNull() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertNull(widget.getContent());
+    }
+
+    @Test
+    public void setContentToEmptyWidget_correctContentIsSet() {
+        Div content = new Div();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setContent(content);
+        Assert.assertEquals(content, widget.getContent());
+    }
+
+    @Test
+    public void setAnotherContentToNonEmptyWidget_correctContentIsSet() {
+        DashboardWidget widget = new DashboardWidget();
+        widget.setContent(new Div());
+        Span newContent = new Span();
+        widget.setContent(newContent);
+        Assert.assertEquals(newContent, widget.getContent());
+    }
+
+    @Test
+    public void setTheSameContentToNonEmptyWidget_correctContentIsSet() {
+        Div content = new Div();
+        DashboardWidget widget = new DashboardWidget();
+        widget.setContent(content);
+        widget.setContent(content);
+        Assert.assertEquals(content, widget.getContent());
+    }
+
+    @Test
+    public void setNullContentToNonEmptyWidget_contentIsRemoved() {
+        DashboardWidget widget = new DashboardWidget();
+        widget.setContent(new Div());
+        widget.setContent(null);
+        Assert.assertNull(widget.getContent());
     }
 
     private void fakeClientCommunication() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -37,6 +37,18 @@ public class DashboardWidgetElement extends TestBenchElement {
         return colspanStr.isEmpty() ? null : Integer.valueOf(colspanStr);
     }
 
+    /**
+     * Returns the content of the widget.
+     *
+     * @return the content element set to the widget
+     */
+    public TestBenchElement getContent() {
+        Object content = executeScript(
+                "return Array.from(arguments[0].children).filter(child => child.slot !== 'title')[0]",
+                this);
+        return content == null ? null : (TestBenchElement) content;
+    }
+
     private String getComputedCssValue(String propertyName) {
         return (String) executeScript(
                 "return getComputedStyle(arguments[0]).getPropertyValue(arguments[1]);",

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -44,7 +44,7 @@ public class DashboardWidgetElement extends TestBenchElement {
      */
     public TestBenchElement getContent() {
         Object content = executeScript(
-                "return Array.from(arguments[0].children).filter(child => child.slot !== 'title')[0]",
+                "return Array.from(arguments[0].children).filter(child => !child.slot)[0]",
                 this);
         return content == null ? null : (TestBenchElement) content;
     }


### PR DESCRIPTION
## Description

Adds APIs for getting and setting widget content.

Added API:
- `Component getContent()`: Returns the content of the widget
- `void setContent(Component content)`:  Sets the content of the widget (`null` to remove content)

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=78740474

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature