### PR TITLE
Avoid creating potentially large empty arrays when clearing grid cache

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -510,7 +510,11 @@ import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js"
             // Update the items in the grid cache or set an array of undefined items
             // to remove the page from the grid cache if there are no corresponding items
             // in the connector cache.
-            gridCache.setPage(page, items || Array.from({ length: grid.pageSize }));
+            if (items) {
+              gridCache.setPage(page, items);
+            } else {
+              gridCache.clearPage(page);
+            }
           }
 
           return items;


### PR DESCRIPTION
## Description

This PR adds a more efficient code path in gridConnector.ts that avoids creating potentially large Arrays in order to clear values in the grid cache. This change depends on https://github.com/vaadin/web-components/pull/7808

Fixes #6648

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
