### PR TITLE
fix: also pass identifier provider to key mapper for lazy data views

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.HasLazyDataView;
+import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.ItemCountChangeEvent;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.shared.Registration;
@@ -71,6 +72,14 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
     public void setItemCountCallback(
             CallbackDataProvider.CountCallback<T, String> callback) {
         getDataCommunicator().setCountCallback(callback);
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+        getDataCommunicator().getKeyMapper()
+                .setIdentifierGetter(identifierProvider);
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.combobox.dataview;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -34,6 +36,7 @@ import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.function.SerializableConsumer;
 
@@ -331,4 +334,29 @@ public class ComboBoxLazyDataViewTest {
         dataView.getItem(1234567);
     }
 
+    @Test
+    public void setIdentifierProvider_customIdentifier_keyMapperUsesIdentifier() {
+        Item first = new Item(1L, "first");
+        Item second = new Item(2L, "middle");
+
+        List<Item> items = new ArrayList<>(Arrays.asList(first, second));
+
+        ComboBox<Item> component = new ComboBox<>();
+
+        DataCommunicator<Item> dataCommunicator = new DataCommunicator<>(
+                (item, jsonObject) -> {
+                }, null, null, component.getElement().getNode());
+        dataCommunicator.setDataProvider(
+                new CallbackDataProvider<>(query -> Stream.of(), query -> 0),
+                "", true);
+
+        ComboBoxLazyDataView<Item> dataView = new ComboBoxLazyDataView<>(
+                dataCommunicator, component);
+        DataKeyMapper<Item> keyMapper = dataCommunicator.getKeyMapper();
+        items.forEach(keyMapper::key);
+
+        Assert.assertFalse(keyMapper.has(new Item(1L, "non-present")));
+        dataView.setIdentifierProvider(Item::getId);
+        Assert.assertTrue(keyMapper.has(new Item(1L, "non-present")));
+    }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.combobox.dataview;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
@@ -153,53 +152,4 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
         return new ComboBox<>();
     }
 
-    private static class Item {
-        private long id;
-        private String value;
-
-        public Item(long id) {
-            this.id = id;
-        }
-
-        public Item(long id, String value) {
-            this.id = id;
-            this.value = value;
-        }
-
-        public long getId() {
-            return id;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public void setId(long id) {
-            this.id = id;
-        }
-
-        public void setValue(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o)
-                return true;
-            if (o == null || getClass() != o.getClass())
-                return false;
-            Item item = (Item) o;
-            return id == item.id && Objects.equals(value, item.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(id, value);
-        }
-
-        @Override
-        public String toString() {
-            return String.valueOf(value);
-        }
-    }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/Item.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/Item.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.dataview;
+
+import java.util.Objects;
+
+class Item {
+    private long id;
+    private String value;
+
+    public Item(long id) {
+        this.id = id;
+    }
+
+    public Item(long id, String value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    // equals and hashCode should use both id and value for a valid test setup
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Item item = (Item) o;
+        return id == item.id && Objects.equals(value, item.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, value);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}


### PR DESCRIPTION
Previously only the generic and list data views would pass a custom identifier provider to the key mapper. This fixes lazy data view to do the same. Effectively, if there are duplicate items in the dropdown, this change will now show all of them as checked if one of them is selected.

Fixes https://github.com/vaadin/flow/issues/19361