### PR TITLE
refactor: use id instead of nodeid in client items array

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardItemMovePage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardItemMovePage.java
@@ -18,10 +18,10 @@ import com.vaadin.flow.router.Route;
 /**
  * @author Vaadin Ltd
  */
-@Route("vaadin-dashboard/drag-reorder")
-public class DashboardDragReorderPage extends Div {
+@Route("vaadin-dashboard/item-move")
+public class DashboardItemMovePage extends Div {
 
-    public DashboardDragReorderPage() {
+    public DashboardItemMovePage() {
         Dashboard dashboard = new Dashboard();
         dashboard.setEditable(true);
         dashboard.setMinimumRowHeight("100px");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizePage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizePage.java
@@ -17,10 +17,10 @@ import com.vaadin.flow.router.Route;
 /**
  * @author Vaadin Ltd
  */
-@Route("vaadin-dashboard/drag-resize")
-public class DashboardDragResizePage extends Div {
+@Route("vaadin-dashboard/item-resize")
+public class DashboardItemResizePage extends Div {
 
-    public DashboardDragResizePage() {
+    public DashboardItemResizePage() {
         Dashboard dashboard = new Dashboard();
         dashboard.setEditable(true);
         dashboard.setMinimumRowHeight("200px");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemMoveIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemMoveIT.java
@@ -68,12 +68,40 @@ public class DashboardItemMoveIT extends AbstractComponentIT {
         var expectedTitle = widgetToMove.getTitle();
         // Select and move the widget
         widgetToMove.sendKeys(Keys.ENTER, Keys.RIGHT);
-        var widgetAtIndex1 = dashboardElement.getWidgets().get(1);
-        Assert.assertEquals(expectedTitle, widgetAtIndex1.getTitle());
+        widgetToMove = dashboardElement.getWidgets().get(1);
+        Assert.assertEquals(expectedTitle, widgetToMove.getTitle());
         // Move the widget back
         widgetToMove.sendKeys(Keys.LEFT);
         Assert.assertEquals(expectedTitle,
                 dashboardElement.getWidgets().get(0).getTitle());
+    }
+
+    @Test
+    public void keyboardMoveSection_itemIsMovedCorrectly() {
+        var sectionToMove = dashboardElement.getSections().get(0);
+        var expectedTitle = sectionToMove.getTitle();
+        // Select and move the section
+        sectionToMove.sendKeys(Keys.ENTER, Keys.RIGHT);
+        sectionToMove = dashboardElement.getSections().get(1);
+        Assert.assertEquals(expectedTitle, sectionToMove.getTitle());
+        // Move the section back
+        sectionToMove.sendKeys(Keys.LEFT);
+        Assert.assertEquals(expectedTitle,
+                dashboardElement.getSections().get(0).getTitle());
+    }
+
+    @Test
+    public void keyboardMoveWidgetInSection_itemIsMovedCorrectly() {
+        var widgetToMove = dashboardElement.getWidgets().get(2);
+        var expectedTitle = widgetToMove.getTitle();
+        // Select and move the widget
+        widgetToMove.sendKeys(Keys.ENTER, Keys.RIGHT);
+        widgetToMove = dashboardElement.getWidgets().get(3);
+        Assert.assertEquals(expectedTitle, widgetToMove.getTitle());
+        // Move the widget back
+        widgetToMove.sendKeys(Keys.LEFT);
+        Assert.assertEquals(expectedTitle,
+                dashboardElement.getWidgets().get(2).getTitle());
     }
 
     @Test

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemMoveIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemMoveIT.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.dashboard.tests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
@@ -21,8 +22,8 @@ import com.vaadin.tests.AbstractComponentIT;
 /**
  * @author Vaadin Ltd
  */
-@TestPath("vaadin-dashboard/drag-reorder")
-public class DashboardDragReorderIT extends AbstractComponentIT {
+@TestPath("vaadin-dashboard/item-move")
+public class DashboardItemMoveIT extends AbstractComponentIT {
 
     private DashboardElement dashboardElement;
 
@@ -33,43 +34,57 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
     }
 
     @Test
-    public void reorderWidgetOnClientSide_itemsAreReorderedCorrectly() {
+    public void dragMoveWidget_itemIsMovedCorrectly() {
         var draggedWidget = dashboardElement.getWidgets().get(0);
         var targetWidget = dashboardElement.getWidgets().get(1);
-        dragReorderElement(draggedWidget, targetWidget);
+        dragMoveElement(draggedWidget, targetWidget);
         Assert.assertEquals(draggedWidget.getTitle(),
                 dashboardElement.getWidgets().get(1).getTitle());
     }
 
     @Test
-    public void reorderSectionOnClientSide_itemsAreReorderedCorrectly() {
+    public void dragMoveSection_itemIsMovedCorrectly() {
         var draggedSection = dashboardElement.getSections().get(1);
         var targetWidget = dashboardElement.getWidgets().get(0);
-        dragReorderElement(draggedSection, targetWidget);
+        dragMoveElement(draggedSection, targetWidget);
         Assert.assertEquals(draggedSection.getTitle(),
                 dashboardElement.getSections().get(0).getTitle());
     }
 
     @Test
-    public void reorderWidgetInSectionOnClientSide_itemsAreReorderedCorrectly() {
+    public void dragMoveWidgetInSection_itemIsMovedCorrectly() {
         var firstSection = dashboardElement.getSections().get(0);
         var draggedWidget = firstSection.getWidgets().get(0);
         var targetWidget = firstSection.getWidgets().get(1);
-        dragReorderElement(draggedWidget, targetWidget);
+        dragMoveElement(draggedWidget, targetWidget);
         firstSection = dashboardElement.getSections().get(0);
         Assert.assertEquals(draggedWidget.getTitle(),
                 firstSection.getWidgets().get(1).getTitle());
     }
 
     @Test
-    public void detachReattach_reorderWidgetOnClientSide_itemsAreReorderedCorrectly() {
+    public void keyboardMoveWidget_itemIsMovedCorrectly() {
+        var widgetToMove = dashboardElement.getWidgets().get(0);
+        var expectedTitle = widgetToMove.getTitle();
+        // Select and move the widget
+        widgetToMove.sendKeys(Keys.ENTER, Keys.RIGHT);
+        var widgetAtIndex1 = dashboardElement.getWidgets().get(1);
+        Assert.assertEquals(expectedTitle, widgetAtIndex1.getTitle());
+        // Move the widget back
+        widgetToMove.sendKeys(Keys.LEFT);
+        Assert.assertEquals(expectedTitle,
+                dashboardElement.getWidgets().get(0).getTitle());
+    }
+
+    @Test
+    public void detachReattach_dragMoveWidget_itemIsMovedCorrectly() {
         clickElementWithJs("toggle-attached");
         clickElementWithJs("toggle-attached");
         dashboardElement = $(DashboardElement.class).waitForFirst();
-        reorderWidgetOnClientSide_itemsAreReorderedCorrectly();
+        dragMoveWidget_itemIsMovedCorrectly();
     }
 
-    private void dragReorderElement(TestBenchElement draggedElement,
+    private void dragMoveElement(TestBenchElement draggedElement,
             TestBenchElement targetElement) {
         var dragHandle = getDragHandle(draggedElement);
 
@@ -78,7 +93,7 @@ public class DashboardDragReorderIT extends AbstractComponentIT {
         var xOffset = draggedElement.getLocation().getX() < targetElement
                 .getLocation().getX() ? 10 : -10;
 
-        new Actions(driver).clickAndHold(dragHandle)
+        new Actions(getDriver()).clickAndHold(dragHandle)
                 .moveToElement(targetElement, xOffset, yOffset)
                 .release(targetElement).build().perform();
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizeIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizeIT.java
@@ -37,18 +37,28 @@ public class DashboardItemResizeIT extends AbstractComponentIT {
     }
 
     @Test
-    public void dragResizeWidgetBothHorizontallyAndVertically_widgetIsResizedCorrectly() {
+    public void dragResizeWidget_widgetIsResizedCorrectly() {
         assertWidgetResized(0);
     }
 
     @Test
-    public void dragResizeWidgetInSectionBothHorizontallyAndVertically_widgetIsResizedCorrectly() {
+    public void dragResizeWidgetInSection_widgetIsResizedCorrectly() {
         assertWidgetResized(1);
     }
 
     @Test
     public void keyboardResizeWidget_widgetIsResizedCorrectly() {
-        var widgetToResize = dashboardElement.getWidgets().get(0);
+        assertWidgetKeyboardResized(0);
+    }
+
+    @Test
+    public void keyboardResizeWidgetInSection_widgetIsResizedCorrectly() {
+        assertWidgetKeyboardResized(1);
+    }
+
+    private void assertWidgetKeyboardResized(int widgetIndexToResize) {
+        var widgetToResize = dashboardElement.getWidgets()
+                .get(widgetIndexToResize);
         var initialWidth = widgetToResize.getSize().getWidth();
         // Select widget
         widgetToResize.sendKeys(Keys.ENTER);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizeIT.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizeIT.java
@@ -12,6 +12,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.dashboard.testbench.DashboardElement;
@@ -23,8 +24,8 @@ import com.vaadin.tests.AbstractComponentIT;
 /**
  * @author Vaadin Ltd
  */
-@TestPath("vaadin-dashboard/drag-resize")
-public class DashboardDragResizeIT extends AbstractComponentIT {
+@TestPath("vaadin-dashboard/item-resize")
+public class DashboardItemResizeIT extends AbstractComponentIT {
 
     private DashboardElement dashboardElement;
 
@@ -36,20 +37,39 @@ public class DashboardDragResizeIT extends AbstractComponentIT {
     }
 
     @Test
-    public void resizeWidgetBothHorizontallyAndVertically_widgetIsResizedCorrectly() {
+    public void dragResizeWidgetBothHorizontallyAndVertically_widgetIsResizedCorrectly() {
         assertWidgetResized(0);
     }
 
     @Test
-    public void resizeWidgetInSectionBothHorizontallyAndVertically_widgetIsResizedCorrectly() {
+    public void dragResizeWidgetInSectionBothHorizontallyAndVertically_widgetIsResizedCorrectly() {
         assertWidgetResized(1);
+    }
+
+    @Test
+    public void keyboardResizeWidget_widgetIsResizedCorrectly() {
+        var widgetToResize = dashboardElement.getWidgets().get(0);
+        var initialWidth = widgetToResize.getSize().getWidth();
+        // Select widget
+        widgetToResize.sendKeys(Keys.ENTER);
+        // Grow the widget
+        new Actions(getDriver()).keyDown(Keys.SHIFT).sendKeys(Keys.RIGHT)
+                .build().perform();
+        var delta = 20;
+        Assert.assertEquals(initialWidth * 2,
+                widgetToResize.getSize().getWidth(), delta);
+        // Shrink the widget back
+        new Actions(getDriver()).keyDown(Keys.SHIFT).sendKeys(Keys.LEFT).build()
+                .perform();
+        Assert.assertEquals(initialWidth, widgetToResize.getSize().getWidth(),
+                delta);
     }
 
     private void assertWidgetResized(int widgetIndexToResize) {
         var widgetToResize = dashboardElement.getWidgets()
                 .get(widgetIndexToResize);
-        int xResizeRatio = 2;
-        int yResizeRatio = 2;
+        var xResizeRatio = 2;
+        var yResizeRatio = 2;
         var expectedWidth = widgetToResize.getSize().getWidth() * xResizeRatio;
         var expectedHeight = widgetToResize.getSize().getHeight()
                 * yResizeRatio;
@@ -72,7 +92,7 @@ public class DashboardDragResizeIT extends AbstractComponentIT {
         var yOffset = (int) (widgetToResize.getSize().getHeight()
                 * (yResizeRatio - 1));
         TestBenchElement resizeHandle = getResizeHandle(widgetToResize);
-        int trackStartOffset = 5;
+        var trackStartOffset = 5;
         new Actions(driver).moveToElement(resizeHandle).clickAndHold()
                 // This is necessary for the Polymer track event to be fired.
                 .moveByOffset(trackStartOffset, trackStartOffset)

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -663,7 +663,7 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
 
     private void handleItemRemovedClientEvent(DomEvent e, String idKey) {
         int nodeId = (int) e.getEventData().getNumber(idKey);
-            Component removedItem = getItem(nodeId);
+        Component removedItem = getItem(nodeId);
         removedItem.removeFromParent();
         fireEvent(new DashboardItemRemovedEvent(this, true, removedItem,
                 getChildren().toList()));

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.DomEvent;
-import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.shared.Registration;
@@ -588,6 +587,7 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
                 return;
             }
             handleItemMovedClientEvent(e, itemKey, itemsKey, sectionKey);
+            updateClient();
         }).addEventData(itemKey).addEventData(itemsKey)
                 .addEventData(sectionKey);
     }
@@ -631,6 +631,7 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
                 return;
             }
             handleItemResizedClientEvent(e, idKey, colspanKey, rowspanKey);
+            updateClient();
         }).addEventData(idKey).addEventData(colspanKey)
                 .addEventData(rowspanKey);
     }
@@ -651,14 +652,13 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
 
     private void initItemRemovedClientEventListener() {
         String idKey = "event.detail.item.id";
-        DomListenerRegistration registration = getElement()
-                .addEventListener("dashboard-item-removed", e -> {
-                    if (!isEditable()) {
-                        return;
-                    }
-                    handleItemRemovedClientEvent(e, idKey);
-                });
-        registration.addEventData(idKey);
+        getElement().addEventListener("dashboard-item-removed", e -> {
+            if (!isEditable()) {
+                return;
+            }
+            handleItemRemovedClientEvent(e, idKey);
+            updateClient();
+        }).addEventData(idKey);
     }
 
     private void handleItemRemovedClientEvent(DomEvent e, String idKey) {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemMoveModeChangedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemMoveModeChangedEvent.java
@@ -37,18 +37,16 @@ public class DashboardItemMoveModeChangedEvent
      * @param fromClient
      *            {@code true} if the event originated from the client side,
      *            {@code false} otherwise
-     * @param itemNodeId
-     *            The node ID of the item of which the move mode state has
-     *            changed
+     * @param itemId
+     *            The ID of the item of which the move mode state has changed
      * @param moveMode
      *            Whether the item is in move mode
      */
     public DashboardItemMoveModeChangedEvent(Dashboard source,
-            boolean fromClient,
-            @EventData("event.detail.item.nodeid") int itemNodeId,
+            boolean fromClient, @EventData("event.detail.item.id") int itemId,
             @EventData("event.detail.value") boolean moveMode) {
         super(source, fromClient);
-        this.item = source.getItem(itemNodeId);
+        this.item = source.getItem(itemId);
         this.moveMode = moveMode;
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemResizeModeChangedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemResizeModeChangedEvent.java
@@ -37,19 +37,17 @@ public class DashboardItemResizeModeChangedEvent
      * @param fromClient
      *            {@code true} if the event originated from the client side,
      *            {@code false} otherwise
-     * @param itemNodeId
-     *            The node ID of the item of which the resize mode state has
-     *            changed
+     * @param itemId
+     *            The ID of the item of which the resize mode state has changed
      * @param resizeMode
      *            Whether the item is in resize mode
      */
     public DashboardItemResizeModeChangedEvent(Dashboard source,
-            boolean fromClient,
-            @EventData("event.detail.item.nodeid") int itemNodeId,
+            boolean fromClient, @EventData("event.detail.item.id") int itemId,
             @EventData("event.detail.value") boolean resizeMode) {
         super(source, fromClient);
         this.item = source.getWidgets().stream().filter(
-                widget -> itemNodeId == widget.getElement().getNode().getId())
+                widget -> itemId == widget.getElement().getNode().getId())
                 .findAny().orElseThrow();
         this.resizeMode = resizeMode;
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemSelectedChangedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemSelectedChangedEvent.java
@@ -37,18 +37,16 @@ public class DashboardItemSelectedChangedEvent
      * @param fromClient
      *            {@code true} if the event originated from the client side,
      *            {@code false} otherwise
-     * @param itemNodeId
-     *            The node ID of the item of which the selected state has
-     *            changed
+     * @param itemId
+     *            The ID of the item of which the selected state has changed
      * @param selected
      *            Whether the item is selected
      */
     public DashboardItemSelectedChangedEvent(Dashboard source,
-            boolean fromClient,
-            @EventData("event.detail.item.nodeid") int itemNodeId,
+            boolean fromClient, @EventData("event.detail.item.id") int itemId,
             @EventData("event.detail.value") boolean selected) {
         super(source, fromClient);
-        this.item = source.getItem(itemNodeId);
+        this.item = source.getItem(itemId);
         this.selected = selected;
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -10,7 +10,6 @@ package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -187,9 +186,6 @@ public class DashboardSection extends Component implements HasWidgets {
     }
 
     void reorderWidgets(List<DashboardWidget> orderedWidgets) {
-        if (!new HashSet<>(orderedWidgets).equals(new HashSet<>(widgets))) {
-            return;
-        }
         widgets.clear();
         widgets.addAll(orderedWidgets);
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -183,6 +184,14 @@ public class DashboardSection extends Component implements HasWidgets {
     private void doAddWidget(DashboardWidget widget) {
         getElement().appendChild(widget.getElement());
         widgets.add(widget);
+    }
+
+    void reorderWidgets(List<DashboardWidget> orderedWidgets) {
+        if (!new HashSet<>(orderedWidgets).equals(new HashSet<>(widgets))) {
+            return;
+        }
+        widgets.clear();
+        widgets.addAll(orderedWidgets);
     }
 
     void updateClient() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestBase.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestBase.java
@@ -61,12 +61,12 @@ public class DashboardTestBase {
         JsonArray itemsArray = Json.createArray();
         rootLevelComponents.forEach(child -> {
             JsonObject rootLevelItem = Json.createObject();
-            rootLevelItem.put("nodeid", child.getElement().getNode().getId());
+            rootLevelItem.put("id", child.getElement().getNode().getId());
             if (child instanceof DashboardSection section) {
                 JsonArray sectionItemsArray = Json.createArray();
                 section.getWidgets().forEach(widget -> {
                     JsonObject sectionItem = Json.createObject();
-                    sectionItem.put("nodeid",
+                    sectionItem.put("id",
                             widget.getElement().getNode().getId());
                     sectionItemsArray.set(sectionItemsArray.length(),
                             sectionItem);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestHelper.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestHelper.java
@@ -22,7 +22,7 @@ public class DashboardTestHelper {
     static void fireItemResizeModeChangedEvent(Dashboard dashboard,
             int itemNodeId, boolean resizeMode) {
         JsonObject eventData = Json.createObject();
-        eventData.put("event.detail.item.nodeid", itemNodeId);
+        eventData.put("event.detail.item.id", itemNodeId);
         eventData.put("event.detail.value", resizeMode);
         fireDomEvent(dashboard, "dashboard-item-resize-mode-changed",
                 eventData);
@@ -31,7 +31,7 @@ public class DashboardTestHelper {
     static void fireItemResizedEvent(Dashboard dashboard,
             DashboardWidget widget, int targetColspan, int targetRowspan) {
         JsonObject eventData = Json.createObject();
-        eventData.put("event.detail.item.nodeid",
+        eventData.put("event.detail.item.id",
                 widget.getElement().getNode().getId());
         eventData.put("event.detail.item.rowspan", targetRowspan);
         eventData.put("event.detail.item.colspan", targetColspan);
@@ -52,21 +52,21 @@ public class DashboardTestHelper {
     static void fireItemMoveModeChangedEvent(Dashboard dashboard,
             int itemNodeId, boolean moveMode) {
         JsonObject eventData = Json.createObject();
-        eventData.put("event.detail.item.nodeid", itemNodeId);
+        eventData.put("event.detail.item.id", itemNodeId);
         eventData.put("event.detail.value", moveMode);
         fireDomEvent(dashboard, "dashboard-item-move-mode-changed", eventData);
     }
 
     static void fireItemRemovedEvent(Dashboard dashboard, int nodeId) {
         JsonObject eventData = Json.createObject();
-        eventData.put("event.detail.item.nodeid", nodeId);
+        eventData.put("event.detail.item.id", nodeId);
         fireDomEvent(dashboard, "dashboard-item-removed", eventData);
     }
 
     static void fireItemSelectedChangedEvent(Dashboard dashboard,
             int itemNodeId, boolean selected) {
         JsonObject eventData = Json.createObject();
-        eventData.put("event.detail.item.nodeid", itemNodeId);
+        eventData.put("event.detail.item.id", itemNodeId);
         eventData.put("event.detail.value", selected);
         fireDomEvent(dashboard, "dashboard-item-selected-changed", eventData);
     }


### PR DESCRIPTION
## Description

This PR

- updates the dashboard to use `id` in items array instead of a custom `nodeid`, as introduced in the [web component](https://github.com/vaadin/web-components/pull/7869) 
- adds integration tests for keyboard item resize and keyboard item move
- updates handling the client item move event so that the widgets in sections do not get removed and readded
- renames some item move and item resize tests in order to align with the naming convention

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=81029438

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor