### PR TITLE
refactor: throw exception when setting and getting visibility

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -378,14 +378,9 @@ public class Dashboard extends Component implements HasWidgets {
                 "Dashboard does not support setting visibility");
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     *             Dashboard does not support setting visibility
-     */
     @Override
     public boolean isVisible() {
-        throw new UnsupportedOperationException(
-                "Dashboard does not support setting visibility");
+        return true;
     }
 
     @Override

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -368,6 +368,26 @@ public class Dashboard extends Component implements HasWidgets {
         return childrenComponents.stream();
     }
 
+    /**
+     * @throws UnsupportedOperationException
+     *             Dashboard does not support setting visibility
+     */
+    @Override
+    public void setVisible(boolean visible) {
+        throw new UnsupportedOperationException(
+                "Dashboard does not support setting visibility");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     *             Dashboard does not support setting visibility
+     */
+    @Override
+    public boolean isVisible() {
+        throw new UnsupportedOperationException(
+                "Dashboard does not support setting visibility");
+    }
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -151,6 +151,26 @@ public class DashboardSection extends Component implements HasWidgets {
         getParent().ifPresent(parent -> ((Dashboard) parent).remove(this));
     }
 
+    /**
+     * @throws UnsupportedOperationException
+     *             Dashboard section does not support setting visibility
+     */
+    @Override
+    public void setVisible(boolean visible) {
+        throw new UnsupportedOperationException(
+                "Dashboard section does not support setting visibility");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     *             Dashboard section does not support setting visibility
+     */
+    @Override
+    public boolean isVisible() {
+        throw new UnsupportedOperationException(
+                "Dashboard section does not support setting visibility");
+    }
+
     private void doRemoveAll() {
         new ArrayList<>(widgets).forEach(this::doRemoveWidget);
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -161,14 +161,9 @@ public class DashboardSection extends Component implements HasWidgets {
                 "Dashboard section does not support setting visibility");
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     *             Dashboard section does not support setting visibility
-     */
     @Override
     public boolean isVisible() {
-        throw new UnsupportedOperationException(
-                "Dashboard section does not support setting visibility");
+        return true;
     }
 
     private void doRemoveAll() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -165,14 +165,9 @@ public class DashboardWidget extends Component {
                 "Dashboard widget does not support setting visibility");
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     *             Dashboard widget does not support setting visibility
-     */
     @Override
     public boolean isVisible() {
-        throw new UnsupportedOperationException(
-                "Dashboard widget does not support setting visibility");
+        return true;
     }
 
     private void notifyParentDashboardOrSection() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -155,6 +155,26 @@ public class DashboardWidget extends Component {
         SlotUtils.setSlot(this, "header", header);
     }
 
+    /**
+     * @throws UnsupportedOperationException
+     *             Dashboard widget does not support setting visibility
+     */
+    @Override
+    public void setVisible(boolean visible) {
+        throw new UnsupportedOperationException(
+                "Dashboard widget does not support setting visibility");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     *             Dashboard widget does not support setting visibility
+     */
+    @Override
+    public boolean isVisible() {
+        throw new UnsupportedOperationException(
+                "Dashboard widget does not support setting visibility");
+    }
+
     private void notifyParentDashboardOrSection() {
         getParent().ifPresent(parent -> {
             if (parent instanceof Dashboard dashboard) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -870,16 +870,14 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
-    public void getDashboardVisibility_exceptionIsThrown() {
-        Assert.assertThrows(UnsupportedOperationException.class,
-                () -> dashboard.isVisible());
+    public void getDashboardVisibility_returnsTrue() {
+        Assert.assertTrue(dashboard.isVisible());
     }
 
     @Test
-    public void getSectionVisibility_exceptionIsThrown() {
+    public void getSectionVisibility_returnsTrue() {
         DashboardSection section = dashboard.addSection();
-        Assert.assertThrows(UnsupportedOperationException.class,
-                section::isVisible);
+        Assert.assertTrue(section.isVisible());
     }
 
     private void fireItemRemovedEvent(int nodeId) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -852,6 +852,36 @@ public class DashboardTest extends DashboardTestBase {
         Assert.assertFalse(actualNodeIds.contains(nodeIdToBeRemoved));
     }
 
+    @Test
+    public void setDashboardVisibility_exceptionIsThrown() {
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> dashboard.setVisible(false));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> dashboard.setVisible(true));
+    }
+
+    @Test
+    public void setDashboardSectionVisibility_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> section.setVisible(false));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> section.setVisible(true));
+    }
+
+    @Test
+    public void getDashboardVisibility_exceptionIsThrown() {
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> dashboard.isVisible());
+    }
+
+    @Test
+    public void getSectionVisibility_exceptionIsThrown() {
+        DashboardSection section = dashboard.addSection();
+        Assert.assertThrows(UnsupportedOperationException.class,
+                section::isVisible);
+    }
+
     private void fireItemRemovedEvent(int nodeId) {
         ComponentUtil.fireEvent(dashboard,
                 new DashboardItemRemovedEvent(dashboard, false, nodeId));

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -249,4 +249,20 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Assert.assertEquals(content, widget.getContent());
         Assert.assertEquals(header, widget.getHeader());
     }
+
+    @Test
+    public void setWidgetVisibility_exceptionIsThrown() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> widget.setVisible(false));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> widget.setVisible(true));
+    }
+
+    @Test
+    public void getWidgetVisibility_exceptionIsThrown() {
+        DashboardWidget widget = new DashboardWidget();
+        Assert.assertThrows(UnsupportedOperationException.class,
+                widget::isVisible);
+    }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -260,9 +260,8 @@ public class DashboardWidgetTest extends DashboardTestBase {
     }
 
     @Test
-    public void getWidgetVisibility_exceptionIsThrown() {
+    public void getWidgetVisibility_returnsTrue() {
         DashboardWidget widget = new DashboardWidget();
-        Assert.assertThrows(UnsupportedOperationException.class,
-                widget::isVisible);
+        Assert.assertTrue(widget.isVisible());
     }
 }


### PR DESCRIPTION
## Description

This PR makes `setVisible` and `isVisible` throw an `UnsupportedOperationException` for `Dashboard`, `DashboardSection`, and `DashboardWidget`.

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor