### PR TITLE
refactor: return reordered items and parent from event

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
@@ -36,7 +36,7 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
     public void reorderWidgetOnClientSide_itemsAreReorderedCorrectly() {
         var draggedWidget = dashboardElement.getWidgets().get(0);
         var targetWidget = dashboardElement.getWidgets().get(1);
-        dragResizeElement(draggedWidget, targetWidget);
+        dragReorderElement(draggedWidget, targetWidget);
         Assert.assertEquals(draggedWidget.getTitle(),
                 dashboardElement.getWidgets().get(1).getTitle());
     }
@@ -45,7 +45,7 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
     public void reorderSectionOnClientSide_itemsAreReorderedCorrectly() {
         var draggedSection = dashboardElement.getSections().get(1);
         var targetWidget = dashboardElement.getWidgets().get(0);
-        dragResizeElement(draggedSection, targetWidget);
+        dragReorderElement(draggedSection, targetWidget);
         Assert.assertEquals(draggedSection.getTitle(),
                 dashboardElement.getSections().get(0).getTitle());
     }
@@ -55,7 +55,7 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
         var firstSection = dashboardElement.getSections().get(0);
         var draggedWidget = firstSection.getWidgets().get(0);
         var targetWidget = firstSection.getWidgets().get(1);
-        dragResizeElement(draggedWidget, targetWidget);
+        dragReorderElement(draggedWidget, targetWidget);
         firstSection = dashboardElement.getSections().get(0);
         Assert.assertEquals(draggedWidget.getTitle(),
                 firstSection.getWidgets().get(1).getTitle());
@@ -69,7 +69,7 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
         reorderWidgetOnClientSide_itemsAreReorderedCorrectly();
     }
 
-    private void dragResizeElement(TestBenchElement draggedElement,
+    private void dragReorderElement(TestBenchElement draggedElement,
             TestBenchElement targetElement) {
         var dragHandle = getDragHandle(draggedElement);
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderIT.java
@@ -83,10 +83,6 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
                 .release(targetElement).build().perform();
     }
 
-    private static boolean isDragHandleVisible(TestBenchElement element) {
-        return !"none".equals(getDragHandle(element).getCssValue("display"));
-    }
-
     private static TestBenchElement getDragHandle(TestBenchElement element) {
         return element.$("*").withClassName("drag-handle").first();
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragResizeIT.java
@@ -81,12 +81,6 @@ public class DashboardDragResizeIT extends AbstractComponentIT {
                 .release().build().perform();
     }
 
-    private boolean isResizeHandleVisible(
-            DashboardWidgetElement widgetElement) {
-        return !"none"
-                .equals(getResizeHandle(widgetElement).getCssValue("display"));
-    }
-
     private static TestBenchElement getResizeHandle(
             DashboardWidgetElement widgetElement) {
         return widgetElement.$("*").withClassName("resize-handle").first();

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderEndEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderEndEvent.java
@@ -8,12 +8,20 @@
  */
 package com.vaadin.flow.component.dashboard;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 
 import elemental.json.JsonArray;
+import elemental.json.JsonObject;
 
 /**
  * Widget or section reorder end event of {@link Dashboard}.
@@ -24,7 +32,11 @@ import elemental.json.JsonArray;
 @DomEvent("dashboard-item-reorder-end-flow")
 public class DashboardItemReorderEndEvent extends ComponentEvent<Dashboard> {
 
-    private final JsonArray items;
+    private List<Component> reorderedItems;
+
+    private JsonArray reorderedItemsFromClient;
+
+    private HasWidgets reorderedItemsParent;
 
     /**
      * Creates a dashboard item reorder end event.
@@ -34,19 +46,93 @@ public class DashboardItemReorderEndEvent extends ComponentEvent<Dashboard> {
      * @param fromClient
      *            <code>true</code> if the event originated from the client
      *            side, <code>false</code> otherwise
+     * @param items
+     *            The ordered items represented by node IDs as a
+     *            {@link JsonArray}
      */
     public DashboardItemReorderEndEvent(Dashboard source, boolean fromClient,
             @EventData("event.detail.items") JsonArray items) {
         super(source, fromClient);
-        this.items = items;
+        setReorderedItemParent(source, items);
+        setReorderedItems();
     }
 
     /**
-     * Returns the ordered items from the client side
+     * Returns the parent of the reordered items. Either a dashboard or a
+     * section.
      *
-     * @return items the ordered items as a {@link JsonArray}
+     * @return the parent of the reordered items
      */
-    public JsonArray getItems() {
-        return items;
+    public HasWidgets getReorderedItemsParent() {
+        return reorderedItemsParent;
+    }
+
+    /**
+     * Returns the list of the reordered item and its sibling items
+     *
+     * @return the list of the reordered item and its sibling items
+     */
+    public List<Component> getReorderedItems() {
+        return reorderedItems;
+    }
+
+    private void setReorderedItemParent(Dashboard source,
+            JsonArray itemsFromClient) {
+        List<Component> serverItems = source.getChildren().toList();
+        for (int rootLevelIdx = 0; rootLevelIdx < itemsFromClient
+                .length(); rootLevelIdx++) {
+            if (isNodeIdDifferentForIndex(itemsFromClient, serverItems,
+                    rootLevelIdx)) {
+                this.reorderedItemsParent = source;
+                this.reorderedItemsFromClient = itemsFromClient;
+                return;
+            }
+            if (serverItems
+                    .get(rootLevelIdx) instanceof DashboardSection section
+                    && isSectionItemReordered(section,
+                            itemsFromClient.get(rootLevelIdx))) {
+                this.reorderedItemsParent = section;
+                this.reorderedItemsFromClient = ((JsonObject) itemsFromClient
+                        .get(rootLevelIdx)).getArray("items");
+                return;
+            }
+        }
+    }
+
+    private void setReorderedItems() {
+        Map<Integer, Component> nodeIdToItems = ((Component) reorderedItemsParent)
+                .getChildren()
+                .collect(Collectors.toMap(
+                        item -> item.getElement().getNode().getId(),
+                        Function.identity()));
+        List<Component> items = new ArrayList<>();
+        for (int index = 0; index < reorderedItemsFromClient
+                .length(); index++) {
+            int nodeIdFromClient = (int) ((JsonObject) reorderedItemsFromClient
+                    .get(index)).getNumber("nodeid");
+            items.add(nodeIdToItems.get(nodeIdFromClient));
+        }
+        this.reorderedItems = items;
+    }
+
+    private static boolean isSectionItemReordered(DashboardSection section,
+            JsonObject itemFromClient) {
+        List<Component> sectionItems = section.getChildren().toList();
+        JsonArray clientSectionItems = itemFromClient.getArray("items");
+        for (int index = 0; index < clientSectionItems.length(); index++) {
+            if (isNodeIdDifferentForIndex(clientSectionItems, sectionItems,
+                    index)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isNodeIdDifferentForIndex(JsonArray clientItems,
+            List<Component> items, int index) {
+        JsonObject itemFromClient = clientItems.get(index);
+        int nodeIdFromClient = (int) itemFromClient.getNumber("nodeid");
+        int nodeIdFromServer = items.get(index).getElement().getNode().getId();
+        return nodeIdFromClient != nodeIdFromServer;
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderEndEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemReorderEndEvent.java
@@ -54,7 +54,13 @@ public class DashboardItemReorderEndEvent extends ComponentEvent<Dashboard> {
             @EventData("event.detail.items") JsonArray items) {
         super(source, fromClient);
         setReorderedItemParent(source, items);
-        setReorderedItems();
+        if (reorderedItemsParent == null) {
+            // No reordering
+            reorderedItemsParent = source;
+            reorderedItems = source.getChildren().toList();
+        } else {
+            setReorderedItems();
+        }
     }
 
     /**

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardDragReorderTest.java
@@ -51,6 +51,11 @@ public class DashboardDragReorderTest extends DashboardTestBase {
     }
 
     @Test
+    public void reorderWidgetToSamePosition_orderIsNotUpdated() {
+        assertRootLevelItemReorder(0, 0);
+    }
+
+    @Test
     public void reorderSection_orderIsUpdated() {
         assertRootLevelItemReorder(2, 1);
     }
@@ -58,6 +63,11 @@ public class DashboardDragReorderTest extends DashboardTestBase {
     @Test
     public void reorderWidgetInSection_orderIsUpdated() {
         assertSectionWidgetReorder(2, 0, 1);
+    }
+
+    @Test
+    public void reorderWidgetInSectionToSamePosition_orderIsNotUpdated() {
+        assertSectionWidgetReorder(2, 0, 0);
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR updates the `DashboardItemReorderEndEvent` to return the list of reordered items and their parent instead of the JSON array containing the node IDs of all items.

Added API:
- `List<Component> getReorderedItems()`: Returns the list of the reordered item and its sibling items
- `HasWidgets getReorderedItemsParent()`: Returns the parent of the reordered items

Removed API:
- `JsonArray getItems()`: Returns the ordered items from the client side

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor