### PR TITLE
fix: ignore non-column children when setting column order

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -174,8 +174,8 @@ class GridColumnOrderHelper<T> {
 
         // holds the current immediate child columns.
         final Set<AbstractColumn<?>> childColumns = new HashSet<>();
-        column.getChildren().filter(c -> !(c instanceof GridSelectionColumn))
-                .forEach(it -> childColumns.add((AbstractColumn) it));
+        column.getChildren().filter(c -> c instanceof AbstractColumn<?>)
+                .forEach(it -> childColumns.add((AbstractColumn<?>) it));
         // the new order of the children is computed here.
         final List<AbstractColumn<?>> newOrder = new ArrayList<>();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.data.renderer.IconRenderer;
 
@@ -312,6 +313,16 @@ public class GridColumnOrderTest {
                 thirdColumn);
         assertArrayEquals(new Object[] { firstColumn, fourthColumn,
                 secondColumn, thirdColumn }, grid.getColumns().toArray());
+    }
+
+    @Test
+    public void setColumnOrder_ignoresNonColumnChildren() {
+        grid.setEmptyStateComponent(new Div());
+
+        grid.setColumnOrder(fourthColumn, thirdColumn, secondColumn,
+                firstColumn);
+        assertArrayEquals(new Object[] { fourthColumn, thirdColumn,
+                secondColumn, firstColumn }, grid.getColumns().toArray());
     }
 
     private String dumpColumnHierarchyFromDOM() {


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/6730