### PR TITLE
feat: implement i18n support

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nPage.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardSection;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-dashboard/i18n")
+public class DashboardI18nPage extends Div {
+
+    enum I18nEntry {
+        SELECT_SECTION_TITLE_FOR_EDITING("selectSectionTitleForEditing",
+                "Select section title for editing"),
+
+        SELECT_WIDGET_TITLE_FOR_EDITING("selectWidgetTitleForEditing",
+                "Select widget title for editing"),
+
+        REMOVE("remove", "Remove"),
+
+        RESIZE("resize", "Resize"),
+
+        RESIZE_APPLY("resizeApply", "Apply"),
+
+        RESIZE_SHRINK_WIDTH("resizeShrinkWidth", "Shrink width"),
+
+        RESIZE_GROW_WIDTH("resizeGrowWidth", "Grow width"),
+
+        RESIZE_SHRINK_HEIGHT("resizeShrinkHeight", "Shrink height"),
+
+        RESIZE_GROW_HEIGHT("resizeGrowHeight", "Grow height"),
+
+        MOVE("move", "Move"),
+
+        MOVE_APPLY("moveApply", "Apply"),
+
+        MOVE_FORWARD("moveForward", "Move Forward"),
+
+        MOVE_BACKWARD("moveBackward", "Move Backward");
+
+        private final String key;
+        private final String defaultValue;
+
+        I18nEntry(String key, String defaultValue) {
+            this.key = key;
+            this.defaultValue = defaultValue;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public String getCustomValue() {
+            return "Custom " + defaultValue;
+        }
+    }
+
+    public DashboardI18nPage() {
+        Dashboard dashboard = new Dashboard();
+        dashboard.setEditable(true);
+
+        dashboard.add(new DashboardWidget());
+        DashboardSection section = dashboard.addSection();
+        section.add(new DashboardWidget());
+
+        NativeButton setCustomI18n = new NativeButton("Set custom i18n",
+                e -> dashboard.setI18n(getCustomI18n()));
+        setCustomI18n.setId("set-custom-i18n");
+
+        add(setCustomI18n, dashboard);
+    }
+
+    private static Dashboard.DashboardI18n getCustomI18n() {
+        Dashboard.DashboardI18n dashboardI18n = new Dashboard.DashboardI18n();
+        dashboardI18n.setSelectSectionTitleForEditing(
+                I18nEntry.SELECT_SECTION_TITLE_FOR_EDITING.getCustomValue());
+        dashboardI18n.setSelectWidgetTitleForEditing(
+                I18nEntry.SELECT_WIDGET_TITLE_FOR_EDITING.getCustomValue());
+        dashboardI18n.setRemove(I18nEntry.REMOVE.getCustomValue());
+        dashboardI18n.setResize(I18nEntry.RESIZE.getCustomValue());
+        dashboardI18n.setResizeApply(I18nEntry.RESIZE_APPLY.getCustomValue());
+        dashboardI18n.setResizeShrinkWidth(
+                I18nEntry.RESIZE_SHRINK_WIDTH.getCustomValue());
+        dashboardI18n.setResizeGrowWidth(
+                I18nEntry.RESIZE_GROW_WIDTH.getCustomValue());
+        dashboardI18n.setResizeShrinkHeight(
+                I18nEntry.RESIZE_SHRINK_HEIGHT.getCustomValue());
+        dashboardI18n.setResizeGrowHeight(
+                I18nEntry.RESIZE_GROW_HEIGHT.getCustomValue());
+        dashboardI18n.setMove(I18nEntry.MOVE.getCustomValue());
+        dashboardI18n.setMoveApply(I18nEntry.MOVE_APPLY.getCustomValue());
+        dashboardI18n.setMoveForward(I18nEntry.MOVE_FORWARD.getCustomValue());
+        dashboardI18n.setMoveBackward(I18nEntry.MOVE_BACKWARD.getCustomValue());
+        return dashboardI18n;
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nPage.java
@@ -19,9 +19,9 @@ import com.vaadin.flow.router.Route;
 public class DashboardI18nPage extends Div {
 
     enum I18nEntry {
-        SELECT_SECTION_TITLE_FOR_EDITING("selectSectionTitleForEditing"),
+        SELECT_SECTION("selectSection"),
 
-        SELECT_WIDGET_TITLE_FOR_EDITING("selectWidgetTitleForEditing"),
+        SELECT_WIDGET("selectWidget"),
 
         REMOVE("remove"),
 
@@ -77,10 +77,9 @@ public class DashboardI18nPage extends Div {
 
     private static Dashboard.DashboardI18n getCustomI18n() {
         Dashboard.DashboardI18n dashboardI18n = new Dashboard.DashboardI18n();
-        dashboardI18n.setSelectSectionTitleForEditing(
-                I18nEntry.SELECT_SECTION_TITLE_FOR_EDITING.getCustomValue());
-        dashboardI18n.setSelectWidgetTitleForEditing(
-                I18nEntry.SELECT_WIDGET_TITLE_FOR_EDITING.getCustomValue());
+        dashboardI18n
+                .setSelectSection(I18nEntry.SELECT_SECTION.getCustomValue());
+        dashboardI18n.setSelectWidget(I18nEntry.SELECT_WIDGET.getCustomValue());
         dashboardI18n.setRemove(I18nEntry.REMOVE.getCustomValue());
         dashboardI18n.setResize(I18nEntry.RESIZE.getCustomValue());
         dashboardI18n.setResizeApply(I18nEntry.RESIZE_APPLY.getCustomValue());

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nPage.java
@@ -19,52 +19,44 @@ import com.vaadin.flow.router.Route;
 public class DashboardI18nPage extends Div {
 
     enum I18nEntry {
-        SELECT_SECTION_TITLE_FOR_EDITING("selectSectionTitleForEditing",
-                "Select section title for editing"),
+        SELECT_SECTION_TITLE_FOR_EDITING("selectSectionTitleForEditing"),
 
-        SELECT_WIDGET_TITLE_FOR_EDITING("selectWidgetTitleForEditing",
-                "Select widget title for editing"),
+        SELECT_WIDGET_TITLE_FOR_EDITING("selectWidgetTitleForEditing"),
 
-        REMOVE("remove", "Remove"),
+        REMOVE("remove"),
 
-        RESIZE("resize", "Resize"),
+        RESIZE("resize"),
 
-        RESIZE_APPLY("resizeApply", "Apply"),
+        RESIZE_APPLY("resizeApply"),
 
-        RESIZE_SHRINK_WIDTH("resizeShrinkWidth", "Shrink width"),
+        RESIZE_SHRINK_WIDTH("resizeShrinkWidth"),
 
-        RESIZE_GROW_WIDTH("resizeGrowWidth", "Grow width"),
+        RESIZE_GROW_WIDTH("resizeGrowWidth"),
 
-        RESIZE_SHRINK_HEIGHT("resizeShrinkHeight", "Shrink height"),
+        RESIZE_SHRINK_HEIGHT("resizeShrinkHeight"),
 
-        RESIZE_GROW_HEIGHT("resizeGrowHeight", "Grow height"),
+        RESIZE_GROW_HEIGHT("resizeGrowHeight"),
 
-        MOVE("move", "Move"),
+        MOVE("move"),
 
-        MOVE_APPLY("moveApply", "Apply"),
+        MOVE_APPLY("moveApply"),
 
-        MOVE_FORWARD("moveForward", "Move Forward"),
+        MOVE_FORWARD("moveForward"),
 
-        MOVE_BACKWARD("moveBackward", "Move Backward");
+        MOVE_BACKWARD("moveBackward");
 
         private final String key;
-        private final String defaultValue;
 
-        I18nEntry(String key, String defaultValue) {
+        I18nEntry(String key) {
             this.key = key;
-            this.defaultValue = defaultValue;
         }
 
         public String getKey() {
             return key;
         }
 
-        public String getDefaultValue() {
-            return defaultValue;
-        }
-
         public String getCustomValue() {
-            return "Custom " + defaultValue;
+            return "Custom " + key;
         }
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nIT.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * Integration tests for the {@link DashboardI18nPage}.
+ *
+ * @author Vaadin Ltd.
+ */
+@TestPath("vaadin-dashboard/i18n")
+public class DashboardI18nIT extends AbstractComponentIT {
+
+    private DashboardElement dashboardElement;
+
+    @Before
+    public void init() {
+        open();
+        dashboardElement = $(DashboardElement.class).waitForFirst();
+    }
+
+    @Test
+    public void itemsHaveCorrectDefaultI18N() {
+        assertI18nValues(true);
+    }
+
+    @Test
+    public void setCustomI18n_i18nIsUpdated() {
+        clickElementWithJs("set-custom-i18n");
+        assertI18nValues(false);
+    }
+
+    private void assertI18nValues(boolean isDefault) {
+        for (DashboardI18nPage.I18nEntry i18NEntry : DashboardI18nPage.I18nEntry
+                .values()) {
+            String expectedValue = isDefault ? i18NEntry.getDefaultValue()
+                    : i18NEntry.getCustomValue();
+            Assert.assertEquals(expectedValue, dashboardElement
+                    .getPropertyString("i18n", i18NEntry.getKey()));
+        }
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardI18nIT.java
@@ -33,23 +33,24 @@ public class DashboardI18nIT extends AbstractComponentIT {
     }
 
     @Test
-    public void itemsHaveCorrectDefaultI18N() {
-        assertI18nValues(true);
+    public void dashboardHasCorrectDefaultI18nKeys() {
+        for (DashboardI18nPage.I18nEntry i18NEntry : DashboardI18nPage.I18nEntry
+                .values()) {
+            Assert.assertNotNull(getI18nValue(i18NEntry));
+        }
     }
 
     @Test
     public void setCustomI18n_i18nIsUpdated() {
         clickElementWithJs("set-custom-i18n");
-        assertI18nValues(false);
-    }
-
-    private void assertI18nValues(boolean isDefault) {
         for (DashboardI18nPage.I18nEntry i18NEntry : DashboardI18nPage.I18nEntry
                 .values()) {
-            String expectedValue = isDefault ? i18NEntry.getDefaultValue()
-                    : i18NEntry.getCustomValue();
-            Assert.assertEquals(expectedValue, dashboardElement
-                    .getPropertyString("i18n", i18NEntry.getKey()));
+            String expectedI18nValue = i18NEntry.getCustomValue();
+            Assert.assertEquals(expectedI18nValue, getI18nValue(i18NEntry));
         }
+    }
+
+    private String getI18nValue(DashboardI18nPage.I18nEntry i18NEntry) {
+        return dashboardElement.getPropertyString("i18n", i18NEntry.getKey());
     }
 }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -711,10 +711,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         private String moveBackward;
 
         /**
-         * Gets the text for the {@code aria-label} attribute of section focus
-         * buttons
+         * Gets the accessible name of section focus buttons
          *
-         * @return the section focus button {@code aria-label}, or {@code null}
+         * @return the accessible name of section focus button, or {@code null}
          *         if not set
          */
         public String getSelectSection() {
@@ -722,11 +721,10 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code aria-label} attribute of section focus
-         * buttons
+         * Sets the accessible name of section focus buttons
          *
          * @param selectSection
-         *            the section focus button {@code aria-label} to set
+         *            the accessible name of section focus button to set
          * @return this instance for method chaining
          */
         public DashboardI18n setSelectSection(String selectSection) {
@@ -735,10 +733,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code aria-label} attribute of widget focus
-         * buttons
+         * Gets the accessible name of widget focus buttons
          *
-         * @return the widget focus button {@code aria-label}, or {@code null}
+         * @return the accessible name of widget focus button, or {@code null}
          *         if not set
          */
         public String getSelectWidget() {
@@ -746,11 +743,10 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code aria-label} attribute of widget focus
-         * buttons
+         * Sets the accessible name of widget focus buttons
          *
          * @param selectWidget
-         *            the widget focus button {@code aria-label} to set
+         *            the accessible name of widget focus button to set
          * @return this instance for method chaining
          */
         public DashboardI18n setSelectWidget(String selectWidget) {
@@ -759,10 +755,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of dashboard item
-         * remove buttons
+         * Gets the accessible name of dashboard item remove buttons
          *
-         * @return the dashboard item remove button {@code title}, or
+         * @return the accessible name of dashboard item remove button, or
          *         {@code null} if not set
          */
         public String getRemove() {
@@ -770,11 +765,10 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of dashboard item
-         * remove buttons
+         * Sets the accessible name of dashboard item remove buttons
          *
          * @param remove
-         *            the dashboard item remove button {@code title} to set
+         *            the accessible name of dashboard item remove button to set
          * @return this instance for method chaining
          */
         public DashboardI18n setRemove(String remove) {
@@ -783,22 +777,20 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of widget resize
-         * handles
+         * Gets the accessible name of widget resize handles
          *
-         * @return the widget resize handle {@code title}, or {@code null} if
-         *         not set
+         * @return the accessible name of widget resize handle, or {@code null}
+         *         if not set
          */
         public String getResize() {
             return resize;
         }
 
         /**
-         * Sets the text for the {@code title} attribute of widget resize
-         * handles
+         * Sets the accessible name of widget resize handles
          *
          * @param resize
-         *            the widget resize handle {@code title} to set
+         *            the accessible name of widget resize handle to set
          * @return this instance for method chaining
          */
         public DashboardI18n setResize(String resize) {
@@ -807,22 +799,20 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of widget resize apply
-         * buttons
+         * Gets the accessible name of widget resize apply buttons
          *
-         * @return the widget resize apply button {@code title}, or {@code null}
-         *         if not set
+         * @return the accessible name of widget resize apply button, or
+         *         {@code null} if not set
          */
         public String getResizeApply() {
             return resizeApply;
         }
 
         /**
-         * Sets the text for the {@code title} attribute of widget resize apply
-         * buttons
+         * Sets the accessible name of widget resize apply buttons
          *
          * @param resizeApply
-         *            the widget resize apply button {@code title} to set
+         *            the accessible name of widget resize apply button to set
          * @return this instance for method chaining
          */
         public DashboardI18n setResizeApply(String resizeApply) {
@@ -831,10 +821,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of widget resize shrink
-         * width buttons
+         * Gets the accessible name of widget resize shrink width buttons
          *
-         * @return the widget resize shrink width button {@code title}, or
+         * @return the accessible name of widget resize shrink width button, or
          *         {@code null} if not set
          */
         public String getResizeShrinkWidth() {
@@ -842,11 +831,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of widget resize shrink
-         * width buttons
+         * Sets the accessible name of widget resize shrink width buttons
          *
          * @param resizeShrinkWidth
-         *            the widget resize shrink width button {@code title} to set
+         *            the accessible name of widget resize shrink width button
+         *            to set
          * @return this instance for method chaining
          */
         public DashboardI18n setResizeShrinkWidth(String resizeShrinkWidth) {
@@ -855,10 +844,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of widget resize grow
-         * width buttons
+         * Gets the accessible name of widget resize grow width buttons
          *
-         * @return the widget resize grow width button {@code title}, or
+         * @return the accessible name of widget resize grow width button, or
          *         {@code null} if not set
          */
         public String getResizeGrowWidth() {
@@ -866,11 +854,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of widget resize grow
-         * width buttons
+         * Sets the accessible name of widget resize grow width buttons
          *
          * @param resizeGrowWidth
-         *            the widget resize grow width button {@code title} to set
+         *            the accessible name of widget resize grow width button to
+         *            set
          * @return this instance for method chaining
          */
         public DashboardI18n setResizeGrowWidth(String resizeGrowWidth) {
@@ -879,10 +867,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of widget resize shrink
-         * height buttons
+         * Gets the accessible name of widget resize shrink height buttons
          *
-         * @return the widget resize shrink height button {@code title}, or
+         * @return the accessible name of widget resize shrink height button, or
          *         {@code null} if not set
          */
         public String getResizeShrinkHeight() {
@@ -890,12 +877,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of widget resize shrink
-         * height buttons
+         * Sets the accessible name of widget resize shrink height buttons
          *
          * @param resizeShrinkHeight
-         *            the widget resize shrink height button {@code title} to
-         *            set
+         *            the accessible name of widget resize shrink height button
+         *            to set
          * @return this instance for method chaining
          */
         public DashboardI18n setResizeShrinkHeight(String resizeShrinkHeight) {
@@ -904,10 +890,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of widget resize grow
-         * height buttons
+         * Gets the accessible name of widget resize grow height buttons
          *
-         * @return the widget resize grow height button {@code title}, or
+         * @return the accessible name of widget resize grow height button, or
          *         {@code null} if not set
          */
         public String getResizeGrowHeight() {
@@ -915,11 +900,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of widget resize grow
-         * height buttons
+         * Sets the accessible name of widget resize grow height buttons
          *
          * @param resizeGrowHeight
-         *            the widget resize grow height button {@code title} to set
+         *            the accessible name of widget resize grow height button to
+         *            set
          * @return this instance for method chaining
          */
         public DashboardI18n setResizeGrowHeight(String resizeGrowHeight) {
@@ -928,22 +913,20 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of dashboard item drag
-         * handles
+         * Gets the accessible name of dashboard item drag handles
          *
-         * @return the dashboard item drag handle {@code title}, or {@code null}
-         *         if not set
+         * @return the accessible name of dashboard item drag handle, or
+         *         {@code null} if not set
          */
         public String getMove() {
             return move;
         }
 
         /**
-         * Sets the text for the {@code title} attribute of dashboard item drag
-         * handles
+         * Sets the accessible name of dashboard item drag handles
          *
          * @param move
-         *            the dashboard item drag handle {@code title} to set
+         *            the accessible name of dashboard item drag handle to set
          * @return this instance for method chaining
          */
         public DashboardI18n setMove(String move) {
@@ -952,10 +935,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of dashboard item move
-         * apply buttons
+         * Gets the accessible name of dashboard item move apply buttons
          *
-         * @return the dashboard item move apply button {@code title}, or
+         * @return the accessible name of dashboard item move apply button, or
          *         {@code null} if not set
          */
         public String getMoveApply() {
@@ -963,11 +945,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of dashboard item move
-         * apply buttons
+         * Sets the accessible name of dashboard item move apply buttons
          *
          * @param moveApply
-         *            the dashboard item move apply button {@code title} to set
+         *            the accessible name of dashboard item move apply button to
+         *            set
          * @return this instance for method chaining
          */
         public DashboardI18n setMoveApply(String moveApply) {
@@ -976,10 +958,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of dashboard item move
-         * forward buttons
+         * Gets the accessible name of dashboard item move forward buttons
          *
-         * @return the dashboard item move forward button {@code title}, or
+         * @return the accessible name of dashboard item move forward button, or
          *         {@code null} if not set
          */
         public String getMoveForward() {
@@ -987,12 +968,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Sets the text for the {@code title} attribute of dashboard item move
-         * forward buttons
+         * Sets the accessible name of dashboard item move forward buttons
          *
          * @param moveForward
-         *            the dashboard item move forward button {@code title} to
-         *            set
+         *            the accessible name of dashboard item move forward button
+         *            to set
          * @return this instance for method chaining
          */
         public DashboardI18n setMoveForward(String moveForward) {
@@ -1001,23 +981,21 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         }
 
         /**
-         * Gets the text for the {@code title} attribute of dashboard item move
-         * backward buttons
+         * Gets the accessible name of dashboard item move backward buttons
          *
-         * @return the dashboard item move backward button {@code title}, or
-         *         {@code null} if not set
+         * @return the accessible name of dashboard item move backward button,
+         *         or {@code null} if not set
          */
         public String getMoveBackward() {
             return moveBackward;
         }
 
         /**
-         * Sets the text for the {@code title} attribute of dashboard item move
-         * backward buttons
+         * Sets the accessible name of dashboard item move backward buttons
          *
          * @param moveBackward
-         *            the dashboard item move backward button {@code title} to
-         *            set
+         *            the accessible name of dashboard item move backward button
+         *            to set
          * @return this instance for method chaining
          */
         public DashboardI18n setMoveBackward(String moveBackward) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -696,8 +696,8 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
      */
     public static class DashboardI18n implements Serializable {
 
-        private String selectSectionTitleForEditing;
-        private String selectWidgetTitleForEditing;
+        private String selectSection;
+        private String selectWidget;
         private String remove;
         private String resize;
         private String resizeApply;
@@ -717,21 +717,20 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
          * @return the section focus button {@code aria-label}, or {@code null}
          *         if not set
          */
-        public String getSelectSectionTitleForEditing() {
-            return selectSectionTitleForEditing;
+        public String getSelectSection() {
+            return selectSection;
         }
 
         /**
          * Sets the text for the {@code aria-label} attribute of section focus
          * buttons
          *
-         * @param selectSectionTitleForEditing
+         * @param selectSection
          *            the section focus button {@code aria-label} to set
          * @return this instance for method chaining
          */
-        public DashboardI18n setSelectSectionTitleForEditing(
-                String selectSectionTitleForEditing) {
-            this.selectSectionTitleForEditing = selectSectionTitleForEditing;
+        public DashboardI18n setSelectSection(String selectSection) {
+            this.selectSection = selectSection;
             return this;
         }
 
@@ -742,21 +741,20 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
          * @return the widget focus button {@code aria-label}, or {@code null}
          *         if not set
          */
-        public String getSelectWidgetTitleForEditing() {
-            return selectWidgetTitleForEditing;
+        public String getSelectWidget() {
+            return selectWidget;
         }
 
         /**
          * Sets the text for the {@code aria-label} attribute of widget focus
          * buttons
          *
-         * @param selectWidgetTitleForEditing
+         * @param selectWidget
          *            the widget focus button {@code aria-label} to set
          * @return this instance for method chaining
          */
-        public DashboardI18n setSelectWidgetTitleForEditing(
-                String selectWidgetTitleForEditing) {
-            this.selectWidgetTitleForEditing = selectWidgetTitleForEditing;
+        public DashboardI18n setSelectWidget(String selectWidget) {
+            this.selectWidget = selectWidget;
             return this;
         }
 


### PR DESCRIPTION
## Description

This PR adds internationalization support through `Dashboard.DashboardI18n`.

Added API:
- For `Dashboard`
  - `DashboardI18n getI18n()`: Gets the internationalization object previously set for the dashboard
  - `void setI18n(DashboardI18n i18n)`: Sets the internationalization object for the dashboard
- For `Dashboard.DashboardI18n`
  - `String getSelectSectionTitleForEditing()`: Gets the text for the `aria-label` attribute of section focus buttons
  - `DashboardI18n setSelectSectionTitleForEditing(String selectSectionTitleForEditing)`: Sets the text for the `aria-label` attribute of section focus buttons
  - `String getSelectWidgetTitleForEditing()`: Gets the text for the `aria-label` attribute of widget focus buttons
  - `DashboardI18n setSelectWidgetTitleForEditing(String selectWidgetTitleForEditing)`: Sets the text for the `aria-label` attribute of widget focus buttons
  - `String getRemove()`: Gets the text for the `title` attribute of dashboard item remove buttons
  - `DashboardI18n setRemove(String remove)`: Sets the text for the `title` attribute of dashboard item remove buttons
  - `String getResize()`: Gets the text for the `title` attribute of widget resize handles
  - `DashboardI18n setResize(String resize)`: Sets the text for the `title` attribute of widget resize handles
  - `String getResizeApply()`: Gets the text for the `title` attribute of widget resize apply buttons
  - `DashboardI18n setResizeApply(String resizeApply)`: Sets the text for the `title` attribute of widget resize apply buttons
  - `String getResizeShrinkWidth()`: Gets the text for the `title` attribute of widget resize shrink width buttons
  - `DashboardI18n setResizeShrinkWidth(String resizeShrinkWidth)`: Sets the text for the `title` attribute of widget resize shrink width buttons
  - `String getResizeGrowWidth()`: Gets the text for the `title` attribute of widget resize grow width buttons
  - `DashboardI18n setResizeGrowWidth(String resizeGrowWidth)`: Sets the text for the `title` attribute of widget resize grow width buttons
  - `String getResizeShrinkHeight()`: Gets the text for the `title` attribute of widget resize shrink height buttons
  - `DashboardI18n setResizeShrinkHeight(String resizeShrinkHeight)`: Sets the text for the `title` attribute of widget resize shrink height buttons
  - `String getResizeGrowHeight()`: Gets the text for the `title` attribute of widget resize grow height buttons
  - `DashboardI18n setResizeGrowHeight(String resizeGrowHeight)`: Sets the text for the `title` attribute of widget resize grow height buttons
  - `String getMove()`: Gets the text for the `title` attribute of dashboard item drag handles
  - `DashboardI18n setMove(String move)`: Sets the text for the `title` attribute of dashboard item drag handles
  - `String getMoveApply()`: Gets the text for the `title` attribute of dashboard item move apply buttons
  - `DashboardI18n setMoveApply(String moveApply)`: Sets the text for the `title` attribute of dashboard item move apply buttons
  - `String getMoveForward()`: Gets the text for the `title` attribute of dashboard item move forward buttons
  - `DashboardI18n setMoveForward(String moveForward)`: Sets the text for the `title` attribute of dashboard item move forward buttons
  - `String getMoveBackward()`: Gets the text for the `title` attribute of dashboard item move backward buttons
  - `DashboardI18n setMoveBackward(String moveBackward)`: Sets the text for the `title` attribute of dashboard item move backward buttons

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=80848635

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature