### PR TITLE
fix: preserve maxFiles set after MultiFileReceiver in same roundtrip

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/SwitchReceiversPage.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/SwitchReceiversPage.java
@@ -48,7 +48,8 @@ public class SwitchReceiversPage extends Div {
                     upload.setReceiver(buffer);
                     upload.setMaxFiles(3);
                 });
-        setMultiFileReceiverAndMaxFiles.setId("set-multi-file-receiver-and-max-files");
+        setMultiFileReceiverAndMaxFiles
+                .setId("set-multi-file-receiver-and-max-files");
 
         add(upload, setSingleFileReceiver, setMultiFileReceiver,
                 setMultiFileReceiverAndMaxFiles);

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/SwitchReceiversPage.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/SwitchReceiversPage.java
@@ -42,7 +42,16 @@ public class SwitchReceiversPage extends Div {
                 });
         setMultiFileReceiver.setId("set-multi-file-receiver");
 
-        add(upload, setSingleFileReceiver, setMultiFileReceiver);
+        NativeButton setMultiFileReceiverAndMaxFiles = new NativeButton(
+                "Set multi file receiver and max files", event -> {
+                    MultiFileMemoryBuffer buffer = new MultiFileMemoryBuffer();
+                    upload.setReceiver(buffer);
+                    upload.setMaxFiles(3);
+                });
+        setMultiFileReceiverAndMaxFiles.setId("set-multi-file-receiver-and-max-files");
+
+        add(upload, setSingleFileReceiver, setMultiFileReceiver,
+                setMultiFileReceiverAndMaxFiles);
     }
 
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversIT.java
@@ -50,5 +50,10 @@ public class SwitchReceiversIT extends AbstractUploadIT {
         Assert.assertEquals(
                 "The maxFiles property should equal 1 when single file receiver is set",
                 1, (int) upload.getPropertyInteger("maxFiles"));
+
+        $("button").id("set-multi-file-receiver-and-max-files").click();
+        Assert.assertEquals(
+                "The maxFiles property should equal 3 when multi file receiver and max files is set",
+                3, (int) upload.getPropertyInteger("maxFiles"));
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -221,7 +221,7 @@ public class Upload extends Component implements HasSize, HasStyle {
         return (int) getElement().getProperty("maxFiles", 0.0);
     }
 
-    private void resetMaxFiles() {
+    private void removeMaxFiles() {
         getElement().removeProperty("maxFiles");
         getElement().executeJs("this.maxFiles = Infinity");
     }
@@ -638,12 +638,20 @@ public class Upload extends Component implements HasSize, HasStyle {
      *            receiver to use for file reception
      */
     public void setReceiver(Receiver receiver) {
+        Receiver oldReceiver = this.receiver;
         this.receiver = receiver;
-        if (receiver instanceof MultiFileReceiver) {
-            resetMaxFiles();
+
+        if (isMultiFileReceiver(receiver)) {
+            if (oldReceiver != null && !isMultiFileReceiver(oldReceiver)) {
+                removeMaxFiles();
+            }
         } else {
             setMaxFiles(1);
         }
+    }
+
+    private boolean isMultiFileReceiver(Receiver receiver) {
+        return receiver instanceof MultiFileReceiver;
     }
 
     /**

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -221,7 +221,7 @@ public class Upload extends Component implements HasSize, HasStyle {
         return (int) getElement().getProperty("maxFiles", 0.0);
     }
 
-    private void removeMaxFiles() {
+    private void resetMaxFiles() {
         getElement().removeProperty("maxFiles");
         getElement().executeJs("this.maxFiles = Infinity");
     }
@@ -640,7 +640,7 @@ public class Upload extends Component implements HasSize, HasStyle {
     public void setReceiver(Receiver receiver) {
         this.receiver = receiver;
         if (receiver instanceof MultiFileReceiver) {
-            removeMaxFiles();
+            resetMaxFiles();
         } else {
             setMaxFiles(1);
         }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -209,6 +209,7 @@ public class Upload extends Component implements HasSize, HasStyle {
      */
     public void setMaxFiles(int maxFiles) {
         getElement().setProperty("maxFiles", maxFiles);
+        getElement().executeJs("this.maxFiles = $0", maxFiles);
     }
 
     /**
@@ -218,6 +219,11 @@ public class Upload extends Component implements HasSize, HasStyle {
      */
     public int getMaxFiles() {
         return (int) getElement().getProperty("maxFiles", 0.0);
+    }
+
+    private void removeMaxFiles() {
+        getElement().removeProperty("maxFiles");
+        getElement().executeJs("this.maxFiles = Infinity");
     }
 
     /**
@@ -634,8 +640,7 @@ public class Upload extends Component implements HasSize, HasStyle {
     public void setReceiver(Receiver receiver) {
         this.receiver = receiver;
         if (receiver instanceof MultiFileReceiver) {
-            getElement().removeProperty("maxFiles");
-            getElement().executeJs("this.maxFiles = Infinity");
+            removeMaxFiles();
         } else {
             setMaxFiles(1);
         }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
@@ -53,7 +53,7 @@ public class SwitchReceiversTest {
     }
 
     @Test
-    public void setMaxFiles_setMultiFileReceiver_setAnotherMultiFileReceive_maxFilesArePreserved() {
+    public void setMaxFiles_setMultiFileReceiver_setAnotherMultiFileReceiver_maxFilesArePreserved() {
         Upload upload = new Upload();
         upload.setMaxFiles(3);
         upload.setReceiver(new MultiFileMemoryBuffer());

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
@@ -51,4 +51,13 @@ public class SwitchReceiversTest {
         upload.setReceiver(new MultiFileMemoryBuffer());
         Assert.assertEquals(3, upload.getElement().getProperty("maxFiles", 0));
     }
+
+    @Test
+    public void setMaxFiles_setMultiFileReceiver_setAnotherMultiFileReceive_maxFilesArePreserved() {
+        Upload upload = new Upload();
+        upload.setMaxFiles(3);
+        upload.setReceiver(new MultiFileMemoryBuffer());
+        upload.setReceiver(new MultiFileMemoryBuffer());
+        Assert.assertEquals(3, upload.getElement().getProperty("maxFiles", 0));
+    }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.upload.tests;
 
 import org.junit.Assert;

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/SwitchReceiversTest.java
@@ -1,0 +1,39 @@
+package com.vaadin.flow.component.upload.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
+import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+
+public class SwitchReceiversTest {
+    @Test
+    public void switchBetweenSingleAndMultiFileReceiver_assertMaxFilesProperty() {
+        Upload upload = new Upload();
+        upload.setReceiver(new MemoryBuffer());
+        Assert.assertEquals(1, upload.getElement().getProperty("maxFiles", 0));
+
+        upload.setReceiver(new MultiFileMemoryBuffer());
+        Assert.assertFalse(upload.getElement().hasProperty("maxFiles"));
+
+        upload.setReceiver(new MemoryBuffer());
+        Assert.assertEquals(1, upload.getElement().getProperty("maxFiles", 0));
+    }
+
+    @Test
+    public void setMaxFiles_setSingleFileReceiver_maxFilesAreSetToOne() {
+        Upload upload = new Upload();
+        upload.setMaxFiles(3);
+        upload.setReceiver(new MemoryBuffer());
+        Assert.assertEquals(1, upload.getElement().getProperty("maxFiles", 0));
+    }
+
+    @Test
+    public void setMaxFiles_setMultiFileReceiver_maxFilesArePreserved() {
+        Upload upload = new Upload();
+        upload.setMaxFiles(3);
+        upload.setReceiver(new MultiFileMemoryBuffer());
+        Assert.assertEquals(3, upload.getElement().getProperty("maxFiles", 0));
+    }
+}


### PR DESCRIPTION
## Description

The PR fixes the regression where maxFiles could be reset to Infinity when it was set after MultiFileReceiver in the same round-trip or when switching between different MultiFileReceivers. This regression was introduced in https://github.com/vaadin/flow-components/pull/6253.

Fixes https://github.com/vaadin/flow-components/issues/6622

## Type of change

- [x] Bugfix
