### PR TITLE
fix: access UI through container element in ComponentRenderer (#6759) (CP: 24.4)

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/ComponentRendererInNewThreadIT.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/ComponentRendererInNewThreadIT.java
@@ -16,8 +16,10 @@
 package com.vaadin.flow.data.renderer.tests;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
@@ -25,16 +27,32 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-renderer-flow/component-renderer-in-new-thread")
 public class ComponentRendererInNewThreadIT extends AbstractComponentIT {
 
-    @Test
-    public void componentRendererInNewThread_uiNotNullWhileTemplateExpressionIsCalculated() {
+    @Before
+    public void init() {
         open();
-        findElement(By.id("add-component")).click();
+    }
 
-        waitUntil(driver -> findElement(By.id("null-ui-count")) != null
-                && findElement(By.id("non-null-ui-count")) != null, 2);
+    @Test
+    public void addComponentRendererBeforeAttach_componentIsRendered() {
+        findElement(By.id("add-component-renderer-before-attach")).click();
 
-        Assert.assertEquals("0", findElement(By.id("null-ui-count")).getText());
-        Assert.assertNotEquals("0",
-                findElement(By.id("non-null-ui-count")).getText());
+        WebElement component = waitUntil(driver -> findElement(
+                By.tagName("lit-renderer-test-component")));
+
+        WebElement item0 = component.findElement(By.id("item-0"));
+        Assert.assertNotNull(item0);
+        Assert.assertEquals("Item", item0.getText());
+    }
+
+    @Test
+    public void addComponentRendererAfterAttach_componentIsRendered() {
+        findElement(By.id("add-component-renderer-after-attach")).click();
+
+        WebElement component = waitUntil(driver -> findElement(
+                By.tagName("lit-renderer-test-component")));
+
+        WebElement item0 = component.findElement(By.id("item-0"));
+        Assert.assertNotNull(item0);
+        Assert.assertEquals("Item", item0.getText());
     }
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.data.renderer;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataGenerator;
@@ -144,12 +143,7 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
 
     @Override
     protected String getTemplateExpression() {
-        var appId = UI.getCurrent() != null
-                ? UI.getCurrent().getInternals().getAppId()
-                : "";
-
-        return "${Vaadin.FlowComponentHost.getNode('" + appId
-                + "', item.nodeid)}";
+        return "${Vaadin.FlowComponentHost.getNode(appId, item.nodeid)}";
     }
 
     Element getOwner() {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
@@ -160,13 +161,21 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
         };
     }
 
+    private UI getElementUI(Element element) {
+        return ((StateTree) element.getNode().getOwner()).getUI();
+    }
+
     private void setElementRenderer(Element container, String rendererName,
             String templateExpression, ReturnChannelRegistration returnChannel,
             JsonArray clientCallablesArray, String propertyNamespace) {
+        assert container.getNode().isAttached() : "Container must be attached";
+
+        String appId = getElementUI(container).getInternals().getAppId();
+
         container.executeJs(
-                "window.Vaadin.setLitRenderer(this, $0, $1, $2, $3, $4)",
+                "window.Vaadin.setLitRenderer(this, $0, $1, $2, $3, $4, $5)",
                 rendererName, templateExpression, returnChannel,
-                clientCallablesArray, propertyNamespace);
+                clientCallablesArray, propertyNamespace, appId);
     }
 
     /**

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/lit-renderer.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/lit-renderer.ts
@@ -34,13 +34,14 @@ _window.Vaadin.setLitRenderer = (
   returnChannel: (name: string, itemKey: string, args: any[]) => void,
   clientCallables: string[],
   propertyNamespace: string,
+  appId: string
 ) => {
   // Dynamically created function that renders the templateExpression
   // inside the given root element using Lit
   const renderFunction = Function(`
     "use strict";
 
-    const [render, html, live, returnChannel] = arguments;
+    const [render, html, live, appId, returnChannel] = arguments;
 
     return (root, model, itemKey) => {
       const { item, index } = model;
@@ -58,7 +59,7 @@ _window.Vaadin.setLitRenderer = (
 
       render(html\`${templateExpression}\`, root)
     }
-  `)(render, html, live, returnChannel);
+  `)(render, html, live, appId, returnChannel);
 
   const renderer: Renderer = (root, _, model) => {
     const { item } = model;


### PR DESCRIPTION
## Description

Cherry-picks #6759 to 24.4

There was one merge conflict in `lit-renderer.ts` because the `renderFunction` function is written differently in 24.4

## Type of change

- [x] Bugfix
