### PR TITLE
feat: implement HasEnabled for Upload

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
@@ -63,7 +64,7 @@ import elemental.json.JsonType;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/upload", version = "24.6.0-alpha7")
 @JsModule("@vaadin/upload/src/vaadin-upload.js")
-public class Upload extends Component implements HasSize, HasStyle {
+public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
 
     /**
      * Server-side component for the default {@code <vaadin-upload>} icon.
@@ -193,7 +194,7 @@ public class Upload extends Component implements HasSize, HasStyle {
         return addListener(AllFinishedEvent.class, listener);
     }
 
-    private StreamVariable getStreamVariable() {
+    StreamVariable getStreamVariable() {
         if (streamVariable == null) {
             streamVariable = new DefaultStreamVariable(this);
         }
@@ -425,6 +426,10 @@ public class Upload extends Component implements HasSize, HasStyle {
      * accepted on same component.
      */
     private void startUpload() {
+        if (!isEnabled()) {
+            throw new IllegalStateException(
+                    "Cannot start upload because the Upload component is disabled");
+        }
         if (getMaxFiles() != 0 && getMaxFiles() <= activeUploads) {
             throw new IllegalStateException(
                     "Maximum supported amount of uploads already started");

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/DisabledUploadTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/DisabledUploadTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DisabledUploadTest {
+    @Test
+    public void preventsStartingUploads() {
+        Upload upload = new Upload();
+        upload.setEnabled(false);
+
+        IllegalStateException exception = Assert
+                .assertThrows(IllegalStateException.class, () -> {
+                    upload.getStreamVariable().streamingStarted(null);
+                });
+        Assert.assertTrue(exception.getMessage().contains(
+                "Cannot start upload because the Upload component is disabled"));
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.upload.tests;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
 import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
@@ -28,6 +29,11 @@ public class UploadTest {
     public void uploadNewUpload() {
         // Test no NPE due missing UI when setAttribute is called.
         Upload upload = new Upload();
+    }
+
+    @Test
+    public void implementsHasEnabled() {
+        Assert.assertTrue(HasEnabled.class.isAssignableFrom(Upload.class));
     }
 
     @Test


### PR DESCRIPTION
Allows to disable the upload component, which disables all buttons, prevents drag and drop of files and focusing elements within the component.

When disabled, the upload component does not accept new uploads, but keeps processing existing ones.

Part of https://github.com/vaadin/web-components/issues/1278
Depends on https://github.com/vaadin/web-components/pull/8090