### PR TITLE
feat: add `dragged` event to Dialog

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -84,7 +84,10 @@ public class DialogTestPage extends Div {
             eventSourceMessage.setText("The event came from "
                     + (event.isFromClient() ? "client" : "server"));
         });
-        add(button, message, eventCounterMessage, eventSourceMessage, dialog);
+        add(button, new NativeButton("set top/left", e -> {
+            dialog.setTop("100px");
+            dialog.setLeft("300px");
+        }), message, eventCounterMessage, eventSourceMessage, dialog);
     }
 
     private void createDialogWithoutAddingToTheUi() {
@@ -197,13 +200,19 @@ public class DialogTestPage extends Div {
         message.setId("dialog-resizable-draggable-message");
 
         dialog.addResizeListener(e -> message.setText(String.format(
-                "Resize listener called with width (%d) and height (%d)",
+                "Resize listener called with top (%d), left (%d), width (%d) and height (%d)",
+                getDimension(e.getTop()), getDimension(e.getLeft()),
                 getDimension(e.getWidth()), getDimension(e.getHeight()))));
 
-        dialog.addOpenedChangeListener(e -> message.setText(
-                String.format("Initial size with width (%d) and height (%d)",
-                        getDimension(dialog.getWidth()),
-                        getDimension(dialog.getHeight()))));
+        dialog.addDraggedListener(e -> message.setText(String.format(
+                "Dragged listener called with top (%d) and left (%d)",
+                getDimension(e.getTop()), getDimension(e.getLeft()))));
+
+        dialog.addOpenedChangeListener(e -> message.setText(String.format(
+                "Initial size with top (%d), left (%d), width (%d) and height (%d)",
+                getDimension(dialog.getTop()), getDimension(dialog.getLeft()),
+                getDimension(dialog.getWidth()),
+                getDimension(dialog.getHeight()))));
 
         NativeButton closeButton = new NativeButton(CLOSE_CAPTION,
                 e -> dialog.close());

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -185,6 +185,9 @@ public class DialogTestPage extends Div {
     }
 
     private int getDimension(String dimension) {
+        if (dimension == null) {
+            return -1;
+        }
         return (int) Math.round(Float.parseFloat(dimension.replace("px", "")));
     }
 
@@ -219,6 +222,14 @@ public class DialogTestPage extends Div {
         closeButton.setId("dialog-resizable-draggable-close-button");
         dialog.add(closeButton);
 
+        NativeButton setInitialPosition = new NativeButton(
+                "set initial position", e -> {
+                    dialog.setTop("50px");
+                    dialog.setLeft("50px");
+                });
+        setInitialPosition.setId(
+                "dialog-resizable-draggable-set-initial-position-button");
+
         NativeButton openDialog = new NativeButton("open resizable dialog",
                 e -> dialog.open());
         openDialog.setId("dialog-resizable-draggable-open-button");
@@ -239,7 +250,8 @@ public class DialogTestPage extends Div {
                 });
         sizeRestrictions.setId("dialog-resizing-restrictions-button");
 
-        add(openDialog, setPosition, message, sizeRestrictions);
+        add(openDialog, setInitialPosition, setPosition, message,
+                sizeRestrictions);
     }
 
     private void changeDialogDimensions() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -84,10 +84,7 @@ public class DialogTestPage extends Div {
             eventSourceMessage.setText("The event came from "
                     + (event.isFromClient() ? "client" : "server"));
         });
-        add(button, new NativeButton("set top/left", e -> {
-            dialog.setTop("100px");
-            dialog.setLeft("300px");
-        }), message, eventCounterMessage, eventSourceMessage, dialog);
+        add(button, message, eventCounterMessage, eventSourceMessage, dialog);
     }
 
     private void createDialogWithoutAddingToTheUi() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -162,6 +162,24 @@ public class DialogTestPageIT extends AbstractComponentIT {
         assertButtonText(1);
     }
 
+    @Test
+    public void dragDialog_draggedEventFired() {
+        findElement(By.id("dialog-resizable-draggable-set-position-button"))
+                .click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        TestBenchElement dialogOverlay = $("*").id("overlay");
+        TestBenchElement content = dialogOverlay.$("*").id("content");
+
+        Actions draggingAction = new Actions(getDriver());
+        draggingAction.dragAndDropBy(content, 20, 20);
+        draggingAction.perform();
+        Assert.assertEquals(
+                "Dragged listener called with top (120) and left (220)",
+                findElement(By.id("dialog-resizable-draggable-message"))
+                        .getText());
+    }
+
     private void assertButtonText(int index) {
         Assert.assertEquals("Button Text is not correct", "Added Button",
                 findElements(By.cssSelector(DIALOG_OVERLAY_TAG)).get(0)
@@ -343,7 +361,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         WebElement message = findElement(
                 By.id("dialog-resizable-draggable-message"));
 
-        Assert.assertEquals("Initial size with width (200) and height (200)",
+        Assert.assertEquals("Initial size with top (50), left (50), width (200) and height (200)",
                 message.getText());
 
         TestBenchElement overlayContent = getOverlayContent();
@@ -351,13 +369,22 @@ public class DialogTestPageIT extends AbstractComponentIT {
         resizeDialog(overlayContent, 50, 50);
 
         Assert.assertEquals(
-                "Resize listener called with width (250) and height (250)",
+                "Resize listener called with top (50), left (50), width (250) and height (250)",
+                message.getText());
+
+        resizeDialog(overlayContent, -50, -50, "nw");
+
+        Assert.assertEquals("Resize listener called with top (0), left (0), width (300) and height (300)",
                 message.getText());
     }
 
     private void resizeDialog(TestBenchElement overlayContent, int xOffset,
-            int yOffset) {
-        WebElement resizerSE = overlayContent.$(".resizer.se").first();
+        int yOffset) {
+        resizeDialog(overlayContent, xOffset, yOffset, "se");
+    }
+    private void resizeDialog(TestBenchElement overlayContent, int xOffset,
+            int yOffset, String direction) {
+        WebElement resizerSE = overlayContent.$(".resizer." + direction).first();
 
         Actions resizeAction = new Actions(getDriver());
         resizeAction.dragAndDropBy(resizerSE, xOffset, yOffset);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -371,11 +371,11 @@ public class DialogTestPageIT extends AbstractComponentIT {
     }
 
     private void resizeDialog(TestBenchElement overlayContent, int xOffset,
-            int yOffset, String resizer) {
-        WebElement resizerSE = overlayContent.$(".resizer." + resizer).first();
+            int yOffset, String direction) {
+        WebElement resizer = overlayContent.$(".resizer." + direction).first();
 
         Actions resizeAction = new Actions(getDriver());
-        resizeAction.dragAndDropBy(resizerSE, xOffset, yOffset);
+        resizeAction.dragAndDropBy(resizer, xOffset, yOffset);
         resizeAction.perform();
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -162,24 +162,6 @@ public class DialogTestPageIT extends AbstractComponentIT {
         assertButtonText(1);
     }
 
-    @Test
-    public void dragDialog_draggedEventFired() {
-        findElement(By.id("dialog-resizable-draggable-set-position-button"))
-                .click();
-        findElement(By.id("dialog-resizable-draggable-open-button")).click();
-
-        TestBenchElement dialogOverlay = $("*").id("overlay");
-        TestBenchElement content = dialogOverlay.$("*").id("content");
-
-        Actions draggingAction = new Actions(getDriver());
-        draggingAction.dragAndDropBy(content, 20, 20);
-        draggingAction.perform();
-        Assert.assertEquals(
-                "Dragged listener called with top (120) and left (220)",
-                findElement(By.id("dialog-resizable-draggable-message"))
-                        .getText());
-    }
-
     private void assertButtonText(int index) {
         Assert.assertEquals("Button Text is not correct", "Added Button",
                 findElements(By.cssSelector(DIALOG_OVERLAY_TAG)).get(0)
@@ -357,11 +339,15 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
     @Test
     public void resizableDialogListenerIsCalled() {
+        findElement(
+                By.id("dialog-resizable-draggable-set-initial-position-button"))
+                .click();
         findElement(By.id("dialog-resizable-draggable-open-button")).click();
         WebElement message = findElement(
                 By.id("dialog-resizable-draggable-message"));
 
-        Assert.assertEquals("Initial size with top (50), left (50), width (200) and height (200)",
+        Assert.assertEquals(
+                "Initial size with top (50), left (50), width (200) and height (200)",
                 message.getText());
 
         TestBenchElement overlayContent = getOverlayContent();
@@ -374,17 +360,20 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         resizeDialog(overlayContent, -50, -50, "nw");
 
-        Assert.assertEquals("Resize listener called with top (0), left (0), width (300) and height (300)",
+        Assert.assertEquals(
+                "Resize listener called with top (0), left (0), width (300) and height (300)",
                 message.getText());
     }
 
     private void resizeDialog(TestBenchElement overlayContent, int xOffset,
-        int yOffset) {
+            int yOffset) {
         resizeDialog(overlayContent, xOffset, yOffset, "se");
     }
+
     private void resizeDialog(TestBenchElement overlayContent, int xOffset,
             int yOffset, String direction) {
-        WebElement resizerSE = overlayContent.$(".resizer." + direction).first();
+        WebElement resizerSE = overlayContent.$(".resizer." + direction)
+                .first();
 
         Actions resizeAction = new Actions(getDriver());
         resizeAction.dragAndDropBy(resizerSE, xOffset, yOffset);
@@ -465,6 +454,24 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertNotEquals(overlayLeft, overlay.getCssValue("left"));
         Assert.assertNotEquals(overlayTop, overlay.getCssValue("top"));
+    }
+
+    @Test
+    public void dragDialog_draggedEventFired() {
+        findElement(By.id("dialog-resizable-draggable-set-position-button"))
+                .click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        TestBenchElement dialogOverlay = $("*").id("overlay");
+        TestBenchElement content = dialogOverlay.$("*").id("content");
+
+        Actions draggingAction = new Actions(getDriver());
+        draggingAction.dragAndDropBy(content, 20, 20);
+        draggingAction.perform();
+        Assert.assertEquals(
+                "Dragged listener called with top (120) and left (220)",
+                findElement(By.id("dialog-resizable-draggable-message"))
+                        .getText());
     }
 
     @Test

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -371,9 +371,8 @@ public class DialogTestPageIT extends AbstractComponentIT {
     }
 
     private void resizeDialog(TestBenchElement overlayContent, int xOffset,
-            int yOffset, String direction) {
-        WebElement resizerSE = overlayContent.$(".resizer." + direction)
-                .first();
+            int yOffset, String resizer) {
+        WebElement resizerSE = overlayContent.$(".resizer." + resizer).first();
 
         Actions resizeAction = new Actions(getDriver());
         resizeAction.dragAndDropBy(resizerSE, xOffset, yOffset);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -122,8 +122,15 @@ public class Dialog extends Component implements HasComponents, HasSize,
         });
 
         addListener(DialogResizeEvent.class, event -> {
-            width = event.getWidth();
-            height = event.getHeight();
+            setWidth(event.getWidth());
+            setHeight(event.getHeight());
+            setTop(event.getTop());
+            setLeft(event.getLeft());
+        });
+
+        addListener(DialogDraggedEvent.class, event -> {
+            setTop(event.getTop());
+            setLeft(event.getLeft());
         });
 
         setOverlayRole("dialog");
@@ -148,13 +155,19 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
         private final String width;
         private final String height;
+        private final String left;
+        private final String top;
 
         public DialogResizeEvent(Dialog source, boolean fromClient,
                 @EventData("event.detail.width") String width,
-                @EventData("event.detail.height") String height) {
+                @EventData("event.detail.height") String height,
+                @EventData("event.detail.left") String left,
+                @EventData("event.detail.top") String top) {
             super(source, fromClient);
             this.width = width;
             this.height = height;
+            this.left = left;
+            this.top = top;
         }
 
         /**
@@ -173,6 +186,59 @@ public class Dialog extends Component implements HasComponents, HasSize,
          */
         public String getHeight() {
             return height;
+        }
+
+        /**
+         * Gets the left position of the overlay after resize is done
+         *
+         * @return the left position in pixels of the overlay
+         */
+        public String getLeft() {
+            return left;
+        }
+
+        /**
+         * Gets the top position of the overlay after resize is done
+         *
+         * @return the top position in pixels of the overlay
+         */
+        public String getTop() {
+            return top;
+        }
+    }
+
+    /**
+     * `dragged` event is sent when the user finishes dragging the overlay.
+     */
+    @DomEvent("dragged")
+    public static class DialogDraggedEvent extends ComponentEvent<Dialog> {
+        private final String left;
+        private final String top;
+
+        public DialogDraggedEvent(Dialog source, boolean fromClient,
+                @EventData("event.detail.left") String left,
+                @EventData("event.detail.top") String top) {
+            super(source, fromClient);
+            this.left = left;
+            this.top = top;
+        }
+
+        /**
+         * Gets the left position of the overlay after dragging is done
+         *
+         * @return the left position in pixels of the overlay
+         */
+        public String getLeft() {
+            return left;
+        }
+
+        /**
+         * Gets the top position of the overlay after dragging is done
+         *
+         * @return the top position in pixels of the overlay
+         */
+        public String getTop() {
+            return top;
         }
     }
 
@@ -273,11 +339,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * {@link #close()} method should be called explicitly to close the dialog
      * in case there are close listeners.
      *
-     * @see #close()
-     *
      * @param listener
      *            the listener to add
      * @return registration for removal of listener
+     * @see #close()
      */
     public Registration addDialogCloseActionListener(
             ComponentEventListener<DialogCloseActionEvent> listener) {
@@ -321,6 +386,23 @@ public class Dialog extends Component implements HasComponents, HasSize,
     public Registration addResizeListener(
             ComponentEventListener<DialogResizeEvent> listener) {
         return addListener(DialogResizeEvent.class, listener);
+    }
+
+    /**
+     * Adds a listener that is called after user finishes dragging the overlay.
+     * It is called only if dragging is enabled (see
+     * {@link Dialog#setDraggable(boolean)}).
+     * <p>
+     * Note: By default, the component will sync the top/left values after every
+     * dragging.
+     *
+     * @param listener
+     *            the listener to add
+     * @return registration for removal of listener
+     */
+    public Registration addDraggedListener(
+            ComponentEventListener<DialogDraggedEvent> listener) {
+        return addListener(DialogDraggedEvent.class, listener);
     }
 
     /**
@@ -385,7 +467,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
      *
      * @param index
      *            the index, where the component will be added.
-     *
      * @param component
      *            the component to add
      */
@@ -747,9 +828,9 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * For a modal dialog the server-side modality will be removed when dialog
      * is not visible so that interactions can be made in the application.
      *
-     * @see Component#setVisible(boolean)
      * @param visible
      *            dialog visibility
+     * @see Component#setVisible(boolean)
      */
     @Override
     public void setVisible(boolean visible) {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -420,8 +420,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * It is called only if resizing is enabled (see
      * {@link Dialog#setResizable(boolean)}).
      * <p>
-     * Note: By default, the component will sync the width/height values after
-     * every resizing.
+     * Note: By default, the component will sync the width/height and top/left
+     * values after every resizing.
      *
      * @param listener
      *            the listener to add

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.Shortcuts;
@@ -129,6 +130,32 @@ public class DialogTest {
 
         Assert.assertTrue("draggable can be set to true",
                 dialog.getElement().getProperty("draggable", false));
+    }
+
+    @Test
+    public void draggedEvent_TopLeftPropertiesSynced() {
+        Dialog dialog = new Dialog();
+
+        // Emulate a drag event
+        ComponentUtil.fireEvent(dialog,
+                new Dialog.DialogDraggedEvent(dialog, true, "20", "10"));
+
+        Assert.assertEquals("20", dialog.getLeft());
+        Assert.assertEquals("10", dialog.getTop());
+    }
+
+    @Test
+    public void resizeEvent_WidthHeightTopLeftPropertiesSynced() {
+        Dialog dialog = new Dialog();
+
+        // Emulate a resize event
+        ComponentUtil.fireEvent(dialog, new Dialog.DialogResizeEvent(dialog,
+                true, "200", "100", "10", "20"));
+
+        Assert.assertEquals("200", dialog.getWidth());
+        Assert.assertEquals("100", dialog.getHeight());
+        Assert.assertEquals("10", dialog.getLeft());
+        Assert.assertEquals("20", dialog.getTop());
     }
 
     @Test

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -133,7 +133,7 @@ public class DialogTest {
     }
 
     @Test
-    public void draggedEvent_TopLeftPropertiesSynced() {
+    public void draggedEvent_topLeftPropertiesSynced() {
         Dialog dialog = new Dialog();
 
         // Emulate a drag event
@@ -145,7 +145,7 @@ public class DialogTest {
     }
 
     @Test
-    public void resizeEvent_WidthHeightTopLeftPropertiesSynced() {
+    public void resizeEvent_widthHeightTopLeftPropertiesSynced() {
         Dialog dialog = new Dialog();
 
         // Emulate a resize event


### PR DESCRIPTION
## Description

Adds the API to allow listening to the `dragged` event sent by the web component. 

This PR:
- Add the `DialogDraggedEvent` class and the `addDraggedListener` method in `Dialog` to allow registering event listeners.
- Adds a default listener to the event to allow synching the `top` and `left` values when the event is fired
- Modifies the `DialogResizeEvent` class to add the `top` and `left` values sent by the client event
	- Modifies the default listener also to sync the `top` and `left` values on resize


Depends on #6782
Part of https://github.com/vaadin/web-components/issues/1060

## Type of change

- Feature
