### PR TITLE
refactor: rename header apis and use header content slot

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
@@ -29,7 +29,7 @@ public class DashboardWidgetPage extends Div {
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
         widget1.setContent(new Div("Some content"));
-        widget1.setHeader(new Span("Some header"));
+        widget1.setHeaderComponent(new Span("Some header"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();
@@ -89,7 +89,7 @@ public class DashboardWidgetPage extends Div {
         updateHeaderOfTheFirstWidget.addClickListener(click -> {
             List<DashboardWidget> widgets = dashboard.getWidgets();
             if (!widgets.isEmpty()) {
-                widgets.get(0).setHeader(new Span("Updated header"));
+                widgets.get(0).setHeaderComponent(new Span("Updated header"));
             }
         });
         updateHeaderOfTheFirstWidget.setId("update-header-of-the-first-widget");
@@ -99,7 +99,7 @@ public class DashboardWidgetPage extends Div {
         removeHeaderOfTheFirstWidget.addClickListener(click -> {
             List<DashboardWidget> widgets = dashboard.getWidgets();
             if (!widgets.isEmpty()) {
-                widgets.get(0).setHeader(null);
+                widgets.get(0).setHeaderComponent(null);
             }
         });
         removeHeaderOfTheFirstWidget.setId("remove-header-of-the-first-widget");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -134,25 +134,25 @@ public class DashboardWidget extends Component {
     }
 
     /**
-     * Gets the component in the header slot of this widget.
+     * Gets the component in the header content slot of this widget.
      *
      * @return the header component of this widget, or {@code null} if no header
      *         component has been set
      */
-    public Component getHeader() {
-        return SlotUtils.getChildInSlot(this, "header");
+    public Component getHeaderComponent() {
+        return SlotUtils.getChildInSlot(this, "header-content");
     }
 
     /**
-     * Sets the component in the header slot of this widget, replacing any
-     * existing header component.
+     * Sets the component in the header content slot of this widget, replacing
+     * any existing header component.
      *
      * @param header
      *            the component to set, can be {@code null} to remove existing
      *            header component
      */
-    public void setHeader(Component header) {
-        SlotUtils.setSlot(this, "header", header);
+    public void setHeaderComponent(Component header) {
+        SlotUtils.setSlot(this, "header-content", header);
     }
 
     /**

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -173,41 +173,41 @@ public class DashboardWidgetTest extends DashboardTestBase {
     @Test
     public void defaultHeaderIsNull() {
         DashboardWidget widget = new DashboardWidget();
-        Assert.assertNull(widget.getHeader());
+        Assert.assertNull(widget.getHeaderComponent());
     }
 
     @Test
     public void setHeaderToEmptyWidget_correctHeaderIsSet() {
         Div header = new Div();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeader(header);
-        Assert.assertEquals(header, widget.getHeader());
+        widget.setHeaderComponent(header);
+        Assert.assertEquals(header, widget.getHeaderComponent());
     }
 
     @Test
     public void setAnotherHeaderToNonEmptyWidget_correctHeaderIsSet() {
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeader(new Div());
+        widget.setHeaderComponent(new Div());
         Span newHeader = new Span();
-        widget.setHeader(newHeader);
-        Assert.assertEquals(newHeader, widget.getHeader());
+        widget.setHeaderComponent(newHeader);
+        Assert.assertEquals(newHeader, widget.getHeaderComponent());
     }
 
     @Test
     public void setTheSameHeaderToNonEmptyWidget_correctHeaderIsSet() {
         Div header = new Div();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeader(header);
-        widget.setHeader(header);
-        Assert.assertEquals(header, widget.getHeader());
+        widget.setHeaderComponent(header);
+        widget.setHeaderComponent(header);
+        Assert.assertEquals(header, widget.getHeaderComponent());
     }
 
     @Test
     public void setNullHeaderToNonEmptyWidget_headerIsRemoved() {
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeader(new Div());
-        widget.setHeader(null);
-        Assert.assertNull(widget.getHeader());
+        widget.setHeaderComponent(new Div());
+        widget.setHeaderComponent(null);
+        Assert.assertNull(widget.getHeaderComponent());
     }
 
     @Test
@@ -215,7 +215,7 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Div content = new Div();
         DashboardWidget widget = new DashboardWidget();
         widget.setContent(content);
-        widget.setHeader(null);
+        widget.setHeaderComponent(null);
         Assert.assertEquals(content, widget.getContent());
     }
 
@@ -223,9 +223,9 @@ public class DashboardWidgetTest extends DashboardTestBase {
     public void setNullContentToWidgetWithHeader_headerIsNotRemoved() {
         Div header = new Div();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeader(header);
+        widget.setHeaderComponent(header);
         widget.setContent(null);
-        Assert.assertEquals(header, widget.getHeader());
+        Assert.assertEquals(header, widget.getHeaderComponent());
     }
 
     @Test
@@ -234,9 +234,9 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Span header = new Span();
         DashboardWidget widget = new DashboardWidget();
         widget.setContent(content);
-        widget.setHeader(header);
+        widget.setHeaderComponent(header);
         Assert.assertEquals(content, widget.getContent());
-        Assert.assertEquals(header, widget.getHeader());
+        Assert.assertEquals(header, widget.getHeaderComponent());
     }
 
     @Test
@@ -244,10 +244,10 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Div content = new Div();
         Span header = new Span();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeader(header);
+        widget.setHeaderComponent(header);
         widget.setContent(content);
         Assert.assertEquals(content, widget.getContent());
-        Assert.assertEquals(header, widget.getHeader());
+        Assert.assertEquals(header, widget.getHeaderComponent());
     }
 
     @Test

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardWidgetElement.java
@@ -67,7 +67,7 @@ public class DashboardWidgetElement extends TestBenchElement {
      */
     public TestBenchElement getHeader() {
         Object header = executeScript(
-                "return Array.from(arguments[0].children).filter(child => child.slot === 'header')[0]",
+                "return Array.from(arguments[0].children).filter(child => child.slot === 'header-content')[0]",
                 this);
         return header == null ? null : (TestBenchElement) header;
     }


### PR DESCRIPTION
## Description

This PR renames widget header APIs and updates the slot name to `header-content`.

Renamed API:
- `DashboardWidget.getHeader`-> `DashboardWidget.getHeaderComponent`
- `DashboardWidget.setHeader`-> `DashboardWidget.setHeaderComponent`

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor