### PR TITLE
refactor: rename gap to spacing

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -272,16 +272,19 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
     }
 
     /**
-     * Returns the spacing between the cells of the dashboard.
+     * Returns the spacing of the dashboard. This value adjusts the spacing
+     * between elements within the component and the space around its outer
+     * edges.
      *
-     * @return the spacing between the cells of the dashboard
+     * @return the spacing of the dashboard
      */
     public String getSpacing() {
         return getStyle().get("--vaadin-dashboard-spacing");
     }
 
     /**
-     * Sets the spacing between the cells of the dashboard.
+     * Sets the spacing of the dashboard. This value adjusts the spacing between
+     * elements within the component and the space around its outer edges.
      *
      * @param spacing
      *            the new spacing. Pass in {@code null} to set the spacing back

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -272,23 +272,23 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
     }
 
     /**
-     * Returns the gap between the cells of the dashboard.
+     * Returns the spacing between the cells of the dashboard.
      *
-     * @return the gap between the cells of the dashboard
+     * @return the spacing between the cells of the dashboard
      */
-    public String getGap() {
-        return getStyle().get("--vaadin-dashboard-gap");
+    public String getSpacing() {
+        return getStyle().get("--vaadin-dashboard-spacing");
     }
 
     /**
-     * Sets the gap between the cells of the dashboard.
+     * Sets the spacing between the cells of the dashboard.
      *
-     * @param gap
-     *            the new gap. Pass in {@code null} to set the gap back to the
-     *            default value.
+     * @param spacing
+     *            the new spacing. Pass in {@code null} to set the spacing back
+     *            to the default value.
      */
-    public void setGap(String gap) {
-        getStyle().set("--vaadin-dashboard-gap", gap);
+    public void setSpacing(String spacing) {
+        getStyle().set("--vaadin-dashboard-spacing", spacing);
     }
 
     /**

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardTest.java
@@ -750,40 +750,41 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
-    public void setGap_valueIsCorrectlySet() {
-        String propertyName = "--vaadin-dashboard-gap";
+    public void setSpacing_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-spacing";
         String valueToSet = "10px";
         Assert.assertNull(dashboard.getStyle().get(propertyName));
-        dashboard.setGap(valueToSet);
+        dashboard.setSpacing(valueToSet);
         Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
-        dashboard.setGap(null);
+        dashboard.setSpacing(null);
         Assert.assertNull(dashboard.getStyle().get(propertyName));
     }
 
     @Test
-    public void setGapNull_propertyIsRemoved() {
-        dashboard.setGap("10px");
-        dashboard.setGap(null);
-        Assert.assertNull(dashboard.getStyle().get("--vaadin-dashboard-gap"));
+    public void setSpacingNull_propertyIsRemoved() {
+        dashboard.setSpacing("10px");
+        dashboard.setSpacing(null);
+        Assert.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-spacing"));
     }
 
     @Test
-    public void defaultGapValueIsCorrectlyRetrieved() {
-        Assert.assertNull(dashboard.getGap());
+    public void defaultSpacingValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getSpacing());
     }
 
     @Test
-    public void setGap_valueIsCorrectlyRetrieved() {
+    public void setSpacing_valueIsCorrectlyRetrieved() {
         String valueToSet = "10px";
-        dashboard.setGap(valueToSet);
-        Assert.assertEquals(valueToSet, dashboard.getGap());
+        dashboard.setSpacing(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getSpacing());
     }
 
     @Test
-    public void setGapNull_valueIsCorrectlyRetrieved() {
-        dashboard.setGap("10px");
-        dashboard.setGap(null);
-        Assert.assertNull(dashboard.getGap());
+    public void setSpacingNull_valueIsCorrectlyRetrieved() {
+        dashboard.setSpacing("10px");
+        dashboard.setSpacing(null);
+        Assert.assertNull(dashboard.getSpacing());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR

- renames gap APIs to use the name spacing
- updates the dashboard to use the property `--vaadin-dashboard-spacing` instead of `--vaadin-dashboard-gap` 

Renamed API:
- `Dashboard.getGap`-> `Dashboard.getSpacing`
- `Dashboard.setGap`-> `Dashboard.setSpacing`

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor