### PR TITLE
fix: remove default login listener when setting form action

### DIFF
--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -124,7 +124,7 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
                 registration.remove();
                 registration = null;
             }
-            checkActionAttributeUsedWithLoginListeners();
+            warnIfActionAndLoginListenerUsedTogether();
         }
     }
 
@@ -254,7 +254,7 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
             ComponentEventListener<LoginEvent> listener) {
         Registration registration = ComponentUtil.addListener(this,
                 LoginEvent.class, listener);
-        checkActionAttributeUsedWithLoginListeners();
+        warnIfActionAndLoginListenerUsedTogether();
         return registration;
     }
 
@@ -312,7 +312,7 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
         getElement().setProperty(PROP_DISABLED, !enabled);
     }
 
-    private void checkActionAttributeUsedWithLoginListeners() {
+    private void warnIfActionAndLoginListenerUsedTogether() {
         if (getElement().hasProperty(PROP_ACTION)
                 && !getListeners(LoginEvent.class).isEmpty()) {
             LoggerFactory.getLogger(getClass()).warn(

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -148,18 +148,6 @@ public class LoginFormTest {
     }
 
     @Test
-    public void setAction_nullValue_restoreDefaultListener() {
-        final LoginForm form = new LoginForm();
-        form.setAction("login");
-        form.setError(true);
-
-        ComponentUtil.fireEvent(form, new AbstractLogin.LoginEvent(form, true,
-                "username", "password"));
-        Assert.assertTrue(form.isEnabled());
-        Assert.assertTrue(form.isError());
-    }
-
-    @Test
     public void addLoginListener_actionSet_throws() {
         final LoginForm form = new LoginForm();
         form.setAction("login");

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.shared.Registration;
 
 public class LoginFormTest {
 
@@ -102,4 +103,73 @@ public class LoginFormTest {
         Assert.assertEquals("Custom username",
                 form.getI18n().getForm().getUsername());
     }
+
+    @Test
+    public void setAction_customLoginListeners_throws() {
+        final LoginForm form = new LoginForm();
+        Registration registration1 = form.addLoginListener(ev -> {
+        });
+        Registration registration2 = form.addLoginListener(ev -> {
+        });
+        Assert.assertThrows(IllegalStateException.class,
+                () -> form.setAction("login"));
+
+        registration1.remove();
+        Assert.assertThrows(IllegalStateException.class,
+                () -> form.setAction("login"));
+
+        registration2.remove();
+        form.setAction("login");
+    }
+
+    @Test
+    public void setAction_unregisterAndRegisterDefaultLoginListener() {
+        final LoginForm form = new LoginForm();
+        form.setAction("login");
+        form.setError(true);
+
+        ComponentUtil.fireEvent(form, new AbstractLogin.LoginEvent(form, true,
+                "username", "password"));
+        Assert.assertTrue(
+                "Expected form not being disabled by default listener",
+                form.isEnabled());
+        Assert.assertTrue(
+                "Expected error status not being reset by default listener",
+                form.isError());
+
+        form.setAction(null);
+        ComponentUtil.fireEvent(form, new AbstractLogin.LoginEvent(form, true,
+                "username", "password"));
+        Assert.assertFalse("Expected form being disabled by default listener",
+                form.isEnabled());
+        Assert.assertFalse(
+                "Expected error status being reset by default listener",
+                form.isError());
+    }
+
+    @Test
+    public void setAction_nullValue_restoreDefaultListener() {
+        final LoginForm form = new LoginForm();
+        form.setAction("login");
+        form.setError(true);
+
+        ComponentUtil.fireEvent(form, new AbstractLogin.LoginEvent(form, true,
+                "username", "password"));
+        Assert.assertTrue(form.isEnabled());
+        Assert.assertTrue(form.isError());
+    }
+
+    @Test
+    public void addLoginListener_actionSet_throws() {
+        final LoginForm form = new LoginForm();
+        form.setAction("login");
+        Assert.assertThrows(IllegalStateException.class,
+                () -> form.addLoginListener(ev -> {
+                }));
+
+        form.setAction(null);
+        form.addLoginListener(ev -> {
+        });
+    }
+
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
@@ -105,18 +105,6 @@ public class LoginOverlayTest {
     }
 
     @Test
-    public void setAction_nullValue_restoreDefaultListener() {
-        final LoginOverlay overlay = new LoginOverlay();
-        overlay.setAction("login");
-        overlay.setError(true);
-
-        ComponentUtil.fireEvent(overlay, new AbstractLogin.LoginEvent(overlay,
-                true, "username", "password"));
-        Assert.assertTrue(overlay.isEnabled());
-        Assert.assertTrue(overlay.isError());
-    }
-
-    @Test
     public void addLoginListener_actionSet_throws() {
         final LoginOverlay overlay = new LoginOverlay();
         overlay.setAction("login");

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.login;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.shared.Registration;
+
 public class LoginOverlayTest {
     @Test
     public void showErrorMessage_fromNullI18n() {
@@ -57,4 +60,73 @@ public class LoginOverlayTest {
         Assert.assertEquals("Custom username",
                 overlay.getI18n().getForm().getUsername());
     }
+
+    @Test
+    public void setAction_customLoginListeners_throws() {
+        final LoginOverlay overlay = new LoginOverlay();
+        Registration registration1 = overlay.addLoginListener(ev -> {
+        });
+        Registration registration2 = overlay.addLoginListener(ev -> {
+        });
+        Assert.assertThrows(IllegalStateException.class,
+                () -> overlay.setAction("login"));
+
+        registration1.remove();
+        Assert.assertThrows(IllegalStateException.class,
+                () -> overlay.setAction("login"));
+
+        registration2.remove();
+        overlay.setAction("login");
+    }
+
+    @Test
+    public void setAction_unregisterAndRegisterDefaultLoginListener() {
+        final LoginOverlay overlay = new LoginOverlay();
+        overlay.setAction("login");
+        overlay.setError(true);
+
+        ComponentUtil.fireEvent(overlay, new AbstractLogin.LoginEvent(overlay,
+                true, "username", "password"));
+        Assert.assertTrue(
+                "Expected form not being disabled by default listener",
+                overlay.isEnabled());
+        Assert.assertTrue(
+                "Expected error status not being reset by default listener",
+                overlay.isError());
+
+        overlay.setAction(null);
+        ComponentUtil.fireEvent(overlay, new AbstractLogin.LoginEvent(overlay,
+                true, "username", "password"));
+        Assert.assertFalse("Expected form being disabled by default listener",
+                overlay.isEnabled());
+        Assert.assertFalse(
+                "Expected error status being reset by default listener",
+                overlay.isError());
+    }
+
+    @Test
+    public void setAction_nullValue_restoreDefaultListener() {
+        final LoginOverlay overlay = new LoginOverlay();
+        overlay.setAction("login");
+        overlay.setError(true);
+
+        ComponentUtil.fireEvent(overlay, new AbstractLogin.LoginEvent(overlay,
+                true, "username", "password"));
+        Assert.assertTrue(overlay.isEnabled());
+        Assert.assertTrue(overlay.isError());
+    }
+
+    @Test
+    public void addLoginListener_actionSet_throws() {
+        final LoginOverlay overlay = new LoginOverlay();
+        overlay.setAction("login");
+        Assert.assertThrows(IllegalStateException.class,
+                () -> overlay.addLoginListener(ev -> {
+                }));
+
+        overlay.setAction(null);
+        overlay.addLoginListener(ev -> {
+        });
+    }
+
 }


### PR DESCRIPTION
## Description

Setting both login listeners and form action can cause unexpected behaviors because of concurrent processing of form submission processing and login event.
For example, if form submission ends in a session ID change and a redirect to a different page, the UIDL request may fail with a session expiration response, causing the Flow client to reload the page and potentially cancel the ongoing redirection.
In addition, after from submission, the login event would be sent to a dismissed UI.

This change removes the default login listener when setting a form action, and logs a warning when setting both an action and custom login listeners.

References vaadin/flow#12640

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
