### PR TITLE
feat: add position API to Dialog

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -192,6 +192,8 @@ public class DialogTestPage extends Div {
         dialog.setDraggable(true);
         dialog.setWidth("200px");
         dialog.setHeight("200px");
+        dialog.setTop("50px");
+        dialog.setLeft("50px");
 
         Div message = new Div();
         message.setId("dialog-resizable-draggable-message");
@@ -214,6 +216,13 @@ public class DialogTestPage extends Div {
                 e -> dialog.open());
         openDialog.setId("dialog-resizable-draggable-open-button");
 
+        NativeButton setPosition = new NativeButton("set custom position",
+                e -> {
+                    dialog.setTop("100px");
+                    dialog.setLeft("200px");
+                });
+        setPosition.setId("dialog-resizable-draggable-set-position-button");
+
         NativeButton sizeRestrictions = new NativeButton(
                 "set resizing restrictions", e -> {
                     dialog.setMinWidth("175px");
@@ -223,7 +232,7 @@ public class DialogTestPage extends Div {
                 });
         sizeRestrictions.setId("dialog-resizing-restrictions-button");
 
-        add(openDialog, message, sizeRestrictions);
+        add(openDialog, setPosition, message, sizeRestrictions);
     }
 
     private void changeDialogDimensions() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -192,8 +192,6 @@ public class DialogTestPage extends Div {
         dialog.setDraggable(true);
         dialog.setWidth("200px");
         dialog.setHeight("200px");
-        dialog.setTop("50px");
-        dialog.setLeft("50px");
 
         Div message = new Div();
         message.setId("dialog-resizable-draggable-message");

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -162,18 +162,6 @@ public class DialogTestPageIT extends AbstractComponentIT {
         assertButtonText(1);
     }
 
-    @Test
-    public void setDialogPosition() {
-        findElement(By.id("dialog-resizable-draggable-set-position-button"))
-                .click();
-        findElement(By.id("dialog-resizable-draggable-open-button")).click();
-
-        TestBenchElement dialogOverlay = $("*").id("overlay");
-        TestBenchElement overlay = dialogOverlay.$("*").id("overlay");
-        Assert.assertEquals("100px", overlay.getCssValue("top"));
-        Assert.assertEquals("200px", overlay.getCssValue("left"));
-    }
-
     private void assertButtonText(int index) {
         Assert.assertEquals("Button Text is not correct", "Added Button",
                 findElements(By.cssSelector(DIALOG_OVERLAY_TAG)).get(0)
@@ -450,6 +438,18 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertNotEquals(overlayLeft, overlay.getCssValue("left"));
         Assert.assertNotEquals(overlayTop, overlay.getCssValue("top"));
+    }
+
+    @Test
+    public void setDialogPosition() {
+        findElement(By.id("dialog-resizable-draggable-set-position-button"))
+                .click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        TestBenchElement dialogOverlay = $("*").id("overlay");
+        TestBenchElement overlay = dialogOverlay.$("*").id("overlay");
+        Assert.assertEquals("100px", overlay.getCssValue("top"));
+        Assert.assertEquals("200px", overlay.getCssValue("left"));
     }
 
     /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -162,6 +162,18 @@ public class DialogTestPageIT extends AbstractComponentIT {
         assertButtonText(1);
     }
 
+    @Test
+    public void setDialogPosition() {
+        findElement(By.id("dialog-resizable-draggable-set-position-button"))
+                .click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        TestBenchElement dialogOverlay = $("*").id("overlay");
+        TestBenchElement overlay = dialogOverlay.$("*").id("overlay");
+        Assert.assertEquals("100px", overlay.getCssValue("top"));
+        Assert.assertEquals("200px", overlay.getCssValue("left"));
+    }
+
     private void assertButtonText(int index) {
         Assert.assertEquals("Button Text is not correct", "Added Button",
                 findElements(By.cssSelector(DIALOG_OVERLAY_TAG)).get(0)

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -141,6 +141,51 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
+     * Gets the top position of the overlay.
+     *
+     * @return the top position of the overlay
+     */
+    public String getTop() {
+        return getElement().getProperty("top");
+    }
+
+    /**
+     * Sets the top position of the overlay. If a unitless number is provided,
+     * pixels are assumed.
+     * <p>
+     * Note that the overlay top edge may not be the same as the viewport top
+     * edge (e.g. the "Lumo" theme defines some spacing to prevent the overlay
+     * from stretching all the way to the top of the viewport).
+     *
+     * @param top
+     *            the top position of the overlay
+     */
+    public void setTop(String top) {
+        getElement().setProperty("top", top);
+    }
+
+    /**
+     * Gets the left position of the overlay.
+     *
+     * @return the left position of the overlay
+     */
+    public String getLeft() {
+        return getElement().getProperty("left");
+    }
+
+    /**
+     * Sets the distance of the overlay from the left of its container. If a
+     * unitless number is provided, pixels are assumed.
+     * <p>
+     * Note that the overlay left edge may not be the same as the viewport left
+     * edge (e.g. the "Lumo" theme defines some spacing to prevent the overlay
+     * from stretching all the way to the left of the viewport).
+     */
+    public void setLeft(String left) {
+        getElement().setProperty("left", left);
+    }
+
+    /**
      * `resize` event is sent when the user finishes resizing the overlay.
      */
     @DomEvent("resize")

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -180,6 +180,9 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * Note that the overlay left edge may not be the same as the viewport left
      * edge (e.g. the "Lumo" theme defines some spacing to prevent the overlay
      * from stretching all the way to the left of the viewport).
+     *
+     * @param left
+     *            the left position of the overlay
      */
     public void setLeft(String left) {
         getElement().setProperty("left", left);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -382,6 +382,16 @@ public class DialogTest {
         Assert.assertNull(dialog.getElement().getParent());
     }
 
+    @Test
+    public void position_setTopLeft_positionIsDefined() {
+        Dialog dialog = new Dialog();
+        dialog.setTop("10px");
+        dialog.setLeft("20px");
+
+        Assert.assertEquals("10px", dialog.getTop());
+        Assert.assertEquals("20px", dialog.getLeft());
+    }
+
     private void fakeClientResponse() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {


### PR DESCRIPTION
## Description

Adds the position API that uses the newly introduced `top` and `left` properties added to the Dialog web component.

Part of https://github.com/vaadin/web-components/issues/1060

## Type of change

- Feature
