### PR TITLE
chore: deprecate ICON_ON_TOP Tabs and TabSheet variants

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
@@ -22,6 +22,10 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  */
 public enum TabSheetVariant implements ThemeVariant {
     //@formatter:off
+    /**
+     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} instead.
+     */
+    @Deprecated
     LUMO_TABS_ICON_ON_TOP("icon-on-top"),
     LUMO_TABS_CENTERED("centered"),
     LUMO_TABS_SMALL("small"),

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.shared.ThemeVariant;
 public enum TabSheetVariant implements ThemeVariant {
     //@formatter:off
     /**
-     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} instead.
+     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} on individual {@code Tab} instances instead.
      */
     @Deprecated
     LUMO_TABS_ICON_ON_TOP("icon-on-top"),

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
@@ -22,6 +22,10 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  */
 public enum TabsVariant implements ThemeVariant {
     //@formatter:off
+    /**
+     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} instead.
+     */
+    @Deprecated
     LUMO_ICON_ON_TOP("icon-on-top"),
     LUMO_CENTERED("centered"),
     LUMO_SMALL("small"),

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.shared.ThemeVariant;
 public enum TabsVariant implements ThemeVariant {
     //@formatter:off
     /**
-     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} instead.
+     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} on individual {@code Tab} instances instead.
      */
     @Deprecated
     LUMO_ICON_ON_TOP("icon-on-top"),


### PR DESCRIPTION
## Description

Related to #6652

Marked these incorrectly added variants as deprecated with the suggestion to use `TabVariant` instead:

<img width="494" alt="Screenshot 2024-10-01 at 14 16 12" src="https://github.com/user-attachments/assets/6f0c1fe5-7dd7-4189-8731-829f330d6c9e">

## Type of change

- Deprecation