### PR TITLE
fix: do not trigger data communicator reset when no filters

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4568,7 +4568,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void setDropMode(GridDropMode dropMode) {
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
-        if (dragFilter != defaultDragFilter || dropFilter != defaultDropFilter) {
+
+        // Workaround to prevent scroll position reset when setting dropMode
+        // dynamically on drag start in tree grids. This can be removed when
+        // Flow will provide a way to request refresh for only items that
+        // are in the viewport.
+        if (dragFilter != defaultDragFilter
+                || dropFilter != defaultDropFilter) {
             getDataCommunicator().reset();
         }
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4569,8 +4569,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
 
-        // Workaround to prevent scroll position reset when setting dropMode
-        // dynamically on drag start in tree grids. This can be removed when
+        // Do not reset the data communicator if no filters are applied in order
+        // to avoid unnecessary scroll position reset. This can be removed when
         // Flow will provide a way to request refresh for only items that
         // are in the viewport.
         if (dragFilter != defaultDragFilter
@@ -4602,8 +4602,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void setRowsDraggable(boolean rowsDraggable) {
         getElement().setProperty("rowsDraggable", rowsDraggable);
 
-        // Workaround to prevent scroll position reset when setting dropMode
-        // dynamically on drag start in tree grids. This can be removed when
+        // Do not reset the data communicator if no filters are applied in order
+        // to avoid unnecessary scroll position reset. This can be removed when
         // Flow will provide a way to request refresh for only items that
         // are in the viewport.
         if (dragFilter != defaultDragFilter

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4601,7 +4601,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void setRowsDraggable(boolean rowsDraggable) {
         getElement().setProperty("rowsDraggable", rowsDraggable);
-        getDataCommunicator().reset();
+
+        // Workaround to prevent scroll position reset when setting dropMode
+        // dynamically on drag start in tree grids. This can be removed when
+        // Flow will provide a way to request refresh for only items that
+        // are in the viewport.
+        if (dragFilter != defaultDragFilter
+                || dropFilter != defaultDropFilter) {
+            getDataCommunicator().reset();
+        }
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1448,8 +1448,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private SerializableFunction<T, String> classNameGenerator = item -> null;
     private SerializableFunction<T, String> partNameGenerator = item -> null;
-    private SerializablePredicate<T> dropFilter = item -> true;
-    private SerializablePredicate<T> dragFilter = item -> true;
+    private SerializablePredicate<T> defaultDropFilter = item -> true;
+    private SerializablePredicate<T> defaultDragFilter = item -> true;
+    private SerializablePredicate<T> dropFilter = defaultDropFilter;
+    private SerializablePredicate<T> dragFilter = defaultDragFilter;
     private Map<String, SerializableFunction<T, String>> dragDataGenerators = new HashMap<>();
 
     private Registration dataProviderChangeRegistration;
@@ -4566,7 +4568,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void setDropMode(GridDropMode dropMode) {
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
-        getDataCommunicator().reset();
+        if (dragFilter != defaultDragFilter || dropFilter != defaultDropFilter) {
+            getDataCommunicator().reset();
+        }
     }
 
     /**


### PR DESCRIPTION
The `setDropMode` and `setRowsDraggable` methods were [updated](https://github.com/vaadin/flow-components/pull/6339) to call `dataCommunicator.reset` to ensure drop filters are applied when the drop mode is set dynamically. While this fixed the original issue, it introduced an unintended side effect: an annoying scroll position reset that now happens e.g. when setting the drop mode dynamically on drag start. 

Unfortunately, resolving this new issue completely is impossible without introducing new API in `DataCommunicator`. An API that would allow us to request `refreshItem` for only items that are in the viewport. 

Since not working filters appear to be a more critical issue, it was decided to keep the original change but try to mitigate its impact by preventing the data reset when no filters are set.

Fixes https://github.com/vaadin/flow-components/issues/6662
