### PR TITLE
feat: support drag drop for dashboard

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
@@ -23,6 +23,7 @@ public class DashboardDragDropPage extends Div {
 
     public DashboardDragDropPage() {
         Dashboard dashboard = new Dashboard();
+        dashboard.setEditable(true);
 
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardSection;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+/**
+ * @author Vaadin Ltd
+ */
+@Route("vaadin-dashboard/drag-drop")
+public class DashboardDragDropPage extends Div {
+
+    public DashboardDragDropPage() {
+        Dashboard dashboard = new Dashboard();
+
+        DashboardWidget widget1 = new DashboardWidget();
+        widget1.setTitle("Widget 1");
+
+        DashboardWidget widget2 = new DashboardWidget();
+        widget2.setTitle("Widget 2");
+
+        dashboard.add(widget1, widget2);
+
+        DashboardWidget widget1InSection1 = new DashboardWidget();
+        widget1InSection1.setTitle("Widget 1 in Section 1");
+
+        DashboardWidget widget2InSection1 = new DashboardWidget();
+        widget2InSection1.setTitle("Widget 2 in Section 1");
+
+        DashboardSection section1 = new DashboardSection("Section 1");
+        section1.add(widget1InSection1, widget2InSection1);
+
+        dashboard.addSection(section1);
+
+        DashboardWidget widgetInSection2 = new DashboardWidget();
+        widgetInSection2.setTitle("Widget in Section 2");
+
+        DashboardSection section2 = new DashboardSection("Section 2");
+        section2.add(widgetInSection2);
+
+        dashboard.addSection(section2);
+
+        add(dashboard);
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
@@ -24,6 +24,8 @@ public class DashboardDragDropPage extends Div {
     public DashboardDragDropPage() {
         Dashboard dashboard = new Dashboard();
         dashboard.setEditable(true);
+        dashboard.setMinimumRowHeight("100px");
+        dashboard.setMaximumColumnWidth("400px");
 
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
@@ -61,6 +63,10 @@ public class DashboardDragDropPage extends Div {
         });
         toggleAttached.setId("toggle-attached");
 
-        add(toggleAttached, dashboard);
+        NativeButton toggleEditable = new NativeButton("Toggle editable",
+                e -> dashboard.setEditable(!dashboard.isEditable()));
+        toggleEditable.setId("toggle-editable");
+
+        add(toggleAttached, toggleEditable, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropPage.java
@@ -12,6 +12,7 @@ import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -50,6 +51,15 @@ public class DashboardDragDropPage extends Div {
 
         dashboard.addSection(section2);
 
-        add(dashboard);
+        NativeButton toggleAttached = new NativeButton("Toggle attached", e -> {
+            if (dashboard.getParent().isPresent()) {
+                dashboard.removeFromParent();
+            } else {
+                add(dashboard);
+            }
+        });
+        toggleAttached.setId("toggle-attached");
+
+        add(toggleAttached, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionPage.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.router.Route;
 /**
  * @author Vaadin Ltd
  */
-@Route("vaadin-dashboard-section")
+@Route("vaadin-dashboard/section")
 public class DashboardSectionPage extends Div {
 
     public DashboardSectionPage() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.router.Route;
 /**
  * @author Vaadin Ltd
  */
-@Route("vaadin-dashboard-widget")
+@Route("vaadin-dashboard/widget")
 public class DashboardWidgetPage extends Div {
 
     public DashboardWidgetPage() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropIT.java
@@ -62,6 +62,14 @@ public class DashboardDragDropIT extends AbstractComponentIT {
                 firstSection.getWidgets().get(0).getTitle());
     }
 
+    @Test
+    public void detachReattach_reorderWidgetOnClientSide_itemsAreReorderedCorrectly() {
+        clickElementWithJs("toggle-attached");
+        clickElementWithJs("toggle-attached");
+        dashboardElement = $(DashboardElement.class).waitForFirst();
+        reorderWidgetOnClientSide_itemsAreReorderedCorrectly();
+    }
+
     private void reorderWidgetInSection(int sectionIndex, int initialIndex,
             int targetIndex) {
         executeScript(

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropIT.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
+import com.vaadin.flow.component.dashboard.testbench.DashboardSectionElement;
+import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * @author Vaadin Ltd
+ */
+@TestPath("vaadin-dashboard/drag-drop")
+public class DashboardDragDropIT extends AbstractComponentIT {
+
+    private DashboardElement dashboardElement;
+
+    @Before
+    public void init() {
+        open();
+        dashboardElement = $(DashboardElement.class).waitForFirst();
+    }
+
+    @Test
+    public void reorderWidgetOnClientSide_itemsAreReorderedCorrectly() {
+        DashboardWidgetElement widgetToReorder = dashboardElement.getWidgets()
+                .get(0);
+        reorderRootLevelItem(1, 0);
+        Assert.assertEquals(widgetToReorder.getTitle(),
+                dashboardElement.getWidgets().get(1).getTitle());
+    }
+
+    @Test
+    public void reorderSectionOnClientSide_itemsAreReorderedCorrectly() {
+        DashboardSectionElement sectionToReorder = dashboardElement
+                .getSections().get(0);
+        reorderRootLevelItem(2, 3);
+        Assert.assertEquals(sectionToReorder.getTitle(),
+                dashboardElement.getSections().get(1).getTitle());
+    }
+
+    @Test
+    public void reorderWidgetInSectionOnClientSide_itemsAreReorderedCorrectly() {
+        DashboardSectionElement firstSection = dashboardElement.getSections()
+                .get(0);
+        DashboardWidgetElement widgetToReorder = firstSection.getWidgets()
+                .get(1);
+        reorderWidgetInSection(2, 0, 1);
+        firstSection = dashboardElement.getSections().get(0);
+        Assert.assertEquals(widgetToReorder.getTitle(),
+                firstSection.getWidgets().get(0).getTitle());
+    }
+
+    private void reorderWidgetInSection(int sectionIndex, int initialIndex,
+            int targetIndex) {
+        executeScript(
+                """
+                        const sectionIndex = %d;
+                        const reorderedItem = arguments[0].items[sectionIndex].items.splice(%d, 1)[0];
+                        arguments[0].items[sectionIndex].items.splice(%d, 0, reorderedItem);
+                        arguments[0].dispatchEvent(new CustomEvent('dashboard-item-reorder-end'));"""
+                        .formatted(sectionIndex, initialIndex, targetIndex),
+                dashboardElement);
+    }
+
+    private void reorderRootLevelItem(int initialIndex, int targetIndex) {
+        executeScript(
+                """
+                        const reorderedItem = arguments[0].items.splice(%d, 1)[0];
+                        arguments[0].items.splice(%d, 0, reorderedItem);
+                        arguments[0].dispatchEvent(new CustomEvent('dashboard-item-reorder-end'));"""
+                        .formatted(initialIndex, targetIndex),
+                dashboardElement);
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardSectionIT.java
@@ -24,7 +24,7 @@ import com.vaadin.tests.AbstractComponentIT;
 /**
  * @author Vaadin Ltd
  */
-@TestPath("vaadin-dashboard-section")
+@TestPath("vaadin-dashboard/section")
 public class DashboardSectionIT extends AbstractComponentIT {
 
     private DashboardElement dashboardElement;

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetIT.java
@@ -22,7 +22,7 @@ import com.vaadin.tests.AbstractComponentIT;
 /**
  * @author Vaadin Ltd
  */
-@TestPath("vaadin-dashboard-widget")
+@TestPath("vaadin-dashboard/widget")
 public class DashboardWidgetIT extends AbstractComponentIT {
 
     private DashboardElement dashboardElement;

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -395,7 +395,8 @@ public class Dashboard extends Component implements HasWidgets {
     private static String getWidgetRepresentation(DashboardWidget widget,
             int itemIndex) {
         return "{ component: $%d, colspan: %d, rowspan: %d, nodeid: %d  }"
-                .formatted(itemIndex, widget.getColspan(), widget.getRowspan(), widget.getElement().getNode().getId());
+                .formatted(itemIndex, widget.getColspan(), widget.getRowspan(),
+                        widget.getElement().getNode().getId());
     }
 
     private void doRemoveAll() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -54,7 +54,6 @@ public class Dashboard extends Component implements HasWidgets {
      */
     public Dashboard() {
         childDetachHandler = getChildDetachHandler();
-        setEditable(true);
         addItemReorderEndListener(this::onItemReorderEnd);
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -58,7 +57,6 @@ public class Dashboard extends Component implements HasWidgets {
      */
     public Dashboard() {
         childDetachHandler = getChildDetachHandler();
-        customizeItemReorderEndEvent();
         setEditable(true);
         addItemReorderEndListener(this::onItemReorderEnd);
     }
@@ -341,6 +339,7 @@ public class Dashboard extends Component implements HasWidgets {
         super.onAttach(attachEvent);
         getElement().executeJs(
                 "Vaadin.FlowComponentHost.patchVirtualContainer(this);");
+        customizeItemReorderEndEvent();
         doUpdateClient();
     }
 
@@ -435,16 +434,11 @@ public class Dashboard extends Component implements HasWidgets {
     }
 
     private DashboardChildDetachHandler getChildDetachHandler() {
-        return new DashboardChildDetachHandler() {
+        return new DashboardChildDetachHandler(this) {
             @Override
             void removeChild(Component child) {
                 childrenComponents.remove(child);
                 updateClient();
-            }
-
-            @Override
-            Collection<Component> getDirectChildren() {
-                return Dashboard.this.getChildren().toList();
             }
         };
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -574,23 +574,14 @@ public class Dashboard extends Component implements HasWidgets {
         getElement().executeJs(
                 """
                         this.addEventListener('dashboard-item-reorder-end', (e) => {
-                          const itemsCopy = [];
-                          for (let rootLevelIdx = 0; rootLevelIdx < this.items; rootLevelIdx++) {
-                            const item = this.items[rootLevelIdx];
-                            const itemCopy = { nodeid: item.nodeid };
-                            if (item.items) {
-                              const sectionItemsCopy = [];
-                              const sectionItems = item.items;
-                              for (let sectionItemIdx = 0; sectionItemIdx < sectionItems; sectionItemIdx++) {
-                                const sectionItemCopy = { nodeid: sectionItems[sectionItemIdx].nodeid };
-                                sectionItemsCopy.push(sectionItemCopy);
-                              }
-                              itemCopy.items = sectionItemsCopy;
-                            }
-                            itemsCopy.push(itemCopy);
+                          function mapItems(items) {
+                            return items.map(({nodeid, items}) => ({
+                              nodeid,
+                              ...(items && { items: mapItems(items) })
+                            }));
                           }
                           const flowReorderEvent = new CustomEvent('dashboard-item-reorder-end-flow', {
-                            detail: { items: itemsCopy },
+                            detail: { items: mapItems(this.items) }
                           });
                           this.dispatchEvent(flowReorderEvent);
                         });""");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderEndEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderEndEvent.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+import elemental.json.JsonArray;
+
+/**
+ * Widget or section reorder end event of {@link Dashboard}.
+ *
+ * @author Vaadin Ltd.
+ * @see Dashboard#addItemReorderEndListener(ComponentEventListener)
+ */
+@DomEvent("dashboard-item-reorder-end-flow")
+public class DashboardItemReorderEndEvent extends ComponentEvent<Dashboard> {
+
+    private final JsonArray items;
+
+    /**
+     * Creates a dashboard item reorder end event.
+     *
+     * @param source
+     *            Dashboard that contains the item that was dragged
+     * @param fromClient
+     *            <code>true</code> if the event originated from the client
+     *            side, <code>false</code> otherwise
+     */
+    public DashboardItemReorderEndEvent(Dashboard source, boolean fromClient,
+            @EventData("event.detail.items") JsonArray items) {
+        super(source, fromClient);
+        this.items = items;
+    }
+
+    /**
+     * Returns the ordered items from the client side
+     *
+     * @return items the ordered items as a {@link JsonArray}
+     */
+    public JsonArray getItems() {
+        return items;
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderStartEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderStartEvent.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
+
+/**
+ * Widget or section reorder start event of {@link Dashboard}.
+ *
+ * @author Vaadin Ltd.
+ * @see Dashboard#addItemReorderStartListener(ComponentEventListener)
+ */
+@DomEvent("dashboard-item-reorder-start")
+public class DashboardItemReorderStartEvent extends ComponentEvent<Dashboard> {
+
+    /**
+     * Creates a dashboard item reorder start event.
+     *
+     * @param source
+     *            Dashboard that contains the item that was dragged
+     * @param fromClient
+     *            <code>true</code> if the event originated from the client
+     *            side, <code>false</code> otherwise
+     */
+    public DashboardItemReorderStartEvent(Dashboard source,
+            boolean fromClient) {
+        super(source, fromClient);
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -177,16 +176,11 @@ public class DashboardSection extends Component implements HasWidgets {
     }
 
     private DashboardChildDetachHandler getChildDetachHandler() {
-        return new DashboardChildDetachHandler() {
+        return new DashboardChildDetachHandler(this) {
             @Override
             void removeChild(Component child) {
                 widgets.remove(child);
                 updateClient();
-            }
-
-            @Override
-            Collection<Component> getDirectChildren() {
-                return DashboardSection.this.getChildren().toList();
             }
         };
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropTest.java
@@ -59,67 +59,6 @@ public class DashboardDragDropTest extends DashboardTestBase {
         assertSectionWidgetReorder(2, 0, 1);
     }
 
-    @Test
-    public void invalidNumberOfRootLevelItemsInEvent_itemsAreUnchanged() {
-        JsonObject newItem = Json.createObject();
-        newItem.put("nodeid", 50);
-        itemsArray.set(itemsArray.length(), newItem);
-        assertInvalidItemsAreDisregarded();
-    }
-
-    @Test
-    public void invalidNumberOfWidgetsInSectionInEvent_itemsAreUnchanged() {
-        JsonObject sectionItem = itemsArray.get(2);
-        JsonArray sectionItems = sectionItem.getArray("items");
-        JsonObject newItem = Json.createObject();
-        sectionItems.set(sectionItems.length(), newItem);
-        assertInvalidItemsAreDisregarded();
-    }
-
-    @Test
-    public void invalidRootLevelItemNodeIdInEvent_itemsAreUnchanged() {
-        JsonObject item = itemsArray.get(0);
-        item.put("nodeid", -2);
-        assertInvalidItemsAreDisregarded();
-    }
-
-    @Test
-    public void duplicateRootLevelItemNodeIdInEvent_itemsAreUnchanged() {
-        JsonObject item1 = itemsArray.get(0);
-        JsonObject item2 = itemsArray.get(1);
-        item2.put("nodeid", item1.getNumber("nodeid"));
-        assertInvalidItemsAreDisregarded();
-    }
-
-    @Test
-    public void invalidWidgetInSectionNodeIdInEvent_itemsAreUnchanged() {
-        JsonObject sectionItem = itemsArray.get(2);
-        JsonArray sectionItems = sectionItem.getArray("items");
-        JsonObject item = sectionItems.get(0);
-        item.put("nodeid", -2);
-        assertInvalidItemsAreDisregarded();
-    }
-
-    @Test
-    public void duplicateWidgetInSectionNodeIdInEvent_itemsAreUnchanged() {
-        JsonObject sectionItem = itemsArray.get(2);
-        JsonArray sectionItems = sectionItem.getArray("items");
-        JsonObject item1 = sectionItems.get(0);
-        JsonObject item2 = sectionItems.get(1);
-        item2.put("nodeid", item1.getNumber("nodeid"));
-        assertInvalidItemsAreDisregarded();
-    }
-
-    @Test
-    public void duplicateNodeIdForRootLevelItemAndWidgetInSectionInEvent_itemsAreUnchanged() {
-        JsonObject rootLevelItem = itemsArray.get(0);
-        JsonObject sectionItem = itemsArray.get(2);
-        JsonArray sectionItems = sectionItem.getArray("items");
-        JsonObject itemInSection = sectionItems.get(0);
-        itemInSection.put("nodeid", rootLevelItem.getNumber("nodeid"));
-        assertInvalidItemsAreDisregarded();
-    }
-
     private void fireItemReorderEndEvent() {
         ComponentUtil.fireEvent(dashboard,
                 new DashboardItemReorderEndEvent(dashboard, false, itemsArray));
@@ -188,13 +127,6 @@ public class DashboardDragDropTest extends DashboardTestBase {
                 initialIndex, finalIndex);
         fireItemReorderEndEvent();
         Assert.assertEquals(expectedRootLevelNodeIds, getRootLevelNodeIds());
-    }
-
-    private void assertInvalidItemsAreDisregarded() {
-        reorderRootLevelItem(0, 1);
-        List<Integer> initialRootLevelNodeIds = getRootLevelNodeIds();
-        fireItemReorderEndEvent();
-        Assert.assertEquals(initialRootLevelNodeIds, getRootLevelNodeIds());
     }
 
     private static JsonArray reorderItemInJsonArray(int initialIndex,

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragDropTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardItemReorderEndEvent;
+import com.vaadin.flow.component.dashboard.DashboardSection;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+public class DashboardDragDropTest extends DashboardTestBase {
+    private Dashboard dashboard;
+
+    private JsonArray itemsArray;
+
+    @Before
+    @Override
+    public void setup() {
+        super.setup();
+        dashboard = new Dashboard();
+        dashboard.add(new DashboardWidget(), new DashboardWidget());
+        DashboardSection section = dashboard.addSection();
+        section.add(new DashboardWidget(), new DashboardWidget());
+        getUi().add(dashboard);
+        fakeClientCommunication();
+        itemsArray = getItemsArray(dashboard.getChildren().toList());
+    }
+
+    @Test
+    public void reorderWidget_orderIsUpdated() {
+        assertRootLevelItemReorder(0, 1);
+    }
+
+    @Test
+    public void reorderSection_orderIsUpdated() {
+        assertRootLevelItemReorder(2, 1);
+    }
+
+    @Test
+    public void reorderWidgetInSection_orderIsUpdated() {
+        assertSectionWidgetReorder(2, 0, 1);
+    }
+
+    @Test
+    public void invalidNumberOfRootLevelItemsInEvent_itemsAreUnchanged() {
+        JsonObject newItem = Json.createObject();
+        newItem.put("nodeid", 50);
+        itemsArray.set(itemsArray.length(), newItem);
+        assertInvalidItemsAreDisregarded();
+    }
+
+    @Test
+    public void invalidNumberOfWidgetsInSectionInEvent_itemsAreUnchanged() {
+        JsonObject sectionItem = itemsArray.get(2);
+        JsonArray sectionItems = sectionItem.getArray("items");
+        JsonObject newItem = Json.createObject();
+        sectionItems.set(sectionItems.length(), newItem);
+        assertInvalidItemsAreDisregarded();
+    }
+
+    @Test
+    public void invalidRootLevelItemNodeIdInEvent_itemsAreUnchanged() {
+        JsonObject item = itemsArray.get(0);
+        item.put("nodeid", -2);
+        assertInvalidItemsAreDisregarded();
+    }
+
+    @Test
+    public void duplicateRootLevelItemNodeIdInEvent_itemsAreUnchanged() {
+        JsonObject item1 = itemsArray.get(0);
+        JsonObject item2 = itemsArray.get(1);
+        item2.put("nodeid", item1.getNumber("nodeid"));
+        assertInvalidItemsAreDisregarded();
+    }
+
+    @Test
+    public void invalidWidgetInSectionNodeIdInEvent_itemsAreUnchanged() {
+        JsonObject sectionItem = itemsArray.get(2);
+        JsonArray sectionItems = sectionItem.getArray("items");
+        JsonObject item = sectionItems.get(0);
+        item.put("nodeid", -2);
+        assertInvalidItemsAreDisregarded();
+    }
+
+    @Test
+    public void duplicateWidgetInSectionNodeIdInEvent_itemsAreUnchanged() {
+        JsonObject sectionItem = itemsArray.get(2);
+        JsonArray sectionItems = sectionItem.getArray("items");
+        JsonObject item1 = sectionItems.get(0);
+        JsonObject item2 = sectionItems.get(1);
+        item2.put("nodeid", item1.getNumber("nodeid"));
+        assertInvalidItemsAreDisregarded();
+    }
+
+    @Test
+    public void duplicateNodeIdForRootLevelItemAndWidgetInSectionInEvent_itemsAreUnchanged() {
+        JsonObject rootLevelItem = itemsArray.get(0);
+        JsonObject sectionItem = itemsArray.get(2);
+        JsonArray sectionItems = sectionItem.getArray("items");
+        JsonObject itemInSection = sectionItems.get(0);
+        itemInSection.put("nodeid", rootLevelItem.getNumber("nodeid"));
+        assertInvalidItemsAreDisregarded();
+    }
+
+    private void fireItemReorderEndEvent() {
+        ComponentUtil.fireEvent(dashboard,
+                new DashboardItemReorderEndEvent(dashboard, false, itemsArray));
+    }
+
+    private List<Integer> getSectionWidgetNodeIds(int sectionIndex) {
+        DashboardSection section = (DashboardSection) dashboard.getChildren()
+                .toList().get(sectionIndex);
+        return section.getWidgets().stream()
+                .map(component -> component.getElement().getNode().getId())
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private List<Integer> getRootLevelNodeIds() {
+        return dashboard.getChildren()
+                .map(component -> component.getElement().getNode().getId())
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private List<Integer> getExpectedSectionWidgetNodeIds(int sectionIndex,
+            int initialIndex, int finalIndex) {
+        List<Integer> expectedSectionWidgetNodeIds = getSectionWidgetNodeIds(
+                sectionIndex);
+        int nodeId = expectedSectionWidgetNodeIds.get(initialIndex);
+        expectedSectionWidgetNodeIds.remove((Object) nodeId);
+        expectedSectionWidgetNodeIds.add(finalIndex, nodeId);
+        return expectedSectionWidgetNodeIds;
+    }
+
+    private List<Integer> getExpectedRootLevelItemNodeIds(int initialIndex,
+            int finalIndex) {
+        List<Integer> expectedRootLevelNodeIds = getRootLevelNodeIds();
+        int nodeId = expectedRootLevelNodeIds.get(initialIndex);
+        expectedRootLevelNodeIds.remove((Object) nodeId);
+        expectedRootLevelNodeIds.add(finalIndex, nodeId);
+        return expectedRootLevelNodeIds;
+    }
+
+    private void reorderSectionWidget(int sectionIndex, int initialIndex,
+            int finalIndex) {
+        JsonObject sectionItem = itemsArray.get(sectionIndex);
+        JsonArray sectionItems = sectionItem.getArray("items");
+        sectionItem.put("items",
+                reorderItemInJsonArray(initialIndex, finalIndex, sectionItems));
+    }
+
+    private void reorderRootLevelItem(int initialIndex, int finalIndex) {
+        itemsArray = reorderItemInJsonArray(initialIndex, finalIndex,
+                itemsArray);
+    }
+
+    private void assertSectionWidgetReorder(int sectionIndex, int initialIndex,
+            int finalIndex) {
+        reorderSectionWidget(sectionIndex, initialIndex, finalIndex);
+        List<Integer> expectedSectionWidgetNodeIds = getExpectedSectionWidgetNodeIds(
+                sectionIndex, initialIndex, finalIndex);
+        fireItemReorderEndEvent();
+        Assert.assertEquals(expectedSectionWidgetNodeIds,
+                getSectionWidgetNodeIds(sectionIndex));
+    }
+
+    private void assertRootLevelItemReorder(int initialIndex, int finalIndex) {
+
+        reorderRootLevelItem(initialIndex, finalIndex);
+        List<Integer> expectedRootLevelNodeIds = getExpectedRootLevelItemNodeIds(
+                initialIndex, finalIndex);
+        fireItemReorderEndEvent();
+        Assert.assertEquals(expectedRootLevelNodeIds, getRootLevelNodeIds());
+    }
+
+    private void assertInvalidItemsAreDisregarded() {
+        reorderRootLevelItem(0, 1);
+        List<Integer> initialRootLevelNodeIds = getRootLevelNodeIds();
+        fireItemReorderEndEvent();
+        Assert.assertEquals(initialRootLevelNodeIds, getRootLevelNodeIds());
+    }
+
+    private static JsonArray reorderItemInJsonArray(int initialIndex,
+            int finalIndex, JsonArray initialArray) {
+        JsonObject itemToMove = initialArray.get(initialIndex);
+        initialArray.remove(initialIndex);
+        JsonArray newArray = Json.createArray();
+        for (int i = 0; i < finalIndex; i++) {
+            JsonObject currentItem = initialArray.get(i);
+            newArray.set(i, currentItem);
+        }
+        newArray.set(finalIndex, itemToMove);
+        for (int i = finalIndex; i < initialArray.length(); i++) {
+            JsonObject currentItem = initialArray.get(i);
+            newArray.set(i + 1, currentItem);
+        }
+        return newArray;
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -8,42 +8,25 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.server.VaadinSession;
 
-public class DashboardTest {
-    private final UI ui = new UI();
+public class DashboardTest extends DashboardTestBase {
     private Dashboard dashboard;
 
     @Before
+    @Override
     public void setup() {
-        UI.setCurrent(ui);
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        Mockito.when(session.hasLock()).thenReturn(true);
-        ui.getInternals().setSession(session);
+        super.setup();
         dashboard = new Dashboard();
-        ui.add(dashboard);
+        getUi().add(dashboard);
         fakeClientCommunication();
-    }
-
-    @After
-    public void tearDown() {
-        UI.setCurrent(null);
     }
 
     @Test
@@ -176,7 +159,7 @@ public class DashboardTest {
     @Test
     public void addWidgetFromLayoutToDashboard_widgetIsMoved() {
         Div parent = new Div();
-        ui.add(parent);
+        getUi().add(parent);
         DashboardWidget widget = new DashboardWidget();
         parent.add(widget);
         fakeClientCommunication();
@@ -192,7 +175,7 @@ public class DashboardTest {
         dashboard.add(widget);
         fakeClientCommunication();
         Div parent = new Div();
-        ui.add(parent);
+        getUi().add(parent);
         parent.add(widget);
         fakeClientCommunication();
         assertChildComponents(dashboard);
@@ -205,7 +188,7 @@ public class DashboardTest {
         dashboard.add(widget);
         fakeClientCommunication();
         Dashboard newDashboard = new Dashboard();
-        ui.add(newDashboard);
+        getUi().add(newDashboard);
         newDashboard.add(widget);
         fakeClientCommunication();
         assertChildComponents(dashboard);
@@ -545,7 +528,7 @@ public class DashboardTest {
     public void addWidgetFromLayoutToSection_widgetIsMoved() {
         DashboardSection section = dashboard.addSection();
         Div parent = new Div();
-        ui.add(parent);
+        getUi().add(parent);
         DashboardWidget widget = new DashboardWidget();
         parent.add(widget);
         fakeClientCommunication();
@@ -563,7 +546,7 @@ public class DashboardTest {
         section.add(widget);
         fakeClientCommunication();
         Div parent = new Div();
-        ui.add(parent);
+        getUi().add(parent);
         parent.add(widget);
         fakeClientCommunication();
         assertSectionWidgets(section);
@@ -795,40 +778,21 @@ public class DashboardTest {
         Assert.assertNull(dashboard.getGap());
     }
 
-    private void fakeClientCommunication() {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
+    @Test
+    public void dashboardIsEditableByDefault() {
+        Assert.assertTrue(dashboard.isEditable());
     }
 
-    private static void assertChildComponents(Dashboard dashboard,
-            Component... expectedChildren) {
-        List<DashboardWidget> expectedWidgets = getExpectedWidgets(
-                expectedChildren);
-        Assert.assertEquals(expectedWidgets, dashboard.getWidgets());
-        Assert.assertEquals(Arrays.asList(expectedChildren),
-                dashboard.getChildren().toList());
+    @Test
+    public void setEditableFalse_valueIsCorrectlyRetrieved() {
+        dashboard.setEditable(false);
+        Assert.assertFalse(dashboard.isEditable());
     }
 
-    private static List<DashboardWidget> getExpectedWidgets(
-            Component... expectedChildren) {
-        List<DashboardWidget> expectedWidgets = new ArrayList<>();
-        for (Component child : expectedChildren) {
-            if (child instanceof DashboardSection section) {
-                expectedWidgets.addAll(section.getWidgets());
-            } else if (child instanceof DashboardWidget widget) {
-                expectedWidgets.add(widget);
-            } else {
-                throw new IllegalArgumentException(
-                        "A dashboard can only contain widgets or sections.");
-            }
-        }
-        return expectedWidgets;
-    }
-
-    private static void assertSectionWidgets(DashboardSection section,
-            DashboardWidget... expectedWidgets) {
-        Assert.assertEquals(Arrays.asList(expectedWidgets),
-                section.getWidgets());
+    @Test
+    public void setEditableTrue_valueIsCorrectlyRetrieved() {
+        dashboard.setEditable(false);
+        dashboard.setEditable(true);
+        Assert.assertTrue(dashboard.isEditable());
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -779,8 +779,8 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
-    public void dashboardIsEditableByDefault() {
-        Assert.assertTrue(dashboard.isEditable());
+    public void dashboardIsNotEditableByDefault() {
+        Assert.assertFalse(dashboard.isEditable());
     }
 
     @Test

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -795,4 +795,24 @@ public class DashboardTest extends DashboardTestBase {
         dashboard.setEditable(true);
         Assert.assertTrue(dashboard.isEditable());
     }
+
+    @Test
+    public void addWidget_detachDashboard_widgetIsRetained() {
+        DashboardWidget widget = new DashboardWidget();
+        dashboard.add(widget);
+        fakeClientCommunication();
+        getUi().remove(dashboard);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, widget);
+    }
+
+    @Test
+    public void detachDashboard_addWidget_reattachDashboard_widgetIsAdded() {
+        getUi().remove(dashboard);
+        fakeClientCommunication();
+        DashboardWidget widget = new DashboardWidget();
+        dashboard.add(widget);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, widget);
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestBase.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestBase.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardSection;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.server.VaadinSession;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+public class DashboardTestBase {
+
+    private final UI ui = new UI();
+
+    @Before
+    public void setup() {
+        UI.setCurrent(ui);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+        fakeClientCommunication();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
+    protected UI getUi() {
+        return ui;
+    }
+
+    protected void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    protected static JsonArray getItemsArray(
+            List<Component> rootLevelComponents) {
+        JsonArray itemsArray = Json.createArray();
+        rootLevelComponents.forEach(child -> {
+            JsonObject rootLevelItem = Json.createObject();
+            rootLevelItem.put("nodeid", child.getElement().getNode().getId());
+            if (child instanceof DashboardSection section) {
+                JsonArray sectionItemsArray = Json.createArray();
+                section.getWidgets().forEach(widget -> {
+                    JsonObject sectionItem = Json.createObject();
+                    sectionItem.put("nodeid",
+                            widget.getElement().getNode().getId());
+                    sectionItemsArray.set(sectionItemsArray.length(),
+                            sectionItem);
+                });
+                rootLevelItem.put("items", sectionItemsArray);
+            }
+            itemsArray.set(itemsArray.length(), rootLevelItem);
+        });
+        return itemsArray;
+    }
+
+    protected static void assertChildComponents(Dashboard dashboard,
+            Component... expectedChildren) {
+        List<DashboardWidget> expectedWidgets = getExpectedWidgets(
+                expectedChildren);
+        Assert.assertEquals(expectedWidgets, dashboard.getWidgets());
+        Assert.assertEquals(Arrays.asList(expectedChildren),
+                dashboard.getChildren().toList());
+    }
+
+    protected static List<DashboardWidget> getExpectedWidgets(
+            Component... expectedChildren) {
+        List<DashboardWidget> expectedWidgets = new ArrayList<>();
+        for (Component child : expectedChildren) {
+            if (child instanceof DashboardSection section) {
+                expectedWidgets.addAll(section.getWidgets());
+            } else if (child instanceof DashboardWidget widget) {
+                expectedWidgets.add(widget);
+            } else {
+                throw new IllegalArgumentException(
+                        "A dashboard can only contain widgets or sections.");
+            }
+        }
+        return expectedWidgets;
+    }
+
+    protected static void assertSectionWidgets(DashboardSection section,
+            DashboardWidget... expectedWidgets) {
+        Assert.assertEquals(Arrays.asList(expectedWidgets),
+                section.getWidgets());
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -8,39 +8,41 @@
  */
 package com.vaadin.flow.component.dashboard.tests;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.server.VaadinSession;
 
-public class DashboardWidgetTest {
+public class DashboardWidgetTest extends DashboardTestBase {
 
-    private final UI ui = new UI();
-
-    @Before
-    public void setup() {
-        UI.setCurrent(ui);
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        Mockito.when(session.hasLock()).thenReturn(true);
-        ui.getInternals().setSession(session);
+    @Test
+    public void assertDefaultTitle() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertNull(widget.getTitle());
     }
 
-    @After
-    public void tearDown() {
-        UI.setCurrent(null);
+    @Test
+    public void setTitle_returnsCorrectTitle() {
+        String valueToSet = "New title";
+        DashboardWidget widget = new DashboardWidget();
+        widget.setTitle(valueToSet);
+        Assert.assertEquals(valueToSet, widget.getTitle());
+    }
+
+    @Test
+    public void setTitleNull_returnsEmptyTitle() {
+        DashboardWidget widget = new DashboardWidget();
+        widget.setTitle("New title");
+        widget.setTitle(null);
+        Assert.assertNull(widget.getTitle());
     }
 
     @Test
     public void addWidgetToLayout_widgetIsAdded() {
         Div layout = new Div();
-        ui.add(layout);
+        getUi().add(layout);
         DashboardWidget widget = new DashboardWidget();
         layout.add(widget);
         fakeClientCommunication();
@@ -50,7 +52,7 @@ public class DashboardWidgetTest {
     @Test
     public void removeWidgetFromLayout_widgetIsRemoved() {
         Div layout = new Div();
-        ui.add(layout);
+        getUi().add(layout);
         DashboardWidget widget = new DashboardWidget();
         layout.add(widget);
         fakeClientCommunication();
@@ -62,7 +64,7 @@ public class DashboardWidgetTest {
     @Test
     public void addWidgetToLayout_removeFromParent_widgetIsRemoved() {
         Div layout = new Div();
-        ui.add(layout);
+        getUi().add(layout);
         DashboardWidget widget = new DashboardWidget();
         layout.add(widget);
         fakeClientCommunication();
@@ -74,12 +76,12 @@ public class DashboardWidgetTest {
     @Test
     public void addWidgetFromLayoutToAnotherLayout_widgetIsMoved() {
         Div parent = new Div();
-        ui.add(parent);
+        getUi().add(parent);
         DashboardWidget widget = new DashboardWidget();
         parent.add(widget);
         fakeClientCommunication();
         Div newParent = new Div();
-        ui.add(newParent);
+        getUi().add(newParent);
         newParent.add(widget);
         fakeClientCommunication();
         Assert.assertTrue(parent.getChildren().noneMatch(widget::equals));
@@ -246,11 +248,5 @@ public class DashboardWidgetTest {
         widget.setContent(content);
         Assert.assertEquals(content, widget.getContent());
         Assert.assertEquals(header, widget.getHeader());
-    }
-
-    private void fakeClientCommunication() {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -36,7 +36,7 @@ public class DashboardWidgetTest extends DashboardTestBase {
         DashboardWidget widget = new DashboardWidget();
         widget.setTitle("New title");
         widget.setTitle(null);
-        Assert.assertNull(widget.getTitle());
+        Assert.assertEquals("", widget.getTitle());
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds drag drop support for dashboard.

Added API:
- `void setEditable(boolean editable)`: Sets the option to make the dashboard editable
- `boolean isEditable()`: Returns whether the dashboard is editable
- `Registration addItemReorderStartListener(ComponentEventListener listener)`: Adds an item reorder start listener to the dashboard
- `Registration addItemReorderEndListener(ComponentEventListener listener)`: Adds an item reorder end listener to the dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=78740411

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature