### PR TITLE
feat: implement item mode changed events

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -348,6 +348,42 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
     }
 
     /**
+     * Adds an item selected change listener to this dashboard.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    public Registration addItemSelectedChangedListener(
+            ComponentEventListener<DashboardItemSelectedChangedEvent> listener) {
+        return addListener(DashboardItemSelectedChangedEvent.class, listener);
+    }
+
+    /**
+     * Adds an item move mode change listener to this dashboard.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    public Registration addItemMoveModeChangedListener(
+            ComponentEventListener<DashboardItemMoveModeChangedEvent> listener) {
+        return addListener(DashboardItemMoveModeChangedEvent.class, listener);
+    }
+
+    /**
+     * Adds an item resize mode change listener to this dashboard.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    public Registration addItemResizeModeChangedListener(
+            ComponentEventListener<DashboardItemResizeModeChangedEvent> listener) {
+        return addListener(DashboardItemResizeModeChangedEvent.class, listener);
+    }
+
+    /**
      * Gets the internationalization object previously set for this component.
      * <p>
      * NOTE: Updating the instance that is returned from this method will not
@@ -404,6 +440,21 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
                 "Vaadin.FlowComponentHost.patchVirtualContainer(this);");
         customizeItemMovedEvent();
         doUpdateClient();
+    }
+
+    Component getItem(int nodeId) {
+        return getChildren().map(item -> {
+            if (nodeId == item.getElement().getNode().getId()) {
+                return item;
+            }
+            if (item instanceof DashboardSection section) {
+                return section.getWidgets().stream()
+                        .filter(sectionItem -> nodeId == sectionItem
+                                .getElement().getNode().getId())
+                        .findAny().orElse(null);
+            }
+            return null;
+        }).filter(Objects::nonNull).findAny().orElseThrow();
     }
 
     void updateClient() {
@@ -616,25 +667,10 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
 
     private void handleItemRemovedClientEvent(DomEvent e, String nodeIdKey) {
         int nodeId = (int) e.getEventData().getNumber(nodeIdKey);
-        Component removedItem = getRemovedItem(nodeId);
+        Component removedItem = getItem(nodeId);
         removedItem.removeFromParent();
         fireEvent(new DashboardItemRemovedEvent(this, true, removedItem,
                 getChildren().toList()));
-    }
-
-    private Component getRemovedItem(int nodeId) {
-        return getChildren().map(item -> {
-            if (nodeId == item.getElement().getNode().getId()) {
-                return item;
-            }
-            if (item instanceof DashboardSection section) {
-                return section.getWidgets().stream()
-                        .filter(sectionItem -> nodeId == sectionItem
-                                .getElement().getNode().getId())
-                        .findAny().orElse(null);
-            }
-            return null;
-        }).filter(Objects::nonNull).findAny().orElseThrow();
     }
 
     private void customizeItemMovedEvent() {

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemMoveModeChangedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemMoveModeChangedEvent.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+/**
+ * Widget or section move mode state changed event of {@link Dashboard}.
+ *
+ * @author Vaadin Ltd.
+ * @see Dashboard#addItemMoveModeChangedListener(ComponentEventListener)
+ */
+@DomEvent("dashboard-item-move-mode-changed")
+public class DashboardItemMoveModeChangedEvent
+        extends ComponentEvent<Dashboard> {
+
+    private final Component item;
+
+    private final boolean moveMode;
+
+    /**
+     * Creates a dashboard item move mode changed event.
+     *
+     * @param source
+     *            Dashboard that contains the item of which the move mode state
+     *            has changed
+     * @param fromClient
+     *            {@code true} if the event originated from the client side,
+     *            {@code false} otherwise
+     * @param itemNodeId
+     *            The node ID of the item of which the move mode state has
+     *            changed
+     * @param moveMode
+     *            Whether the item is in move mode
+     */
+    public DashboardItemMoveModeChangedEvent(Dashboard source,
+            boolean fromClient,
+            @EventData("event.detail.item.nodeid") int itemNodeId,
+            @EventData("event.detail.value") boolean moveMode) {
+        super(source, fromClient);
+        this.item = source.getItem(itemNodeId);
+        this.moveMode = moveMode;
+    }
+
+    /**
+     * Returns the item of which the move mode state has changed
+     *
+     * @return the item of which the move mode state has changed
+     */
+    public Component getItem() {
+        return item;
+    }
+
+    /**
+     * Returns whether the item is in move mode
+     *
+     * @return whether the item is in move mode
+     */
+    public boolean isMoveMode() {
+        return moveMode;
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemResizeModeChangedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemResizeModeChangedEvent.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+/**
+ * Widget resize mode state changed event of {@link Dashboard}.
+ *
+ * @author Vaadin Ltd.
+ * @see Dashboard#addItemResizeModeChangedListener(ComponentEventListener)
+ */
+@DomEvent("dashboard-item-resize-mode-changed")
+public class DashboardItemResizeModeChangedEvent
+        extends ComponentEvent<Dashboard> {
+
+    private final Component item;
+
+    private final boolean resizeMode;
+
+    /**
+     * Creates a dashboard item resize mode changed event.
+     *
+     * @param source
+     *            Dashboard that contains the item of which the resize mode
+     *            state has changed
+     * @param fromClient
+     *            {@code true} if the event originated from the client side,
+     *            {@code false} otherwise
+     * @param itemNodeId
+     *            The node ID of the item of which the resize mode state has
+     *            changed
+     * @param resizeMode
+     *            Whether the item is in resize mode
+     */
+    public DashboardItemResizeModeChangedEvent(Dashboard source,
+            boolean fromClient,
+            @EventData("event.detail.item.nodeid") int itemNodeId,
+            @EventData("event.detail.value") boolean resizeMode) {
+        super(source, fromClient);
+        this.item = source.getWidgets().stream().filter(
+                widget -> itemNodeId == widget.getElement().getNode().getId())
+                .findAny().orElseThrow();
+        this.resizeMode = resizeMode;
+    }
+
+    /**
+     * Returns the item of which the resize mode state has changed;
+     *
+     * @return the item of which the resize mode state has changed
+     */
+    public Component getItem() {
+        return item;
+    }
+
+    /**
+     * Returns whether the item is in resize mode
+     *
+     * @return whether the item is in resize mode
+     */
+    public boolean isResizeMode() {
+        return resizeMode;
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemSelectedChangedEvent.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardItemSelectedChangedEvent.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+/**
+ * Widget or section selected state changed event of {@link Dashboard}.
+ *
+ * @author Vaadin Ltd.
+ * @see Dashboard#addItemSelectedChangedListener(ComponentEventListener)
+ */
+@DomEvent("dashboard-item-selected-changed")
+public class DashboardItemSelectedChangedEvent
+        extends ComponentEvent<Dashboard> {
+
+    private final Component item;
+
+    private final boolean selected;
+
+    /**
+     * Creates a dashboard item selected changed event.
+     *
+     * @param source
+     *            Dashboard that contains the item of which the selected state
+     *            has changed
+     * @param fromClient
+     *            {@code true} if the event originated from the client side,
+     *            {@code false} otherwise
+     * @param itemNodeId
+     *            The node ID of the item of which the selected state has
+     *            changed
+     * @param selected
+     *            Whether the item is selected
+     */
+    public DashboardItemSelectedChangedEvent(Dashboard source,
+            boolean fromClient,
+            @EventData("event.detail.item.nodeid") int itemNodeId,
+            @EventData("event.detail.value") boolean selected) {
+        super(source, fromClient);
+        this.item = source.getItem(itemNodeId);
+        this.selected = selected;
+    }
+
+    /**
+     * Returns the item of which the selected state has changed
+     *
+     * @return the item of which the selected state has changed
+     */
+    public Component getItem() {
+        return item;
+    }
+
+    /**
+     * Returns whether the item is selected
+     *
+     * @return whether the item is selected
+     */
+    public boolean isSelected() {
+        return selected;
+    }
+}

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestHelper.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTestHelper.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.dashboard.tests;
+
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardWidget;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+public class DashboardTestHelper {
+
+    static void fireItemResizeModeChangedEvent(Dashboard dashboard,
+            int itemNodeId, boolean resizeMode) {
+        JsonObject eventData = Json.createObject();
+        eventData.put("event.detail.item.nodeid", itemNodeId);
+        eventData.put("event.detail.value", resizeMode);
+        fireDomEvent(dashboard, "dashboard-item-resize-mode-changed",
+                eventData);
+    }
+
+    static void fireItemResizedEvent(Dashboard dashboard,
+            DashboardWidget widget, int targetColspan, int targetRowspan) {
+        JsonObject eventData = Json.createObject();
+        eventData.put("event.detail.item.nodeid",
+                widget.getElement().getNode().getId());
+        eventData.put("event.detail.item.rowspan", targetRowspan);
+        eventData.put("event.detail.item.colspan", targetColspan);
+        fireDomEvent(dashboard, "dashboard-item-resized", eventData);
+    }
+
+    static void fireItemMovedEvent(Dashboard dashboard, int itemNodeId,
+            JsonArray itemsArray, Integer sectionNodeId) {
+        JsonObject eventData = Json.createObject();
+        eventData.put("event.detail.item", itemNodeId);
+        eventData.put("event.detail.items", itemsArray);
+        if (sectionNodeId != null) {
+            eventData.put("event.detail.section", sectionNodeId);
+        }
+        fireDomEvent(dashboard, "dashboard-item-moved-flow", eventData);
+    }
+
+    static void fireItemMoveModeChangedEvent(Dashboard dashboard,
+            int itemNodeId, boolean moveMode) {
+        JsonObject eventData = Json.createObject();
+        eventData.put("event.detail.item.nodeid", itemNodeId);
+        eventData.put("event.detail.value", moveMode);
+        fireDomEvent(dashboard, "dashboard-item-move-mode-changed", eventData);
+    }
+
+    static void fireItemRemovedEvent(Dashboard dashboard, int nodeId) {
+        JsonObject eventData = Json.createObject();
+        eventData.put("event.detail.item.nodeid", nodeId);
+        fireDomEvent(dashboard, "dashboard-item-removed", eventData);
+    }
+
+    static void fireItemSelectedChangedEvent(Dashboard dashboard,
+            int itemNodeId, boolean selected) {
+        JsonObject eventData = Json.createObject();
+        eventData.put("event.detail.item.nodeid", itemNodeId);
+        eventData.put("event.detail.value", selected);
+        fireDomEvent(dashboard, "dashboard-item-selected-changed", eventData);
+    }
+
+    private static void fireDomEvent(Dashboard dashboard, String eventType,
+            JsonObject eventData) {
+        DomEvent domEvent = new DomEvent(dashboard.getElement(), eventType,
+                eventData);
+        dashboard.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(domEvent);
+    }
+}


### PR DESCRIPTION
## Description

This PR implements item mode changed events for the dashboard Flow counterpart.

Added API:
- `Dashboard.addItemSelectedChangedListener`: Adds an item selected change listener to the dashboard
- `Dashboard.addItemMoveModeChangedListener`: Adds an item move mode change listener to the dashboard
- `Dashboard.addItemResizeModeChangedListener`: Adds an item resize mode change listener to the dashboard

New events:
- `DashboardItemSelectedChangedEvent`:
  -  `Component getItem()`: Returns the item of which the selected state has changed
  -  `boolean isSelected()`: Returns whether the item is selected
- `DashboardItemResizeModeChangedEvent`:
  -  `Component getItem()`: Returns the item of which the resize mode state has changed
  -  `boolean isResizeMode()`: Returns whether the item is in resize mode
- `DashboardItemMoveModeChangedEvent`:
  -  `Component getItem()`: Returns the item of which the move mode state has changed
  -  `boolean isMoveMode()`: Returns whether the item is in move mode

Extra:
- Renaming and cleanup in unit tests
- A new test helper class `DashboardTestHelper` that contains DOM event related code
- Related minor cleanup and refactoring

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feat