### PR TITLE
refactor: do not handle clients events if dashboard is not editable

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -479,6 +479,9 @@ public class Dashboard extends Component implements HasWidgets {
 
     private void onItemReorderEnd(
             DashboardItemReorderEndEvent dashboardItemReorderEndEvent) {
+        if (!isEditable()) {
+            return;
+        }
         JsonArray orderedItemsFromClient = dashboardItemReorderEndEvent
                 .getItems();
         reorderItems(orderedItemsFromClient);
@@ -487,6 +490,9 @@ public class Dashboard extends Component implements HasWidgets {
 
     private void onItemResizeEnd(
             DashboardItemResizeEndEvent dashboardItemResizeEndEvent) {
+        if (!isEditable()) {
+            return;
+        }
         DashboardWidget resizedWidget = dashboardItemResizeEndEvent
                 .getResizedWidget();
         resizedWidget.setRowspan(dashboardItemResizeEndEvent.getRowspan());
@@ -495,6 +501,9 @@ public class Dashboard extends Component implements HasWidgets {
 
     private void onItemRemoved(
             DashboardItemRemovedEvent dashboardItemRemovedEvent) {
+        if (!isEditable()) {
+            return;
+        }
         dashboardItemRemovedEvent.getRemovedItem().removeFromParent();
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderTest.java
@@ -37,6 +37,7 @@ public class DashboardDragReorderTest extends DashboardTestBase {
         super.setup();
         dashboard = new Dashboard();
         dashboard.add(new DashboardWidget(), new DashboardWidget());
+        dashboard.setEditable(true);
         DashboardSection section = dashboard.addSection();
         section.add(new DashboardWidget(), new DashboardWidget());
         getUi().add(dashboard);
@@ -57,6 +58,15 @@ public class DashboardDragReorderTest extends DashboardTestBase {
     @Test
     public void reorderWidgetInSection_orderIsUpdated() {
         assertSectionWidgetReorder(2, 0, 1);
+    }
+
+    @Test
+    public void setDashboardNotEditable_reorderWidget_orderIsNotUpdated() {
+        dashboard.setEditable(false);
+        List<Integer> expectedRootLevelNodeIds = getRootLevelNodeIds();
+        reorderRootLevelItem(0, 1);
+        fireItemReorderEndEvent();
+        Assert.assertEquals(expectedRootLevelNodeIds, getRootLevelNodeIds());
     }
 
     private void fireItemReorderEndEvent() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeTest.java
@@ -27,6 +27,7 @@ public class DashboardDragResizeTest extends DashboardTestBase {
         super.setup();
         dashboard = new Dashboard();
         dashboard.add(new DashboardWidget());
+        dashboard.setEditable(true);
         DashboardSection section = dashboard.addSection();
         section.add(new DashboardWidget());
         getUi().add(dashboard);
@@ -61,6 +62,15 @@ public class DashboardDragResizeTest extends DashboardTestBase {
     @Test
     public void resizeWidgetInSectionBothHorizontallyAndVertically_sizeIsUpdated() {
         assertWidgetResized(1, 2, 2);
+    }
+
+    @Test
+    public void setDashboardNotEditable_resizeWidget_sizeIsNotUpdated() {
+        dashboard.setEditable(false);
+        DashboardWidget widgetToResize = dashboard.getWidgets().get(0);
+        fireItemResizeEndEvent(widgetToResize, 2, 2);
+        Assert.assertEquals(1, widgetToResize.getColspan());
+        Assert.assertEquals(1, widgetToResize.getRowspan());
     }
 
     private void assertWidgetResized(int widgetIndexToResize, int targetColspan,


### PR DESCRIPTION
## Description

This PR adds a check for whether the dashboard is editable before handling client events (resize, reorder, remove).

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor