### PR TITLE
test: don't test by generated item property names (CP: 24.4)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
@@ -134,14 +134,12 @@ public class ComboBoxIT extends AbstractComboBoxIT {
         items.forEach(item -> {
             Assert.assertNotNull(item.get("key"));
             Assert.assertNotNull(item.get("label"));
-            Assert.assertNotNull(item.get("lr_0_song"));
-            Assert.assertNotNull(item.get("lr_0_artist"));
         });
 
         Map<String, ?> firstItem = items.get(0);
         Assert.assertEquals("A V Club Disagrees", firstItem.get("label"));
-        Assert.assertEquals("A V Club Disagrees", firstItem.get("lr_0_song"));
-        Assert.assertEquals("Haircuts for Men", firstItem.get("lr_0_artist"));
+        Assert.assertEquals("A V Club Disagrees\nHaircuts for Men",
+                $("vaadin-combo-box-item").get(0).getText());
 
         executeScript(
                 "arguments[0].selectedItem = arguments[0].filteredItems[1]",
@@ -172,9 +170,10 @@ public class ComboBoxIT extends AbstractComboBoxIT {
         List<Map<String, ?>> items = (List<Map<String, ?>>) executeScript(
                 "return arguments[0].filteredItems", comboBox);
 
-        Assert.assertEquals("Haircuts for Men",
-                items.get(0).get("lr_0_artist"));
-        Assert.assertEquals("Haywyre", items.get(1).get("lr_0_artist"));
+        Assert.assertEquals("A V Club Disagrees\nHaircuts for Men",
+                $("vaadin-combo-box-item").get(0).getText());
+        Assert.assertEquals("Sculpted\nHaywyre",
+                $("vaadin-combo-box-item").get(1).getText());
     }
 
     @Test


### PR DESCRIPTION
## Description

Applied the workaround from https://github.com/vaadin/flow-components/pull/6781/commits/17839951dc47923efd0e316e76584f3147e1ee05 for `24.4` branch.

## Type of change

- Test