### PR TITLE
refactor: make dashboard implement hassize

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -41,7 +42,7 @@ import elemental.json.JsonObject;
 @JsModule("@vaadin/dashboard/src/vaadin-dashboard.js")
 @JsModule("./flow-component-renderer.js")
 // @NpmPackage(value = "@vaadin/dashboard", version = "24.6.0-alpha0")
-public class Dashboard extends Component implements HasWidgets {
+public class Dashboard extends Component implements HasWidgets, HasSize {
 
     private final List<Component> childrenComponents = new ArrayList<>();
 


### PR DESCRIPTION
## Description

This PR makes `Dashboard` implement `HasSize`. This adds all the APIs from `HasSize` to `Dashboard`.

Added API:
- `void setWidth(String width)`
- `void setWidth(float width, Unit unit)`
- `void setMinWidth(String minWidth)`
- `void setMinWidth(float minWidth, Unit unit)`
- `void setMaxWidth(String maxWidth)`
- `void setMaxWidth(float maxWidth, Unit unit)`
- `String getWidth()`
- `String getMinWidth()`
- `String getMaxWidth()`
- `Optional<Unit> getWidthUnit()`
- `void setHeight(String height)`
- `void setHeight(float height, Unit unit)`
- `void setMinHeight(String minHeight)`
- `void setMinHeight(float minHeight, Unit unit)`
- `void setMaxHeight(String maxHeight)`
- `void setMaxHeight(float maxHeight, Unit unit)`
- `String getHeight()`
- `String getMinHeight()`
- `String getMaxHeight()`
- `Optional<Unit> getHeightUnit()`
- `void setSizeFull()`
- `void setWidthFull()`
- `void setHeightFull()`
- `void setSizeUndefined()`

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor