### PR TITLE
feat: support dashboard item remove using button

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderPage.java
@@ -63,10 +63,6 @@ public class DashboardDragReorderPage extends Div {
         });
         toggleAttached.setId("toggle-attached");
 
-        NativeButton toggleEditable = new NativeButton("Toggle editable",
-                e -> dashboard.setEditable(!dashboard.isEditable()));
-        toggleEditable.setId("toggle-editable");
-
-        add(toggleAttached, toggleEditable, dashboard);
+        add(toggleAttached, dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizePage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizePage.java
@@ -12,7 +12,6 @@ import com.vaadin.flow.component.dashboard.Dashboard;
 import com.vaadin.flow.component.dashboard.DashboardSection;
 import com.vaadin.flow.component.dashboard.DashboardWidget;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -37,10 +36,6 @@ public class DashboardDragResizePage extends Div {
         DashboardSection section = dashboard.addSection("Section");
         section.add(widgetInSection);
 
-        NativeButton toggleEditable = new NativeButton("Toggle editable",
-                e -> dashboard.setEditable(!dashboard.isEditable()));
-        toggleEditable.setId("toggle-editable");
-
-        add(toggleEditable, dashboard);
+        add(dashboard);
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardPage.java
@@ -128,9 +128,14 @@ public class DashboardPage extends Div {
                 click -> dashboard.setMaximumColumnCount(null));
         setMaximumColumnCountNull.setId("set-maximum-column-count-null");
 
+        NativeButton toggleEditable = new NativeButton("Toggle editable",
+                e -> dashboard.setEditable(!dashboard.isEditable()));
+        toggleEditable.setId("toggle-editable");
+
         add(addMultipleWidgets, removeFirstAndLastWidgets, removeAll,
                 addSectionWithMultipleWidgets, removeFirstSection,
-                setMaximumColumnCount1, setMaximumColumnCountNull, dashboard);
+                setMaximumColumnCount1, setMaximumColumnCountNull,
+                toggleEditable, dashboard);
     }
 
     private static Optional<DashboardSection> getFirstSection(

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
@@ -78,7 +78,7 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setDashboardEditable_dragHandleNotVisible() {
+    public void setDashboardEditable_dragHandleIsVisible() {
         clickElementWithJs("toggle-editable");
         clickElementWithJs("toggle-editable");
         Assert.assertTrue(

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
@@ -69,22 +69,6 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
         reorderWidgetOnClientSide_itemsAreReorderedCorrectly();
     }
 
-    @Test
-    public void setDashboardNotEditable_dragHandleNotVisible() {
-        var widget = dashboardElement.getWidgets().get(0);
-        Assert.assertTrue(isDragHandleVisible(widget));
-        clickElementWithJs("toggle-editable");
-        Assert.assertFalse(isDragHandleVisible(widget));
-    }
-
-    @Test
-    public void setDashboardEditable_dragHandleIsVisible() {
-        clickElementWithJs("toggle-editable");
-        clickElementWithJs("toggle-editable");
-        Assert.assertTrue(
-                isDragHandleVisible(dashboardElement.getWidgets().get(0)));
-    }
-
     private void dragResizeElement(TestBenchElement draggedElement,
             TestBenchElement targetElement) {
         var dragHandle = getDragHandle(draggedElement);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeIT.java
@@ -45,22 +45,6 @@ public class DashboardDragResizeIT extends AbstractComponentIT {
         assertWidgetResized(1);
     }
 
-    @Test
-    public void setDashboardNotEditable_resizeHandleNotVisible() {
-        var widget = dashboardElement.getWidgets().get(0);
-        Assert.assertTrue(isResizeHandleVisible(widget));
-        clickElementWithJs("toggle-editable");
-        Assert.assertFalse(isResizeHandleVisible(widget));
-    }
-
-    @Test
-    public void setDashboardEditable_resizeHandleIsVisible() {
-        clickElementWithJs("toggle-editable");
-        clickElementWithJs("toggle-editable");
-        Assert.assertTrue(
-                isResizeHandleVisible(dashboardElement.getWidgets().get(0)));
-    }
-
     private void assertWidgetResized(int widgetIndexToResize) {
         var widgetToResize = dashboardElement.getWidgets()
                 .get(widgetIndexToResize);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeIT.java
@@ -54,7 +54,7 @@ public class DashboardDragResizeIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setDashboardEditable_resizeHandleNotVisible() {
+    public void setDashboardEditable_resizeHandleIsVisible() {
         clickElementWithJs("toggle-editable");
         clickElementWithJs("toggle-editable");
         Assert.assertTrue(

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -60,6 +60,7 @@ public class DashboardIT extends AbstractComponentIT {
 
     @Test
     public void removeWidgetUsingButton_widgetIsRemoved() {
+        clickElementWithJs("toggle-editable");
         DashboardWidgetElement widgetToRemove = dashboardElement.getWidgets()
                 .get(0);
         getRemoveButton(widgetToRemove).click();
@@ -70,6 +71,7 @@ public class DashboardIT extends AbstractComponentIT {
 
     @Test
     public void removeWidgetInSectionUsingButton_widgetIsRemoved() {
+        clickElementWithJs("toggle-editable");
         DashboardSectionElement section = dashboardElement.getSections().get(0);
         DashboardWidgetElement widgetToRemove = section.getWidgets().get(0);
         getRemoveButton(widgetToRemove).click();
@@ -122,6 +124,7 @@ public class DashboardIT extends AbstractComponentIT {
 
     @Test
     public void removeFirstSectionUsingButton_sectionIsRemoved() {
+        clickElementWithJs("toggle-editable");
         DashboardSectionElement sectionToRemove = dashboardElement.getSections()
                 .get(0);
         String sectionTitle = sectionToRemove.getTitle();
@@ -160,22 +163,6 @@ public class DashboardIT extends AbstractComponentIT {
         Assert.assertEquals(yOfWidget1, widgets.get(1).getLocation().getY());
     }
 
-    @Test
-    public void setDashboardEditable_removeButtonIsVisible() {
-        var widget = dashboardElement.getWidgets().get(0);
-        Assert.assertFalse(isRemoveButtonVisible(widget));
-        clickElementWithJs("toggle-editable");
-        Assert.assertTrue(isRemoveButtonVisible(widget));
-    }
-
-    @Test
-    public void setDashboardNotEditable_removeButtonNotVisible() {
-        clickElementWithJs("toggle-editable");
-        clickElementWithJs("toggle-editable");
-        Assert.assertFalse(
-                isRemoveButtonVisible(dashboardElement.getWidgets().get(0)));
-    }
-
     private void assertDashboardWidgetsByTitle(String... expectedWidgetTitles) {
         assertWidgetsByTitle(dashboardElement.getWidgets(),
                 expectedWidgetTitles);
@@ -192,10 +179,6 @@ public class DashboardIT extends AbstractComponentIT {
         List<String> widgetTitles = actualWidgets.stream()
                 .map(DashboardWidgetElement::getTitle).toList();
         Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
-    }
-
-    private static boolean isRemoveButtonVisible(TestBenchElement element) {
-        return !"none".equals(getRemoveButton(element).getCssValue("display"));
     }
 
     private static TestBenchElement getRemoveButton(TestBenchElement element) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardIT.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
 import com.vaadin.flow.component.dashboard.testbench.DashboardSectionElement;
 import com.vaadin.flow.component.dashboard.testbench.DashboardWidgetElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 /**
@@ -55,6 +56,25 @@ public class DashboardIT extends AbstractComponentIT {
         clickElementWithJs("remove-first-and-last-widgets");
         assertDashboardWidgetsByTitle("Widget 2", "Widget 3",
                 "Widget 1 in Section 1", "Widget 2 in Section 1");
+    }
+
+    @Test
+    public void removeWidgetUsingButton_widgetIsRemoved() {
+        DashboardWidgetElement widgetToRemove = dashboardElement.getWidgets()
+                .get(0);
+        getRemoveButton(widgetToRemove).click();
+        assertDashboardWidgetsByTitle("Widget 2", "Widget 3",
+                "Widget 1 in Section 1", "Widget 2 in Section 1",
+                "Widget 1 in Section 2");
+    }
+
+    @Test
+    public void removeWidgetInSectionUsingButton_widgetIsRemoved() {
+        DashboardSectionElement section = dashboardElement.getSections().get(0);
+        DashboardWidgetElement widgetToRemove = section.getWidgets().get(0);
+        getRemoveButton(widgetToRemove).click();
+        assertDashboardWidgetsByTitle("Widget 1", "Widget 2", "Widget 3",
+                "Widget 2 in Section 1", "Widget 1 in Section 2");
     }
 
     @Test
@@ -101,6 +121,19 @@ public class DashboardIT extends AbstractComponentIT {
     }
 
     @Test
+    public void removeFirstSectionUsingButton_sectionIsRemoved() {
+        DashboardSectionElement sectionToRemove = dashboardElement.getSections()
+                .get(0);
+        String sectionTitle = sectionToRemove.getTitle();
+        getRemoveButton(sectionToRemove).click();
+        assertDashboardWidgetsByTitle("Widget 1", "Widget 2", "Widget 3",
+                "Widget 1 in Section 2");
+        List<String> sectionTitles = dashboardElement.getSections().stream()
+                .map(DashboardSectionElement::getTitle).toList();
+        Assert.assertFalse(sectionTitles.contains(sectionTitle));
+    }
+
+    @Test
     public void changeMaximumColumnCountTo1_widgetsShouldBeOnTheSameColumn() {
         List<DashboardWidgetElement> widgets = dashboardElement.getWidgets();
         // The first two widgets should initially be on the same horizontal line
@@ -127,6 +160,22 @@ public class DashboardIT extends AbstractComponentIT {
         Assert.assertEquals(yOfWidget1, widgets.get(1).getLocation().getY());
     }
 
+    @Test
+    public void setDashboardEditable_removeButtonIsVisible() {
+        var widget = dashboardElement.getWidgets().get(0);
+        Assert.assertFalse(isRemoveButtonVisible(widget));
+        clickElementWithJs("toggle-editable");
+        Assert.assertTrue(isRemoveButtonVisible(widget));
+    }
+
+    @Test
+    public void setDashboardNotEditable_removeButtonNotVisible() {
+        clickElementWithJs("toggle-editable");
+        clickElementWithJs("toggle-editable");
+        Assert.assertFalse(
+                isRemoveButtonVisible(dashboardElement.getWidgets().get(0)));
+    }
+
     private void assertDashboardWidgetsByTitle(String... expectedWidgetTitles) {
         assertWidgetsByTitle(dashboardElement.getWidgets(),
                 expectedWidgetTitles);
@@ -143,5 +192,13 @@ public class DashboardIT extends AbstractComponentIT {
         List<String> widgetTitles = actualWidgets.stream()
                 .map(DashboardWidgetElement::getTitle).toList();
         Assert.assertEquals(Arrays.asList(expectedWidgetTitles), widgetTitles);
+    }
+
+    private static boolean isRemoveButtonVisible(TestBenchElement element) {
+        return !"none".equals(getRemoveButton(element).getCssValue("display"));
+    }
+
+    private static TestBenchElement getRemoveButton(TestBenchElement element) {
+        return element.$("button").withId("remove-button").first();
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -56,6 +56,7 @@ public class Dashboard extends Component implements HasWidgets {
         childDetachHandler = getChildDetachHandler();
         addItemReorderEndListener(this::onItemReorderEnd);
         addItemResizeEndListener(this::onItemResizeEnd);
+        addItemRemovedListener(this::onItemRemoved);
     }
 
     /**
@@ -350,6 +351,18 @@ public class Dashboard extends Component implements HasWidgets {
         return addListener(DashboardItemResizeEndEvent.class, listener);
     }
 
+    /**
+     * Adds an item removed listener to this dashboard.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    public Registration addItemRemovedListener(
+            ComponentEventListener<DashboardItemRemovedEvent> listener) {
+        return addListener(DashboardItemRemovedEvent.class, listener);
+    }
+
     @Override
     public Stream<Component> getChildren() {
         return childrenComponents.stream();
@@ -478,6 +491,11 @@ public class Dashboard extends Component implements HasWidgets {
                 .getResizedWidget();
         resizedWidget.setRowspan(dashboardItemResizeEndEvent.getRowspan());
         resizedWidget.setColspan(dashboardItemResizeEndEvent.getColspan());
+    }
+
+    private void onItemRemoved(
+            DashboardItemRemovedEvent dashboardItemRemovedEvent) {
+        dashboardItemRemovedEvent.getRemovedItem().removeFromParent();
     }
 
     private void reorderItems(JsonArray orderedItemsFromClient) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemRemovedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemRemovedEvent.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+/**
+ * Widget or section removed event of {@link Dashboard}.
+ *
+ * @author Vaadin Ltd.
+ * @see Dashboard#addItemRemovedListener(ComponentEventListener)
+ */
+@DomEvent("dashboard-item-removed")
+public class DashboardItemRemovedEvent extends ComponentEvent<Dashboard> {
+
+    private final Component removedItem;
+
+    /**
+     * Creates a dashboard item removed event.
+     *
+     * @param source
+     *            Dashboard that contains the item that was removed
+     * @param fromClient
+     *            <code>true</code> if the event originated from the client
+     *            side, <code>false</code> otherwise
+     */
+    public DashboardItemRemovedEvent(Dashboard source, boolean fromClient,
+            @EventData("event.detail.item.nodeid") int nodeId) {
+        super(source, fromClient);
+        this.removedItem = getRemovedItem(source, nodeId);
+    }
+
+    /**
+     * Returns the removed item
+     *
+     * @return the removed item
+     */
+    public Component getRemovedItem() {
+        return removedItem;
+    }
+
+    private static Component getRemovedItem(Dashboard dashboard, int nodeId) {
+        return dashboard.getChildren().map(item -> {
+            if (nodeId == item.getElement().getNode().getId()) {
+                return item;
+            }
+            if (item instanceof DashboardSection section) {
+                return section.getWidgets().stream()
+                        .filter(sectionItem -> nodeId == sectionItem
+                                .getElement().getNode().getId())
+                        .findAny().orElse(null);
+            }
+            return null;
+        }).filter(Objects::nonNull).findAny().orElse(null);
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderTest.java
@@ -121,7 +121,6 @@ public class DashboardDragReorderTest extends DashboardTestBase {
     }
 
     private void assertRootLevelItemReorder(int initialIndex, int finalIndex) {
-
         reorderRootLevelItem(initialIndex, finalIndex);
         List<Integer> expectedRootLevelNodeIds = getExpectedRootLevelItemNodeIds(
                 initialIndex, finalIndex);


### PR DESCRIPTION
## Description

Adds remove item using button support for dashboard.

Note: This PR does not add functionality for canceling the removal.

Added API:
- `Registration addItemRemovedListener(ComponentEventListener listener)`: Adds an item removed listener to this dashboard

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=79872649

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature