### PR TITLE
fix: allow replacing item instances with `refreshItem`

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -1053,7 +1053,10 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
             getItems()
                     .filter(vaadinItem -> updatedItemId.equals(
                             identifierProvider.apply(vaadinItem.getItem())))
-                    .findAny().ifPresent(this::updateItem);
+                    .findAny().ifPresent(item -> {
+                        item.setItem(updatedItem);
+                        updateItem(item);
+                    });
         } else {
             reset();
         }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/VaadinItem.java
@@ -49,6 +49,10 @@ class VaadinItem<T> extends Component implements
         return item;
     }
 
+    void setItem(T item) {
+        this.item = item;
+    }
+
     @Override
     public void onEnabledStateChanged(boolean enabled) {
         // Not setting the disabled attribute because vaadin-item's that are

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectDataViewTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectDataViewTest.java
@@ -63,10 +63,9 @@ public class SelectDataViewTest extends AbstractComponentDataViewTest {
 
         dataView.setIdentifierProvider(Item::getId);
 
-        first.setValue("changed-1");
         second.setValue("changed-2");
 
-        dataProvider.refreshItem(new Item(1L));
+        dataProvider.refreshItem(new Item(1L, "changed-1"));
 
         Assert.assertTrue(containsItem(component, "changed-1"));
         Assert.assertFalse(containsItem(component, "changed-2"));
@@ -85,10 +84,9 @@ public class SelectDataViewTest extends AbstractComponentDataViewTest {
         Select<Item> component = new Select<>();
         component.setItems(dataProvider);
 
-        first.setValue("changed-1");
         second.setValue("changed-2");
 
-        dataProvider.refreshItem(new Item(1L));
+        dataProvider.refreshItem(new Item(1L, "changed-1"));
 
         Assert.assertTrue(containsItem(component, "changed-1"));
         Assert.assertFalse(containsItem(component, "changed-2"));


### PR DESCRIPTION
When refreshing a single item in a `Select` data provider, the component currently assumes that the existing item instance has been updated, but does not handle replacing item instances. However the `refreshItem` JavaDoc explicitly mentions that use case:
> Refreshes the given item. This method should be used to inform all DataProviderListeners that an item has been updated or replaced with a new instance.

This change makes `Select` handle replacing item instances as well.

Fixes https://github.com/vaadin/flow-components/issues/6579