### PR TITLE
chore: pin Charts SVG generator npm dependencies

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package.json
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package.json
@@ -10,13 +10,13 @@
   "dependencies": {
     "highcharts": "9.2.2",
     "jsdom": "16.5.3",
-    "string-pixel-width": "^1.11.0"
+    "string-pixel-width": "1.11.0"
   },
   "devDependencies": {
     "chai": "4.3.4",
     "mocha": "8.4.0",
     "mock-fs": "5.0.0",
-    "rewire": "^7.0.0",
+    "rewire": "7.0.0",
     "webpack": "5.76.0",
     "webpack-cli": "4.9.2"
   },


### PR DESCRIPTION
## Description

Pin dependencies in package.json used by the Charts SVG generator