### PR TITLE
refactor: remove tryCatchWrapper for better stack trace

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -2,285 +2,276 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
 
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Combo Box');
-};
+function initLazy() {
+  // Check whether the connector was already initialized for the ComboBox
+  if (comboBox.$connector) {
+    return;
+  }
 
-window.Vaadin.Flow.comboBoxConnector = {
-  initLazy: (comboBox) =>
-    tryCatchWrapper(function (comboBox) {
-      // Check whether the connector was already initialized for the ComboBox
-      if (comboBox.$connector) {
-        return;
+  comboBox.$connector = {};
+
+  // holds pageIndex -> callback pairs of subsequent indexes (current active range)
+  const pageCallbacks = {};
+  let cache = {};
+  let lastFilter = '';
+  const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
+
+  const serverFacade = (() => {
+    // Private variables
+    let lastFilterSentToServer = '';
+    let dataCommunicatorResetNeeded = false;
+
+    // Public methods
+    const needsDataCommunicatorReset = () => (dataCommunicatorResetNeeded = true);
+    const getLastFilterSentToServer = () => lastFilterSentToServer;
+    const requestData = (startIndex, endIndex, params) => {
+      const count = endIndex - startIndex;
+      const filter = params.filter;
+
+      comboBox.$server.setRequestedRange(startIndex, count, filter);
+      lastFilterSentToServer = filter;
+      if (dataCommunicatorResetNeeded) {
+        comboBox.$server.resetDataCommunicator();
+        dataCommunicatorResetNeeded = false;
       }
+    };
 
-      comboBox.$connector = {};
+    return {
+      needsDataCommunicatorReset,
+      getLastFilterSentToServer,
+      requestData
+    };
+  })();
 
-      // holds pageIndex -> callback pairs of subsequent indexes (current active range)
-      const pageCallbacks = {};
-      let cache = {};
-      let lastFilter = '';
-      const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
+  const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
+    // Flush and empty the existing requests
+    pages.forEach((page) => {
+      pageCallbacks[page]([], comboBox.size);
+      delete pageCallbacks[page];
 
-      const serverFacade = (() => {
-        // Private variables
-        let lastFilterSentToServer = '';
-        let dataCommunicatorResetNeeded = false;
+      // Empty the comboBox's internal cache without invoking observers by filling
+      // the filteredItems array with placeholders (comboBox will request for data when it
+      // encounters a placeholder)
+      const pageStart = parseInt(page) * comboBox.pageSize;
+      const pageEnd = pageStart + comboBox.pageSize;
+      const end = Math.min(pageEnd, comboBox.filteredItems.length);
+      for (let i = pageStart; i < end; i++) {
+        comboBox.filteredItems[i] = placeHolder;
+      }
+    });
+  };
 
-        // Public methods
-        const needsDataCommunicatorReset = () => (dataCommunicatorResetNeeded = true);
-        const getLastFilterSentToServer = () => lastFilterSentToServer;
-        const requestData = (startIndex, endIndex, params) => {
-          const count = endIndex - startIndex;
-          const filter = params.filter;
+  comboBox.dataProvider = function (params, callback) {
+    if (params.pageSize != comboBox.pageSize) {
+      throw 'Invalid pageSize';
+    }
 
-          comboBox.$server.setRequestedRange(startIndex, count, filter);
-          lastFilterSentToServer = filter;
-          if (dataCommunicatorResetNeeded) {
-            comboBox.$server.resetDataCommunicator();
-            dataCommunicatorResetNeeded = false;
-          }
-        };
+    if (comboBox._clientSideFilter) {
+      // For clientside filter we first make sure we have all data which we also
+      // filter based on comboBox.filter. While later we only filter clientside data.
 
-        return {
-          needsDataCommunicatorReset,
-          getLastFilterSentToServer,
-          requestData
-        };
-      })();
+      if (cache[0]) {
+        performClientSideFilter(cache[0], params.filter, callback);
+        return;
+      } else {
+        // If client side filter is enabled then we need to first ask all data
+        // and filter it on client side, otherwise next time when user will
+        // input another filter, eg. continue to type, the local cache will be only
+        // what was received for the first filter, which may not be the whole
+        // data from server (keep in mind that client side filter is enabled only
+        // when the items count does not exceed one page).
+        params.filter = '';
+      }
+    }
 
-      const clearPageCallbacks = (pages = Object.keys(pageCallbacks)) => {
-        // Flush and empty the existing requests
-        pages.forEach((page) => {
-          pageCallbacks[page]([], comboBox.size);
-          delete pageCallbacks[page];
-
-          // Empty the comboBox's internal cache without invoking observers by filling
-          // the filteredItems array with placeholders (comboBox will request for data when it
-          // encounters a placeholder)
-          const pageStart = parseInt(page) * comboBox.pageSize;
-          const pageEnd = pageStart + comboBox.pageSize;
-          const end = Math.min(pageEnd, comboBox.filteredItems.length);
-          for (let i = pageStart; i < end; i++) {
-            comboBox.filteredItems[i] = placeHolder;
-          }
-        });
-      };
-
-      comboBox.dataProvider = function (params, callback) {
-        if (params.pageSize != comboBox.pageSize) {
-          throw 'Invalid pageSize';
+    const filterChanged = params.filter !== lastFilter;
+    if (filterChanged) {
+      cache = {};
+      lastFilter = params.filter;
+      this._filterDebouncer = Debouncer.debounce(this._filterDebouncer, timeOut.after(500), () => {
+        if (serverFacade.getLastFilterSentToServer() === params.filter) {
+          // Fixes the case when the filter changes
+          // to something else and back to the original value
+          // within debounce timeout, and the
+          // DataCommunicator thinks it doesn't need to send data
+          serverFacade.needsDataCommunicatorReset();
         }
-
-        if (comboBox._clientSideFilter) {
-          // For clientside filter we first make sure we have all data which we also
-          // filter based on comboBox.filter. While later we only filter clientside data.
-
-          if (cache[0]) {
-            performClientSideFilter(cache[0], params.filter, callback);
-            return;
-          } else {
-            // If client side filter is enabled then we need to first ask all data
-            // and filter it on client side, otherwise next time when user will
-            // input another filter, eg. continue to type, the local cache will be only
-            // what was received for the first filter, which may not be the whole
-            // data from server (keep in mind that client side filter is enabled only
-            // when the items count does not exceed one page).
-            params.filter = '';
-          }
+        if (params.filter !== lastFilter) {
+          throw new Error("Expected params.filter to be '" + lastFilter + "' but was '" + params.filter + "'");
         }
-
-        const filterChanged = params.filter !== lastFilter;
-        if (filterChanged) {
-          cache = {};
-          lastFilter = params.filter;
-          this._filterDebouncer = Debouncer.debounce(this._filterDebouncer, timeOut.after(500), () => {
-            if (serverFacade.getLastFilterSentToServer() === params.filter) {
-              // Fixes the case when the filter changes
-              // to something else and back to the original value
-              // within debounce timeout, and the
-              // DataCommunicator thinks it doesn't need to send data
-              serverFacade.needsDataCommunicatorReset();
-            }
-            if (params.filter !== lastFilter) {
-              throw new Error("Expected params.filter to be '" + lastFilter + "' but was '" + params.filter + "'");
-            }
-            // Remove the debouncer before clearing page callbacks.
-            // This makes sure that they are executed.
-            this._filterDebouncer = undefined;
-            // Call the method again after debounce.
-            clearPageCallbacks();
-            comboBox.dataProvider(params, callback);
-          });
-          return;
-        }
-
-        // Postpone the execution of new callbacks if there is an active debouncer.
-        // They will be executed when the page callbacks are cleared within the debouncer.
-        if (this._filterDebouncer) {
-          pageCallbacks[params.page] = callback;
-          return;
-        }
-
-        if (cache[params.page]) {
-          // This may happen after skipping pages by scrolling fast
-          commitPage(params.page, callback);
-        } else {
-          pageCallbacks[params.page] = callback;
-          const maxRangeCount = Math.max(params.pageSize * 2, 500); // Max item count in active range
-          const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
-          const rangeMin = Math.min(...activePages);
-          const rangeMax = Math.max(...activePages);
-
-          if (activePages.length * params.pageSize > maxRangeCount) {
-            if (params.page === rangeMin) {
-              clearPageCallbacks([String(rangeMax)]);
-            } else {
-              clearPageCallbacks([String(rangeMin)]);
-            }
-            comboBox.dataProvider(params, callback);
-          } else if (rangeMax - rangeMin + 1 !== activePages.length) {
-            // Wasn't a sequential page index, clear the cache so combo-box will request for new pages
-            clearPageCallbacks();
-          } else {
-            // The requested page was sequential, extend the requested range
-            const startIndex = params.pageSize * rangeMin;
-            const endIndex = params.pageSize * (rangeMax + 1);
-
-            serverFacade.requestData(startIndex, endIndex, params);
-          }
-        }
-      };
-
-      comboBox.$connector.clear = tryCatchWrapper((start, length) => {
-        const firstPageToClear = Math.floor(start / comboBox.pageSize);
-        const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
-
-        for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
-          delete cache[i];
-        }
-      });
-
-      comboBox.$connector.filter = tryCatchWrapper(function (item, filter) {
-        filter = filter ? filter.toString().toLowerCase() : '';
-        return comboBox._getItemLabel(item, comboBox.itemLabelPath).toString().toLowerCase().indexOf(filter) > -1;
-      });
-
-      comboBox.$connector.set = tryCatchWrapper(function (index, items, filter) {
-        if (filter != serverFacade.getLastFilterSentToServer()) {
-          return;
-        }
-
-        if (index % comboBox.pageSize != 0) {
-          throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
-        }
-
-        if (index === 0 && items.length === 0 && pageCallbacks[0]) {
-          // Makes sure that the dataProvider callback is called even when server
-          // returns empty data set (no items match the filter).
-          cache[0] = [];
-          return;
-        }
-
-        const firstPageToSet = index / comboBox.pageSize;
-        const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
-
-        for (let i = 0; i < updatedPageCount; i++) {
-          let page = firstPageToSet + i;
-          let slice = items.slice(i * comboBox.pageSize, (i + 1) * comboBox.pageSize);
-
-          cache[page] = slice;
-        }
-      });
-
-      comboBox.$connector.updateData = tryCatchWrapper(function (items) {
-        const itemsMap = new Map(items.map((item) => [item.key, item]));
-
-        comboBox.filteredItems = comboBox.filteredItems.map((item) => {
-          return itemsMap.get(item.key) || item;
-        });
-      });
-
-      comboBox.$connector.updateSize = tryCatchWrapper(function (newSize) {
-        if (!comboBox._clientSideFilter) {
-          // FIXME: It may be that this size set is unnecessary, since when
-          // providing data to combobox via callback we may use data's size.
-          // However, if this size reflect the whole data size, including
-          // data not fetched yet into client side, and combobox expect it
-          // to be set as such, the at least, we don't need it in case the
-          // filter is clientSide only, since it'll increase the height of
-          // the popup at only at first user filter to this size, while the
-          // filtered items count are less.
-          comboBox.size = newSize;
-        }
-      });
-
-      comboBox.$connector.reset = tryCatchWrapper(function () {
+        // Remove the debouncer before clearing page callbacks.
+        // This makes sure that they are executed.
+        this._filterDebouncer = undefined;
+        // Call the method again after debounce.
         clearPageCallbacks();
-        cache = {};
-        comboBox.clearCache();
+        comboBox.dataProvider(params, callback);
       });
+      return;
+    }
 
-      comboBox.$connector.confirm = tryCatchWrapper(function (id, filter) {
-        if (filter != serverFacade.getLastFilterSentToServer()) {
-          return;
-        }
+    // Postpone the execution of new callbacks if there is an active debouncer.
+    // They will be executed when the page callbacks are cleared within the debouncer.
+    if (this._filterDebouncer) {
+      pageCallbacks[params.page] = callback;
+      return;
+    }
 
-        // We're done applying changes from this batch, resolve pending
-        // callbacks
-        let activePages = Object.getOwnPropertyNames(pageCallbacks);
-        for (let i = 0; i < activePages.length; i++) {
-          let page = activePages[i];
+    if (cache[params.page]) {
+      // This may happen after skipping pages by scrolling fast
+      commitPage(params.page, callback);
+    } else {
+      pageCallbacks[params.page] = callback;
+      const maxRangeCount = Math.max(params.pageSize * 2, 500); // Max item count in active range
+      const activePages = Object.keys(pageCallbacks).map((page) => parseInt(page));
+      const rangeMin = Math.min(...activePages);
+      const rangeMax = Math.max(...activePages);
 
-          if (cache[page]) {
-            commitPage(page, pageCallbacks[page]);
-          }
-        }
-
-        // Let server know we're done
-        comboBox.$server.confirmUpdate(id);
-      });
-
-      const commitPage = tryCatchWrapper(function (page, callback) {
-        let data = cache[page];
-
-        if (comboBox._clientSideFilter) {
-          performClientSideFilter(data, comboBox.filter, callback);
+      if (activePages.length * params.pageSize > maxRangeCount) {
+        if (params.page === rangeMin) {
+          clearPageCallbacks([String(rangeMax)]);
         } else {
-          // Remove the data if server-side filtering, but keep it for client-side
-          // filtering
-          delete cache[page];
-
-          // FIXME: It may be that we ought to provide data.length instead of
-          // comboBox.size and remove updateSize function.
-          callback(data, comboBox.size);
+          clearPageCallbacks([String(rangeMin)]);
         }
-      });
+        comboBox.dataProvider(params, callback);
+      } else if (rangeMax - rangeMin + 1 !== activePages.length) {
+        // Wasn't a sequential page index, clear the cache so combo-box will request for new pages
+        clearPageCallbacks();
+      } else {
+        // The requested page was sequential, extend the requested range
+        const startIndex = params.pageSize * rangeMin;
+        const endIndex = params.pageSize * (rangeMax + 1);
 
-      // Perform filter on client side (here) using the items from specified page
-      // and submitting the filtered items to specified callback.
-      // The filter used is the one from combobox, not the lastFilter stored since
-      // that may not reflect user's input.
-      const performClientSideFilter = tryCatchWrapper(function (page, filter, callback) {
-        let filteredItems = page;
+        serverFacade.requestData(startIndex, endIndex, params);
+      }
+    }
+  };
 
-        if (filter) {
-          filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
-        }
+  comboBox.$connector.clear = (start, length) => {
+    const firstPageToClear = Math.floor(start / comboBox.pageSize);
+    const numberOfPagesToClear = Math.ceil(length / comboBox.pageSize);
 
-        callback(filteredItems, filteredItems.length);
-      });
+    for (let i = firstPageToClear; i < firstPageToClear + numberOfPagesToClear; i++) {
+      delete cache[i];
+    }
+  };
 
-      // Prevent setting the custom value as the 'value'-prop automatically
-      comboBox.addEventListener(
-        'custom-value-set',
-        tryCatchWrapper((e) => e.preventDefault())
-      );
+  comboBox.$connector.filter = (item, filter) => {
+    filter = filter ? filter.toString().toLowerCase() : '';
+    return comboBox._getItemLabel(item, comboBox.itemLabelPath).toString().toLowerCase().indexOf(filter) > -1;
+  };
 
-      comboBox.itemClassNameGenerator = tryCatchWrapper(function (item) {
-        return item.className || '';
-      });
-    })(comboBox)
-};
+  comboBox.$connector.set = (index, items, filter) => {
+    if (filter != serverFacade.getLastFilterSentToServer()) {
+      return;
+    }
+
+    if (index % comboBox.pageSize != 0) {
+      throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
+    }
+
+    if (index === 0 && items.length === 0 && pageCallbacks[0]) {
+      // Makes sure that the dataProvider callback is called even when server
+      // returns empty data set (no items match the filter).
+      cache[0] = [];
+      return;
+    }
+
+    const firstPageToSet = index / comboBox.pageSize;
+    const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
+
+    for (let i = 0; i < updatedPageCount; i++) {
+      let page = firstPageToSet + i;
+      let slice = items.slice(i * comboBox.pageSize, (i + 1) * comboBox.pageSize);
+
+      cache[page] = slice;
+    }
+  };
+
+  comboBox.$connector.updateData = (items) => {
+    const itemsMap = new Map(items.map((item) => [item.key, item]));
+
+    comboBox.filteredItems = comboBox.filteredItems.map((item) => {
+      return itemsMap.get(item.key) || item;
+    });
+  };
+
+  comboBox.$connector.updateSize = function (newSize) {
+    if (!comboBox._clientSideFilter) {
+      // FIXME: It may be that this size set is unnecessary, since when
+      // providing data to combobox via callback we may use data's size.
+      // However, if this size reflect the whole data size, including
+      // data not fetched yet into client side, and combobox expect it
+      // to be set as such, the at least, we don't need it in case the
+      // filter is clientSide only, since it'll increase the height of
+      // the popup at only at first user filter to this size, while the
+      // filtered items count are less.
+      comboBox.size = newSize;
+    }
+  };
+
+  comboBox.$connector.reset = function () {
+    clearPageCallbacks();
+    cache = {};
+    comboBox.clearCache();
+  };
+
+  comboBox.$connector.confirm = function (id, filter) {
+    if (filter != serverFacade.getLastFilterSentToServer()) {
+      return;
+    }
+
+    // We're done applying changes from this batch, resolve pending
+    // callbacks
+    let activePages = Object.getOwnPropertyNames(pageCallbacks);
+    for (let i = 0; i < activePages.length; i++) {
+      let page = activePages[i];
+
+      if (cache[page]) {
+        commitPage(page, pageCallbacks[page]);
+      }
+    }
+
+    // Let server know we're done
+    comboBox.$server.confirmUpdate(id);
+  };
+
+  const commitPage = function (page, callback) {
+    let data = cache[page];
+
+    if (comboBox._clientSideFilter) {
+      performClientSideFilter(data, comboBox.filter, callback);
+    } else {
+      // Remove the data if server-side filtering, but keep it for client-side
+      // filtering
+      delete cache[page];
+
+      // FIXME: It may be that we ought to provide data.length instead of
+      // comboBox.size and remove updateSize function.
+      callback(data, comboBox.size);
+    }
+  };
+
+  // Perform filter on client side (here) using the items from specified page
+  // and submitting the filtered items to specified callback.
+  // The filter used is the one from combobox, not the lastFilter stored since
+  // that may not reflect user's input.
+  const performClientSideFilter = function (page, filter, callback) {
+    let filteredItems = page;
+
+    if (filter) {
+      filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
+    }
+
+    callback(filteredItems, filteredItems.length);
+  };
+
+  // Prevent setting the custom value as the 'value'-prop automatically
+  comboBox.addEventListener('custom-value-set', (e) => e.preventDefault());
+
+  comboBox.itemClassNameGenerator = function (item) {
+    return item.className || '';
+  };
+}
 
 window.Vaadin.ComboBoxPlaceholder = ComboBoxPlaceholder;
+window.Vaadin.Flow.comboBoxConnector = { initLazy };

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -2,7 +2,8 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
 
-function initLazy() {
+window.Vaadin.Flow.comboBoxConnector = {}
+window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   // Check whether the connector was already initialized for the ComboBox
   if (comboBox.$connector) {
     return;
@@ -274,4 +275,3 @@ function initLazy() {
 }
 
 window.Vaadin.ComboBoxPlaceholder = ComboBoxPlaceholder;
-window.Vaadin.Flow.comboBoxConnector = { initLazy };

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -1,7 +1,3 @@
-function tryCatchWrapper(callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu');
-}
-
 function getContainer(appId, nodeId) {
   try {
     return window.Vaadin.Flow.clients[appId].getByNodeId(nodeId);
@@ -28,11 +24,11 @@ function initLazy(contextMenu, appId) {
      *
      * @param {number} nodeId
      */
-    generateItems: tryCatchWrapper((nodeId) => {
+    generateItems(nodeId) {
       const items = generateItemsTree(appId, nodeId);
 
       contextMenu.items = items;
-    })
+    }
   };
 }
 
@@ -118,23 +114,9 @@ function setTheme(component, theme) {
 }
 
 window.Vaadin.Flow.contextMenuConnector = {
-  initLazy(...args) {
-    return tryCatchWrapper(initLazy)(...args);
-  },
-
-  generateItemsTree(...args) {
-    return tryCatchWrapper(generateItemsTree)(...args);
-  },
-
-  setChecked(...args) {
-    return tryCatchWrapper(setChecked)(...args);
-  },
-
-  setKeepOpen(...args) {
-    return tryCatchWrapper(setKeepOpen)(...args);
-  },
-
-  setTheme(...args) {
-    return tryCatchWrapper(setTheme)(...args);
-  }
+  initLazy,
+  generateItemsTree,
+  setChecked,
+  setKeepOpen,
+  setTheme
 };

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuTargetConnector.js
@@ -1,16 +1,12 @@
 import * as Gestures from '@vaadin/component-base/src/gestures.js';
 
-function tryCatchWrapper(callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Context Menu Target');
-}
-
 function init(target) {
   if (target.$contextMenuTargetConnector) {
     return;
   }
 
   target.$contextMenuTargetConnector = {
-    openOnHandler: tryCatchWrapper(function (e) {
+    openOnHandler(e) {
       // used by Grid to prevent context menu on selection column click
       if (target.preventContextMenu && target.preventContextMenu(e)) {
         return;
@@ -27,24 +23,22 @@ function init(target) {
           detail: detail
         })
       );
-    }),
+    },
 
-    updateOpenOn: tryCatchWrapper(function (eventType) {
+    updateOpenOn(eventType) {
       this.removeListener();
       this.openOnEventType = eventType;
 
-      customElements.whenDefined('vaadin-context-menu').then(
-        tryCatchWrapper(() => {
-          if (Gestures.gestures[eventType]) {
-            Gestures.addListener(target, eventType, this.openOnHandler);
-          } else {
-            target.addEventListener(eventType, this.openOnHandler);
-          }
-        })
-      );
-    }),
+      customElements.whenDefined('vaadin-context-menu').then(() => {
+        if (Gestures.gestures[eventType]) {
+          Gestures.addListener(target, eventType, this.openOnHandler);
+        } else {
+          target.addEventListener(eventType, this.openOnHandler);
+        }
+      });
+    },
 
-    removeListener: tryCatchWrapper(function () {
+    removeListener() {
       if (this.openOnEventType) {
         if (Gestures.gestures[this.openOnEventType]) {
           Gestures.removeListener(target, this.openOnEventType, this.openOnHandler);
@@ -52,21 +46,17 @@ function init(target) {
           target.removeEventListener(this.openOnEventType, this.openOnHandler);
         }
       }
-    }),
+    },
 
-    openMenu: tryCatchWrapper(function (contextMenu) {
+    openMenu(contextMenu) {
       contextMenu.open(this.openEvent);
-    }),
+    },
 
-    removeConnector: tryCatchWrapper(function () {
+    removeConnector() {
       this.removeListener();
       target.$contextMenuTargetConnector = undefined;
-    })
+    },
   };
 }
 
-window.Vaadin.Flow.contextMenuTargetConnector = {
-  init(...args) {
-    return tryCatchWrapper(init)(...args);
-  }
-};
+window.Vaadin.Flow.contextMenuTargetConnector = { init };

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/test/env-setup.ts
@@ -1,10 +1,3 @@
 window.Vaadin ||= {};
-const Flow = {
-  tryCatchWrapper: function (originalFunction) {
-    return function () {
-      return originalFunction.apply(this, arguments);
-    };
-  }
-};
 // @ts-expect-error
-window.Vaadin.Flow = Flow;
+window.Vaadin.Flow = {};

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -3,183 +3,178 @@ import dateFnsParse from 'date-fns/parse';
 import dateFnsIsValid from 'date-fns/isValid';
 import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker');
-};
+function initLazy(datepicker) {
+  // Check whether the connector was already initialized for the datepicker
+  if (datepicker.$connector) {
+    return;
+  }
 
-window.Vaadin.Flow.datepickerConnector = {
-  initLazy: (datepicker) =>
-    tryCatchWrapper(function (datepicker) {
-      // Check whether the connector was already initialized for the datepicker
-      if (datepicker.$connector) {
+  datepicker.$connector = {};
+
+  const createLocaleBasedDateFormat = function (locale) {
+    try {
+      // Check whether the locale is supported or not
+      new Date().toLocaleDateString(locale);
+    } catch (e) {
+      console.warn('The locale is not supported, using default format setting (ISO 8601).');
+      return 'yyyy-MM-dd';
+    }
+
+    // format test date and convert to date-fns pattern
+    const testDate = new Date(Date.UTC(1234, 4, 6));
+    let pattern = testDate.toLocaleDateString(locale, { timeZone: 'UTC' });
+    pattern = pattern
+      // escape date-fns pattern letters by enclosing them in single quotes
+      .replace(/([a-zA-Z]+)/g, "'$1'")
+      // insert date placeholder
+      .replace('06', 'dd')
+      .replace('6', 'd')
+      // insert month placeholder
+      .replace('05', 'MM')
+      .replace('5', 'M')
+      // insert year placeholder
+      .replace('1234', 'yyyy');
+    const isValidPattern = pattern.includes('d') && pattern.includes('M') && pattern.includes('y');
+    if (!isValidPattern) {
+      console.warn('The locale is not supported, using default format setting (ISO 8601).');
+      return 'yyyy-MM-dd';
+    }
+
+    return pattern;
+  };
+
+  function createFormatterAndParser(formats) {
+    if (!formats || formats.length === 0) {
+      throw new Error('Array of custom date formats is null or empty');
+    }
+
+    function getShortYearFormat(format) {
+      if (format.includes('yyyy') && !format.includes('yyyyy')) {
+        return format.replace('yyyy', 'yy');
+      }
+      if (format.includes('YYYY') && !format.includes('YYYYY')) {
+        return format.replace('YYYY', 'YY');
+      }
+      return undefined;
+    }
+
+    function isFormatWithYear(format) {
+      return format.includes('y') || format.includes('Y');
+    }
+
+    function isShortYearFormat(format) {
+      // Format is long if it includes a four-digit year.
+      return !format.includes('yyyy') && !format.includes('YYYY');
+    }
+
+    function getExtendedFormats(formats) {
+      return formats.reduce((acc, format) => {
+        // We first try to match the date with the shorter version,
+        // as short years are supported with the long date format.
+        if (isFormatWithYear(format) && !isShortYearFormat(format)) {
+          acc.push(getShortYearFormat(format));
+        }
+        acc.push(format);
+        return acc;
+      }, []);
+    }
+
+    function correctFullYear(date) {
+      // The last parsed date check handles the case where a four-digit year is parsed, then formatted
+      // as a two-digit year, and then parsed again. In this case we want to keep the century of the
+      // originally parsed year, instead of using the century of the reference date.
+
+      // Do not apply any correction if the previous parse attempt was failed.
+      if (datepicker.$connector._lastParseStatus === 'error') {
         return;
       }
 
-      datepicker.$connector = {};
-
-      const createLocaleBasedDateFormat = function (locale) {
-        try {
-          // Check whether the locale is supported or not
-          new Date().toLocaleDateString(locale);
-        } catch (e) {
-          console.warn('The locale is not supported, using default format setting (ISO 8601).');
-          return 'yyyy-MM-dd';
+      // Update century if the last parsed date is the same except the century.
+      if (datepicker.$connector._lastParseStatus === 'successful') {
+        if (
+          datepicker.$connector._lastParsedDate.day === date.getDate() &&
+          datepicker.$connector._lastParsedDate.month === date.getMonth() &&
+          datepicker.$connector._lastParsedDate.year % 100 === date.getFullYear() % 100
+        ) {
+          date.setFullYear(datepicker.$connector._lastParsedDate.year);
         }
-
-        // format test date and convert to date-fns pattern
-        const testDate = new Date(Date.UTC(1234, 4, 6));
-        let pattern = testDate.toLocaleDateString(locale, { timeZone: 'UTC' });
-        pattern = pattern
-          // escape date-fns pattern letters by enclosing them in single quotes
-          .replace(/([a-zA-Z]+)/g, "'$1'")
-          // insert date placeholder
-          .replace('06', 'dd')
-          .replace('6', 'd')
-          // insert month placeholder
-          .replace('05', 'MM')
-          .replace('5', 'M')
-          // insert year placeholder
-          .replace('1234', 'yyyy');
-        const isValidPattern = pattern.includes('d') && pattern.includes('M') && pattern.includes('y');
-        if (!isValidPattern) {
-          console.warn('The locale is not supported, using default format setting (ISO 8601).');
-          return 'yyyy-MM-dd';
-        }
-
-        return pattern;
-      };
-
-      const createFormatterAndParser = tryCatchWrapper(function (formats) {
-        if (!formats || formats.length === 0) {
-          throw new Error('Array of custom date formats is null or empty');
-        }
-
-        function getShortYearFormat(format) {
-          if (format.includes('yyyy') && !format.includes('yyyyy')) {
-            return format.replace('yyyy', 'yy');
-          }
-          if (format.includes('YYYY') && !format.includes('YYYYY')) {
-            return format.replace('YYYY', 'YY');
-          }
-          return undefined;
-        }
-
-        function isFormatWithYear(format) {
-          return format.includes('y') || format.includes('Y');
-        }
-
-        function isShortYearFormat(format) {
-          // Format is long if it includes a four-digit year.
-          return !format.includes('yyyy') && !format.includes('YYYY');
-        }
-
-        function getExtendedFormats(formats) {
-          return formats.reduce((acc, format) => {
-            // We first try to match the date with the shorter version,
-            // as short years are supported with the long date format.
-            if (isFormatWithYear(format) && !isShortYearFormat(format)) {
-              acc.push(getShortYearFormat(format));
-            }
-            acc.push(format);
-            return acc;
-          }, []);
-        }
-
-        function correctFullYear(date) {
-          // The last parsed date check handles the case where a four-digit year is parsed, then formatted
-          // as a two-digit year, and then parsed again. In this case we want to keep the century of the
-          // originally parsed year, instead of using the century of the reference date.
-
-          // Do not apply any correction if the previous parse attempt was failed.
-          if (datepicker.$connector._lastParseStatus === 'error') {
-            return;
-          }
-
-          // Update century if the last parsed date is the same except the century.
-          if (datepicker.$connector._lastParseStatus === 'successful') {
-            if (
-              datepicker.$connector._lastParsedDate.day === date.getDate() &&
-              datepicker.$connector._lastParsedDate.month === date.getMonth() &&
-              datepicker.$connector._lastParsedDate.year % 100 === date.getFullYear() % 100
-            ) {
-              date.setFullYear(datepicker.$connector._lastParsedDate.year);
-            }
-            return;
-          }
-
-          // Update century if this is the first parse after overlay open.
-          const currentValue = _parseDate(datepicker.value);
-          if (
-            dateFnsIsValid(currentValue) &&
-            currentValue.getDate() === date.getDate() &&
-            currentValue.getMonth() === date.getMonth() &&
-            currentValue.getFullYear() % 100 === date.getFullYear() % 100
-          ) {
-            date.setFullYear(currentValue.getFullYear());
-          }
-        }
-
-        function formatDate(dateParts) {
-          const format = formats[0];
-          const date = _parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
-
-          return dateFnsFormat(date, format);
-        }
-
-        function doParseDate(dateString, format, referenceDate) {
-          // When format does not contain a year, then current year should be used.
-          const refDate = isFormatWithYear(format) ? referenceDate : new Date();
-          const date = dateFnsParse(dateString, format, refDate);
-          if (dateFnsIsValid(date)) {
-            if (isFormatWithYear(format) && isShortYearFormat(format)) {
-              correctFullYear(date);
-            }
-            return {
-              day: date.getDate(),
-              month: date.getMonth(),
-              year: date.getFullYear()
-            };
-          }
-        }
-
-        function parseDate(dateString) {
-          const referenceDate = _getReferenceDate();
-          for (let format of getExtendedFormats(formats)) {
-            const parsedDate = doParseDate(dateString, format, referenceDate);
-            if (parsedDate) {
-              datepicker.$connector._lastParseStatus = 'successful';
-              datepicker.$connector._lastParsedDate = parsedDate;
-              return parsedDate;
-            }
-          }
-          datepicker.$connector._lastParseStatus = 'error';
-          return false;
-        }
-
-        return {
-          formatDate: formatDate,
-          parseDate: parseDate
-        };
-      });
-
-      function _getReferenceDate() {
-        const { referenceDate } = datepicker.i18n;
-        return referenceDate ? new Date(referenceDate.year, referenceDate.month, referenceDate.day) : new Date();
+        return;
       }
 
-      datepicker.$connector.updateI18n = tryCatchWrapper(function (locale, i18n) {
-        // Either use custom formats specified in I18N, or create format from locale
-        const hasCustomFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
-        if (i18n && i18n.referenceDate) {
-          i18n.referenceDate = extractDateParts(new Date(i18n.referenceDate));
+      // Update century if this is the first parse after overlay open.
+      const currentValue = _parseDate(datepicker.value);
+      if (
+        dateFnsIsValid(currentValue) &&
+        currentValue.getDate() === date.getDate() &&
+        currentValue.getMonth() === date.getMonth() &&
+        currentValue.getFullYear() % 100 === date.getFullYear() % 100
+      ) {
+        date.setFullYear(currentValue.getFullYear());
+      }
+    }
+
+    function formatDate(dateParts) {
+      const format = formats[0];
+      const date = _parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
+
+      return dateFnsFormat(date, format);
+    }
+
+    function doParseDate(dateString, format, referenceDate) {
+      // When format does not contain a year, then current year should be used.
+      const refDate = isFormatWithYear(format) ? referenceDate : new Date();
+      const date = dateFnsParse(dateString, format, refDate);
+      if (dateFnsIsValid(date)) {
+        if (isFormatWithYear(format) && isShortYearFormat(format)) {
+          correctFullYear(date);
         }
-        const usedFormats = hasCustomFormats ? i18n.dateFormats : [createLocaleBasedDateFormat(locale)];
-        const formatterAndParser = createFormatterAndParser(usedFormats);
+        return {
+          day: date.getDate(),
+          month: date.getMonth(),
+          year: date.getFullYear()
+        };
+      }
+    }
 
-        // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
-        datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
-      });
+    function parseDate(dateString) {
+      const referenceDate = _getReferenceDate();
+      for (let format of getExtendedFormats(formats)) {
+        const parsedDate = doParseDate(dateString, format, referenceDate);
+        if (parsedDate) {
+          datepicker.$connector._lastParseStatus = 'successful';
+          datepicker.$connector._lastParsedDate = parsedDate;
+          return parsedDate;
+        }
+      }
+      datepicker.$connector._lastParseStatus = 'error';
+      return false;
+    }
 
-      datepicker.addEventListener('opened-changed', () => (datepicker.$connector._lastParseStatus = undefined));
-    })(datepicker)
-};
+    return {
+      formatDate: formatDate,
+      parseDate: parseDate
+    };
+  }
+
+  function _getReferenceDate() {
+    const { referenceDate } = datepicker.i18n;
+    return referenceDate ? new Date(referenceDate.year, referenceDate.month, referenceDate.day) : new Date();
+  }
+
+  datepicker.$connector.updateI18n = (locale, i18n) => {
+    // Either use custom formats specified in I18N, or create format from locale
+    const hasCustomFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
+    if (i18n && i18n.referenceDate) {
+      i18n.referenceDate = extractDateParts(new Date(i18n.referenceDate));
+    }
+    const usedFormats = hasCustomFormats ? i18n.dateFormats : [createLocaleBasedDateFormat(locale)];
+    const formatterAndParser = createFormatterAndParser(usedFormats);
+
+    // Merge current web component I18N settings with new I18N settings and the formatting and parsing functions
+    datepicker.i18n = Object.assign({}, datepicker.i18n, i18n, formatterAndParser);
+  };
+
+  datepicker.addEventListener('opened-changed', () => (datepicker.$connector._lastParseStatus = undefined));
+}
+
+window.Vaadin.Flow.datepickerConnector = { initLazy };

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -3,7 +3,8 @@ import dateFnsParse from 'date-fns/parse';
 import dateFnsIsValid from 'date-fns/isValid';
 import { extractDateParts, parseDate as _parseDate } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 
-function initLazy(datepicker) {
+window.Vaadin.Flow.datepickerConnector = {};
+window.Vaadin.Flow.datepickerConnector.initLazy = (datepicker) => {
   // Check whether the connector was already initialized for the datepicker
   if (datepicker.$connector) {
     return;
@@ -176,5 +177,3 @@ function initLazy(datepicker) {
 
   datepicker.addEventListener('opened-changed', () => (datepicker.$connector._lastParseStatus = undefined));
 }
-
-window.Vaadin.Flow.datepickerConnector = { initLazy };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/env-setup.ts
@@ -1,10 +1,3 @@
 window.Vaadin ||= {};
-const Flow = {
-  tryCatchWrapper: function (originalFunction) {
-    return function () {
-      return originalFunction.apply(this, arguments);
-    };
-  }
-};
 // @ts-expect-error
-window.Vaadin.Flow = Flow;
+window.Vaadin.Flow = {};

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -5,1272 +5,1200 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js";
 
-window.Vaadin.Flow.gridConnector = {
-  initLazy(grid) {
-    // Check whether the connector was already initialized for the grid
-    if (grid.$connector) {
+window.Vaadin.Flow.gridConnector = {};
+window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
+  // Check whether the connector was already initialized for the grid
+  if (grid.$connector) {
+    return;
+  }
+
+  const dataProviderController = grid._dataProviderController;
+
+  dataProviderController.ensureFlatIndexHierarchyOriginal = dataProviderController.ensureFlatIndexHierarchy;
+  dataProviderController.ensureFlatIndexHierarchy = function (flatIndex) {
+    const { item } = this.getFlatIndexContext(flatIndex);
+    if (!item || !this.isExpanded(item)) {
       return;
     }
 
-    const dataProviderController = grid._dataProviderController;
+    const isCached = grid.$connector.hasCacheForParentKey(grid.getItemId(item));
+    if (isCached) {
+      // The sub-cache items are already in the connector's cache. Skip the debouncing process.
+      this.ensureFlatIndexHierarchyOriginal(flatIndex);
+    } else {
+      grid.$connector.beforeEnsureFlatIndexHierarchy(flatIndex, item);
+    }
+  };
 
-    dataProviderController.ensureFlatIndexHierarchyOriginal = dataProviderController.ensureFlatIndexHierarchy;
-    dataProviderController.ensureFlatIndexHierarchy = function(flatIndex) {
-      const { item } = this.getFlatIndexContext(flatIndex);
-      if (!item || !this.isExpanded(item)) {
-        return;
+  dataProviderController.isLoadingOriginal = dataProviderController.isLoading;
+  dataProviderController.isLoading = function () {
+    return grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
+  };
+
+  dataProviderController.getItemSubCache = function (item) {
+    return this.getItemContext(item)?.subCache;
+  };
+
+  let cache = {};
+
+  /* parentRequestDelay - optimizes parent requests by batching several requests
+    *  into one request. Delay in milliseconds. Disable by setting to 0.
+    *  parentRequestBatchMaxSize - maximum size of the batch.
+    */
+  const parentRequestDelay = 50;
+  const parentRequestBatchMaxSize = 20;
+
+  let parentRequestQueue = [];
+  let parentRequestDebouncer;
+  let ensureSubCacheQueue = [];
+  let ensureSubCacheDebouncer;
+
+  const rootRequestDelay = 150;
+  let rootRequestDebouncer;
+
+  let lastRequestedRanges = {};
+  const root = 'null';
+  lastRequestedRanges[root] = [0, 0];
+
+  let currentUpdateClearRange = null;
+  let currentUpdateSetRange = null;
+
+  const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
+  let selectedKeys = {};
+  let selectionMode = 'SINGLE';
+
+  let sorterDirectionsSetFromServer = false;
+
+  grid.size = 0; // To avoid NaN here and there before we get proper data
+  grid.itemIdPath = 'key';
+
+  function createEmptyItemFromKey(key) {
+    return { [grid.itemIdPath]: key };
+  }
+
+  grid.$connector = {};
+
+  grid.$connector.hasCacheForParentKey = (parentKey) => cache[parentKey]?.size !== undefined;
+
+  grid.$connector.hasEnsureSubCacheQueue = () => ensureSubCacheQueue.length > 0;
+
+  grid.$connector.hasParentRequestQueue = () => parentRequestQueue.length > 0;
+
+  grid.$connector.hasRootRequestQueue = () => {
+    const { pendingRequests } = dataProviderController.rootCache;
+    return Object.keys(pendingRequests).length > 0 || !!rootRequestDebouncer?.isActive();
+  };
+
+  grid.$connector.beforeEnsureFlatIndexHierarchy = function (flatIndex, item) {
+    // add call to queue
+    ensureSubCacheQueue.push({
+      flatIndex,
+      itemkey: grid.getItemId(item)
+    });
+
+    ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
+      while (ensureSubCacheQueue.length) {
+        grid.$connector.flushEnsureSubCache();
       }
+    });
+  };
 
-      const isCached = grid.$connector.hasCacheForParentKey(grid.getItemId(item));
-      if (isCached) {
-        // The sub-cache items are already in the connector's cache. Skip the debouncing process.
-        this.ensureFlatIndexHierarchyOriginal(flatIndex);
-      } else {
-        grid.$connector.beforeEnsureFlatIndexHierarchy(flatIndex, item);
-      }
-    };
-
-    dataProviderController.isLoadingOriginal = dataProviderController.isLoading;
-    dataProviderController.isLoading = function() {
-      return grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
-    };
-
-    dataProviderController.getItemSubCache = function(item) {
-      return this.getItemContext(item)?.subCache;
-    };
-
-    let cache = {};
-
-    /* parentRequestDelay - optimizes parent requests by batching several requests
-      *  into one request. Delay in milliseconds. Disable by setting to 0.
-      *  parentRequestBatchMaxSize - maximum size of the batch.
-      */
-    const parentRequestDelay = 50;
-    const parentRequestBatchMaxSize = 20;
-
-    let parentRequestQueue = [];
-    let parentRequestDebouncer;
-    let ensureSubCacheQueue = [];
-    let ensureSubCacheDebouncer;
-
-    const rootRequestDelay = 150;
-    let rootRequestDebouncer;
-
-    let lastRequestedRanges = {};
-    const root = 'null';
-    lastRequestedRanges[root] = [0, 0];
-
-    let currentUpdateClearRange = null;
-    let currentUpdateSetRange = null;
-
-    const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
-    let selectedKeys = {};
-    let selectionMode = 'SINGLE';
-
-    let sorterDirectionsSetFromServer = false;
-
-    grid.size = 0; // To avoid NaN here and there before we get proper data
-    grid.itemIdPath = 'key';
-
-    function createEmptyItemFromKey(key) {
-      return { [grid.itemIdPath]: key };
+  grid.$connector.doSelection = function (items, userOriginated) {
+    if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
+      return;
+    }
+    if (selectionMode === 'SINGLE') {
+      selectedKeys = {};
     }
 
-    grid.$connector = {};
-
-    grid.$connector.hasCacheForParentKey = (parentKey) => cache[parentKey]?.size !== undefined;
-
-    grid.$connector.hasEnsureSubCacheQueue = () => ensureSubCacheQueue.length > 0;
-
-    grid.$connector.hasParentRequestQueue = () => parentRequestQueue.length > 0;
-
-    grid.$connector.hasRootRequestQueue = () => {
-      const { pendingRequests } = dataProviderController.rootCache;
-      return Object.keys(pendingRequests).length > 0 || !!rootRequestDebouncer?.isActive();
-    };
-
-    grid.$connector.beforeEnsureFlatIndexHierarchy = (flatIndex, item) => {
-      // add call to queue
-      ensureSubCacheQueue.push({
-        flatIndex,
-        itemkey: grid.getItemId(item)
-      });
-
-      ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
-        while (ensureSubCacheQueue.length) {
-          grid.$connector.flushEnsureSubCache();
-        }
-      });
-    };
-
-    grid.$connector.doSelection = (items, userOriginated) => {
-      if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
-        return;
-      }
-      if (selectionMode === 'SINGLE') {
-        selectedKeys = {};
-      }
-
-      grid.$connector = {};
-
-      grid.$connector.hasCacheForParentKey = (parentKey) => cache[parentKey]?.size !== undefined;
-
-      grid.$connector.hasEnsureSubCacheQueue = () => ensureSubCacheQueue.length > 0;
-
-      grid.$connector.hasParentRequestQueue = () => parentRequestQueue.length > 0;
-
-      grid.$connector.hasRootRequestQueue = () => {
-        const { pendingRequests } = dataProviderController.rootCache;
-        return Object.keys(pendingRequests).length > 0 || !!rootRequestDebouncer?.isActive();
-      };
-
-      grid.$connector.beforeEnsureFlatIndexHierarchy = function (flatIndex, item) {
-        // add call to queue
-        ensureSubCacheQueue.push({
-          flatIndex,
-          itemkey: grid.getItemId(item)
-        });
-
-        ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
-          while (ensureSubCacheQueue.length) {
-            grid.$connector.flushEnsureSubCache();
-          }
-        });
-      };
-
-      grid.$connector.doSelection = function (items, userOriginated) {
-        if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
-          return;
-        }
-        if (selectionMode === 'SINGLE') {
-          selectedKeys = {};
-        }
-
-        let selectedItemsChanged = false;
-        items.forEach((item) => {
-          const selectable = !userOriginated || grid.isItemSelectable(item);
-          selectedItemsChanged = selectedItemsChanged || selectable;
-          if (item && selectable) {
-            selectedKeys[item.key] = item;
-            item.selected = true;
-            if (userOriginated) {
-              grid.$server.select(item.key);
-            }
-          }
-
-          // FYI: In single selection mode, the server can send items = [null]
-          // which means a "Deselect All" command.
-          const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
-          if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
-            grid.activeItem = item;
-          }
-        });
-
-        if (selectedItemsChanged) {
-          grid.selectedItems = Object.values(selectedKeys);
-        }
-      });
-
-      grid.$connector.doDeselection = function (items, userOriginated) {
-        if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
-          return;
-        }
-
-        const updatedSelectedItems = grid.selectedItems.slice();
-        while (items.length) {
-          const itemToDeselect = items.shift();
-          const selectable = !userOriginated || grid.isItemSelectable(itemToDeselect);
-          if (!selectable) {
-            continue;
-          }
-          for (let i = 0; i < updatedSelectedItems.length; i++) {
-            const selectedItem = updatedSelectedItems[i];
-            if (itemToDeselect?.key === selectedItem.key) {
-              updatedSelectedItems.splice(i, 1);
-              break;
-            }
-          }
-          if (itemToDeselect) {
-            delete selectedKeys[itemToDeselect.key];
-            delete itemToDeselect.selected;
-            if (userOriginated) {
-              grid.$server.deselect(itemToDeselect.key);
-            }
-          }
-        }
-
-        // FYI: In single selection mode, the server can send items = [null]
-        // which means a "Deselect All" command.
-        const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
-        if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
-          grid.activeItem = item;
-        }
-      };
-
-      grid.__activeItemChanged = function (newVal, oldVal) {
-        if (selectionMode != 'SINGLE') {
-          return;
-        }
-        if (!newVal) {
-          if (oldVal && selectedKeys[oldVal.key]) {
-            if (grid.__deselectDisallowed) {
-              grid.activeItem = oldVal;
-            } else {
-              // The item instance may have changed since the item was stored as active item
-              // and information such as whether the item may be selected or deselected may
-              // be stale. Use data provider controller to get updated instance from grid
-              // cache.
-              oldVal = dataProviderController.getItemContext(oldVal).item;
-              grid.$connector.doDeselection([oldVal], true);
-            }
-          }
-        }
-        if (itemToDeselect) {
-          delete selectedKeys[itemToDeselect.key];
-          delete itemToDeselect.selected;
-          if (userOriginated) {
-            grid.$server.deselect(itemToDeselect.key);
-          }
+    let selectedItemsChanged = false;
+    items.forEach((item) => {
+      const selectable = !userOriginated || grid.isItemSelectable(item);
+      selectedItemsChanged = selectedItemsChanged || selectable;
+      if (item && selectable) {
+        selectedKeys[item.key] = item;
+        item.selected = true;
+        if (userOriginated) {
+          grid.$server.select(item.key);
         }
       }
-      grid.selectedItems = updatedSelectedItems;
-    };
 
-    grid.__activeItemChanged = (newVal, oldVal) => {
-      if (selectionMode != 'SINGLE') {
-        return;
+      // FYI: In single selection mode, the server can send items = [null]
+      // which means a "Deselect All" command.
+      const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
+      if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
+        grid.activeItem = item;
       }
-      if (!newVal) {
-        if (oldVal && selectedKeys[oldVal.key]) {
-          if (grid.__deselectDisallowed) {
-            grid.activeItem = oldVal;
-          } else {
-            grid.$connector.doDeselection([oldVal], true);
-          }
+    });
+
+    if (selectedItemsChanged) {
+      grid.selectedItems = Object.values(selectedKeys);
+    }
+  };
+
+  grid.$connector.doDeselection = function (items, userOriginated) {
+    if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
+      return;
+    }
+
+    const updatedSelectedItems = grid.selectedItems.slice();
+    while (items.length) {
+      const itemToDeselect = items.shift();
+      const selectable = !userOriginated || grid.isItemSelectable(itemToDeselect);
+      if (!selectable) {
+        continue;
+      }
+      for (let i = 0; i < updatedSelectedItems.length; i++) {
+        const selectedItem = updatedSelectedItems[i];
+        if (itemToDeselect?.key === selectedItem.key) {
+          updatedSelectedItems.splice(i, 1);
+          break;
         }
-      } else if (!selectedKeys[newVal.key]) {
-        grid.$connector.doSelection([newVal], true);
       }
-    };
-    grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
-
-    grid.__activeItemChangedDetails = (newVal, oldVal) => {
-      if (grid.__disallowDetailsOnClick) {
-        return;
-      }
-      // when grid is attached, newVal is not set and oldVal is undefined
-      // do nothing
-      if (newVal == null && oldVal === undefined) {
-        return;
-      }
-      if (newVal && !newVal.detailsOpened) {
-        grid.$server.setDetailsVisible(newVal.key);
-      } else {
-        grid.$server.setDetailsVisible(null);
-      }
-    };
-    grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
-
-    grid.$connector._getSameLevelPage = (parentKey, currentCache, currentCacheItemIndex) => {
-      const currentParentKey = currentCache.parentItem ? grid.getItemId(currentCache.parentItem) : root;
-      if (currentParentKey === parentKey) {
-        // Level match found, return the page number.
-        return Math.floor(currentCacheItemIndex / grid.pageSize);
-      }
-      const { parentCache, parentCacheIndex } = currentCache;
-      if (!parentCache) {
-        // There is no parent cache to match level
-        return null;
-      }
-      // Traverse the tree upwards until a match is found or the end is reached
-      return grid.$connector._getSameLevelPage(parentKey, parentCache, parentCacheIndex);
-    };
-
-    grid.$connector.flushEnsureSubCache = () => {
-      const pendingFetch = ensureSubCacheQueue.shift();
-      if (pendingFetch) {
-        dataProviderController.ensureFlatIndexHierarchyOriginal(pendingFetch.flatIndex);
-        return true;
-      }
-      return false;
-    };
-
-    grid.$connector.debounceRootRequest = (page) => {
-      const delay = grid._hasData ? rootRequestDelay : 0;
-
-      rootRequestDebouncer = Debouncer.debounce(rootRequestDebouncer, timeOut.after(delay), () => {
-        grid.$connector.fetchPage(
-          (firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size),
-          page,
-          root
-        );
-      });
-    };
-
-    grid.$connector.flushParentRequests = () => {
-      const pendingFetches = [];
-
-      parentRequestQueue.splice(0, parentRequestBatchMaxSize).forEach(({ parentKey, page }) => {
-        grid.$connector.fetchPage(
-          (firstIndex, size) => pendingFetches.push({ parentKey, firstIndex, size }),
-          page,
-          parentKey
-        );
-      });
-
-      if (pendingFetches.length) {
-        grid.$server.setParentRequestedRanges(pendingFetches);
-      }
-    };
-
-    grid.$connector.debounceParentRequest = (parentKey, page) => {
-      // Remove any pending requests for the same parentKey.
-      parentRequestQueue = parentRequestQueue.filter((request) => request.parentKey !== parentKey);
-      // Add the new request to the queue.
-      parentRequestQueue.push({ parentKey, page });
-      // Debounce the request to avoid sending multiple requests for the same parentKey.
-      parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay), () => {
-        while (parentRequestQueue.length) {
-          grid.$connector.flushParentRequests();
+      if (itemToDeselect) {
+        delete selectedKeys[itemToDeselect.key];
+        delete itemToDeselect.selected;
+        if (userOriginated) {
+          grid.$server.deselect(itemToDeselect.key);
         }
-      });
-    };
-
-    grid.$connector.fetchPage = (fetch, page, parentKey) => {
-      // Adjust the requested page to be within the valid range in case
-      // the grid size has changed while fetchPage was debounced.
-      if (parentKey === root) {
-        page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
       }
+    }
+    grid.selectedItems = updatedSelectedItems;
+  };
 
-      // Determine what to fetch based on scroll position and not only
-      // what grid asked for
-      const visibleRows = grid._getRenderedRows();
-      let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
-      let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
-
-      // The buffer size could be multiplied by some constant defined by the user,
-      // if he needs to reduce the number of items sent to the Grid to improve performance
-      // or to increase it to make Grid smoother when scrolling
-      let buffer = end - start;
-      let firstNeededIndex = Math.max(0, start - buffer);
-      let lastNeededIndex = Math.min(end + buffer, grid._flatSize);
-
-      let pageRange = [null, null];
-      for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
-        const { cache, index } = dataProviderController.getFlatIndexContext(idx);
-        // Try to match level by going up in hierarchy. The page range should include
-        // pages that contain either of the following:
-        //   - visible items of the current cache
-        //   - same level parents of visible descendant items
-        // If the parent items are not considered, Flow would remove the hidden parent
-        // items from the current level cache. This can lead to an infinite loop when using
-        // scrollToIndex feature.
-        const sameLevelPage = grid.$connector._getSameLevelPage(parentKey, cache, index);
-        if (sameLevelPage === null) {
-          continue;
-        }
-        pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
-        pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
-      }
-
-      // When the viewport doesn't contain the requested page or it doesn't contain any items from
-      // the requested level at all, it means that the scroll position has changed while fetchPage
-      // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
-      // then immediately back to the top. In this case, the request for the last page will be left
-      // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
-      // to make sure all hanging requests are resolved. After that, the grid requests the first page
-      // or whatever in the viewport again.
-      if (pageRange.some((p) => p === null) || page < pageRange[0] || page > pageRange[1]) {
-        pageRange = [page, page];
-      }
-
-      let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
-      if (lastRequestedRange[0] != pageRange[0] || lastRequestedRange[1] != pageRange[1]) {
-        lastRequestedRanges[parentKey] = pageRange;
-        let pageCount = pageRange[1] - pageRange[0] + 1;
-        fetch(pageRange[0] * grid.pageSize, pageCount * grid.pageSize);
-      }
-    };
-
-    grid.dataProvider = (params, callback) => {
-      if (params.pageSize != grid.pageSize) {
-        throw 'Invalid pageSize';
-      }
-
-      let page = params.page;
-
-      if (params.parentItem) {
-        let parentUniqueKey = grid.getItemId(params.parentItem);
-
-        const parentItemSubCache = dataProviderController.getItemSubCache(params.parentItem);
-        if (cache[parentUniqueKey]?.[page] && parentItemSubCache) {
-          // Ensure grid isn't in loading state when the callback executes
-          ensureSubCacheQueue = [];
-          // Resolve the callback from cache
-          callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
+  grid.__activeItemChanged = function (newVal, oldVal) {
+    if (selectionMode != 'SINGLE') {
+      return;
+    }
+    if (!newVal) {
+      if (oldVal && selectedKeys[oldVal.key]) {
+        if (grid.__deselectDisallowed) {
+          grid.activeItem = oldVal;
         } else {
-          grid.$connector.debounceParentRequest(parentUniqueKey, page);
-        }
-      } else {
-        // size is controlled by the server (data communicator), so if the
-        // size is zero, we know that there is no data to fetch.
-        // This also prevents an empty grid getting stuck in a loading state.
-        // The connector does not cache empty pages, so if the grid requests
-        // data again, there would be no cache entry, causing a request to
-        // the server. However, the data communicator will never respond,
-        // as it assumes that the data is already cached.
-        if (grid.size === 0) {
-          callback([], 0);
-          return;
-        }
-
-        if (cache[root]?.[page]) {
-          callback(cache[root][page]);
-        } else {
-          grid.$connector.debounceRootRequest(page);
+          // The item instance may have changed since the item was stored as active item
+          // and information such as whether the item may be selected or deselected may
+          // be stale. Use data provider controller to get updated instance from grid
+          // cache.
+          oldVal = dataProviderController.getItemContext(oldVal).item;
+          grid.$connector.doDeselection([oldVal], true);
         }
       }
-    };
-
-    grid.$connector.setSorterDirections = (directions) => {
-      sorterDirectionsSetFromServer = true;
-      setTimeout(() => {
-        try {
-          const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
-
-          // Sorters for hidden columns are removed from DOM but stored in the web component.
-          // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
-          grid._sorters.forEach((sorter) => {
-            if (!sorters.includes(sorter)) {
-              sorters.push(sorter);
-            }
-          });
-
-          sorters.forEach((sorter) => {
-            sorter.direction = null;
-          });
-
-          // Apply directions in correct order, depending on configured multi-sort priority.
-          // For the default "prepend" mode, directions need to be applied in reverse, in
-          // order for the sort indicators to match the order on the server. For "append"
-          // just keep the order passed from the server.
-          if (grid.multiSortPriority !== 'append') {
-            directions = directions.reverse();
-          }
-          directions.forEach(({ column, direction }) => {
-            sorters.forEach((sorter) => {
-              if (sorter.getAttribute('path') === column) {
-                sorter.direction = direction;
-              }
-            });
-          });
-
-          // Manually trigger a re-render of the sorter priority indicators
-          // in case some of the sorters were hidden while being updated above
-          // and therefore didn't notify the grid about their direction change.
-          grid.__applySorters();
-        } finally {
-          sorterDirectionsSetFromServer = false;
-        }
-      });
-    };
-
-    grid._updateItem = (row, item) => {
-      Grid.prototype._updateItem.call(grid, row, item);
-
-      // There might be inactive component renderers on hidden rows that still refer to the
-      // same component instance as one of the renderers on a visible row. Making the
-      // inactive/hidden renderer attach the component might steal it from a visible/active one.
-      if (!row.hidden) {
-        // make sure that component renderers are updated
-        Array.from(row.children).forEach((cell) => {
-          Array.from(cell?._content?.__templateInstance?.children || []).forEach((content) => {
-            if (content._attachRenderedComponentIfAble) {
-              content._attachRenderedComponentIfAble();
-            }
-            // In hierarchy column of tree grid, the component renderer is inside its content,
-            // this updates it renderer from innerContent
-            Array.from(content?.children || []).forEach((innerContent) => {
-              if (innerContent._attachRenderedComponentIfAble) {
-                innerContent._attachRenderedComponentIfAble();
-              }
-            });
-          });
-        });
-      }
-      // since no row can be selected when selection mode is NONE
-      // if selectionMode is set to NONE, remove aria-selected attribute from the row
-      if (selectionMode === validSelectionModes[1]) {
-        // selectionMode === NONE
-        row.removeAttribute('aria-selected');
-        Array.from(row.children).forEach((cell) => cell.removeAttribute('aria-selected'));
-      }
-    };
-
-    const itemExpandedChanged = (item, expanded) => {
-      // method available only for the TreeGrid server-side component
-      if (item == undefined || grid.$server.updateExpandedState == undefined) {
-        return;
-      }
-      let parentKey = grid.getItemId(item);
-      grid.$server.updateExpandedState(parentKey, expanded);
-    };
-
-    // Patch grid.expandItem and grid.collapseItem to have
-    // itemExpandedChanged run when either happens.
-    grid.expandItem = (item) => {
-      itemExpandedChanged(item, true);
-      Grid.prototype.expandItem.call(grid, item);
-    };
-
-    grid.collapseItem = (item) => {
-      itemExpandedChanged(item, false);
-      Grid.prototype.collapseItem.call(grid, item);
-    };
-
-    function itemsUpdated(items) {
-      if (!items || !Array.isArray(items)) {
-        throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
-      }
-      let detailsOpenedItems = Array.from(grid.detailsOpenedItems);
-      for (let i = 0; i < items.length; ++i) {
-        const item = items[i];
-        if (!item) {
-          continue;
-        }
-        if (item.detailsOpened) {
-          if (grid._getItemIndexInArray(item, detailsOpenedItems) < 0) {
-            detailsOpenedItems.push(item);
-          }
-        } else if (grid._getItemIndexInArray(item, detailsOpenedItems) >= 0) {
-          detailsOpenedItems.splice(grid._getItemIndexInArray(item, detailsOpenedItems), 1);
-        }
-      }
-      grid.detailsOpenedItems = detailsOpenedItems;
-    };
-
-    /**
-     * Updates the cache for the given page for grid or tree-grid.
-     *
-     * @param page index of the page to update
-     * @param parentKey the key of the parent item for the page
-     * @returns an array of the updated items for the page, or undefined if no items were cached for the page
-     */
-    function updateGridCache(page, parentKey = root) {
-      const items = cache[parentKey][page];
-      const parentItem = createEmptyItemFromKey(parentKey);
-
-      let gridCache = parentKey === root
-        ? dataProviderController.rootCache
-        : dataProviderController.getItemSubCache(parentItem);
-
-      // Force update unless there's a callback waiting
-      if (gridCache && !gridCache.pendingRequests[page]) {
-        // Update the items in the grid cache or set an array of undefined items
-        // to remove the page from the grid cache if there are no corresponding items
-        // in the connector cache.
-        gridCache.setPage(page, items || Array.from({ length: grid.pageSize }));
-      }
-
-      return items;
-    };
-
-    /**
-     * Updates all visible grid rows in DOM.
-     */
-    function updateAllGridRowsInDomBasedOnCache() {
-      updateGridFlatSize();
-      grid.__updateVisibleRows();
+    } else if (!selectedKeys[newVal.key]) {
+      grid.$connector.doSelection([newVal], true);
     }
+  };
+  grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
 
-    /**
-     * Updates the <vaadin-grid>'s internal cache size and flat size.
-     */
-    function updateGridFlatSize() {
-      dataProviderController.recalculateFlatSize();
-      grid._flatSize = dataProviderController.flatSize;
+  grid.__activeItemChangedDetails = function (newVal, oldVal) {
+    if (grid.__disallowDetailsOnClick) {
+      return;
     }
-
-    /**
-     * Update the given items in DOM if currently visible.
-     *
-     * @param array items the items to update in DOM
-     */
-    function updateGridItemsInDomBasedOnCache(items) {
-      if (!items || !grid.$ || grid.$.items.childElementCount === 0) {
-        return;
-      }
-
-      const itemKeys = items.map((item) => item.key);
-      const indexes = grid
-        ._getRenderedRows()
-        .filter((row) => row._item && itemKeys.includes(row._item.key))
-        .map((row) => row.index);
-      if (indexes.length > 0) {
-        grid.__updateVisibleRows(indexes[0], indexes[indexes.length - 1]);
-      }
+    // when grid is attached, newVal is not set and oldVal is undefined
+    // do nothing
+    if (newVal == null && oldVal === undefined) {
+      return;
     }
+    if (newVal && !newVal.detailsOpened) {
+      grid.$server.setDetailsVisible(newVal.key);
+    } else {
+      grid.$server.setDetailsVisible(null);
+    }
+  };
+  grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
 
-    grid.$connector.set = (index, items, parentKey) => {
-      if (index % grid.pageSize != 0) {
-        throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
-      }
-      let pkey = parentKey || root;
-
-      const firstPage = index / grid.pageSize;
-      const updatedPageCount = Math.ceil(items.length / grid.pageSize);
-
-      // For root cache, remember the range of pages that were set during an update
-      if (pkey === root) {
-        currentUpdateSetRange = [firstPage, firstPage + updatedPageCount - 1];
-      }
-
-      for (let i = 0; i < updatedPageCount; i++) {
-        let page = firstPage + i;
-        let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
-        if (!cache[pkey]) {
-          cache[pkey] = {};
-        }
-        cache[pkey][page] = slice;
-
-        grid.$connector.doSelection(slice.filter((item) => item.selected));
-        grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
-
-        const updatedItems = updateGridCache(page, pkey);
-        if (updatedItems) {
-          itemsUpdated(updatedItems);
-          updateGridItemsInDomBasedOnCache(updatedItems);
-        }
-      }
-    };
-
-    function itemToCacheLocation(item) {
-      let parent = item.parentUniqueKey || root;
-      if (cache[parent]) {
-        for (let page in cache[parent]) {
-          for (let index in cache[parent][page]) {
-            if (grid.getItemId(cache[parent][page][index]) === grid.getItemId(item)) {
-              return { page: page, index: index, parentKey: parent };
-            }
-          }
-        }
-      }
+  grid.$connector._getSameLevelPage = function (parentKey, currentCache, currentCacheItemIndex) {
+    const currentParentKey = currentCache.parentItem ? grid.getItemId(currentCache.parentItem) : root;
+    if (currentParentKey === parentKey) {
+      // Level match found, return the page number.
+      return Math.floor(currentCacheItemIndex / grid.pageSize);
+    }
+    const { parentCache, parentCacheIndex } = currentCache;
+    if (!parentCache) {
+      // There is no parent cache to match level
       return null;
     }
+    // Traverse the tree upwards until a match is found or the end is reached
+    return this._getSameLevelPage(parentKey, parentCache, parentCacheIndex);
+  };
 
-    /**
-     * Updates the given items for a hierarchical grid.
-     *
-     * @param updatedItems the updated items array
-     */
-    grid.$connector.updateHierarchicalData = (updatedItems) => {
-      let pagesToUpdate = [];
-      // locate and update the items in cache
-      // find pages that need updating
-      for (let i = 0; i < updatedItems.length; i++) {
-        let cacheLocation = itemToCacheLocation(updatedItems[i]);
-        if (cacheLocation) {
-          cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
-          let key = cacheLocation.parentKey + ':' + cacheLocation.page;
-          if (!pagesToUpdate[key]) {
-            pagesToUpdate[key] = {
-              parentKey: cacheLocation.parentKey,
-              page: cacheLocation.page
-            };
-          }
-        }
+  grid.$connector.flushEnsureSubCache = function () {
+    const pendingFetch = ensureSubCacheQueue.shift();
+    if (pendingFetch) {
+      dataProviderController.ensureFlatIndexHierarchyOriginal(pendingFetch.flatIndex);
+      return true;
+    }
+    return false;
+  };
+
+  grid.$connector.debounceRootRequest = function (page) {
+    const delay = grid._hasData ? rootRequestDelay : 0;
+
+    rootRequestDebouncer = Debouncer.debounce(rootRequestDebouncer, timeOut.after(delay), () => {
+      grid.$connector.fetchPage(
+        (firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size),
+        page,
+        root
+      );
+    });
+  };
+
+  grid.$connector.flushParentRequests = function () {
+    const pendingFetches = [];
+
+    parentRequestQueue.splice(0, parentRequestBatchMaxSize).forEach(({ parentKey, page }) => {
+      grid.$connector.fetchPage(
+        (firstIndex, size) => pendingFetches.push({ parentKey, firstIndex, size }),
+        page,
+        parentKey
+      );
+    });
+
+    if (pendingFetches.length) {
+      grid.$server.setParentRequestedRanges(pendingFetches);
+    }
+  };
+
+  grid.$connector.debounceParentRequest = function (parentKey, page) {
+    // Remove any pending requests for the same parentKey.
+    parentRequestQueue = parentRequestQueue.filter((request) => request.parentKey !== parentKey);
+    // Add the new request to the queue.
+    parentRequestQueue.push({ parentKey, page });
+    // Debounce the request to avoid sending multiple requests for the same parentKey.
+    parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay), () => {
+      while (parentRequestQueue.length) {
+        grid.$connector.flushParentRequests();
       }
-      // IE11 doesn't work with the transpiled version of the forEach.
-      let keys = Object.keys(pagesToUpdate);
-      for (let i = 0; i < keys.length; i++) {
-        let pageToUpdate = pagesToUpdate[keys[i]];
-        const affectedUpdatedItems = updateGridCache(pageToUpdate.page, pageToUpdate.parentKey);
-        if (affectedUpdatedItems) {
-          itemsUpdated(affectedUpdatedItems);
-          updateGridItemsInDomBasedOnCache(affectedUpdatedItems);
-        }
-      }
-    };
+    });
+  };
 
-    /**
-     * Updates the given items for a non-hierarchical grid.
-     *
-     * @param updatedItems the updated items array
-     */
-    grid.$connector.updateFlatData = (updatedItems) => {
-      // update (flat) caches
-      for (let i = 0; i < updatedItems.length; i++) {
-        let cacheLocation = itemToCacheLocation(updatedItems[i]);
-        if (cacheLocation) {
-          // update connector cache
-          cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
-
-          // update grid's cache
-          const index = parseInt(cacheLocation.page) * grid.pageSize + parseInt(cacheLocation.index);
-          const { rootCache } = dataProviderController;
-          if (rootCache.items[index]) {
-            rootCache.items[index] = updatedItems[i];
-          }
-        }
-      }
-      itemsUpdated(updatedItems);
-
-      updateGridItemsInDomBasedOnCache(updatedItems);
-    };
-
-    grid.$connector.clearExpanded = () => {
-      grid.expandedItems = [];
-      ensureSubCacheQueue = [];
-      parentRequestQueue = [];
-    };
-
-    /**
-     * Ensures that the last requested page range does not include pages for data that has been cleared.
-     * The last requested range is used in `fetchPage` to skip requests to the server if the page range didn't
-     * change. However, if some pages of that range have been cleared by data communicator, we need to clear the
-     * range to ensure the pages get loaded again. This can happen for example when changing the requested range
-     * on the server (e.g. preload of items on scroll to index), which can cause data communicator to clear pages
-     * that the connector assumes are already loaded.
-     */
-    function sanitizeLastRequestedRange() {
-      // Only relevant for the root cache
-      const range = lastRequestedRanges[root];
-      // Range may not be set yet, or nothing was cleared
-      if (!range || !currentUpdateClearRange) {
-        return;
-      }
-
-      // Determine all pages that were cleared
-      const numClearedPages = currentUpdateClearRange[1] - currentUpdateClearRange[0] + 1;
-      const clearedPages = Array.from({ length: numClearedPages }, (_, i) => currentUpdateClearRange[0] + i);
-
-      // Remove pages that have been set in same update
-      if (currentUpdateSetRange) {
-        const [first, last] = currentUpdateSetRange;
-        for (let page = first; page <= last; page++) {
-          const index = clearedPages.indexOf(page);
-          if (index >= 0) {
-            clearedPages.splice(index, 1);
-          }
-        }
-      }
-
-      // Clear the last requested range if it includes any of the cleared pages
-      if (clearedPages.some((page) => page >= range[0] && page <= range[1])) {
-        range[0] = -1;
-        range[1] = -1;
-      }
+  grid.$connector.fetchPage = function (fetch, page, parentKey) {
+    // Adjust the requested page to be within the valid range in case
+    // the grid size has changed while fetchPage was debounced.
+    if (parentKey === root) {
+      page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
     }
 
-    grid.$connector.clear = (index, length, parentKey) => {
-      let pkey = parentKey || root;
-      if (!cache[pkey] || Object.keys(cache[pkey]).length === 0) {
+    // Determine what to fetch based on scroll position and not only
+    // what grid asked for
+    const visibleRows = grid._getRenderedRows();
+    let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
+    let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
+
+    // The buffer size could be multiplied by some constant defined by the user,
+    // if he needs to reduce the number of items sent to the Grid to improve performance
+    // or to increase it to make Grid smoother when scrolling
+    let buffer = end - start;
+    let firstNeededIndex = Math.max(0, start - buffer);
+    let lastNeededIndex = Math.min(end + buffer, grid._flatSize);
+
+    let pageRange = [null, null];
+    for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
+      const { cache, index } = dataProviderController.getFlatIndexContext(idx);
+      // Try to match level by going up in hierarchy. The page range should include
+      // pages that contain either of the following:
+      //   - visible items of the current cache
+      //   - same level parents of visible descendant items
+      // If the parent items are not considered, Flow would remove the hidden parent
+      // items from the current level cache. This can lead to an infinite loop when using
+      // scrollToIndex feature.
+      const sameLevelPage = grid.$connector._getSameLevelPage(parentKey, cache, index);
+      if (sameLevelPage === null) {
+        continue;
+      }
+      pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
+      pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
+    }
+
+    // When the viewport doesn't contain the requested page or it doesn't contain any items from
+    // the requested level at all, it means that the scroll position has changed while fetchPage
+    // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
+    // then immediately back to the top. In this case, the request for the last page will be left
+    // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
+    // to make sure all hanging requests are resolved. After that, the grid requests the first page
+    // or whatever in the viewport again.
+    if (pageRange.some((p) => p === null) || page < pageRange[0] || page > pageRange[1]) {
+      pageRange = [page, page];
+    }
+
+    let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
+    if (lastRequestedRange[0] != pageRange[0] || lastRequestedRange[1] != pageRange[1]) {
+      lastRequestedRanges[parentKey] = pageRange;
+      let pageCount = pageRange[1] - pageRange[0] + 1;
+      fetch(pageRange[0] * grid.pageSize, pageCount * grid.pageSize);
+    }
+  };
+
+  grid.dataProvider = function (params, callback) {
+    if (params.pageSize != grid.pageSize) {
+      throw 'Invalid pageSize';
+    }
+
+    let page = params.page;
+
+    if (params.parentItem) {
+      let parentUniqueKey = grid.getItemId(params.parentItem);
+
+      const parentItemSubCache = dataProviderController.getItemSubCache(params.parentItem);
+      if (cache[parentUniqueKey]?.[page] && parentItemSubCache) {
+        // Ensure grid isn't in loading state when the callback executes
+        ensureSubCacheQueue = [];
+        // Resolve the callback from cache
+        callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
+      } else {
+        grid.$connector.debounceParentRequest(parentUniqueKey, page);
+      }
+    } else {
+      // size is controlled by the server (data communicator), so if the
+      // size is zero, we know that there is no data to fetch.
+      // This also prevents an empty grid getting stuck in a loading state.
+      // The connector does not cache empty pages, so if the grid requests
+      // data again, there would be no cache entry, causing a request to
+      // the server. However, the data communicator will never respond,
+      // as it assumes that the data is already cached.
+      if (grid.size === 0) {
+        callback([], 0);
         return;
       }
-      if (index % grid.pageSize != 0) {
-        throw (
-          'Got cleared data for index ' + index + ' which is not aligned with the page size of ' + grid.pageSize
-        );
-      }
 
-      let firstPage = Math.floor(index / grid.pageSize);
-      let updatedPageCount = Math.ceil(length / grid.pageSize);
-
-      // For root cache, remember the range of pages that were cleared during an update
-      if (pkey === root) {
-        currentUpdateClearRange = [firstPage, firstPage + updatedPageCount - 1];
+      if (cache[root]?.[page]) {
+        callback(cache[root][page]);
+      } else {
+        grid.$connector.debounceRootRequest(page);
       }
+    }
+  };
 
-      for (let i = 0; i < updatedPageCount; i++) {
-        let page = firstPage + i;
-        let items = cache[pkey][page];
-        grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
-        items.forEach((item) => grid.closeItemDetails(item));
-        delete cache[pkey][page];
-        updateGridCache(page, parentKey);
-        updateGridItemsInDomBasedOnCache(items);
-      }
-      let cacheToClear = dataProviderController.rootCache;
-      if (parentKey) {
-        const parentItem = createEmptyItemFromKey(pkey);
-        cacheToClear = dataProviderController.getItemSubCache(parentItem);
-      }
-      const endIndex = index + updatedPageCount * grid.pageSize;
-      for (let itemIndex = index; itemIndex < endIndex; itemIndex++) {
-        delete cacheToClear.items[itemIndex];
-        cacheToClear.removeSubCache(itemIndex);
-      }
-      updateGridFlatSize();
-    };
+  grid.$connector.setSorterDirections = function (directions) {
+    sorterDirectionsSetFromServer = true;
+    setTimeout(() => {
+      try {
+        const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
-    grid.$connector.reset = () => {
-      grid.size = 0;
-      cache = {};
-      dataProviderController.rootCache.items = [];
-      lastRequestedRanges = {};
-      if (ensureSubCacheDebouncer) {
-        ensureSubCacheDebouncer.cancel();
+        // Sorters for hidden columns are removed from DOM but stored in the web component.
+        // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
+        grid._sorters.forEach((sorter) => {
+          if (!sorters.includes(sorter)) {
+            sorters.push(sorter);
+          }
+        });
+
+        sorters.forEach((sorter) => {
+          sorter.direction = null;
+        });
+
+        // Apply directions in correct order, depending on configured multi-sort priority.
+        // For the default "prepend" mode, directions need to be applied in reverse, in
+        // order for the sort indicators to match the order on the server. For "append"
+        // just keep the order passed from the server.
+        if (grid.multiSortPriority !== 'append') {
+          directions = directions.reverse();
+        }
+        directions.forEach(({ column, direction }) => {
+          sorters.forEach((sorter) => {
+            if (sorter.getAttribute('path') === column) {
+              sorter.direction = direction;
+            }
+          });
+        });
+
+        // Manually trigger a re-render of the sorter priority indicators
+        // in case some of the sorters were hidden while being updated above
+        // and therefore didn't notify the grid about their direction change.
+        grid.__applySorters();
+      } finally {
+        sorterDirectionsSetFromServer = false;
       }
-      if (parentRequestDebouncer) {
-        parentRequestDebouncer.cancel();
+    });
+  };
+
+  grid._updateItem = function (row, item) {
+    Grid.prototype._updateItem.call(grid, row, item);
+
+    // There might be inactive component renderers on hidden rows that still refer to the
+    // same component instance as one of the renderers on a visible row. Making the
+    // inactive/hidden renderer attach the component might steal it from a visible/active one.
+    if (!row.hidden) {
+      // make sure that component renderers are updated
+      Array.from(row.children).forEach((cell) => {
+        Array.from(cell?._content?.__templateInstance?.children || []).forEach((content) => {
+          if (content._attachRenderedComponentIfAble) {
+            content._attachRenderedComponentIfAble();
+          }
+          // In hierarchy column of tree grid, the component renderer is inside its content,
+          // this updates it renderer from innerContent
+          Array.from(content?.children || []).forEach((innerContent) => {
+            if (innerContent._attachRenderedComponentIfAble) {
+              innerContent._attachRenderedComponentIfAble();
+            }
+          });
+        });
+      });
+    }
+    // since no row can be selected when selection mode is NONE
+    // if selectionMode is set to NONE, remove aria-selected attribute from the row
+    if (selectionMode === validSelectionModes[1]) {
+      // selectionMode === NONE
+      row.removeAttribute('aria-selected');
+      Array.from(row.children).forEach((cell) => cell.removeAttribute('aria-selected'));
+    }
+  };
+
+  const itemExpandedChanged = function (item, expanded) {
+    // method available only for the TreeGrid server-side component
+    if (item == undefined || grid.$server.updateExpandedState == undefined) {
+      return;
+    }
+    let parentKey = grid.getItemId(item);
+    grid.$server.updateExpandedState(parentKey, expanded);
+  };
+
+  // Patch grid.expandItem and grid.collapseItem to have
+  // itemExpandedChanged run when either happens.
+  grid.expandItem = function (item) {
+    itemExpandedChanged(item, true);
+    Grid.prototype.expandItem.call(grid, item);
+  };
+
+  grid.collapseItem = function (item) {
+    itemExpandedChanged(item, false);
+    Grid.prototype.collapseItem.call(grid, item);
+  };
+
+  const itemsUpdated = function (items) {
+    if (!items || !Array.isArray(items)) {
+      throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
+    }
+    let detailsOpenedItems = Array.from(grid.detailsOpenedItems);
+    for (let i = 0; i < items.length; ++i) {
+      const item = items[i];
+      if (!item) {
+        continue;
       }
-      if (rootRequestDebouncer) {
-        rootRequestDebouncer.cancel();
+      if (item.detailsOpened) {
+        if (grid._getItemIndexInArray(item, detailsOpenedItems) < 0) {
+          detailsOpenedItems.push(item);
+        }
+      } else if (grid._getItemIndexInArray(item, detailsOpenedItems) >= 0) {
+        detailsOpenedItems.splice(grid._getItemIndexInArray(item, detailsOpenedItems), 1);
       }
-      ensureSubCacheDebouncer = undefined;
-      parentRequestDebouncer = undefined;
-      ensureSubCacheQueue = [];
-      parentRequestQueue = [];
-      updateAllGridRowsInDomBasedOnCache();
-    };
+    }
+    grid.detailsOpenedItems = detailsOpenedItems;
+  };
 
-    grid.$connector.updateSize = (newSize) => (grid.size = newSize);
+  /**
+   * Updates the cache for the given page for grid or tree-grid.
+   *
+   * @param page index of the page to update
+   * @param parentKey the key of the parent item for the page
+   * @returns an array of the updated items for the page, or undefined if no items were cached for the page
+   */
+  const updateGridCache = function (page, parentKey = root) {
+    const items = cache[parentKey][page];
+    const parentItem = createEmptyItemFromKey(parentKey);
 
-    grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
+    let gridCache = parentKey === root
+      ? dataProviderController.rootCache
+      : dataProviderController.getItemSubCache(parentItem);
 
-    grid.$connector.expandItems = (items) => {
-      let newExpandedItems = Array.from(grid.expandedItems);
-      items.filter((item) => !grid._isExpanded(item)).forEach((item) => newExpandedItems.push(item));
-      grid.expandedItems = newExpandedItems;
-    };
+    // Force update unless there's a callback waiting
+    if (gridCache && !gridCache.pendingRequests[page]) {
+      // Update the items in the grid cache or set an array of undefined items
+      // to remove the page from the grid cache if there are no corresponding items
+      // in the connector cache.
+      gridCache.setPage(page, items || Array.from({ length: grid.pageSize }));
+    }
 
-    grid.$connector.collapseItems = (items) => {
-      let newExpandedItems = Array.from(grid.expandedItems);
-      items.forEach((item) => {
-        let index = grid._getItemIndexInArray(item, newExpandedItems);
+    return items;
+  };
+
+  /**
+   * Updates all visible grid rows in DOM.
+   */
+  const updateAllGridRowsInDomBasedOnCache = function () {
+    updateGridFlatSize();
+    grid.__updateVisibleRows();
+  };
+
+  /**
+   * Updates the <vaadin-grid>'s internal cache size and flat size.
+   */
+  const updateGridFlatSize = function () {
+    dataProviderController.recalculateFlatSize();
+    grid._flatSize = dataProviderController.flatSize;
+  };
+
+  /**
+   * Update the given items in DOM if currently visible.
+   *
+   * @param array items the items to update in DOM
+   */
+  const updateGridItemsInDomBasedOnCache = function (items) {
+    if (!items || !grid.$ || grid.$.items.childElementCount === 0) {
+      return;
+    }
+
+    const itemKeys = items.map((item) => item.key);
+    const indexes = grid
+      ._getRenderedRows()
+      .filter((row) => row._item && itemKeys.includes(row._item.key))
+      .map((row) => row.index);
+    if (indexes.length > 0) {
+      grid.__updateVisibleRows(indexes[0], indexes[indexes.length - 1]);
+    }
+  };
+
+  grid.$connector.set = function (index, items, parentKey) {
+    if (index % grid.pageSize != 0) {
+      throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
+    }
+    let pkey = parentKey || root;
+
+    const firstPage = index / grid.pageSize;
+    const updatedPageCount = Math.ceil(items.length / grid.pageSize);
+
+    // For root cache, remember the range of pages that were set during an update
+    if (pkey === root) {
+      currentUpdateSetRange = [firstPage, firstPage + updatedPageCount - 1];
+    }
+
+    for (let i = 0; i < updatedPageCount; i++) {
+      let page = firstPage + i;
+      let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
+      if (!cache[pkey]) {
+        cache[pkey] = {};
+      }
+      cache[pkey][page] = slice;
+
+      grid.$connector.doSelection(slice.filter((item) => item.selected));
+      grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
+
+      const updatedItems = updateGridCache(page, pkey);
+      if (updatedItems) {
+        itemsUpdated(updatedItems);
+        updateGridItemsInDomBasedOnCache(updatedItems);
+      }
+    }
+  };
+
+  const itemToCacheLocation = function (item) {
+    let parent = item.parentUniqueKey || root;
+    if (cache[parent]) {
+      for (let page in cache[parent]) {
+        for (let index in cache[parent][page]) {
+          if (grid.getItemId(cache[parent][page][index]) === grid.getItemId(item)) {
+            return { page: page, index: index, parentKey: parent };
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  /**
+   * Updates the given items for a hierarchical grid.
+   *
+   * @param updatedItems the updated items array
+   */
+  grid.$connector.updateHierarchicalData = function (updatedItems) {
+    let pagesToUpdate = [];
+    // locate and update the items in cache
+    // find pages that need updating
+    for (let i = 0; i < updatedItems.length; i++) {
+      let cacheLocation = itemToCacheLocation(updatedItems[i]);
+      if (cacheLocation) {
+        cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+        let key = cacheLocation.parentKey + ':' + cacheLocation.page;
+        if (!pagesToUpdate[key]) {
+          pagesToUpdate[key] = {
+            parentKey: cacheLocation.parentKey,
+            page: cacheLocation.page
+          };
+        }
+      }
+    }
+    // IE11 doesn't work with the transpiled version of the forEach.
+    let keys = Object.keys(pagesToUpdate);
+    for (let i = 0; i < keys.length; i++) {
+      let pageToUpdate = pagesToUpdate[keys[i]];
+      const affectedUpdatedItems = updateGridCache(pageToUpdate.page, pageToUpdate.parentKey);
+      if (affectedUpdatedItems) {
+        itemsUpdated(affectedUpdatedItems);
+        updateGridItemsInDomBasedOnCache(affectedUpdatedItems);
+      }
+    }
+  };
+
+  /**
+   * Updates the given items for a non-hierarchical grid.
+   *
+   * @param updatedItems the updated items array
+   */
+  grid.$connector.updateFlatData = function (updatedItems) {
+    // update (flat) caches
+    for (let i = 0; i < updatedItems.length; i++) {
+      let cacheLocation = itemToCacheLocation(updatedItems[i]);
+      if (cacheLocation) {
+        // update connector cache
+        cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+
+        // update grid's cache
+        const index = parseInt(cacheLocation.page) * grid.pageSize + parseInt(cacheLocation.index);
+        const { rootCache } = dataProviderController;
+        if (rootCache.items[index]) {
+          rootCache.items[index] = updatedItems[i];
+        }
+      }
+    }
+    itemsUpdated(updatedItems);
+
+    updateGridItemsInDomBasedOnCache(updatedItems);
+  };
+
+  grid.$connector.clearExpanded = function () {
+    grid.expandedItems = [];
+    ensureSubCacheQueue = [];
+    parentRequestQueue = [];
+  };
+
+  /**
+   * Ensures that the last requested page range does not include pages for data that has been cleared.
+   * The last requested range is used in `fetchPage` to skip requests to the server if the page range didn't
+   * change. However, if some pages of that range have been cleared by data communicator, we need to clear the
+   * range to ensure the pages get loaded again. This can happen for example when changing the requested range
+   * on the server (e.g. preload of items on scroll to index), which can cause data communicator to clear pages
+   * that the connector assumes are already loaded.
+   */
+  const sanitizeLastRequestedRange = function () {
+    // Only relevant for the root cache
+    const range = lastRequestedRanges[root];
+    // Range may not be set yet, or nothing was cleared
+    if (!range || !currentUpdateClearRange) {
+      return;
+    }
+
+    // Determine all pages that were cleared
+    const numClearedPages = currentUpdateClearRange[1] - currentUpdateClearRange[0] + 1;
+    const clearedPages = Array.from({ length: numClearedPages }, (_, i) => currentUpdateClearRange[0] + i);
+
+    // Remove pages that have been set in same update
+    if (currentUpdateSetRange) {
+      const [first, last] = currentUpdateSetRange;
+      for (let page = first; page <= last; page++) {
+        const index = clearedPages.indexOf(page);
         if (index >= 0) {
-          newExpandedItems.splice(index, 1);
-        }
-      });
-      grid.expandedItems = newExpandedItems;
-      items.forEach((item) => grid.$connector.removeFromQueue(item));
-    };
-
-    grid.$connector.removeFromQueue = (item) => {
-      // The page callbacks for the given item are about to be discarded ->
-      // Resolve the callbacks with an empty array to not leave grid in loading state
-      const itemSubCache = dataProviderController.getItemSubCache(item);
-      Object.values(itemSubCache?.pendingRequests || {}).forEach((callback) => callback([]));
-
-      const itemId = grid.getItemId(item);
-      ensureSubCacheQueue = ensureSubCacheQueue.filter((item) => item.itemkey !== itemId);
-      parentRequestQueue = parentRequestQueue.filter((item) => item.parentKey !== itemId);
-    };
-
-    grid.$connector.confirmParent = (id, parentKey, levelSize) => {
-      // Create connector cache if it doesn't exist
-      if (!cache[parentKey]) {
-        cache[parentKey] = {};
-      }
-      // Update connector cache size
-      const hasSizeChanged = cache[parentKey].size !== levelSize;
-      cache[parentKey].size = levelSize;
-      if (levelSize === 0) {
-        cache[parentKey][0] = [];
-      }
-
-      const parentItem = createEmptyItemFromKey(parentKey);
-      const parentItemSubCache = dataProviderController.getItemSubCache(parentItem);
-      if (parentItemSubCache) {
-        // If grid has pending requests for this parent, then resolve them
-        // and let grid update the flat size and re-render.
-        const { pendingRequests } = parentItemSubCache;
-        Object.entries(pendingRequests).forEach(([page, callback]) => {
-          let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
-
-          if (
-            (cache[parentKey] && cache[parentKey][page]) ||
-            page < lastRequestedRange[0] ||
-            page > lastRequestedRange[1]
-          ) {
-            let items = cache[parentKey][page] || new Array(levelSize);
-            callback(items, levelSize);
-          } else if (callback && levelSize === 0) {
-            // The parent item has 0 child items => resolve the callback with an empty array
-            callback([], levelSize);
-          }
-        });
-
-        // If size has changed, and there are no pending requests, then
-        // manually update the size of the grid cache and update the effective
-        // size, effectively re-rendering the grid. This is necessary when
-        // individual items are refreshed on the server, in which case there
-        // is no loading request from the grid itself. In that case, if
-        // children were added or removed, the grid will not be aware of it
-        // unless we manually update the size.
-        if (hasSizeChanged && Object.keys(pendingRequests).length === 0) {
-          parentItemSubCache.size = levelSize;
-          updateGridFlatSize();
+          clearedPages.splice(index, 1);
         }
       }
+    }
 
-      // Let server know we're done
-      grid.$server.confirmParentUpdate(id, parentKey);
-    };
+    // Clear the last requested range if it includes any of the cleared pages
+    if (clearedPages.some((page) => page >= range[0] && page <= range[1])) {
+      range[0] = -1;
+      range[1] = -1;
+    }
+  };
 
-    grid.$connector.confirm = (id) => {
-      // We're done applying changes from this batch, resolve pending
-      // callbacks
-      const { pendingRequests } = dataProviderController.rootCache;
+  grid.$connector.clear = function (index, length, parentKey) {
+    let pkey = parentKey || root;
+    if (!cache[pkey] || Object.keys(cache[pkey]).length === 0) {
+      return;
+    }
+    if (index % grid.pageSize != 0) {
+      throw (
+        'Got cleared data for index ' + index + ' which is not aligned with the page size of ' + grid.pageSize
+      );
+    }
+
+    let firstPage = Math.floor(index / grid.pageSize);
+    let updatedPageCount = Math.ceil(length / grid.pageSize);
+
+    // For root cache, remember the range of pages that were cleared during an update
+    if (pkey === root) {
+      currentUpdateClearRange = [firstPage, firstPage + updatedPageCount - 1];
+    }
+
+    for (let i = 0; i < updatedPageCount; i++) {
+      let page = firstPage + i;
+      let items = cache[pkey][page];
+      grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
+      items.forEach((item) => grid.closeItemDetails(item));
+      delete cache[pkey][page];
+      updateGridCache(page, parentKey);
+      updateGridItemsInDomBasedOnCache(items);
+    }
+    let cacheToClear = dataProviderController.rootCache;
+    if (parentKey) {
+      const parentItem = createEmptyItemFromKey(pkey);
+      cacheToClear = dataProviderController.getItemSubCache(parentItem);
+    }
+    const endIndex = index + updatedPageCount * grid.pageSize;
+    for (let itemIndex = index; itemIndex < endIndex; itemIndex++) {
+      delete cacheToClear.items[itemIndex];
+      cacheToClear.removeSubCache(itemIndex);
+    }
+    updateGridFlatSize();
+  };
+
+  grid.$connector.reset = function () {
+    grid.size = 0;
+    cache = {};
+    dataProviderController.rootCache.items = [];
+    lastRequestedRanges = {};
+    if (ensureSubCacheDebouncer) {
+      ensureSubCacheDebouncer.cancel();
+    }
+    if (parentRequestDebouncer) {
+      parentRequestDebouncer.cancel();
+    }
+    if (rootRequestDebouncer) {
+      rootRequestDebouncer.cancel();
+    }
+    ensureSubCacheDebouncer = undefined;
+    parentRequestDebouncer = undefined;
+    ensureSubCacheQueue = [];
+    parentRequestQueue = [];
+    updateAllGridRowsInDomBasedOnCache();
+  };
+
+  grid.$connector.updateSize = (newSize) => (grid.size = newSize);
+
+  grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
+
+  grid.$connector.expandItems = function (items) {
+    let newExpandedItems = Array.from(grid.expandedItems);
+    items.filter((item) => !grid._isExpanded(item)).forEach((item) => newExpandedItems.push(item));
+    grid.expandedItems = newExpandedItems;
+  };
+
+  grid.$connector.collapseItems = function (items) {
+    let newExpandedItems = Array.from(grid.expandedItems);
+    items.forEach((item) => {
+      let index = grid._getItemIndexInArray(item, newExpandedItems);
+      if (index >= 0) {
+        newExpandedItems.splice(index, 1);
+      }
+    });
+    grid.expandedItems = newExpandedItems;
+    items.forEach((item) => grid.$connector.removeFromQueue(item));
+  };
+
+  grid.$connector.removeFromQueue = function (item) {
+    // The page callbacks for the given item are about to be discarded ->
+    // Resolve the callbacks with an empty array to not leave grid in loading state
+    const itemSubCache = dataProviderController.getItemSubCache(item);
+    Object.values(itemSubCache?.pendingRequests || {}).forEach((callback) => callback([]));
+
+    const itemId = grid.getItemId(item);
+    ensureSubCacheQueue = ensureSubCacheQueue.filter((item) => item.itemkey !== itemId);
+    parentRequestQueue = parentRequestQueue.filter((item) => item.parentKey !== itemId);
+  };
+
+  grid.$connector.confirmParent = function (id, parentKey, levelSize) {
+    // Create connector cache if it doesn't exist
+    if (!cache[parentKey]) {
+      cache[parentKey] = {};
+    }
+    // Update connector cache size
+    const hasSizeChanged = cache[parentKey].size !== levelSize;
+    cache[parentKey].size = levelSize;
+    if (levelSize === 0) {
+      cache[parentKey][0] = [];
+    }
+
+    const parentItem = createEmptyItemFromKey(parentKey);
+    const parentItemSubCache = dataProviderController.getItemSubCache(parentItem);
+    if (parentItemSubCache) {
+      // If grid has pending requests for this parent, then resolve them
+      // and let grid update the flat size and re-render.
+      const { pendingRequests } = parentItemSubCache;
       Object.entries(pendingRequests).forEach(([page, callback]) => {
-        const lastRequestedRange = lastRequestedRanges[root] || [0, 0];
-        const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
-        // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
-        const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
-        // Resolve if we have data or if we don't expect to get data
-        if (cache[root]?.[page]) {
-          // Cached data is available, resolve the callback
-          callback(cache[root][page]);
-        } else if (page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
-          // No cached data, resolve the callback with an empty array
-          callback(new Array(grid.pageSize));
-          // Request grid for content update
-          grid.requestContentUpdate();
-        } else if (callback && grid.size === 0) {
-          // The grid has 0 items => resolve the callback with an empty array
-          callback([]);
+        let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
+
+        if (
+          (cache[parentKey] && cache[parentKey][page]) ||
+          page < lastRequestedRange[0] ||
+          page > lastRequestedRange[1]
+        ) {
+          let items = cache[parentKey][page] || new Array(levelSize);
+          callback(items, levelSize);
+        } else if (callback && levelSize === 0) {
+          // The parent item has 0 child items => resolve the callback with an empty array
+          callback([], levelSize);
         }
       });
 
-      // Sanitize last requested range for the root level
-      sanitizeLastRequestedRange();
-      // Clear current update state
-      currentUpdateSetRange = null;
-      currentUpdateClearRange = null;
-
-      // Let server know we're done
-      grid.$server.confirmUpdate(id);
-    };
-
-    grid.$connector.ensureHierarchy = () => {
-      for (let parentKey in cache) {
-        if (parentKey !== root) {
-          delete cache[parentKey];
-        }
-      }
-
-      lastRequestedRanges = {};
-
-      dataProviderController.rootCache.removeSubCaches();
-
-      updateAllGridRowsInDomBasedOnCache();
-    };
-
-    grid.$connector.setSelectionMode = (mode) => {
-      if ((typeof mode === 'string' || mode instanceof String) && validSelectionModes.indexOf(mode) >= 0) {
-        selectionMode = mode;
-        selectedKeys = {};
-        grid.selectedItems = [];
-        grid.$connector.updateMultiSelectable();
-      } else {
-        throw 'Attempted to set an invalid selection mode';
-      }
-    };
-
-    /*
-      * Manage aria-multiselectable attribute depending on the selection mode.
-      * see more: https://github.com/vaadin/web-components/issues/1536
-      * or: https://www.w3.org/TR/wai-aria-1.1/#aria-multiselectable
-      * For selection mode SINGLE, set the aria-multiselectable attribute to false
-      */
-    grid.$connector.updateMultiSelectable = () => {
-      if (!grid.$) {
-        return;
-      }
-
-      if (selectionMode === validSelectionModes[0]) {
-        grid.$.table.setAttribute('aria-multiselectable', false);
-        // For selection mode NONE, remove the aria-multiselectable attribute
-      } else if (selectionMode === validSelectionModes[1]) {
-        grid.$.table.removeAttribute('aria-multiselectable');
-        // For selection mode MULTI, set aria-multiselectable to true
-      } else {
-        grid.$.table.setAttribute('aria-multiselectable', true);
-      }
-    };
-
-    // Have the multi-selectable state updated on attach
-    grid._createPropertyObserver('isAttached', () => grid.$connector.updateMultiSelectable());
-
-    const singleTimeRenderer = (renderer) => {
-      return (root) => {
-        if (renderer) {
-          renderer(root);
-          renderer = null;
-        }
-      };
-    };
-
-    grid.$connector.setHeaderRenderer = (column, options) => {
-      const { content, showSorter, sorterPath } = options;
-
-      if (content === null) {
-        column.headerRenderer = null;
-        return;
-      }
-
-      column.headerRenderer = singleTimeRenderer((root) => {
-        // Clear previous contents
-        root.innerHTML = '';
-        // Render sorter
-        let contentRoot = root;
-        if (showSorter) {
-          const sorter = document.createElement('vaadin-grid-sorter');
-          sorter.setAttribute('path', sorterPath);
-          const ariaLabel = content instanceof Node ? content.textContent : content;
-          if (ariaLabel) {
-            sorter.setAttribute('aria-label', `Sort by ${ariaLabel}`);
-          }
-          root.appendChild(sorter);
-
-          // Use sorter as content root
-          contentRoot = sorter;
-        }
-        // Add content
-        if (content instanceof Node) {
-          contentRoot.appendChild(content);
-        } else {
-          contentRoot.textContent = content;
-        }
-      });
-    };
-
-    // This method is overridden to prevent the grid web component from
-    // automatically excluding columns from sorting when they get hidden.
-    // In Flow, it's the developer's responsibility to remove the column
-    // from the backend sort order when the column gets hidden.
-    grid._getActiveSorters = () => {
-      return grid._sorters.filter((sorter) => sorter.direction);
-    }
-
-    grid.__applySorters = () => {
-      const sorters = grid._mapSorters();
-      const sortersChanged = JSON.stringify(grid._previousSorters) !== JSON.stringify(sorters);
-
-      // Update the _previousSorters in vaadin-grid-sort-mixin so that the __applySorters
-      // method in the mixin will skip calling clearCache().
-      //
-      // In Flow Grid's case, we never want to clear the cache eagerly when the sorter elements
-      // change due to one of the following reasons:
-      //
-      // 1. Sorted by user: The items in the new sort order need to be fetched from the server,
-      // and we want to avoid a heavy re-render before the updated items have actually been fetched.
-      //
-      // 2. Sorted programmatically on the server: The items in the new sort order have already
-      // been fetched and applied to the grid. The sorter element states are updated programmatically
-      // to reflect the new sort order, but there's no need to re-render the grid rows.
-      grid._previousSorters = sorters;
-
-      // Call the original __applySorters method in vaadin-grid-sort-mixin
-      Grid.prototype.__applySorters.call(grid);
-
-      if (sortersChanged && !sorterDirectionsSetFromServer) {
-        grid.$server.sortersChanged(sorters);
-      }
-    };
-
-    grid.$connector.setFooterRenderer = (column, options) => {
-      const { content } = options;
-
-      if (content === null) {
-        column.footerRenderer = null;
-        return;
-      }
-
-      column.footerRenderer = singleTimeRenderer((root) => {
-        // Clear previous contents
-        root.innerHTML = '';
-        // Add content
-        if (content instanceof Node) {
-          root.appendChild(content);
-        } else {
-          root.textContent = content;
-        }
-      });
-    };
-
-    grid.addEventListener(
-      'vaadin-context-menu-before-open',
-      (e) => {
-        const { key, columnId } = e.detail;
-        grid.$server.updateContextMenuTargetItem(key, columnId);
-      }
-    );
-
-    grid.getContextMenuBeforeOpenDetail = (event) => {
-      // For `contextmenu` events, we need to access the source event,
-      // when using open on click we just use the click event itself
-      const sourceEvent = event.detail.sourceEvent || event;
-      const eventContext = grid.getEventContext(sourceEvent);
-      const key = eventContext.item?.key || '';
-      const columnId = eventContext.column?.id || '';
-      return { key, columnId };
-    };
-
-    grid.preventContextMenu = (event) => {
-        const isLeftClick = event.type === 'click';
-        const { column } = grid.getEventContext(event);
-
-        return isLeftClick && column instanceof GridFlowSelectionColumn;
-    };
-
-    grid.addEventListener(
-      'click',
-      (e) => _fireClickEvent(e, 'item-click')
-    );
-    grid.addEventListener(
-      'dblclick',
-      (e) => _fireClickEvent(e, 'item-double-click')
-    );
-
-    grid.addEventListener(
-      'column-resize',
-      (e) => {
-        const cols = grid._getColumnsInOrder().filter((col) => !col.hidden);
-
-        cols.forEach((col) => {
-          col.dispatchEvent(new CustomEvent('column-drag-resize'));
-        });
-
-        grid.dispatchEvent(
-          new CustomEvent('column-drag-resize', {
-            detail: {
-              resizedColumnKey: e.detail.resizedColumn._flowId
-            }
-          })
-        );
-      }
-    );
-
-    grid.addEventListener(
-      'column-reorder',
-      (e) => {
-        const columns = grid._columnTree
-          .slice(0)
-          .pop()
-          .filter((c) => c._flowId)
-          .sort((b, a) => b._order - a._order)
-          .map((c) => c._flowId);
-
-        grid.dispatchEvent(
-          new CustomEvent('column-reorder-all-columns', {
-            detail: { columns }
-          })
-        );
-      }
-    );
-
-    grid.addEventListener(
-      'cell-focus',
-      (e) => {
-        const eventContext = grid.getEventContext(e);
-        const expectedSectionValues = ['header', 'body', 'footer'];
-
-        if (expectedSectionValues.indexOf(eventContext.section) === -1) {
-          return;
-        }
-
-        grid.dispatchEvent(
-          new CustomEvent('grid-cell-focus', {
-            detail: {
-              itemKey: eventContext.item ? eventContext.item.key : null,
-
-              internalColumnId: eventContext.column ? eventContext.column._flowId : null,
-
-              section: eventContext.section
-            }
-          })
-        );
-      }
-    );
-
-    function _fireClickEvent(event, eventName) {
-      // Click event was handled by the component inside grid, do nothing.
-      if (event.defaultPrevented) {
-        return;
-      }
-
-      const path = event.composedPath();
-      const idx = path.findIndex((node) => node.localName === 'td' || node.localName === 'th');
-      const content = path.slice(0, idx);
-
-      // Do not fire item click event if cell content contains focusable elements.
-      // Use this instead of event.target to detect cases like icon inside button.
-      // See https://github.com/vaadin/flow-components/issues/4065
-      if (content.some((node) => isFocusable(node) || node instanceof HTMLLabelElement)) {
-        return;
-      }
-
-      const eventContext = grid.getEventContext(event);
-      const section = eventContext.section;
-
-      if (eventContext.item && section !== 'details') {
-        event.itemKey = eventContext.item.key;
-        // if you have a details-renderer, getEventContext().column is undefined
-        if (eventContext.column) {
-          event.internalColumnId = eventContext.column._flowId;
-        }
-        grid.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+      // If size has changed, and there are no pending requests, then
+      // manually update the size of the grid cache and update the effective
+      // size, effectively re-rendering the grid. This is necessary when
+      // individual items are refreshed on the server, in which case there
+      // is no loading request from the grid itself. In that case, if
+      // children were added or removed, the grid will not be aware of it
+      // unless we manually update the size.
+      if (hasSizeChanged && Object.keys(pendingRequests).length === 0) {
+        parentItemSubCache.size = levelSize;
+        updateGridFlatSize();
       }
     }
 
-    grid.cellClassNameGenerator = (column, rowData) => {
-      const style = rowData.item.style;
-      if (!style) {
-        return;
+    // Let server know we're done
+    grid.$server.confirmParentUpdate(id, parentKey);
+  };
+
+  grid.$connector.confirm = function (id) {
+    // We're done applying changes from this batch, resolve pending
+    // callbacks
+    const { pendingRequests } = dataProviderController.rootCache;
+    Object.entries(pendingRequests).forEach(([page, callback]) => {
+      const lastRequestedRange = lastRequestedRanges[root] || [0, 0];
+      const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
+      // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
+      const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
+      // Resolve if we have data or if we don't expect to get data
+      if (cache[root]?.[page]) {
+        // Cached data is available, resolve the callback
+        callback(cache[root][page]);
+      } else if (page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
+        // No cached data, resolve the callback with an empty array
+        callback(new Array(grid.pageSize));
+        // Request grid for content update
+        grid.requestContentUpdate();
+      } else if (callback && grid.size === 0) {
+        // The grid has 0 items => resolve the callback with an empty array
+        callback([]);
       }
-      return (style.row || '') + ' ' + ((column && style[column._flowId]) || '');
-    };
+    });
 
-    grid.cellPartNameGenerator = (column, rowData) => {
-      const part = rowData.item.part;
-      if (!part) {
-        return;
+    // Sanitize last requested range for the root level
+    sanitizeLastRequestedRange();
+    // Clear current update state
+    currentUpdateSetRange = null;
+    currentUpdateClearRange = null;
+
+    // Let server know we're done
+    grid.$server.confirmUpdate(id);
+  };
+
+  grid.$connector.ensureHierarchy = function () {
+    for (let parentKey in cache) {
+      if (parentKey !== root) {
+        delete cache[parentKey];
       }
-      return (part.row || '') + ' ' + ((column && part[column._flowId]) || '');
+    }
+
+    lastRequestedRanges = {};
+
+    dataProviderController.rootCache.removeSubCaches();
+
+    updateAllGridRowsInDomBasedOnCache();
+  };
+
+  grid.$connector.setSelectionMode = function (mode) {
+    if ((typeof mode === 'string' || mode instanceof String) && validSelectionModes.indexOf(mode) >= 0) {
+      selectionMode = mode;
+      selectedKeys = {};
+      grid.selectedItems = [];
+      grid.$connector.updateMultiSelectable();
+    } else {
+      throw 'Attempted to set an invalid selection mode';
+    }
+  };
+
+  /*
+    * Manage aria-multiselectable attribute depending on the selection mode.
+    * see more: https://github.com/vaadin/web-components/issues/1536
+    * or: https://www.w3.org/TR/wai-aria-1.1/#aria-multiselectable
+    * For selection mode SINGLE, set the aria-multiselectable attribute to false
+    */
+  grid.$connector.updateMultiSelectable = function () {
+    if (!grid.$) {
+      return;
+    }
+
+    if (selectionMode === validSelectionModes[0]) {
+      grid.$.table.setAttribute('aria-multiselectable', false);
+      // For selection mode NONE, remove the aria-multiselectable attribute
+    } else if (selectionMode === validSelectionModes[1]) {
+      grid.$.table.removeAttribute('aria-multiselectable');
+      // For selection mode MULTI, set aria-multiselectable to true
+    } else {
+      grid.$.table.setAttribute('aria-multiselectable', true);
+    }
+  };
+
+  // Have the multi-selectable state updated on attach
+  grid._createPropertyObserver('isAttached', () => grid.$connector.updateMultiSelectable());
+
+  const singleTimeRenderer = (renderer) => {
+    return (root) => {
+      if (renderer) {
+        renderer(root);
+        renderer = null;
+      }
     };
+  };
 
-    grid.dropFilter = (rowData) => rowData.item && !rowData.item.dropDisabled;
+  grid.$connector.setHeaderRenderer = function (column, options) {
+    const { content, showSorter, sorterPath } = options;
 
-    grid.dragFilter = (rowData) => rowData.item && !rowData.item.dragDisabled;
+    if (content === null) {
+      column.headerRenderer = null;
+      return;
+    }
 
-    grid.addEventListener(
-      'grid-dragstart',
-      (e) => {
-        if (grid._isSelected(e.detail.draggedItems[0])) {
-          // Dragging selected (possibly multiple) items
-          if (grid.__selectionDragData) {
-            Object.keys(grid.__selectionDragData).forEach((type) => {
-              e.detail.setDragData(type, grid.__selectionDragData[type]);
-            });
-          } else {
-            (grid.__dragDataTypes || []).forEach((type) => {
-              e.detail.setDragData(type, e.detail.draggedItems.map((item) => item.dragData[type]).join('\n'));
-            });
+    column.headerRenderer = singleTimeRenderer((root) => {
+      // Clear previous contents
+      root.innerHTML = '';
+      // Render sorter
+      let contentRoot = root;
+      if (showSorter) {
+        const sorter = document.createElement('vaadin-grid-sorter');
+        sorter.setAttribute('path', sorterPath);
+        const ariaLabel = content instanceof Node ? content.textContent : content;
+        if (ariaLabel) {
+          sorter.setAttribute('aria-label', `Sort by ${ariaLabel}`);
+        }
+        root.appendChild(sorter);
+
+        // Use sorter as content root
+        contentRoot = sorter;
+      }
+      // Add content
+      if (content instanceof Node) {
+        contentRoot.appendChild(content);
+      } else {
+        contentRoot.textContent = content;
+      }
+    });
+  };
+
+  // This method is overridden to prevent the grid web component from
+  // automatically excluding columns from sorting when they get hidden.
+  // In Flow, it's the developer's responsibility to remove the column
+  // from the backend sort order when the column gets hidden.
+  grid._getActiveSorters = function() {
+    return this._sorters.filter((sorter) => sorter.direction);
+  }
+
+  grid.__applySorters = () => {
+    const sorters = grid._mapSorters();
+    const sortersChanged = JSON.stringify(grid._previousSorters) !== JSON.stringify(sorters);
+
+    // Update the _previousSorters in vaadin-grid-sort-mixin so that the __applySorters
+    // method in the mixin will skip calling clearCache().
+    //
+    // In Flow Grid's case, we never want to clear the cache eagerly when the sorter elements
+    // change due to one of the following reasons:
+    //
+    // 1. Sorted by user: The items in the new sort order need to be fetched from the server,
+    // and we want to avoid a heavy re-render before the updated items have actually been fetched.
+    //
+    // 2. Sorted programmatically on the server: The items in the new sort order have already
+    // been fetched and applied to the grid. The sorter element states are updated programmatically
+    // to reflect the new sort order, but there's no need to re-render the grid rows.
+    grid._previousSorters = sorters;
+
+    // Call the original __applySorters method in vaadin-grid-sort-mixin
+    Grid.prototype.__applySorters.call(grid);
+
+    if (sortersChanged && !sorterDirectionsSetFromServer) {
+      grid.$server.sortersChanged(sorters);
+    }
+  };
+
+  grid.$connector.setFooterRenderer = function (column, options) {
+    const { content } = options;
+
+    if (content === null) {
+      column.footerRenderer = null;
+      return;
+    }
+
+    column.footerRenderer = singleTimeRenderer((root) => {
+      // Clear previous contents
+      root.innerHTML = '';
+      // Add content
+      if (content instanceof Node) {
+        root.appendChild(content);
+      } else {
+        root.textContent = content;
+      }
+    });
+  };
+
+  grid.addEventListener(
+    'vaadin-context-menu-before-open',
+    function (e) {
+      const { key, columnId } = e.detail;
+      grid.$server.updateContextMenuTargetItem(key, columnId);
+    }
+  );
+
+  grid.getContextMenuBeforeOpenDetail = function (event) {
+    // For `contextmenu` events, we need to access the source event,
+    // when using open on click we just use the click event itself
+    const sourceEvent = event.detail.sourceEvent || event;
+    const eventContext = grid.getEventContext(sourceEvent);
+    const key = eventContext.item?.key || '';
+    const columnId = eventContext.column?.id || '';
+    return { key, columnId };
+  };
+
+  grid.preventContextMenu = function (event) {
+      const isLeftClick = event.type === 'click';
+      const { column } = grid.getEventContext(event);
+
+      return isLeftClick && column instanceof GridFlowSelectionColumn;
+  };
+
+  grid.addEventListener(
+    'click',
+    (e) => _fireClickEvent(e, 'item-click')
+  );
+  grid.addEventListener(
+    'dblclick',
+    (e) => _fireClickEvent(e, 'item-double-click')
+  );
+
+  grid.addEventListener(
+    'column-resize',
+    (e) => {
+      const cols = grid._getColumnsInOrder().filter((col) => !col.hidden);
+
+      cols.forEach((col) => {
+        col.dispatchEvent(new CustomEvent('column-drag-resize'));
+      });
+
+      grid.dispatchEvent(
+        new CustomEvent('column-drag-resize', {
+          detail: {
+            resizedColumnKey: e.detail.resizedColumn._flowId
           }
-<<<<<<< HEAD
         })
       );
+    }
+  );
 
-      grid.isItemSelectable = tryCatchWrapper((item) => {
-        // If there is no selectable data, assume the item is selectable
-        return item?.selectable === undefined || item.selectable;
-      });
-    })(grid)
-=======
+  grid.addEventListener(
+    'column-reorder',
+    (e) => {
+      const columns = grid._columnTree
+        .slice(0)
+        .pop()
+        .filter((c) => c._flowId)
+        .sort((b, a) => b._order - a._order)
+        .map((c) => c._flowId);
 
-          if (grid.__selectionDraggedItemsCount > 1) {
-            e.detail.setDraggedItemsCount(grid.__selectionDraggedItemsCount);
+      grid.dispatchEvent(
+        new CustomEvent('column-reorder-all-columns', {
+          detail: { columns }
+        })
+      );
+    }
+  );
+
+  grid.addEventListener(
+    'cell-focus',
+    (e) => {
+      const eventContext = grid.getEventContext(e);
+      const expectedSectionValues = ['header', 'body', 'footer'];
+
+      if (expectedSectionValues.indexOf(eventContext.section) === -1) {
+        return;
+      }
+
+      grid.dispatchEvent(
+        new CustomEvent('grid-cell-focus', {
+          detail: {
+            itemKey: eventContext.item ? eventContext.item.key : null,
+
+            internalColumnId: eventContext.column ? eventContext.column._flowId : null,
+
+            section: eventContext.section
           }
+        })
+      );
+    }
+  );
+
+  function _fireClickEvent(event, eventName) {
+    // Click event was handled by the component inside grid, do nothing.
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    const path = event.composedPath();
+    const idx = path.findIndex((node) => node.localName === 'td' || node.localName === 'th');
+    const content = path.slice(0, idx);
+
+    // Do not fire item click event if cell content contains focusable elements.
+    // Use this instead of event.target to detect cases like icon inside button.
+    // See https://github.com/vaadin/flow-components/issues/4065
+    if (content.some((node) => isFocusable(node) || node instanceof HTMLLabelElement)) {
+      return;
+    }
+
+    const eventContext = grid.getEventContext(event);
+    const section = eventContext.section;
+
+    if (eventContext.item && section !== 'details') {
+      event.itemKey = eventContext.item.key;
+      // if you have a details-renderer, getEventContext().column is undefined
+      if (eventContext.column) {
+        event.internalColumnId = eventContext.column._flowId;
+      }
+      grid.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+    }
+  }
+
+  grid.cellClassNameGenerator = function (column, rowData) {
+    const style = rowData.item.style;
+    if (!style) {
+      return;
+    }
+    return (style.row || '') + ' ' + ((column && style[column._flowId]) || '');
+  };
+
+  grid.cellPartNameGenerator = function (column, rowData) {
+    const part = rowData.item.part;
+    if (!part) {
+      return;
+    }
+    return (part.row || '') + ' ' + ((column && part[column._flowId]) || '');
+  };
+
+  grid.dropFilter = (rowData) => rowData.item && !rowData.item.dropDisabled;
+
+  grid.dragFilter = (rowData) => rowData.item && !rowData.item.dragDisabled;
+
+  grid.addEventListener(
+    'grid-dragstart',
+    (e) => {
+      if (grid._isSelected(e.detail.draggedItems[0])) {
+        // Dragging selected (possibly multiple) items
+        if (grid.__selectionDragData) {
+          Object.keys(grid.__selectionDragData).forEach((type) => {
+            e.detail.setDragData(type, grid.__selectionDragData[type]);
+          });
         } else {
-          // Dragging just one (non-selected) item
           (grid.__dragDataTypes || []).forEach((type) => {
-            e.detail.setDragData(type, e.detail.draggedItems[0].dragData[type]);
+            e.detail.setDragData(type, e.detail.draggedItems.map((item) => item.dragData[type]).join('\n'));
           });
         }
+
+        if (grid.__selectionDraggedItemsCount > 1) {
+          e.detail.setDraggedItemsCount(grid.__selectionDraggedItemsCount);
+        }
+      } else {
+        // Dragging just one (non-selected) item
+        (grid.__dragDataTypes || []).forEach((type) => {
+          e.detail.setDragData(type, e.detail.draggedItems[0].dragData[type]);
+        });
       }
-    );
-  }
->>>>>>> 3bc94eb6a9 (refactor: remove tryCatchWrapper from connectors)
+    }
+  );
+
+  grid.isItemSelectable = (item) => {
+    // If there is no selectable data, assume the item is selectable
+    return item?.selectable === undefined || item.selectable;
+  };
 };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -5,96 +5,126 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 import { GridFlowSelectionColumn } from "./vaadin-grid-flow-selection-column.js";
 
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Grid');
-};
-
 window.Vaadin.Flow.gridConnector = {
-  initLazy: (grid) =>
-    tryCatchWrapper(function (grid) {
-      // Check whether the connector was already initialized for the grid
-      if (grid.$connector) {
+  initLazy(grid) {
+    // Check whether the connector was already initialized for the grid
+    if (grid.$connector) {
+      return;
+    }
+
+    const dataProviderController = grid._dataProviderController;
+
+    dataProviderController.ensureFlatIndexHierarchyOriginal = dataProviderController.ensureFlatIndexHierarchy;
+    dataProviderController.ensureFlatIndexHierarchy = function(flatIndex) {
+      const { item } = this.getFlatIndexContext(flatIndex);
+      if (!item || !this.isExpanded(item)) {
         return;
       }
 
-      const dataProviderController = grid._dataProviderController;
+      const isCached = grid.$connector.hasCacheForParentKey(grid.getItemId(item));
+      if (isCached) {
+        // The sub-cache items are already in the connector's cache. Skip the debouncing process.
+        this.ensureFlatIndexHierarchyOriginal(flatIndex);
+      } else {
+        grid.$connector.beforeEnsureFlatIndexHierarchy(flatIndex, item);
+      }
+    };
 
-      dataProviderController.ensureFlatIndexHierarchyOriginal = dataProviderController.ensureFlatIndexHierarchy;
-      dataProviderController.ensureFlatIndexHierarchy = tryCatchWrapper(function (flatIndex) {
-        const { item } = this.getFlatIndexContext(flatIndex);
-        if (!item || !this.isExpanded(item)) {
-          return;
+    dataProviderController.isLoadingOriginal = dataProviderController.isLoading;
+    dataProviderController.isLoading = function() {
+      return grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
+    };
+
+    dataProviderController.getItemSubCache = function(item) {
+      return this.getItemContext(item)?.subCache;
+    };
+
+    let cache = {};
+
+    /* parentRequestDelay - optimizes parent requests by batching several requests
+      *  into one request. Delay in milliseconds. Disable by setting to 0.
+      *  parentRequestBatchMaxSize - maximum size of the batch.
+      */
+    const parentRequestDelay = 50;
+    const parentRequestBatchMaxSize = 20;
+
+    let parentRequestQueue = [];
+    let parentRequestDebouncer;
+    let ensureSubCacheQueue = [];
+    let ensureSubCacheDebouncer;
+
+    const rootRequestDelay = 150;
+    let rootRequestDebouncer;
+
+    let lastRequestedRanges = {};
+    const root = 'null';
+    lastRequestedRanges[root] = [0, 0];
+
+    let currentUpdateClearRange = null;
+    let currentUpdateSetRange = null;
+
+    const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
+    let selectedKeys = {};
+    let selectionMode = 'SINGLE';
+
+    let sorterDirectionsSetFromServer = false;
+
+    grid.size = 0; // To avoid NaN here and there before we get proper data
+    grid.itemIdPath = 'key';
+
+    function createEmptyItemFromKey(key) {
+      return { [grid.itemIdPath]: key };
+    }
+
+    grid.$connector = {};
+
+    grid.$connector.hasCacheForParentKey = (parentKey) => cache[parentKey]?.size !== undefined;
+
+    grid.$connector.hasEnsureSubCacheQueue = () => ensureSubCacheQueue.length > 0;
+
+    grid.$connector.hasParentRequestQueue = () => parentRequestQueue.length > 0;
+
+    grid.$connector.hasRootRequestQueue = () => {
+      const { pendingRequests } = dataProviderController.rootCache;
+      return Object.keys(pendingRequests).length > 0 || !!rootRequestDebouncer?.isActive();
+    };
+
+    grid.$connector.beforeEnsureFlatIndexHierarchy = (flatIndex, item) => {
+      // add call to queue
+      ensureSubCacheQueue.push({
+        flatIndex,
+        itemkey: grid.getItemId(item)
+      });
+
+      ensureSubCacheDebouncer = Debouncer.debounce(ensureSubCacheDebouncer, animationFrame, () => {
+        while (ensureSubCacheQueue.length) {
+          grid.$connector.flushEnsureSubCache();
         }
-
-        const isCached = grid.$connector.hasCacheForParentKey(grid.getItemId(item));
-        if (isCached) {
-          // The sub-cache items are already in the connector's cache. Skip the debouncing process.
-          this.ensureFlatIndexHierarchyOriginal(flatIndex);
-        } else {
-          grid.$connector.beforeEnsureFlatIndexHierarchy(flatIndex, item);
-        }
       });
+    };
 
-      dataProviderController.isLoadingOriginal = dataProviderController.isLoading;
-      dataProviderController.isLoading = tryCatchWrapper(function () {
-        return grid.$connector.hasEnsureSubCacheQueue() || this.isLoadingOriginal();
-      });
-
-      dataProviderController.getItemSubCache = tryCatchWrapper(function (item) {
-        return this.getItemContext(item)?.subCache;
-      });
-
-      let cache = {};
-
-      /* parentRequestDelay - optimizes parent requests by batching several requests
-        *  into one request. Delay in milliseconds. Disable by setting to 0.
-        *  parentRequestBatchMaxSize - maximum size of the batch.
-        */
-      const parentRequestDelay = 50;
-      const parentRequestBatchMaxSize = 20;
-
-      let parentRequestQueue = [];
-      let parentRequestDebouncer;
-      let ensureSubCacheQueue = [];
-      let ensureSubCacheDebouncer;
-
-      const rootRequestDelay = 150;
-      let rootRequestDebouncer;
-
-      let lastRequestedRanges = {};
-      const root = 'null';
-      lastRequestedRanges[root] = [0, 0];
-
-      let currentUpdateClearRange = null;
-      let currentUpdateSetRange = null;
-
-      const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
-      let selectedKeys = {};
-      let selectionMode = 'SINGLE';
-
-      let sorterDirectionsSetFromServer = false;
-
-      grid.size = 0; // To avoid NaN here and there before we get proper data
-      grid.itemIdPath = 'key';
-
-      function createEmptyItemFromKey(key) {
-        return { [grid.itemIdPath]: key };
+    grid.$connector.doSelection = (items, userOriginated) => {
+      if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
+        return;
+      }
+      if (selectionMode === 'SINGLE') {
+        selectedKeys = {};
       }
 
       grid.$connector = {};
 
-      grid.$connector.hasCacheForParentKey = tryCatchWrapper((parentKey) => cache[parentKey]?.size !== undefined);
+      grid.$connector.hasCacheForParentKey = (parentKey) => cache[parentKey]?.size !== undefined;
 
-      grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(() => ensureSubCacheQueue.length > 0);
+      grid.$connector.hasEnsureSubCacheQueue = () => ensureSubCacheQueue.length > 0;
 
-      grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
+      grid.$connector.hasParentRequestQueue = () => parentRequestQueue.length > 0;
 
-      grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
+      grid.$connector.hasRootRequestQueue = () => {
         const { pendingRequests } = dataProviderController.rootCache;
         return Object.keys(pendingRequests).length > 0 || !!rootRequestDebouncer?.isActive();
-      });
+      };
 
-      grid.$connector.beforeEnsureFlatIndexHierarchy = tryCatchWrapper(function (flatIndex, item) {
+      grid.$connector.beforeEnsureFlatIndexHierarchy = function (flatIndex, item) {
         // add call to queue
         ensureSubCacheQueue.push({
           flatIndex,
@@ -106,9 +136,9 @@ window.Vaadin.Flow.gridConnector = {
             grid.$connector.flushEnsureSubCache();
           }
         });
-      });
+      };
 
-      grid.$connector.doSelection = tryCatchWrapper(function (items, userOriginated) {
+      grid.$connector.doSelection = function (items, userOriginated) {
         if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
           return;
         }
@@ -141,7 +171,7 @@ window.Vaadin.Flow.gridConnector = {
         }
       });
 
-      grid.$connector.doDeselection = tryCatchWrapper(function (items, userOriginated) {
+      grid.$connector.doDeselection = function (items, userOriginated) {
         if (selectionMode === 'NONE' || !items.length || (userOriginated && grid.hasAttribute('disabled'))) {
           return;
         }
@@ -168,10 +198,16 @@ window.Vaadin.Flow.gridConnector = {
             }
           }
         }
-        grid.selectedItems = updatedSelectedItems;
-      });
 
-      grid.__activeItemChanged = tryCatchWrapper(function (newVal, oldVal) {
+        // FYI: In single selection mode, the server can send items = [null]
+        // which means a "Deselect All" command.
+        const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
+        if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
+          grid.activeItem = item;
+        }
+      };
+
+      grid.__activeItemChanged = function (newVal, oldVal) {
         if (selectionMode != 'SINGLE') {
           return;
         }
@@ -188,1019 +224,1032 @@ window.Vaadin.Flow.gridConnector = {
               grid.$connector.doDeselection([oldVal], true);
             }
           }
-        } else if (!selectedKeys[newVal.key]) {
-          grid.$connector.doSelection([newVal], true);
         }
-      });
-      grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
-
-      grid.__activeItemChangedDetails = tryCatchWrapper(function (newVal, oldVal) {
-        if (grid.__disallowDetailsOnClick) {
-          return;
-        }
-        // when grid is attached, newVal is not set and oldVal is undefined
-        // do nothing
-        if (newVal == null && oldVal === undefined) {
-          return;
-        }
-        if (newVal && !newVal.detailsOpened) {
-          grid.$server.setDetailsVisible(newVal.key);
-        } else {
-          grid.$server.setDetailsVisible(null);
-        }
-      });
-      grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
-
-      grid.$connector._getSameLevelPage = tryCatchWrapper(function (parentKey, currentCache, currentCacheItemIndex) {
-        const currentParentKey = currentCache.parentItem ? grid.getItemId(currentCache.parentItem) : root;
-        if (currentParentKey === parentKey) {
-          // Level match found, return the page number.
-          return Math.floor(currentCacheItemIndex / grid.pageSize);
-        }
-        const { parentCache, parentCacheIndex } = currentCache;
-        if (!parentCache) {
-          // There is no parent cache to match level
-          return null;
-        }
-        // Traverse the tree upwards until a match is found or the end is reached
-        return this._getSameLevelPage(parentKey, parentCache, parentCacheIndex);
-      });
-
-      grid.$connector.flushEnsureSubCache = tryCatchWrapper(function () {
-        const pendingFetch = ensureSubCacheQueue.shift();
-        if (pendingFetch) {
-          dataProviderController.ensureFlatIndexHierarchyOriginal(pendingFetch.flatIndex);
-          return true;
-        }
-        return false;
-      });
-
-      grid.$connector.debounceRootRequest = tryCatchWrapper(function (page) {
-        const delay = grid._hasData ? rootRequestDelay : 0;
-
-        rootRequestDebouncer = Debouncer.debounce(rootRequestDebouncer, timeOut.after(delay), () => {
-          grid.$connector.fetchPage(
-            (firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size),
-            page,
-            root
-          );
-        });
-      });
-
-      grid.$connector.flushParentRequests = tryCatchWrapper(function () {
-        const pendingFetches = [];
-
-        parentRequestQueue.splice(0, parentRequestBatchMaxSize).forEach(({ parentKey, page }) => {
-          grid.$connector.fetchPage(
-            (firstIndex, size) => pendingFetches.push({ parentKey, firstIndex, size }),
-            page,
-            parentKey
-          );
-        });
-
-        if (pendingFetches.length) {
-          grid.$server.setParentRequestedRanges(pendingFetches);
-        }
-      });
-
-      grid.$connector.debounceParentRequest = tryCatchWrapper(function (parentKey, page) {
-        // Remove any pending requests for the same parentKey.
-        parentRequestQueue = parentRequestQueue.filter((request) => request.parentKey !== parentKey);
-        // Add the new request to the queue.
-        parentRequestQueue.push({ parentKey, page });
-        // Debounce the request to avoid sending multiple requests for the same parentKey.
-        parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay), () => {
-          while (parentRequestQueue.length) {
-            grid.$connector.flushParentRequests();
+        if (itemToDeselect) {
+          delete selectedKeys[itemToDeselect.key];
+          delete itemToDeselect.selected;
+          if (userOriginated) {
+            grid.$server.deselect(itemToDeselect.key);
           }
-        });
-      });
-
-      grid.$connector.fetchPage = tryCatchWrapper(function (fetch, page, parentKey) {
-        // Adjust the requested page to be within the valid range in case
-        // the grid size has changed while fetchPage was debounced.
-        if (parentKey === root) {
-          page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
         }
+      }
+      grid.selectedItems = updatedSelectedItems;
+    };
 
-        // Determine what to fetch based on scroll position and not only
-        // what grid asked for
-        const visibleRows = grid._getRenderedRows();
-        let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
-        let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
-
-        // The buffer size could be multiplied by some constant defined by the user,
-        // if he needs to reduce the number of items sent to the Grid to improve performance
-        // or to increase it to make Grid smoother when scrolling
-        let buffer = end - start;
-        let firstNeededIndex = Math.max(0, start - buffer);
-        let lastNeededIndex = Math.min(end + buffer, grid._flatSize);
-
-        let pageRange = [null, null];
-        for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
-          const { cache, index } = dataProviderController.getFlatIndexContext(idx);
-          // Try to match level by going up in hierarchy. The page range should include
-          // pages that contain either of the following:
-          //   - visible items of the current cache
-          //   - same level parents of visible descendant items
-          // If the parent items are not considered, Flow would remove the hidden parent
-          // items from the current level cache. This can lead to an infinite loop when using
-          // scrollToIndex feature.
-          const sameLevelPage = grid.$connector._getSameLevelPage(parentKey, cache, index);
-          if (sameLevelPage === null) {
-            continue;
-          }
-          pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
-          pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
-        }
-
-        // When the viewport doesn't contain the requested page or it doesn't contain any items from
-        // the requested level at all, it means that the scroll position has changed while fetchPage
-        // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
-        // then immediately back to the top. In this case, the request for the last page will be left
-        // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
-        // to make sure all hanging requests are resolved. After that, the grid requests the first page
-        // or whatever in the viewport again.
-        if (pageRange.some((p) => p === null) || page < pageRange[0] || page > pageRange[1]) {
-          pageRange = [page, page];
-        }
-
-        let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
-        if (lastRequestedRange[0] != pageRange[0] || lastRequestedRange[1] != pageRange[1]) {
-          lastRequestedRanges[parentKey] = pageRange;
-          let pageCount = pageRange[1] - pageRange[0] + 1;
-          fetch(pageRange[0] * grid.pageSize, pageCount * grid.pageSize);
-        }
-      });
-
-      grid.dataProvider = tryCatchWrapper(function (params, callback) {
-        if (params.pageSize != grid.pageSize) {
-          throw 'Invalid pageSize';
-        }
-
-        let page = params.page;
-
-        if (params.parentItem) {
-          let parentUniqueKey = grid.getItemId(params.parentItem);
-
-          const parentItemSubCache = dataProviderController.getItemSubCache(params.parentItem);
-          if (cache[parentUniqueKey]?.[page] && parentItemSubCache) {
-            // Ensure grid isn't in loading state when the callback executes
-            ensureSubCacheQueue = [];
-            // Resolve the callback from cache
-            callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
+    grid.__activeItemChanged = (newVal, oldVal) => {
+      if (selectionMode != 'SINGLE') {
+        return;
+      }
+      if (!newVal) {
+        if (oldVal && selectedKeys[oldVal.key]) {
+          if (grid.__deselectDisallowed) {
+            grid.activeItem = oldVal;
           } else {
-            grid.$connector.debounceParentRequest(parentUniqueKey, page);
-          }
-        } else {
-          // size is controlled by the server (data communicator), so if the
-          // size is zero, we know that there is no data to fetch.
-          // This also prevents an empty grid getting stuck in a loading state.
-          // The connector does not cache empty pages, so if the grid requests
-          // data again, there would be no cache entry, causing a request to
-          // the server. However, the data communicator will never respond,
-          // as it assumes that the data is already cached.
-          if (grid.size === 0) {
-            callback([], 0);
-            return;
-          }
-
-          if (cache[root]?.[page]) {
-            callback(cache[root][page]);
-          } else {
-            grid.$connector.debounceRootRequest(page);
+            grid.$connector.doDeselection([oldVal], true);
           }
         }
+      } else if (!selectedKeys[newVal.key]) {
+        grid.$connector.doSelection([newVal], true);
+      }
+    };
+    grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
+
+    grid.__activeItemChangedDetails = (newVal, oldVal) => {
+      if (grid.__disallowDetailsOnClick) {
+        return;
+      }
+      // when grid is attached, newVal is not set and oldVal is undefined
+      // do nothing
+      if (newVal == null && oldVal === undefined) {
+        return;
+      }
+      if (newVal && !newVal.detailsOpened) {
+        grid.$server.setDetailsVisible(newVal.key);
+      } else {
+        grid.$server.setDetailsVisible(null);
+      }
+    };
+    grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
+
+    grid.$connector._getSameLevelPage = (parentKey, currentCache, currentCacheItemIndex) => {
+      const currentParentKey = currentCache.parentItem ? grid.getItemId(currentCache.parentItem) : root;
+      if (currentParentKey === parentKey) {
+        // Level match found, return the page number.
+        return Math.floor(currentCacheItemIndex / grid.pageSize);
+      }
+      const { parentCache, parentCacheIndex } = currentCache;
+      if (!parentCache) {
+        // There is no parent cache to match level
+        return null;
+      }
+      // Traverse the tree upwards until a match is found or the end is reached
+      return grid.$connector._getSameLevelPage(parentKey, parentCache, parentCacheIndex);
+    };
+
+    grid.$connector.flushEnsureSubCache = () => {
+      const pendingFetch = ensureSubCacheQueue.shift();
+      if (pendingFetch) {
+        dataProviderController.ensureFlatIndexHierarchyOriginal(pendingFetch.flatIndex);
+        return true;
+      }
+      return false;
+    };
+
+    grid.$connector.debounceRootRequest = (page) => {
+      const delay = grid._hasData ? rootRequestDelay : 0;
+
+      rootRequestDebouncer = Debouncer.debounce(rootRequestDebouncer, timeOut.after(delay), () => {
+        grid.$connector.fetchPage(
+          (firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size),
+          page,
+          root
+        );
       });
+    };
 
-      grid.$connector.setSorterDirections = tryCatchWrapper(function (directions) {
-        sorterDirectionsSetFromServer = true;
-        setTimeout(
-          tryCatchWrapper(() => {
-            try {
-              const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
+    grid.$connector.flushParentRequests = () => {
+      const pendingFetches = [];
 
-              // Sorters for hidden columns are removed from DOM but stored in the web component.
-              // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
-              grid._sorters.forEach((sorter) => {
-                if (!sorters.includes(sorter)) {
-                  sorters.push(sorter);
-                }
-              });
-
-              sorters.forEach((sorter) => {
-                sorter.direction = null;
-              });
-
-              // Apply directions in correct order, depending on configured multi-sort priority.
-              // For the default "prepend" mode, directions need to be applied in reverse, in
-              // order for the sort indicators to match the order on the server. For "append"
-              // just keep the order passed from the server.
-              if (grid.multiSortPriority !== 'append') {
-                directions = directions.reverse();
-              }
-              directions.forEach(({ column, direction }) => {
-                sorters.forEach((sorter) => {
-                  if (sorter.getAttribute('path') === column) {
-                    sorter.direction = direction;
-                  }
-                });
-              });
-
-              // Manually trigger a re-render of the sorter priority indicators
-              // in case some of the sorters were hidden while being updated above
-              // and therefore didn't notify the grid about their direction change.
-              grid.__applySorters();
-            } finally {
-              sorterDirectionsSetFromServer = false;
-            }
-          })
+      parentRequestQueue.splice(0, parentRequestBatchMaxSize).forEach(({ parentKey, page }) => {
+        grid.$connector.fetchPage(
+          (firstIndex, size) => pendingFetches.push({ parentKey, firstIndex, size }),
+          page,
+          parentKey
         );
       });
 
-      grid._updateItem = tryCatchWrapper(function (row, item) {
-        Grid.prototype._updateItem.call(grid, row, item);
+      if (pendingFetches.length) {
+        grid.$server.setParentRequestedRanges(pendingFetches);
+      }
+    };
 
-        // There might be inactive component renderers on hidden rows that still refer to the
-        // same component instance as one of the renderers on a visible row. Making the
-        // inactive/hidden renderer attach the component might steal it from a visible/active one.
-        if (!row.hidden) {
-          // make sure that component renderers are updated
-          Array.from(row.children).forEach((cell) => {
-            Array.from(cell?._content?.__templateInstance?.children || []).forEach((content) => {
-              if (content._attachRenderedComponentIfAble) {
-                content._attachRenderedComponentIfAble();
+    grid.$connector.debounceParentRequest = (parentKey, page) => {
+      // Remove any pending requests for the same parentKey.
+      parentRequestQueue = parentRequestQueue.filter((request) => request.parentKey !== parentKey);
+      // Add the new request to the queue.
+      parentRequestQueue.push({ parentKey, page });
+      // Debounce the request to avoid sending multiple requests for the same parentKey.
+      parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay), () => {
+        while (parentRequestQueue.length) {
+          grid.$connector.flushParentRequests();
+        }
+      });
+    };
+
+    grid.$connector.fetchPage = (fetch, page, parentKey) => {
+      // Adjust the requested page to be within the valid range in case
+      // the grid size has changed while fetchPage was debounced.
+      if (parentKey === root) {
+        page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
+      }
+
+      // Determine what to fetch based on scroll position and not only
+      // what grid asked for
+      const visibleRows = grid._getRenderedRows();
+      let start = visibleRows.length > 0 ? visibleRows[0].index : 0;
+      let end = visibleRows.length > 0 ? visibleRows[visibleRows.length - 1].index : 0;
+
+      // The buffer size could be multiplied by some constant defined by the user,
+      // if he needs to reduce the number of items sent to the Grid to improve performance
+      // or to increase it to make Grid smoother when scrolling
+      let buffer = end - start;
+      let firstNeededIndex = Math.max(0, start - buffer);
+      let lastNeededIndex = Math.min(end + buffer, grid._flatSize);
+
+      let pageRange = [null, null];
+      for (let idx = firstNeededIndex; idx <= lastNeededIndex; idx++) {
+        const { cache, index } = dataProviderController.getFlatIndexContext(idx);
+        // Try to match level by going up in hierarchy. The page range should include
+        // pages that contain either of the following:
+        //   - visible items of the current cache
+        //   - same level parents of visible descendant items
+        // If the parent items are not considered, Flow would remove the hidden parent
+        // items from the current level cache. This can lead to an infinite loop when using
+        // scrollToIndex feature.
+        const sameLevelPage = grid.$connector._getSameLevelPage(parentKey, cache, index);
+        if (sameLevelPage === null) {
+          continue;
+        }
+        pageRange[0] = Math.min(pageRange[0] ?? sameLevelPage, sameLevelPage);
+        pageRange[1] = Math.max(pageRange[1] ?? sameLevelPage, sameLevelPage);
+      }
+
+      // When the viewport doesn't contain the requested page or it doesn't contain any items from
+      // the requested level at all, it means that the scroll position has changed while fetchPage
+      // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
+      // then immediately back to the top. In this case, the request for the last page will be left
+      // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
+      // to make sure all hanging requests are resolved. After that, the grid requests the first page
+      // or whatever in the viewport again.
+      if (pageRange.some((p) => p === null) || page < pageRange[0] || page > pageRange[1]) {
+        pageRange = [page, page];
+      }
+
+      let lastRequestedRange = lastRequestedRanges[parentKey] || [-1, -1];
+      if (lastRequestedRange[0] != pageRange[0] || lastRequestedRange[1] != pageRange[1]) {
+        lastRequestedRanges[parentKey] = pageRange;
+        let pageCount = pageRange[1] - pageRange[0] + 1;
+        fetch(pageRange[0] * grid.pageSize, pageCount * grid.pageSize);
+      }
+    };
+
+    grid.dataProvider = (params, callback) => {
+      if (params.pageSize != grid.pageSize) {
+        throw 'Invalid pageSize';
+      }
+
+      let page = params.page;
+
+      if (params.parentItem) {
+        let parentUniqueKey = grid.getItemId(params.parentItem);
+
+        const parentItemSubCache = dataProviderController.getItemSubCache(params.parentItem);
+        if (cache[parentUniqueKey]?.[page] && parentItemSubCache) {
+          // Ensure grid isn't in loading state when the callback executes
+          ensureSubCacheQueue = [];
+          // Resolve the callback from cache
+          callback(cache[parentUniqueKey][page], cache[parentUniqueKey].size);
+        } else {
+          grid.$connector.debounceParentRequest(parentUniqueKey, page);
+        }
+      } else {
+        // size is controlled by the server (data communicator), so if the
+        // size is zero, we know that there is no data to fetch.
+        // This also prevents an empty grid getting stuck in a loading state.
+        // The connector does not cache empty pages, so if the grid requests
+        // data again, there would be no cache entry, causing a request to
+        // the server. However, the data communicator will never respond,
+        // as it assumes that the data is already cached.
+        if (grid.size === 0) {
+          callback([], 0);
+          return;
+        }
+
+        if (cache[root]?.[page]) {
+          callback(cache[root][page]);
+        } else {
+          grid.$connector.debounceRootRequest(page);
+        }
+      }
+    };
+
+    grid.$connector.setSorterDirections = (directions) => {
+      sorterDirectionsSetFromServer = true;
+      setTimeout(() => {
+        try {
+          const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
+
+          // Sorters for hidden columns are removed from DOM but stored in the web component.
+          // We need to ensure that all the sorters are reset when using `grid.sort(null)`.
+          grid._sorters.forEach((sorter) => {
+            if (!sorters.includes(sorter)) {
+              sorters.push(sorter);
+            }
+          });
+
+          sorters.forEach((sorter) => {
+            sorter.direction = null;
+          });
+
+          // Apply directions in correct order, depending on configured multi-sort priority.
+          // For the default "prepend" mode, directions need to be applied in reverse, in
+          // order for the sort indicators to match the order on the server. For "append"
+          // just keep the order passed from the server.
+          if (grid.multiSortPriority !== 'append') {
+            directions = directions.reverse();
+          }
+          directions.forEach(({ column, direction }) => {
+            sorters.forEach((sorter) => {
+              if (sorter.getAttribute('path') === column) {
+                sorter.direction = direction;
               }
-              // In hierarchy column of tree grid, the component renderer is inside its content,
-              // this updates it renderer from innerContent
-              Array.from(content?.children || []).forEach((innerContent) => {
-                if (innerContent._attachRenderedComponentIfAble) {
-                  innerContent._attachRenderedComponentIfAble();
-                }
-              });
             });
           });
-        }
-        // since no row can be selected when selection mode is NONE
-        // if selectionMode is set to NONE, remove aria-selected attribute from the row
-        if (selectionMode === validSelectionModes[1]) {
-          // selectionMode === NONE
-          row.removeAttribute('aria-selected');
-          Array.from(row.children).forEach((cell) => cell.removeAttribute('aria-selected'));
+
+          // Manually trigger a re-render of the sorter priority indicators
+          // in case some of the sorters were hidden while being updated above
+          // and therefore didn't notify the grid about their direction change.
+          grid.__applySorters();
+        } finally {
+          sorterDirectionsSetFromServer = false;
         }
       });
+    };
 
-      const itemExpandedChanged = tryCatchWrapper(function (item, expanded) {
-        // method available only for the TreeGrid server-side component
-        if (item == undefined || grid.$server.updateExpandedState == undefined) {
-          return;
-        }
-        let parentKey = grid.getItemId(item);
-        grid.$server.updateExpandedState(parentKey, expanded);
-      });
+    grid._updateItem = (row, item) => {
+      Grid.prototype._updateItem.call(grid, row, item);
 
-      // Patch grid.expandItem and grid.collapseItem to have
-      // itemExpandedChanged run when either happens.
-      grid.expandItem = tryCatchWrapper(function (item) {
-        itemExpandedChanged(item, true);
-        Grid.prototype.expandItem.call(grid, item);
-      });
-
-      grid.collapseItem = tryCatchWrapper(function (item) {
-        itemExpandedChanged(item, false);
-        Grid.prototype.collapseItem.call(grid, item);
-      });
-
-      const itemsUpdated = function (items) {
-        if (!items || !Array.isArray(items)) {
-          throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
-        }
-        let detailsOpenedItems = Array.from(grid.detailsOpenedItems);
-        for (let i = 0; i < items.length; ++i) {
-          const item = items[i];
-          if (!item) {
-            continue;
-          }
-          if (item.detailsOpened) {
-            if (grid._getItemIndexInArray(item, detailsOpenedItems) < 0) {
-              detailsOpenedItems.push(item);
+      // There might be inactive component renderers on hidden rows that still refer to the
+      // same component instance as one of the renderers on a visible row. Making the
+      // inactive/hidden renderer attach the component might steal it from a visible/active one.
+      if (!row.hidden) {
+        // make sure that component renderers are updated
+        Array.from(row.children).forEach((cell) => {
+          Array.from(cell?._content?.__templateInstance?.children || []).forEach((content) => {
+            if (content._attachRenderedComponentIfAble) {
+              content._attachRenderedComponentIfAble();
             }
-          } else if (grid._getItemIndexInArray(item, detailsOpenedItems) >= 0) {
-            detailsOpenedItems.splice(grid._getItemIndexInArray(item, detailsOpenedItems), 1);
-          }
-        }
-        grid.detailsOpenedItems = detailsOpenedItems;
-      };
-
-      /**
-       * Updates the cache for the given page for grid or tree-grid.
-       *
-       * @param page index of the page to update
-       * @param parentKey the key of the parent item for the page
-       * @returns an array of the updated items for the page, or undefined if no items were cached for the page
-       */
-      const updateGridCache = function (page, parentKey = root) {
-        const items = cache[parentKey][page];
-        const parentItem = createEmptyItemFromKey(parentKey);
-
-        let gridCache = parentKey === root
-          ? dataProviderController.rootCache
-          : dataProviderController.getItemSubCache(parentItem);
-
-        // Force update unless there's a callback waiting
-        if (gridCache && !gridCache.pendingRequests[page]) {
-          // Update the items in the grid cache or set an array of undefined items
-          // to remove the page from the grid cache if there are no corresponding items
-          // in the connector cache.
-          gridCache.setPage(page, items || Array.from({ length: grid.pageSize }));
-        }
-
-        return items;
-      };
-
-      /**
-       * Updates all visible grid rows in DOM.
-       */
-      const updateAllGridRowsInDomBasedOnCache = function () {
-        updateGridFlatSize();
-        grid.__updateVisibleRows();
-      };
-
-      /**
-       * Updates the <vaadin-grid>'s internal cache size and flat size.
-       */
-      const updateGridFlatSize = function () {
-        dataProviderController.recalculateFlatSize();
-        grid._flatSize = dataProviderController.flatSize;
-      };
-
-      /**
-       * Update the given items in DOM if currently visible.
-       *
-       * @param array items the items to update in DOM
-       */
-      const updateGridItemsInDomBasedOnCache = function (items) {
-        if (!items || !grid.$ || grid.$.items.childElementCount === 0) {
-          return;
-        }
-
-        const itemKeys = items.map((item) => item.key);
-        const indexes = grid
-          ._getRenderedRows()
-          .filter((row) => row._item && itemKeys.includes(row._item.key))
-          .map((row) => row.index);
-        if (indexes.length > 0) {
-          grid.__updateVisibleRows(indexes[0], indexes[indexes.length - 1]);
-        }
-      };
-
-      grid.$connector.set = tryCatchWrapper(function (index, items, parentKey) {
-        if (index % grid.pageSize != 0) {
-          throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
-        }
-        let pkey = parentKey || root;
-
-        const firstPage = index / grid.pageSize;
-        const updatedPageCount = Math.ceil(items.length / grid.pageSize);
-
-        // For root cache, remember the range of pages that were set during an update
-        if (pkey === root) {
-          currentUpdateSetRange = [firstPage, firstPage + updatedPageCount - 1];
-        }
-
-        for (let i = 0; i < updatedPageCount; i++) {
-          let page = firstPage + i;
-          let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
-          if (!cache[pkey]) {
-            cache[pkey] = {};
-          }
-          cache[pkey][page] = slice;
-
-          grid.$connector.doSelection(slice.filter((item) => item.selected));
-          grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
-
-          const updatedItems = updateGridCache(page, pkey);
-          if (updatedItems) {
-            itemsUpdated(updatedItems);
-            updateGridItemsInDomBasedOnCache(updatedItems);
-          }
-        }
-      });
-
-      const itemToCacheLocation = function (item) {
-        let parent = item.parentUniqueKey || root;
-        if (cache[parent]) {
-          for (let page in cache[parent]) {
-            for (let index in cache[parent][page]) {
-              if (grid.getItemId(cache[parent][page][index]) === grid.getItemId(item)) {
-                return { page: page, index: index, parentKey: parent };
+            // In hierarchy column of tree grid, the component renderer is inside its content,
+            // this updates it renderer from innerContent
+            Array.from(content?.children || []).forEach((innerContent) => {
+              if (innerContent._attachRenderedComponentIfAble) {
+                innerContent._attachRenderedComponentIfAble();
               }
+            });
+          });
+        });
+      }
+      // since no row can be selected when selection mode is NONE
+      // if selectionMode is set to NONE, remove aria-selected attribute from the row
+      if (selectionMode === validSelectionModes[1]) {
+        // selectionMode === NONE
+        row.removeAttribute('aria-selected');
+        Array.from(row.children).forEach((cell) => cell.removeAttribute('aria-selected'));
+      }
+    };
+
+    const itemExpandedChanged = (item, expanded) => {
+      // method available only for the TreeGrid server-side component
+      if (item == undefined || grid.$server.updateExpandedState == undefined) {
+        return;
+      }
+      let parentKey = grid.getItemId(item);
+      grid.$server.updateExpandedState(parentKey, expanded);
+    };
+
+    // Patch grid.expandItem and grid.collapseItem to have
+    // itemExpandedChanged run when either happens.
+    grid.expandItem = (item) => {
+      itemExpandedChanged(item, true);
+      Grid.prototype.expandItem.call(grid, item);
+    };
+
+    grid.collapseItem = (item) => {
+      itemExpandedChanged(item, false);
+      Grid.prototype.collapseItem.call(grid, item);
+    };
+
+    function itemsUpdated(items) {
+      if (!items || !Array.isArray(items)) {
+        throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
+      }
+      let detailsOpenedItems = Array.from(grid.detailsOpenedItems);
+      for (let i = 0; i < items.length; ++i) {
+        const item = items[i];
+        if (!item) {
+          continue;
+        }
+        if (item.detailsOpened) {
+          if (grid._getItemIndexInArray(item, detailsOpenedItems) < 0) {
+            detailsOpenedItems.push(item);
+          }
+        } else if (grid._getItemIndexInArray(item, detailsOpenedItems) >= 0) {
+          detailsOpenedItems.splice(grid._getItemIndexInArray(item, detailsOpenedItems), 1);
+        }
+      }
+      grid.detailsOpenedItems = detailsOpenedItems;
+    };
+
+    /**
+     * Updates the cache for the given page for grid or tree-grid.
+     *
+     * @param page index of the page to update
+     * @param parentKey the key of the parent item for the page
+     * @returns an array of the updated items for the page, or undefined if no items were cached for the page
+     */
+    function updateGridCache(page, parentKey = root) {
+      const items = cache[parentKey][page];
+      const parentItem = createEmptyItemFromKey(parentKey);
+
+      let gridCache = parentKey === root
+        ? dataProviderController.rootCache
+        : dataProviderController.getItemSubCache(parentItem);
+
+      // Force update unless there's a callback waiting
+      if (gridCache && !gridCache.pendingRequests[page]) {
+        // Update the items in the grid cache or set an array of undefined items
+        // to remove the page from the grid cache if there are no corresponding items
+        // in the connector cache.
+        gridCache.setPage(page, items || Array.from({ length: grid.pageSize }));
+      }
+
+      return items;
+    };
+
+    /**
+     * Updates all visible grid rows in DOM.
+     */
+    function updateAllGridRowsInDomBasedOnCache() {
+      updateGridFlatSize();
+      grid.__updateVisibleRows();
+    }
+
+    /**
+     * Updates the <vaadin-grid>'s internal cache size and flat size.
+     */
+    function updateGridFlatSize() {
+      dataProviderController.recalculateFlatSize();
+      grid._flatSize = dataProviderController.flatSize;
+    }
+
+    /**
+     * Update the given items in DOM if currently visible.
+     *
+     * @param array items the items to update in DOM
+     */
+    function updateGridItemsInDomBasedOnCache(items) {
+      if (!items || !grid.$ || grid.$.items.childElementCount === 0) {
+        return;
+      }
+
+      const itemKeys = items.map((item) => item.key);
+      const indexes = grid
+        ._getRenderedRows()
+        .filter((row) => row._item && itemKeys.includes(row._item.key))
+        .map((row) => row.index);
+      if (indexes.length > 0) {
+        grid.__updateVisibleRows(indexes[0], indexes[indexes.length - 1]);
+      }
+    }
+
+    grid.$connector.set = (index, items, parentKey) => {
+      if (index % grid.pageSize != 0) {
+        throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
+      }
+      let pkey = parentKey || root;
+
+      const firstPage = index / grid.pageSize;
+      const updatedPageCount = Math.ceil(items.length / grid.pageSize);
+
+      // For root cache, remember the range of pages that were set during an update
+      if (pkey === root) {
+        currentUpdateSetRange = [firstPage, firstPage + updatedPageCount - 1];
+      }
+
+      for (let i = 0; i < updatedPageCount; i++) {
+        let page = firstPage + i;
+        let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
+        if (!cache[pkey]) {
+          cache[pkey] = {};
+        }
+        cache[pkey][page] = slice;
+
+        grid.$connector.doSelection(slice.filter((item) => item.selected));
+        grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
+
+        const updatedItems = updateGridCache(page, pkey);
+        if (updatedItems) {
+          itemsUpdated(updatedItems);
+          updateGridItemsInDomBasedOnCache(updatedItems);
+        }
+      }
+    };
+
+    function itemToCacheLocation(item) {
+      let parent = item.parentUniqueKey || root;
+      if (cache[parent]) {
+        for (let page in cache[parent]) {
+          for (let index in cache[parent][page]) {
+            if (grid.getItemId(cache[parent][page][index]) === grid.getItemId(item)) {
+              return { page: page, index: index, parentKey: parent };
             }
           }
         }
-        return null;
-      };
+      }
+      return null;
+    }
 
-      /**
-       * Updates the given items for a hierarchical grid.
-       *
-       * @param updatedItems the updated items array
-       */
-      grid.$connector.updateHierarchicalData = tryCatchWrapper(function (updatedItems) {
-        let pagesToUpdate = [];
-        // locate and update the items in cache
-        // find pages that need updating
-        for (let i = 0; i < updatedItems.length; i++) {
-          let cacheLocation = itemToCacheLocation(updatedItems[i]);
-          if (cacheLocation) {
-            cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
-            let key = cacheLocation.parentKey + ':' + cacheLocation.page;
-            if (!pagesToUpdate[key]) {
-              pagesToUpdate[key] = {
-                parentKey: cacheLocation.parentKey,
-                page: cacheLocation.page
-              };
-            }
+    /**
+     * Updates the given items for a hierarchical grid.
+     *
+     * @param updatedItems the updated items array
+     */
+    grid.$connector.updateHierarchicalData = (updatedItems) => {
+      let pagesToUpdate = [];
+      // locate and update the items in cache
+      // find pages that need updating
+      for (let i = 0; i < updatedItems.length; i++) {
+        let cacheLocation = itemToCacheLocation(updatedItems[i]);
+        if (cacheLocation) {
+          cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+          let key = cacheLocation.parentKey + ':' + cacheLocation.page;
+          if (!pagesToUpdate[key]) {
+            pagesToUpdate[key] = {
+              parentKey: cacheLocation.parentKey,
+              page: cacheLocation.page
+            };
           }
         }
-        // IE11 doesn't work with the transpiled version of the forEach.
-        let keys = Object.keys(pagesToUpdate);
-        for (let i = 0; i < keys.length; i++) {
-          let pageToUpdate = pagesToUpdate[keys[i]];
-          const affectedUpdatedItems = updateGridCache(pageToUpdate.page, pageToUpdate.parentKey);
-          if (affectedUpdatedItems) {
-            itemsUpdated(affectedUpdatedItems);
-            updateGridItemsInDomBasedOnCache(affectedUpdatedItems);
+      }
+      // IE11 doesn't work with the transpiled version of the forEach.
+      let keys = Object.keys(pagesToUpdate);
+      for (let i = 0; i < keys.length; i++) {
+        let pageToUpdate = pagesToUpdate[keys[i]];
+        const affectedUpdatedItems = updateGridCache(pageToUpdate.page, pageToUpdate.parentKey);
+        if (affectedUpdatedItems) {
+          itemsUpdated(affectedUpdatedItems);
+          updateGridItemsInDomBasedOnCache(affectedUpdatedItems);
+        }
+      }
+    };
+
+    /**
+     * Updates the given items for a non-hierarchical grid.
+     *
+     * @param updatedItems the updated items array
+     */
+    grid.$connector.updateFlatData = (updatedItems) => {
+      // update (flat) caches
+      for (let i = 0; i < updatedItems.length; i++) {
+        let cacheLocation = itemToCacheLocation(updatedItems[i]);
+        if (cacheLocation) {
+          // update connector cache
+          cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+
+          // update grid's cache
+          const index = parseInt(cacheLocation.page) * grid.pageSize + parseInt(cacheLocation.index);
+          const { rootCache } = dataProviderController;
+          if (rootCache.items[index]) {
+            rootCache.items[index] = updatedItems[i];
           }
         }
-      });
+      }
+      itemsUpdated(updatedItems);
 
-      /**
-       * Updates the given items for a non-hierarchical grid.
-       *
-       * @param updatedItems the updated items array
-       */
-      grid.$connector.updateFlatData = tryCatchWrapper(function (updatedItems) {
-        // update (flat) caches
-        for (let i = 0; i < updatedItems.length; i++) {
-          let cacheLocation = itemToCacheLocation(updatedItems[i]);
-          if (cacheLocation) {
-            // update connector cache
-            cache[cacheLocation.parentKey][cacheLocation.page][cacheLocation.index] = updatedItems[i];
+      updateGridItemsInDomBasedOnCache(updatedItems);
+    };
 
-            // update grid's cache
-            const index = parseInt(cacheLocation.page) * grid.pageSize + parseInt(cacheLocation.index);
-            const { rootCache } = dataProviderController;
-            if (rootCache.items[index]) {
-              rootCache.items[index] = updatedItems[i];
-            }
-          }
-        }
-        itemsUpdated(updatedItems);
+    grid.$connector.clearExpanded = () => {
+      grid.expandedItems = [];
+      ensureSubCacheQueue = [];
+      parentRequestQueue = [];
+    };
 
-        updateGridItemsInDomBasedOnCache(updatedItems);
-      });
+    /**
+     * Ensures that the last requested page range does not include pages for data that has been cleared.
+     * The last requested range is used in `fetchPage` to skip requests to the server if the page range didn't
+     * change. However, if some pages of that range have been cleared by data communicator, we need to clear the
+     * range to ensure the pages get loaded again. This can happen for example when changing the requested range
+     * on the server (e.g. preload of items on scroll to index), which can cause data communicator to clear pages
+     * that the connector assumes are already loaded.
+     */
+    function sanitizeLastRequestedRange() {
+      // Only relevant for the root cache
+      const range = lastRequestedRanges[root];
+      // Range may not be set yet, or nothing was cleared
+      if (!range || !currentUpdateClearRange) {
+        return;
+      }
 
-      grid.$connector.clearExpanded = tryCatchWrapper(function () {
-        grid.expandedItems = [];
-        ensureSubCacheQueue = [];
-        parentRequestQueue = [];
-      });
+      // Determine all pages that were cleared
+      const numClearedPages = currentUpdateClearRange[1] - currentUpdateClearRange[0] + 1;
+      const clearedPages = Array.from({ length: numClearedPages }, (_, i) => currentUpdateClearRange[0] + i);
 
-      /**
-       * Ensures that the last requested page range does not include pages for data that has been cleared.
-       * The last requested range is used in `fetchPage` to skip requests to the server if the page range didn't
-       * change. However, if some pages of that range have been cleared by data communicator, we need to clear the
-       * range to ensure the pages get loaded again. This can happen for example when changing the requested range
-       * on the server (e.g. preload of items on scroll to index), which can cause data communicator to clear pages
-       * that the connector assumes are already loaded.
-       */
-      const sanitizeLastRequestedRange = function () {
-        // Only relevant for the root cache
-        const range = lastRequestedRanges[root];
-        // Range may not be set yet, or nothing was cleared
-        if (!range || !currentUpdateClearRange) {
-          return;
-        }
-
-        // Determine all pages that were cleared
-        const numClearedPages = currentUpdateClearRange[1] - currentUpdateClearRange[0] + 1;
-        const clearedPages = Array.from({ length: numClearedPages }, (_, i) => currentUpdateClearRange[0] + i);
-
-        // Remove pages that have been set in same update
-        if (currentUpdateSetRange) {
-          const [first, last] = currentUpdateSetRange;
-          for (let page = first; page <= last; page++) {
-            const index = clearedPages.indexOf(page);
-            if (index >= 0) {
-              clearedPages.splice(index, 1);
-            }
-          }
-        }
-
-        // Clear the last requested range if it includes any of the cleared pages
-        if (clearedPages.some((page) => page >= range[0] && page <= range[1])) {
-          range[0] = -1;
-          range[1] = -1;
-        }
-      };
-
-      grid.$connector.clear = tryCatchWrapper(function (index, length, parentKey) {
-        let pkey = parentKey || root;
-        if (!cache[pkey] || Object.keys(cache[pkey]).length === 0) {
-          return;
-        }
-        if (index % grid.pageSize != 0) {
-          throw (
-            'Got cleared data for index ' + index + ' which is not aligned with the page size of ' + grid.pageSize
-          );
-        }
-
-        let firstPage = Math.floor(index / grid.pageSize);
-        let updatedPageCount = Math.ceil(length / grid.pageSize);
-
-        // For root cache, remember the range of pages that were cleared during an update
-        if (pkey === root) {
-          currentUpdateClearRange = [firstPage, firstPage + updatedPageCount - 1];
-        }
-
-        for (let i = 0; i < updatedPageCount; i++) {
-          let page = firstPage + i;
-          let items = cache[pkey][page];
-          grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
-          items.forEach((item) => grid.closeItemDetails(item));
-          delete cache[pkey][page];
-          updateGridCache(page, parentKey);
-          updateGridItemsInDomBasedOnCache(items);
-        }
-        let cacheToClear = dataProviderController.rootCache;
-        if (parentKey) {
-          const parentItem = createEmptyItemFromKey(pkey);
-          cacheToClear = dataProviderController.getItemSubCache(parentItem);
-        }
-        const endIndex = index + updatedPageCount * grid.pageSize;
-        for (let itemIndex = index; itemIndex < endIndex; itemIndex++) {
-          delete cacheToClear.items[itemIndex];
-          cacheToClear.removeSubCache(itemIndex);
-        }
-        updateGridFlatSize();
-      });
-
-      grid.$connector.reset = tryCatchWrapper(function () {
-        grid.size = 0;
-        cache = {};
-        dataProviderController.rootCache.items = [];
-        lastRequestedRanges = {};
-        if (ensureSubCacheDebouncer) {
-          ensureSubCacheDebouncer.cancel();
-        }
-        if (parentRequestDebouncer) {
-          parentRequestDebouncer.cancel();
-        }
-        if (rootRequestDebouncer) {
-          rootRequestDebouncer.cancel();
-        }
-        ensureSubCacheDebouncer = undefined;
-        parentRequestDebouncer = undefined;
-        ensureSubCacheQueue = [];
-        parentRequestQueue = [];
-        updateAllGridRowsInDomBasedOnCache();
-      });
-
-      grid.$connector.updateSize = (newSize) => (grid.size = newSize);
-
-      grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
-
-      grid.$connector.expandItems = tryCatchWrapper(function (items) {
-        let newExpandedItems = Array.from(grid.expandedItems);
-        items.filter((item) => !grid._isExpanded(item)).forEach((item) => newExpandedItems.push(item));
-        grid.expandedItems = newExpandedItems;
-      });
-
-      grid.$connector.collapseItems = tryCatchWrapper(function (items) {
-        let newExpandedItems = Array.from(grid.expandedItems);
-        items.forEach((item) => {
-          let index = grid._getItemIndexInArray(item, newExpandedItems);
+      // Remove pages that have been set in same update
+      if (currentUpdateSetRange) {
+        const [first, last] = currentUpdateSetRange;
+        for (let page = first; page <= last; page++) {
+          const index = clearedPages.indexOf(page);
           if (index >= 0) {
-            newExpandedItems.splice(index, 1);
-          }
-        });
-        grid.expandedItems = newExpandedItems;
-        items.forEach((item) => grid.$connector.removeFromQueue(item));
-      });
-
-      grid.$connector.removeFromQueue = tryCatchWrapper(function (item) {
-        // The page callbacks for the given item are about to be discarded ->
-        // Resolve the callbacks with an empty array to not leave grid in loading state
-        const itemSubCache = dataProviderController.getItemSubCache(item);
-        Object.values(itemSubCache?.pendingRequests || {}).forEach((callback) => callback([]));
-
-        const itemId = grid.getItemId(item);
-        ensureSubCacheQueue = ensureSubCacheQueue.filter((item) => item.itemkey !== itemId);
-        parentRequestQueue = parentRequestQueue.filter((item) => item.parentKey !== itemId);
-      });
-
-      grid.$connector.confirmParent = tryCatchWrapper(function (id, parentKey, levelSize) {
-        // Create connector cache if it doesn't exist
-        if (!cache[parentKey]) {
-          cache[parentKey] = {};
-        }
-        // Update connector cache size
-        const hasSizeChanged = cache[parentKey].size !== levelSize;
-        cache[parentKey].size = levelSize;
-        if (levelSize === 0) {
-          cache[parentKey][0] = [];
-        }
-
-        const parentItem = createEmptyItemFromKey(parentKey);
-        const parentItemSubCache = dataProviderController.getItemSubCache(parentItem);
-        if (parentItemSubCache) {
-          // If grid has pending requests for this parent, then resolve them
-          // and let grid update the flat size and re-render.
-          const { pendingRequests } = parentItemSubCache;
-          Object.entries(pendingRequests).forEach(([page, callback]) => {
-            let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
-
-            if (
-              (cache[parentKey] && cache[parentKey][page]) ||
-              page < lastRequestedRange[0] ||
-              page > lastRequestedRange[1]
-            ) {
-              let items = cache[parentKey][page] || new Array(levelSize);
-              callback(items, levelSize);
-            } else if (callback && levelSize === 0) {
-              // The parent item has 0 child items => resolve the callback with an empty array
-              callback([], levelSize);
-            }
-          });
-
-          // If size has changed, and there are no pending requests, then
-          // manually update the size of the grid cache and update the effective
-          // size, effectively re-rendering the grid. This is necessary when
-          // individual items are refreshed on the server, in which case there
-          // is no loading request from the grid itself. In that case, if
-          // children were added or removed, the grid will not be aware of it
-          // unless we manually update the size.
-          if (hasSizeChanged && Object.keys(pendingRequests).length === 0) {
-            parentItemSubCache.size = levelSize;
-            updateGridFlatSize();
+            clearedPages.splice(index, 1);
           }
         }
+      }
 
-        // Let server know we're done
-        grid.$server.confirmParentUpdate(id, parentKey);
+      // Clear the last requested range if it includes any of the cleared pages
+      if (clearedPages.some((page) => page >= range[0] && page <= range[1])) {
+        range[0] = -1;
+        range[1] = -1;
+      }
+    }
+
+    grid.$connector.clear = (index, length, parentKey) => {
+      let pkey = parentKey || root;
+      if (!cache[pkey] || Object.keys(cache[pkey]).length === 0) {
+        return;
+      }
+      if (index % grid.pageSize != 0) {
+        throw (
+          'Got cleared data for index ' + index + ' which is not aligned with the page size of ' + grid.pageSize
+        );
+      }
+
+      let firstPage = Math.floor(index / grid.pageSize);
+      let updatedPageCount = Math.ceil(length / grid.pageSize);
+
+      // For root cache, remember the range of pages that were cleared during an update
+      if (pkey === root) {
+        currentUpdateClearRange = [firstPage, firstPage + updatedPageCount - 1];
+      }
+
+      for (let i = 0; i < updatedPageCount; i++) {
+        let page = firstPage + i;
+        let items = cache[pkey][page];
+        grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
+        items.forEach((item) => grid.closeItemDetails(item));
+        delete cache[pkey][page];
+        updateGridCache(page, parentKey);
+        updateGridItemsInDomBasedOnCache(items);
+      }
+      let cacheToClear = dataProviderController.rootCache;
+      if (parentKey) {
+        const parentItem = createEmptyItemFromKey(pkey);
+        cacheToClear = dataProviderController.getItemSubCache(parentItem);
+      }
+      const endIndex = index + updatedPageCount * grid.pageSize;
+      for (let itemIndex = index; itemIndex < endIndex; itemIndex++) {
+        delete cacheToClear.items[itemIndex];
+        cacheToClear.removeSubCache(itemIndex);
+      }
+      updateGridFlatSize();
+    };
+
+    grid.$connector.reset = () => {
+      grid.size = 0;
+      cache = {};
+      dataProviderController.rootCache.items = [];
+      lastRequestedRanges = {};
+      if (ensureSubCacheDebouncer) {
+        ensureSubCacheDebouncer.cancel();
+      }
+      if (parentRequestDebouncer) {
+        parentRequestDebouncer.cancel();
+      }
+      if (rootRequestDebouncer) {
+        rootRequestDebouncer.cancel();
+      }
+      ensureSubCacheDebouncer = undefined;
+      parentRequestDebouncer = undefined;
+      ensureSubCacheQueue = [];
+      parentRequestQueue = [];
+      updateAllGridRowsInDomBasedOnCache();
+    };
+
+    grid.$connector.updateSize = (newSize) => (grid.size = newSize);
+
+    grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
+
+    grid.$connector.expandItems = (items) => {
+      let newExpandedItems = Array.from(grid.expandedItems);
+      items.filter((item) => !grid._isExpanded(item)).forEach((item) => newExpandedItems.push(item));
+      grid.expandedItems = newExpandedItems;
+    };
+
+    grid.$connector.collapseItems = (items) => {
+      let newExpandedItems = Array.from(grid.expandedItems);
+      items.forEach((item) => {
+        let index = grid._getItemIndexInArray(item, newExpandedItems);
+        if (index >= 0) {
+          newExpandedItems.splice(index, 1);
+        }
       });
+      grid.expandedItems = newExpandedItems;
+      items.forEach((item) => grid.$connector.removeFromQueue(item));
+    };
 
-      grid.$connector.confirm = tryCatchWrapper(function (id) {
-        // We're done applying changes from this batch, resolve pending
-        // callbacks
-        const { pendingRequests } = dataProviderController.rootCache;
+    grid.$connector.removeFromQueue = (item) => {
+      // The page callbacks for the given item are about to be discarded ->
+      // Resolve the callbacks with an empty array to not leave grid in loading state
+      const itemSubCache = dataProviderController.getItemSubCache(item);
+      Object.values(itemSubCache?.pendingRequests || {}).forEach((callback) => callback([]));
+
+      const itemId = grid.getItemId(item);
+      ensureSubCacheQueue = ensureSubCacheQueue.filter((item) => item.itemkey !== itemId);
+      parentRequestQueue = parentRequestQueue.filter((item) => item.parentKey !== itemId);
+    };
+
+    grid.$connector.confirmParent = (id, parentKey, levelSize) => {
+      // Create connector cache if it doesn't exist
+      if (!cache[parentKey]) {
+        cache[parentKey] = {};
+      }
+      // Update connector cache size
+      const hasSizeChanged = cache[parentKey].size !== levelSize;
+      cache[parentKey].size = levelSize;
+      if (levelSize === 0) {
+        cache[parentKey][0] = [];
+      }
+
+      const parentItem = createEmptyItemFromKey(parentKey);
+      const parentItemSubCache = dataProviderController.getItemSubCache(parentItem);
+      if (parentItemSubCache) {
+        // If grid has pending requests for this parent, then resolve them
+        // and let grid update the flat size and re-render.
+        const { pendingRequests } = parentItemSubCache;
         Object.entries(pendingRequests).forEach(([page, callback]) => {
-          const lastRequestedRange = lastRequestedRanges[root] || [0, 0];
-          const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
-          // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
-          const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
-          // Resolve if we have data or if we don't expect to get data
-          if (cache[root]?.[page]) {
-            // Cached data is available, resolve the callback
-            callback(cache[root][page]);
-          } else if (page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
-            // No cached data, resolve the callback with an empty array
-            callback(new Array(grid.pageSize));
-            // Request grid for content update
-            grid.requestContentUpdate();
-          } else if (callback && grid.size === 0) {
-            // The grid has 0 items => resolve the callback with an empty array
-            callback([]);
+          let lastRequestedRange = lastRequestedRanges[parentKey] || [0, 0];
+
+          if (
+            (cache[parentKey] && cache[parentKey][page]) ||
+            page < lastRequestedRange[0] ||
+            page > lastRequestedRange[1]
+          ) {
+            let items = cache[parentKey][page] || new Array(levelSize);
+            callback(items, levelSize);
+          } else if (callback && levelSize === 0) {
+            // The parent item has 0 child items => resolve the callback with an empty array
+            callback([], levelSize);
           }
         });
 
-        // Sanitize last requested range for the root level
-        sanitizeLastRequestedRange();
-        // Clear current update state
-        currentUpdateSetRange = null;
-        currentUpdateClearRange = null;
-
-        // Let server know we're done
-        grid.$server.confirmUpdate(id);
-      });
-
-      grid.$connector.ensureHierarchy = tryCatchWrapper(function () {
-        for (let parentKey in cache) {
-          if (parentKey !== root) {
-            delete cache[parentKey];
-          }
-        }
-
-        lastRequestedRanges = {};
-
-        dataProviderController.rootCache.removeSubCaches();
-
-        updateAllGridRowsInDomBasedOnCache();
-      });
-
-      grid.$connector.setSelectionMode = tryCatchWrapper(function (mode) {
-        if ((typeof mode === 'string' || mode instanceof String) && validSelectionModes.indexOf(mode) >= 0) {
-          selectionMode = mode;
-          selectedKeys = {};
-          grid.selectedItems = [];
-          grid.$connector.updateMultiSelectable();
-        } else {
-          throw 'Attempted to set an invalid selection mode';
-        }
-      });
-
-      /*
-        * Manage aria-multiselectable attribute depending on the selection mode.
-        * see more: https://github.com/vaadin/web-components/issues/1536
-        * or: https://www.w3.org/TR/wai-aria-1.1/#aria-multiselectable
-        * For selection mode SINGLE, set the aria-multiselectable attribute to false
-        */
-      grid.$connector.updateMultiSelectable = tryCatchWrapper(function () {
-        if (!grid.$) {
-          return;
-        }
-
-        if (selectionMode === validSelectionModes[0]) {
-          grid.$.table.setAttribute('aria-multiselectable', false);
-          // For selection mode NONE, remove the aria-multiselectable attribute
-        } else if (selectionMode === validSelectionModes[1]) {
-          grid.$.table.removeAttribute('aria-multiselectable');
-          // For selection mode MULTI, set aria-multiselectable to true
-        } else {
-          grid.$.table.setAttribute('aria-multiselectable', true);
-        }
-      });
-
-      // Have the multi-selectable state updated on attach
-      grid._createPropertyObserver('isAttached', () => grid.$connector.updateMultiSelectable());
-
-      const singleTimeRenderer = (renderer) => {
-        return (root) => {
-          if (renderer) {
-            renderer(root);
-            renderer = null;
-          }
-        };
-      };
-
-      grid.$connector.setHeaderRenderer = tryCatchWrapper(function (column, options) {
-        const { content, showSorter, sorterPath } = options;
-
-        if (content === null) {
-          column.headerRenderer = null;
-          return;
-        }
-
-        column.headerRenderer = singleTimeRenderer((root) => {
-          // Clear previous contents
-          root.innerHTML = '';
-          // Render sorter
-          let contentRoot = root;
-          if (showSorter) {
-            const sorter = document.createElement('vaadin-grid-sorter');
-            sorter.setAttribute('path', sorterPath);
-            const ariaLabel = content instanceof Node ? content.textContent : content;
-            if (ariaLabel) {
-              sorter.setAttribute('aria-label', `Sort by ${ariaLabel}`);
-            }
-            root.appendChild(sorter);
-
-            // Use sorter as content root
-            contentRoot = sorter;
-          }
-          // Add content
-          if (content instanceof Node) {
-            contentRoot.appendChild(content);
-          } else {
-            contentRoot.textContent = content;
-          }
-        });
-      });
-
-      // This method is overridden to prevent the grid web component from
-      // automatically excluding columns from sorting when they get hidden.
-      // In Flow, it's the developer's responsibility to remove the column
-      // from the backend sort order when the column gets hidden.
-      grid._getActiveSorters = function() {
-        return this._sorters.filter((sorter) => sorter.direction);
-      }
-
-      grid.__applySorters = () => {
-        const sorters = grid._mapSorters();
-        const sortersChanged = JSON.stringify(grid._previousSorters) !== JSON.stringify(sorters);
-
-        // Update the _previousSorters in vaadin-grid-sort-mixin so that the __applySorters
-        // method in the mixin will skip calling clearCache().
-        //
-        // In Flow Grid's case, we never want to clear the cache eagerly when the sorter elements
-        // change due to one of the following reasons:
-        //
-        // 1. Sorted by user: The items in the new sort order need to be fetched from the server,
-        // and we want to avoid a heavy re-render before the updated items have actually been fetched.
-        //
-        // 2. Sorted programmatically on the server: The items in the new sort order have already
-        // been fetched and applied to the grid. The sorter element states are updated programmatically
-        // to reflect the new sort order, but there's no need to re-render the grid rows.
-        grid._previousSorters = sorters;
-
-        // Call the original __applySorters method in vaadin-grid-sort-mixin
-        Grid.prototype.__applySorters.call(grid);
-
-        if (sortersChanged && !sorterDirectionsSetFromServer) {
-          grid.$server.sortersChanged(sorters);
-        }
-      };
-
-      grid.$connector.setFooterRenderer = tryCatchWrapper(function (column, options) {
-        const { content } = options;
-
-        if (content === null) {
-          column.footerRenderer = null;
-          return;
-        }
-
-        column.footerRenderer = singleTimeRenderer((root) => {
-          // Clear previous contents
-          root.innerHTML = '';
-          // Add content
-          if (content instanceof Node) {
-            root.appendChild(content);
-          } else {
-            root.textContent = content;
-          }
-        });
-      });
-
-      grid.addEventListener(
-        'vaadin-context-menu-before-open',
-        tryCatchWrapper(function (e) {
-          const { key, columnId } = e.detail;
-          grid.$server.updateContextMenuTargetItem(key, columnId);
-        })
-      );
-
-      grid.getContextMenuBeforeOpenDetail = tryCatchWrapper(function (event) {
-        // For `contextmenu` events, we need to access the source event,
-        // when using open on click we just use the click event itself
-        const sourceEvent = event.detail.sourceEvent || event;
-        const eventContext = grid.getEventContext(sourceEvent);
-        const key = eventContext.item?.key || '';
-        const columnId = eventContext.column?.id || '';
-        return { key, columnId };
-      });
-
-      grid.preventContextMenu = tryCatchWrapper(function (event) {
-          const isLeftClick = event.type === 'click';
-          const { column } = grid.getEventContext(event);
-
-          return isLeftClick && column instanceof GridFlowSelectionColumn;
-      });
-
-      grid.addEventListener(
-        'click',
-        tryCatchWrapper((e) => _fireClickEvent(e, 'item-click'))
-      );
-      grid.addEventListener(
-        'dblclick',
-        tryCatchWrapper((e) => _fireClickEvent(e, 'item-double-click'))
-      );
-
-      grid.addEventListener(
-        'column-resize',
-        tryCatchWrapper((e) => {
-          const cols = grid._getColumnsInOrder().filter((col) => !col.hidden);
-
-          cols.forEach((col) => {
-            col.dispatchEvent(new CustomEvent('column-drag-resize'));
-          });
-
-          grid.dispatchEvent(
-            new CustomEvent('column-drag-resize', {
-              detail: {
-                resizedColumnKey: e.detail.resizedColumn._flowId
-              }
-            })
-          );
-        })
-      );
-
-      grid.addEventListener(
-        'column-reorder',
-        tryCatchWrapper((e) => {
-          const columns = grid._columnTree
-            .slice(0)
-            .pop()
-            .filter((c) => c._flowId)
-            .sort((b, a) => b._order - a._order)
-            .map((c) => c._flowId);
-
-          grid.dispatchEvent(
-            new CustomEvent('column-reorder-all-columns', {
-              detail: { columns }
-            })
-          );
-        })
-      );
-
-      grid.addEventListener(
-        'cell-focus',
-        tryCatchWrapper((e) => {
-          const eventContext = grid.getEventContext(e);
-          const expectedSectionValues = ['header', 'body', 'footer'];
-
-          if (expectedSectionValues.indexOf(eventContext.section) === -1) {
-            return;
-          }
-
-          grid.dispatchEvent(
-            new CustomEvent('grid-cell-focus', {
-              detail: {
-                itemKey: eventContext.item ? eventContext.item.key : null,
-
-                internalColumnId: eventContext.column ? eventContext.column._flowId : null,
-
-                section: eventContext.section
-              }
-            })
-          );
-        })
-      );
-
-      function _fireClickEvent(event, eventName) {
-        // Click event was handled by the component inside grid, do nothing.
-        if (event.defaultPrevented) {
-          return;
-        }
-
-        const path = event.composedPath();
-        const idx = path.findIndex((node) => node.localName === 'td' || node.localName === 'th');
-        const content = path.slice(0, idx);
-
-        // Do not fire item click event if cell content contains focusable elements.
-        // Use this instead of event.target to detect cases like icon inside button.
-        // See https://github.com/vaadin/flow-components/issues/4065
-        if (content.some((node) => isFocusable(node) || node instanceof HTMLLabelElement)) {
-          return;
-        }
-
-        const eventContext = grid.getEventContext(event);
-        const section = eventContext.section;
-
-        if (eventContext.item && section !== 'details') {
-          event.itemKey = eventContext.item.key;
-          // if you have a details-renderer, getEventContext().column is undefined
-          if (eventContext.column) {
-            event.internalColumnId = eventContext.column._flowId;
-          }
-          grid.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+        // If size has changed, and there are no pending requests, then
+        // manually update the size of the grid cache and update the effective
+        // size, effectively re-rendering the grid. This is necessary when
+        // individual items are refreshed on the server, in which case there
+        // is no loading request from the grid itself. In that case, if
+        // children were added or removed, the grid will not be aware of it
+        // unless we manually update the size.
+        if (hasSizeChanged && Object.keys(pendingRequests).length === 0) {
+          parentItemSubCache.size = levelSize;
+          updateGridFlatSize();
         }
       }
 
-      grid.cellClassNameGenerator = tryCatchWrapper(function (column, rowData) {
-        const style = rowData.item.style;
-        if (!style) {
-          return;
+      // Let server know we're done
+      grid.$server.confirmParentUpdate(id, parentKey);
+    };
+
+    grid.$connector.confirm = (id) => {
+      // We're done applying changes from this batch, resolve pending
+      // callbacks
+      const { pendingRequests } = dataProviderController.rootCache;
+      Object.entries(pendingRequests).forEach(([page, callback]) => {
+        const lastRequestedRange = lastRequestedRanges[root] || [0, 0];
+        const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
+        // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
+        const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
+        // Resolve if we have data or if we don't expect to get data
+        if (cache[root]?.[page]) {
+          // Cached data is available, resolve the callback
+          callback(cache[root][page]);
+        } else if (page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
+          // No cached data, resolve the callback with an empty array
+          callback(new Array(grid.pageSize));
+          // Request grid for content update
+          grid.requestContentUpdate();
+        } else if (callback && grid.size === 0) {
+          // The grid has 0 items => resolve the callback with an empty array
+          callback([]);
         }
-        return (style.row || '') + ' ' + ((column && style[column._flowId]) || '');
       });
 
-      grid.cellPartNameGenerator = tryCatchWrapper(function (column, rowData) {
-        const part = rowData.item.part;
-        if (!part) {
+      // Sanitize last requested range for the root level
+      sanitizeLastRequestedRange();
+      // Clear current update state
+      currentUpdateSetRange = null;
+      currentUpdateClearRange = null;
+
+      // Let server know we're done
+      grid.$server.confirmUpdate(id);
+    };
+
+    grid.$connector.ensureHierarchy = () => {
+      for (let parentKey in cache) {
+        if (parentKey !== root) {
+          delete cache[parentKey];
+        }
+      }
+
+      lastRequestedRanges = {};
+
+      dataProviderController.rootCache.removeSubCaches();
+
+      updateAllGridRowsInDomBasedOnCache();
+    };
+
+    grid.$connector.setSelectionMode = (mode) => {
+      if ((typeof mode === 'string' || mode instanceof String) && validSelectionModes.indexOf(mode) >= 0) {
+        selectionMode = mode;
+        selectedKeys = {};
+        grid.selectedItems = [];
+        grid.$connector.updateMultiSelectable();
+      } else {
+        throw 'Attempted to set an invalid selection mode';
+      }
+    };
+
+    /*
+      * Manage aria-multiselectable attribute depending on the selection mode.
+      * see more: https://github.com/vaadin/web-components/issues/1536
+      * or: https://www.w3.org/TR/wai-aria-1.1/#aria-multiselectable
+      * For selection mode SINGLE, set the aria-multiselectable attribute to false
+      */
+    grid.$connector.updateMultiSelectable = () => {
+      if (!grid.$) {
+        return;
+      }
+
+      if (selectionMode === validSelectionModes[0]) {
+        grid.$.table.setAttribute('aria-multiselectable', false);
+        // For selection mode NONE, remove the aria-multiselectable attribute
+      } else if (selectionMode === validSelectionModes[1]) {
+        grid.$.table.removeAttribute('aria-multiselectable');
+        // For selection mode MULTI, set aria-multiselectable to true
+      } else {
+        grid.$.table.setAttribute('aria-multiselectable', true);
+      }
+    };
+
+    // Have the multi-selectable state updated on attach
+    grid._createPropertyObserver('isAttached', () => grid.$connector.updateMultiSelectable());
+
+    const singleTimeRenderer = (renderer) => {
+      return (root) => {
+        if (renderer) {
+          renderer(root);
+          renderer = null;
+        }
+      };
+    };
+
+    grid.$connector.setHeaderRenderer = (column, options) => {
+      const { content, showSorter, sorterPath } = options;
+
+      if (content === null) {
+        column.headerRenderer = null;
+        return;
+      }
+
+      column.headerRenderer = singleTimeRenderer((root) => {
+        // Clear previous contents
+        root.innerHTML = '';
+        // Render sorter
+        let contentRoot = root;
+        if (showSorter) {
+          const sorter = document.createElement('vaadin-grid-sorter');
+          sorter.setAttribute('path', sorterPath);
+          const ariaLabel = content instanceof Node ? content.textContent : content;
+          if (ariaLabel) {
+            sorter.setAttribute('aria-label', `Sort by ${ariaLabel}`);
+          }
+          root.appendChild(sorter);
+
+          // Use sorter as content root
+          contentRoot = sorter;
+        }
+        // Add content
+        if (content instanceof Node) {
+          contentRoot.appendChild(content);
+        } else {
+          contentRoot.textContent = content;
+        }
+      });
+    };
+
+    // This method is overridden to prevent the grid web component from
+    // automatically excluding columns from sorting when they get hidden.
+    // In Flow, it's the developer's responsibility to remove the column
+    // from the backend sort order when the column gets hidden.
+    grid._getActiveSorters = () => {
+      return grid._sorters.filter((sorter) => sorter.direction);
+    }
+
+    grid.__applySorters = () => {
+      const sorters = grid._mapSorters();
+      const sortersChanged = JSON.stringify(grid._previousSorters) !== JSON.stringify(sorters);
+
+      // Update the _previousSorters in vaadin-grid-sort-mixin so that the __applySorters
+      // method in the mixin will skip calling clearCache().
+      //
+      // In Flow Grid's case, we never want to clear the cache eagerly when the sorter elements
+      // change due to one of the following reasons:
+      //
+      // 1. Sorted by user: The items in the new sort order need to be fetched from the server,
+      // and we want to avoid a heavy re-render before the updated items have actually been fetched.
+      //
+      // 2. Sorted programmatically on the server: The items in the new sort order have already
+      // been fetched and applied to the grid. The sorter element states are updated programmatically
+      // to reflect the new sort order, but there's no need to re-render the grid rows.
+      grid._previousSorters = sorters;
+
+      // Call the original __applySorters method in vaadin-grid-sort-mixin
+      Grid.prototype.__applySorters.call(grid);
+
+      if (sortersChanged && !sorterDirectionsSetFromServer) {
+        grid.$server.sortersChanged(sorters);
+      }
+    };
+
+    grid.$connector.setFooterRenderer = (column, options) => {
+      const { content } = options;
+
+      if (content === null) {
+        column.footerRenderer = null;
+        return;
+      }
+
+      column.footerRenderer = singleTimeRenderer((root) => {
+        // Clear previous contents
+        root.innerHTML = '';
+        // Add content
+        if (content instanceof Node) {
+          root.appendChild(content);
+        } else {
+          root.textContent = content;
+        }
+      });
+    };
+
+    grid.addEventListener(
+      'vaadin-context-menu-before-open',
+      (e) => {
+        const { key, columnId } = e.detail;
+        grid.$server.updateContextMenuTargetItem(key, columnId);
+      }
+    );
+
+    grid.getContextMenuBeforeOpenDetail = (event) => {
+      // For `contextmenu` events, we need to access the source event,
+      // when using open on click we just use the click event itself
+      const sourceEvent = event.detail.sourceEvent || event;
+      const eventContext = grid.getEventContext(sourceEvent);
+      const key = eventContext.item?.key || '';
+      const columnId = eventContext.column?.id || '';
+      return { key, columnId };
+    };
+
+    grid.preventContextMenu = (event) => {
+        const isLeftClick = event.type === 'click';
+        const { column } = grid.getEventContext(event);
+
+        return isLeftClick && column instanceof GridFlowSelectionColumn;
+    };
+
+    grid.addEventListener(
+      'click',
+      (e) => _fireClickEvent(e, 'item-click')
+    );
+    grid.addEventListener(
+      'dblclick',
+      (e) => _fireClickEvent(e, 'item-double-click')
+    );
+
+    grid.addEventListener(
+      'column-resize',
+      (e) => {
+        const cols = grid._getColumnsInOrder().filter((col) => !col.hidden);
+
+        cols.forEach((col) => {
+          col.dispatchEvent(new CustomEvent('column-drag-resize'));
+        });
+
+        grid.dispatchEvent(
+          new CustomEvent('column-drag-resize', {
+            detail: {
+              resizedColumnKey: e.detail.resizedColumn._flowId
+            }
+          })
+        );
+      }
+    );
+
+    grid.addEventListener(
+      'column-reorder',
+      (e) => {
+        const columns = grid._columnTree
+          .slice(0)
+          .pop()
+          .filter((c) => c._flowId)
+          .sort((b, a) => b._order - a._order)
+          .map((c) => c._flowId);
+
+        grid.dispatchEvent(
+          new CustomEvent('column-reorder-all-columns', {
+            detail: { columns }
+          })
+        );
+      }
+    );
+
+    grid.addEventListener(
+      'cell-focus',
+      (e) => {
+        const eventContext = grid.getEventContext(e);
+        const expectedSectionValues = ['header', 'body', 'footer'];
+
+        if (expectedSectionValues.indexOf(eventContext.section) === -1) {
           return;
         }
-        return (part.row || '') + ' ' + ((column && part[column._flowId]) || '');
-      });
 
-      grid.dropFilter = tryCatchWrapper((rowData) => rowData.item && !rowData.item.dropDisabled);
+        grid.dispatchEvent(
+          new CustomEvent('grid-cell-focus', {
+            detail: {
+              itemKey: eventContext.item ? eventContext.item.key : null,
 
-      grid.dragFilter = tryCatchWrapper((rowData) => rowData.item && !rowData.item.dragDisabled);
+              internalColumnId: eventContext.column ? eventContext.column._flowId : null,
 
-      grid.addEventListener(
-        'grid-dragstart',
-        tryCatchWrapper((e) => {
-          if (grid._isSelected(e.detail.draggedItems[0])) {
-            // Dragging selected (possibly multiple) items
-            if (grid.__selectionDragData) {
-              Object.keys(grid.__selectionDragData).forEach((type) => {
-                e.detail.setDragData(type, grid.__selectionDragData[type]);
-              });
-            } else {
-              (grid.__dragDataTypes || []).forEach((type) => {
-                e.detail.setDragData(type, e.detail.draggedItems.map((item) => item.dragData[type]).join('\n'));
-              });
+              section: eventContext.section
             }
+          })
+        );
+      }
+    );
 
-            if (grid.__selectionDraggedItemsCount > 1) {
-              e.detail.setDraggedItemsCount(grid.__selectionDraggedItemsCount);
-            }
+    function _fireClickEvent(event, eventName) {
+      // Click event was handled by the component inside grid, do nothing.
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      const path = event.composedPath();
+      const idx = path.findIndex((node) => node.localName === 'td' || node.localName === 'th');
+      const content = path.slice(0, idx);
+
+      // Do not fire item click event if cell content contains focusable elements.
+      // Use this instead of event.target to detect cases like icon inside button.
+      // See https://github.com/vaadin/flow-components/issues/4065
+      if (content.some((node) => isFocusable(node) || node instanceof HTMLLabelElement)) {
+        return;
+      }
+
+      const eventContext = grid.getEventContext(event);
+      const section = eventContext.section;
+
+      if (eventContext.item && section !== 'details') {
+        event.itemKey = eventContext.item.key;
+        // if you have a details-renderer, getEventContext().column is undefined
+        if (eventContext.column) {
+          event.internalColumnId = eventContext.column._flowId;
+        }
+        grid.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+      }
+    }
+
+    grid.cellClassNameGenerator = (column, rowData) => {
+      const style = rowData.item.style;
+      if (!style) {
+        return;
+      }
+      return (style.row || '') + ' ' + ((column && style[column._flowId]) || '');
+    };
+
+    grid.cellPartNameGenerator = (column, rowData) => {
+      const part = rowData.item.part;
+      if (!part) {
+        return;
+      }
+      return (part.row || '') + ' ' + ((column && part[column._flowId]) || '');
+    };
+
+    grid.dropFilter = (rowData) => rowData.item && !rowData.item.dropDisabled;
+
+    grid.dragFilter = (rowData) => rowData.item && !rowData.item.dragDisabled;
+
+    grid.addEventListener(
+      'grid-dragstart',
+      (e) => {
+        if (grid._isSelected(e.detail.draggedItems[0])) {
+          // Dragging selected (possibly multiple) items
+          if (grid.__selectionDragData) {
+            Object.keys(grid.__selectionDragData).forEach((type) => {
+              e.detail.setDragData(type, grid.__selectionDragData[type]);
+            });
           } else {
-            // Dragging just one (non-selected) item
             (grid.__dragDataTypes || []).forEach((type) => {
-              e.detail.setDragData(type, e.detail.draggedItems[0].dragData[type]);
+              e.detail.setDragData(type, e.detail.draggedItems.map((item) => item.dragData[type]).join('\n'));
             });
           }
+<<<<<<< HEAD
         })
       );
 
@@ -1209,4 +1258,19 @@ window.Vaadin.Flow.gridConnector = {
         return item?.selectable === undefined || item.selectable;
       });
     })(grid)
+=======
+
+          if (grid.__selectionDraggedItemsCount > 1) {
+            e.detail.setDraggedItemsCount(grid.__selectionDraggedItemsCount);
+          }
+        } else {
+          // Dragging just one (non-selected) item
+          (grid.__dragDataTypes || []).forEach((type) => {
+            e.detail.setDragData(type, e.detail.draggedItems[0].dragData[type]);
+          });
+        }
+      }
+    );
+  }
+>>>>>>> 3bc94eb6a9 (refactor: remove tryCatchWrapper from connectors)
 };

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -15,10 +15,6 @@
  */
 import './contextMenuConnector.js';
 
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Menu Bar');
-};
-
 /**
  * Initializes the connector for a menu bar element.
  *
@@ -52,7 +48,7 @@ function initLazy(menubar, appId) {
      *
      * @param {number | undefined} nodeId
      */
-    generateItems: tryCatchWrapper((nodeId) => {
+    generateItems(nodeId) {
       if (!menubar.shadowRoot) {
         // workaround for https://github.com/vaadin/flow/issues/5722
         setTimeout(() => menubar.$connector.generateItems(nodeId));
@@ -111,7 +107,7 @@ function initLazy(menubar, appId) {
           });
         }
       });
-    })
+    }
   };
 }
 
@@ -123,11 +119,4 @@ function setClassName(component) {
   }
 }
 
-window.Vaadin.Flow.menubarConnector = {
-  initLazy(...args) {
-    return tryCatchWrapper(initLazy)(...args);
-  },
-  setClassName(...args) {
-    return tryCatchWrapper(setClassName)(...args);
-  }
-};
+window.Vaadin.Flow.menubarConnector = { initLazy, setClassName };

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/resources/META-INF/resources/frontend/messageListConnector.js
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/resources/META-INF/resources/frontend/messageListConnector.js
@@ -13,27 +13,21 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Message List');
-};
-
 window.Vaadin.Flow.messageListConnector = {
-  setItems: (list, items, locale) =>
-    tryCatchWrapper(function (list, items, locale) {
-      const formatter = new Intl.DateTimeFormat(locale, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric'
-      });
-      list.items = items.map((item) =>
-        item.time
-          ? Object.assign(item, {
-              time: formatter.format(new Date(item.time))
-            })
-          : item
-      );
-    })(list, items, locale)
+  setItems(list, items, locale) {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric'
+    });
+    list.items = items.map((item) =>
+      item.time
+        ? Object.assign(item, {
+            time: formatter.format(new Date(item.time))
+          })
+        : item
+    );
+  }
 };

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -229,6 +229,7 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         // is no longer used so the registration is cleared by the renderer
         // registration.
         registrations.add(container.addAttachListener(e -> {
+            System.out.println(UI.getCurrent());
             setElementRenderer(container, rendererName, getTemplateExpression(),
                     returnChannel, clientCallablesArray, propertyNamespace);
         }));

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -229,7 +229,6 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         // is no longer used so the registration is cleared by the renderer
         // registration.
         registrations.add(container.addAttachListener(e -> {
-            System.out.println(UI.getCurrent());
             setElementRenderer(container, rendererName, getTemplateExpression(),
                     returnChannel, clientCallablesArray, propertyNamespace);
         }));

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
@@ -1,25 +1,20 @@
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select');
-};
+function initLazy(select) {
+  // do not init this connector twice for the given select
+  if (select.$connector) {
+    return;
+  }
 
-window.Vaadin.Flow.selectConnector = {
-  initLazy: (select) =>
-    tryCatchWrapper(function (select) {
-      // do not init this connector twice for the given select
-      if (select.$connector) {
-        return;
+  select.$connector = {};
+
+  select.renderer = (root) => {
+    const listBox = select.querySelector('vaadin-select-list-box');
+    if (listBox) {
+      if (root.firstChild) {
+        root.removeChild(root.firstChild);
       }
+      root.appendChild(listBox);
+    }
+  };
+}
 
-      select.$connector = {};
-
-      select.renderer = tryCatchWrapper(function (root) {
-        const listBox = select.querySelector('vaadin-select-list-box');
-        if (listBox) {
-          if (root.firstChild) {
-            root.removeChild(root.firstChild);
-          }
-          root.appendChild(listBox);
-        }
-      });
-    })(select)
-};
+window.Vaadin.Flow.selectConnector = { initLazy };

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
@@ -1,4 +1,5 @@
-function initLazy(select) {
+window.Vaadin.Flow.selectConnector = {}
+window.Vaadin.Flow.selectConnector.initLazy = (select) => {
   // do not init this connector twice for the given select
   if (select.$connector) {
     return;
@@ -16,5 +17,3 @@ function initLazy(select) {
     }
   };
 }
-
-window.Vaadin.Flow.selectConnector = { initLazy };

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -34,7 +34,8 @@ function parseISO(text) {
   }
 };
 
-function initLazy(timepicker) {
+window.Vaadin.Flow.timepickerConnector = {};
+window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
   // Check whether the connector was already initialized for the timepicker
   if (timepicker.$connector) {
     return;
@@ -182,5 +183,3 @@ function initLazy(timepicker) {
     }
   };
 }
-
-window.Vaadin.Flow.timepickerConnector = { initLazy };

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/vaadin-time-picker/timepickerConnector.js
@@ -10,10 +10,6 @@ import {
 } from './helpers.js';
 import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
 
-const tryCatchWrapper = function (callback) {
-  return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker');
-};
-
 // Execute callback when predicate returns true.
 // Try again later if predicate returns false.
 function when(predicate, callback, timeout = 0) {
@@ -38,154 +34,153 @@ function parseISO(text) {
   }
 };
 
-window.Vaadin.Flow.timepickerConnector = {
-  initLazy: (timepicker) =>
-    tryCatchWrapper(function (timepicker) {
-      // Check whether the connector was already initialized for the timepicker
-      if (timepicker.$connector) {
-        return;
+function initLazy(timepicker) {
+  // Check whether the connector was already initialized for the timepicker
+  if (timepicker.$connector) {
+    return;
+  }
+
+  timepicker.$connector = {};
+
+  timepicker.$connector.setLocale = (locale) => {
+    // capture previous value if any
+    let previousValueObject;
+    if (timepicker.value && timepicker.value !== '') {
+      previousValueObject = parseISO(timepicker.value);
+    }
+
+    try {
+      // Check whether the locale is supported by the browser or not
+      TEST_PM_TIME.toLocaleTimeString(locale);
+    } catch (e) {
+      locale = 'en-US';
+      // FIXME should do a callback for server to throw an exception ?
+      throw new Error(
+        'vaadin-time-picker: The locale ' +
+          locale +
+          ' is not supported, falling back to default locale setting(en-US).'
+      );
+    }
+
+    // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?
+    const pmString = getPmString(locale);
+    const amString = getAmString(locale);
+
+    // 2. What is the separator ?
+    const separator = getSeparator(locale);
+
+    const includeSeconds = function () {
+      return timepicker.step && timepicker.step < 60;
+    };
+
+    const includeMilliSeconds = function () {
+      return timepicker.step && timepicker.step < 1;
+    };
+
+    let cachedTimeString;
+    let cachedTimeObject;
+
+    timepicker.i18n = {
+      formatTime(timeObject) {
+        if (!timeObject) return;
+
+        const timeToBeFormatted = new Date();
+        timeToBeFormatted.setHours(timeObject.hours);
+        timeToBeFormatted.setMinutes(timeObject.minutes);
+        timeToBeFormatted.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
+
+        // the web component expects the correct granularity used for the time string,
+        // thus need to format the time object in correct granularity by passing the format options
+        let localeTimeString = timeToBeFormatted.toLocaleTimeString(locale, {
+          hour: 'numeric',
+          minute: 'numeric',
+          second: includeSeconds() ? 'numeric' : undefined
+        });
+
+        // milliseconds not part of the time format API
+        if (includeMilliSeconds()) {
+          localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds, amString, pmString);
+        }
+
+        return localeTimeString;
+      },
+
+      parseTime(timeString) {
+        if (timeString && timeString === cachedTimeString && cachedTimeObject) {
+          return cachedTimeObject;
+        }
+
+        if (!timeString) {
+          // when nothing is returned, the component shows the invalid state for the input
+          return;
+        }
+
+        const amToken = searchAmOrPmToken(timeString, amString);
+        const pmToken = searchAmOrPmToken(timeString, pmString);
+
+        const numbersOnlyTimeString = timeString
+          .replace(amToken || '', '')
+          .replace(pmToken || '', '')
+          .trim();
+
+        // A regexp that allows to find the numbers with optional separator and continuing searching after it.
+        const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + separator + ')?', 'g');
+
+        let hours = numbersRegExp.exec(numbersOnlyTimeString);
+        if (hours) {
+          hours = parseDigitsIntoInteger(hours[0].replace(separator, ''));
+          // handle 12 am -> 0
+          // do not do anything if am & pm are not used or if those are the same,
+          // as with locale bg-BG there is always ч. at the end of the time
+          if (amToken !== pmToken) {
+            if (hours === 12 && amToken) {
+              hours = 0;
+            }
+            if (hours !== 12 && pmToken) {
+              hours += 12;
+            }
+          }
+          const minutes = numbersRegExp.exec(numbersOnlyTimeString);
+          const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
+          // detecting milliseconds from input, expects am/pm removed from end, eg. .0 or .00 or .000
+          const millisecondRegExp = /[[\.][\d\u0660-\u0669]{1,3}$/;
+          // reset to end or things can explode
+          let milliseconds = seconds && includeMilliSeconds() && millisecondRegExp.exec(numbersOnlyTimeString);
+          // handle case where last numbers are seconds and . is the separator (invalid regexp match)
+          if (milliseconds && milliseconds['index'] <= seconds['index']) {
+            milliseconds = undefined;
+          }
+          // hours is a number at this point, others are either arrays or null
+          // the string in [0] from the arrays includes the separator too
+          cachedTimeObject = hours !== undefined && {
+            hours: hours,
+            minutes: minutes ? parseDigitsIntoInteger(minutes[0].replace(separator, '')) : 0,
+            seconds: seconds ? parseDigitsIntoInteger(seconds[0].replace(separator, '')) : 0,
+            milliseconds:
+              minutes && seconds && milliseconds
+                ? parseMillisecondsIntoInteger(milliseconds[0].replace('.', ''))
+                : 0
+          };
+          cachedTimeString = timeString;
+          return cachedTimeObject;
+        }
       }
+    };
 
-      timepicker.$connector = {};
-
-      timepicker.$connector.setLocale = tryCatchWrapper(function (locale) {
-        // capture previous value if any
-        let previousValueObject;
-        if (timepicker.value && timepicker.value !== '') {
-          previousValueObject = parseISO(timepicker.value);
+    if (previousValueObject) {
+      when(
+        () => timepicker.$,
+        () => {
+          const newValue = timepicker.i18n.formatTime(previousValueObject);
+          // FIXME works but uses private API, needs fixes in web component
+          if (timepicker.inputElement.value !== newValue) {
+            timepicker.inputElement.value = newValue;
+            timepicker.$.comboBox.value = newValue;
+          }
         }
+      );
+    }
+  };
+}
 
-        try {
-          // Check whether the locale is supported by the browser or not
-          TEST_PM_TIME.toLocaleTimeString(locale);
-        } catch (e) {
-          locale = 'en-US';
-          // FIXME should do a callback for server to throw an exception ?
-          throw new Error(
-            'vaadin-time-picker: The locale ' +
-              locale +
-              ' is not supported, falling back to default locale setting(en-US).'
-          );
-        }
-
-        // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?
-        const pmString = getPmString(locale);
-        const amString = getAmString(locale);
-
-        // 2. What is the separator ?
-        const separator = getSeparator(locale);
-
-        const includeSeconds = function () {
-          return timepicker.step && timepicker.step < 60;
-        };
-
-        const includeMilliSeconds = function () {
-          return timepicker.step && timepicker.step < 1;
-        };
-
-        let cachedTimeString;
-        let cachedTimeObject;
-
-        timepicker.i18n = {
-          formatTime: tryCatchWrapper(function (timeObject) {
-            if (!timeObject) return;
-
-            const timeToBeFormatted = new Date();
-            timeToBeFormatted.setHours(timeObject.hours);
-            timeToBeFormatted.setMinutes(timeObject.minutes);
-            timeToBeFormatted.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
-
-            // the web component expects the correct granularity used for the time string,
-            // thus need to format the time object in correct granularity by passing the format options
-            let localeTimeString = timeToBeFormatted.toLocaleTimeString(locale, {
-              hour: 'numeric',
-              minute: 'numeric',
-              second: includeSeconds() ? 'numeric' : undefined
-            });
-
-            // milliseconds not part of the time format API
-            if (includeMilliSeconds()) {
-              localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds, amString, pmString);
-            }
-
-            return localeTimeString;
-          }),
-
-          parseTime: tryCatchWrapper(function (timeString) {
-            if (timeString && timeString === cachedTimeString && cachedTimeObject) {
-              return cachedTimeObject;
-            }
-
-            if (!timeString) {
-              // when nothing is returned, the component shows the invalid state for the input
-              return;
-            }
-
-            const amToken = searchAmOrPmToken(timeString, amString);
-            const pmToken = searchAmOrPmToken(timeString, pmString);
-
-            const numbersOnlyTimeString = timeString
-              .replace(amToken || '', '')
-              .replace(pmToken || '', '')
-              .trim();
-
-            // A regexp that allows to find the numbers with optional separator and continuing searching after it.
-            const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + separator + ')?', 'g');
-
-            let hours = numbersRegExp.exec(numbersOnlyTimeString);
-            if (hours) {
-              hours = parseDigitsIntoInteger(hours[0].replace(separator, ''));
-              // handle 12 am -> 0
-              // do not do anything if am & pm are not used or if those are the same,
-              // as with locale bg-BG there is always ч. at the end of the time
-              if (amToken !== pmToken) {
-                if (hours === 12 && amToken) {
-                  hours = 0;
-                }
-                if (hours !== 12 && pmToken) {
-                  hours += 12;
-                }
-              }
-              const minutes = numbersRegExp.exec(numbersOnlyTimeString);
-              const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
-              // detecting milliseconds from input, expects am/pm removed from end, eg. .0 or .00 or .000
-              const millisecondRegExp = /[[\.][\d\u0660-\u0669]{1,3}$/;
-              // reset to end or things can explode
-              let milliseconds = seconds && includeMilliSeconds() && millisecondRegExp.exec(numbersOnlyTimeString);
-              // handle case where last numbers are seconds and . is the separator (invalid regexp match)
-              if (milliseconds && milliseconds['index'] <= seconds['index']) {
-                milliseconds = undefined;
-              }
-              // hours is a number at this point, others are either arrays or null
-              // the string in [0] from the arrays includes the separator too
-              cachedTimeObject = hours !== undefined && {
-                hours: hours,
-                minutes: minutes ? parseDigitsIntoInteger(minutes[0].replace(separator, '')) : 0,
-                seconds: seconds ? parseDigitsIntoInteger(seconds[0].replace(separator, '')) : 0,
-                milliseconds:
-                  minutes && seconds && milliseconds
-                    ? parseMillisecondsIntoInteger(milliseconds[0].replace('.', ''))
-                    : 0
-              };
-              cachedTimeString = timeString;
-              return cachedTimeObject;
-            }
-          })
-        };
-
-        if (previousValueObject) {
-          when(
-            () => timepicker.$,
-            () => {
-              const newValue = timepicker.i18n.formatTime(previousValueObject);
-              // FIXME works but uses private API, needs fixes in web component
-              if (timepicker.inputElement.value !== newValue) {
-                timepicker.inputElement.value = newValue;
-                timepicker.$.comboBox.value = newValue;
-              }
-            }
-          );
-        }
-      });
-    })(timepicker)
-};
+window.Vaadin.Flow.timepickerConnector = { initLazy };


### PR DESCRIPTION
## Description

Why tryCatchWrapper is problematic:

- It suppresses exceptions in favour of console error messages. However, the stack trace that the browser displays with these messages omits the function call that caused the original exception, making it much less helpful
- It introduces an extra layer of code nesting, which has a negative impact on the readability and maintainability
- Its error coverage is still limited e.g. it doesn't catch errors in asynchronous contexts created by the web component, where no connector methods are invoked
- It pollutes the stack trace with its own calls, which can be distracting when debugging
- It must be applied to every function including setTimeout callbacks, which is easy to miss

We have decided that the drawbacks now outweigh the benefits, so we are choosing to remove it.

| Before | After |
|--------|------|
| <img width="620" alt="image" src="https://github.com/user-attachments/assets/814d775d-7a14-4af4-b69e-5a1a07167d39"> | <img width="617" alt="image" src="https://github.com/user-attachments/assets/ebfacc65-fe5d-4933-b99b-5a73502ef29f"> |


> [!NOTE]
> I recommend reviewing this PR with "Hide whitespaces" enabled.

## Type of change

- [x] Refactor
