### PR TITLE
refactor: use manualValidation instead of overriding _shouldSetInvalid

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
@@ -88,7 +88,6 @@ public class BasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -109,17 +108,6 @@ public class BasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
@@ -88,6 +88,7 @@ public class BasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -117,6 +118,8 @@ public class BasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationIT.java
@@ -87,6 +87,7 @@ public class CheckboxBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -116,6 +117,8 @@ public class CheckboxBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationIT.java
@@ -87,7 +87,6 @@ public class CheckboxBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -108,17 +107,6 @@ public class CheckboxBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.AbstractSinglePropertyField;
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
@@ -32,7 +31,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Label;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.InputField;
@@ -116,6 +114,7 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
      */
     public Checkbox() {
         super("checked", false, false);
+        getElement().setProperty("manualValidation", true);
         getElement().addPropertyChangeListener("indeterminate",
                 "indeterminate-changed", NO_OP);
         getElement().addPropertyChangeListener("checked", "checked-changed",
@@ -225,13 +224,6 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
             ValueChangeListener<ComponentValueChangeEvent<Checkbox, Boolean>> listener) {
         this(labelText, initialValue);
         addValueChangeListener(listener);
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.AbstractSinglePropertyField;
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasAriaLabel;
@@ -42,7 +41,6 @@ import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupDataView;
 import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupListDataView;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasValidationProperties;
@@ -177,6 +175,8 @@ public class CheckboxGroup<T>
                 CheckboxGroup::presentationToModel,
                 CheckboxGroup::modelToPresentation);
 
+        getElement().setProperty("manualValidation", true);
+
         addValueChangeListener(e -> validate());
 
         initSelectionPreservationHandler();
@@ -279,13 +279,6 @@ public class CheckboxGroup<T>
             T... items) {
         this(label, listener);
         setItems(items);
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
@@ -111,6 +111,7 @@ public class ComboBoxBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -140,6 +141,8 @@ public class ComboBoxBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
@@ -111,7 +111,6 @@ public class ComboBoxBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -132,17 +131,6 @@ public class ComboBoxBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
@@ -117,6 +117,7 @@ public class MultiSelectComboBoxBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -146,6 +147,8 @@ public class MultiSelectComboBoxBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
@@ -117,7 +117,6 @@ public class MultiSelectComboBoxBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -138,17 +137,6 @@ public class MultiSelectComboBoxBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -46,7 +46,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClearButton;
@@ -177,6 +176,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
             SerializableBiFunction<TComponent, TValue, TValueProperty> modelToPresentation) {
         super(valuePropertyName, defaultValue, valuePropertyType,
                 presentationToModel, modelToPresentation);
+
+        getElement().setProperty("manualValidation", true);
 
         // Extracted as implementation to fix serialization issue:
         // https://github.com/vaadin/flow-components/issues/4420
@@ -578,8 +579,6 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
         super.onAttach(attachEvent);
         initConnector();
         dataController.onAttach();
-
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     @Override

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
@@ -216,6 +216,7 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -245,6 +246,8 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
@@ -216,7 +216,6 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -237,17 +236,6 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -44,7 +44,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClearButton;
@@ -250,6 +249,8 @@ public class DatePicker
      */
     private DatePicker(LocalDate initialDate, boolean isInitialValueOptional) {
         super("value", null, String.class, PARSER, FORMATTER);
+
+        getElement().setProperty("manualValidation", true);
 
         // Initialize property value unless it has already been set from a
         // template
@@ -519,7 +520,6 @@ public class DatePicker
         super.onAttach(attachEvent);
         initConnector();
         requestI18nUpdate();
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     private void initConnector() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -288,6 +288,7 @@ public class BasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -317,6 +318,8 @@ public class BasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -288,7 +288,6 @@ public class BasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -309,17 +308,6 @@ public class BasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -232,6 +232,8 @@ public class DateTimePicker
         SlotUtils.addToSlot(this, "date-picker", datePicker);
         SlotUtils.addToSlot(this, "time-picker", timePicker);
 
+        getElement().setProperty("manualValidation", true);
+
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -26,14 +26,12 @@ import java.util.function.Function;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.AbstractSinglePropertyField;
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
@@ -915,12 +913,6 @@ public class DateTimePicker
         getElement().setProperty("autoOpenDisabled", !autoOpen);
         datePicker.setAutoOpen(autoOpen);
         timePicker.setAutoOpen(autoOpen);
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     private String getI18nErrorMessage(

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.HasValidation;
  * to valid as a result of client-side validation.
  *
  * @author Vaadin Ltd
+ * @deprecated since 24.6, use {@code getElement().setProperty("manualValidation", true)} instead.
  */
 public final class ClientValidationUtil {
 
@@ -30,6 +31,9 @@ public final class ClientValidationUtil {
         // utility class should not be instantiated
     }
 
+    /**
+     * @deprecated since 24.6, use {@code getElement().setProperty("manualValidation", true)} instead.
+     */
     public static <C extends Component & HasValidation> void preventWebComponentFromModifyingInvalidState(
             C component) {
         StringBuilder expression = new StringBuilder(

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
@@ -23,7 +23,9 @@ import com.vaadin.flow.component.HasValidation;
  * to valid as a result of client-side validation.
  *
  * @author Vaadin Ltd
- * @deprecated since 24.6, use {@code getElement().setProperty("manualValidation", true)} instead.
+ * @deprecated since 24.6, use
+ *             {@code getElement().setProperty("manualValidation", true)}
+ *             instead.
  */
 public final class ClientValidationUtil {
 
@@ -32,7 +34,9 @@ public final class ClientValidationUtil {
     }
 
     /**
-     * @deprecated since 24.6, use {@code getElement().setProperty("manualValidation", true)} instead.
+     * @deprecated since 24.6, use
+     *             {@code getElement().setProperty("manualValidation", true)}
+     *             instead.
      */
     public static <C extends Component & HasValidation> void preventWebComponentFromModifyingInvalidState(
             C component) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.HasValidation;
  * to valid as a result of client-side validation.
  *
  * @author Vaadin Ltd
- * @deprecated since 24.6, use
+ * @deprecated since 24.8, use
  *             {@code getElement().setProperty("manualValidation", true)}
  *             instead.
  */
@@ -34,7 +34,7 @@ public final class ClientValidationUtil {
     }
 
     /**
-     * @deprecated since 24.6, use
+     * @deprecated since 24.8, use
      *             {@code getElement().setProperty("manualValidation", true)}
      *             instead.
      */

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
@@ -51,6 +52,17 @@ public interface HasClientValidation extends Serializable {
     @Deprecated
     default Registration addClientValidatedEventListener(
             ComponentEventListener<ClientValidatedEvent> listener) {
+        ((HasElement) this).getElement().executeJs(
+                """
+                            this._requestValidation = function () {
+                                Object.getPrototypeOf(this)._requestValidation.call(this);
+                                if (this.manualValidation) {
+                                    const valid = this.checkValidity();
+                                    this.dispatchEvent(new CustomEvent('validated', { detail: { valid } }));
+                                }
+                            }
+                        """);
+
         return ComponentUtil.addListener((Component) this,
                 ClientValidatedEvent.class, listener);
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
@@ -52,6 +52,9 @@ public interface HasClientValidation extends Serializable {
     @Deprecated
     default Registration addClientValidatedEventListener(
             ComponentEventListener<ClientValidatedEvent> listener) {
+        // TODO: Temporary workaround to make the web component fire
+        // the validated event in manual validation mode. This will be
+        // removed in Vaadin 25 along with the validated event.
         ((HasElement) this).getElement().executeJs(
                 """
                             this._requestValidation = function () {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -42,6 +42,11 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
     }
 
     @Test
+    public void webComponentManualValidationEnabled() {
+        Assert.assertTrue(testField.getElement().getProperty("manualValidation", false));
+    }
+
+    @Test
     public void setRequired_setManualValidation_fireValueChangeEvent_noValidation() {
         testField.setRequiredIndicatorVisible(true);
         testField.setManualValidation(true);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -43,7 +43,8 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
 
     @Test
     public void webComponentManualValidationEnabled() {
-        Assert.assertTrue(testField.getElement().getProperty("manualValidation", false));
+        Assert.assertTrue(
+                testField.getElement().getProperty("manualValidation", false));
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationIT.java
@@ -92,23 +92,6 @@ public abstract class AbstractValidationIT<T extends TestBenchElement>
         return !testField.getPropertyBoolean("invalid");
     }
 
-    protected void assertWebComponentCanNotModifyInvalidState() {
-        // There is no good integration test for this, as triggering client
-        // validation will also trigger server validation, with the same
-        // validation constraints as the client validation, making it impossible
-        // to test a difference.
-        // Instead, we test that the web component has been properly configured
-        // to prevent itself from changing the invalid state.
-        Assert.assertFalse(shouldSetInvalid(true));
-        Assert.assertFalse(shouldSetInvalid(false));
-    }
-
-    private boolean shouldSetInvalid(boolean invalid) {
-        return (Boolean) getCommandExecutor().executeScript(
-                "const field = arguments[0]; const invalid = arguments[1]; return field._shouldSetInvalid(invalid)",
-                testField, invalid);
-    }
-
     protected void detachAndReattachField() {
         detachField();
         attachField();

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
@@ -76,6 +76,7 @@ public class BasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -105,6 +106,8 @@ public class BasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make field invalid
         $("button").id(SET_INVALID_BUTTON).click();

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
@@ -76,7 +76,6 @@ public class BasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -97,17 +96,6 @@ public class BasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make field invalid
         $("button").id(SET_INVALID_BUTTON).click();

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -38,7 +38,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupDataView;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasValidationProperties;
@@ -181,6 +180,8 @@ public class RadioButtonGroup<T>
         super("value", null, String.class,
                 RadioButtonGroup::presentationToModel,
                 RadioButtonGroup::modelToPresentation);
+
+        getElement().setProperty("manualValidation", true);
 
         addValueChangeListener(e -> validate());
 
@@ -437,8 +438,6 @@ public class RadioButtonGroup<T>
         if (getDataProvider() != null) {
             setupDataProviderListener(getDataProvider());
         }
-
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     @Override

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
@@ -86,7 +86,6 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -107,17 +106,6 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
@@ -86,6 +86,7 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -115,6 +116,8 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -45,7 +45,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.select.data.SelectDataView;
 import com.vaadin.flow.component.select.data.SelectListDataView;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasClientValidation;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasPrefix;
@@ -181,6 +180,8 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     public Select() {
         super("value", null, String.class, Select::presentationToModel,
                 Select::modelToPresentation);
+
+        getElement().setProperty("manualValidation", true);
 
         setInvalid(false);
         setOpened(false);
@@ -897,8 +898,6 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
-
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
@@ -155,7 +155,6 @@ public class BigDecimalFieldBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -176,17 +175,6 @@ public class BigDecimalFieldBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
@@ -155,6 +155,7 @@ public class BigDecimalFieldBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -184,6 +185,8 @@ public class BigDecimalFieldBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
@@ -171,6 +171,7 @@ public class EmailFieldBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -200,6 +201,8 @@ public class EmailFieldBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
@@ -171,7 +171,6 @@ public class EmailFieldBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -192,17 +191,6 @@ public class EmailFieldBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -278,7 +278,6 @@ public class IntegerFieldBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -299,17 +298,6 @@ public class IntegerFieldBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -278,6 +278,7 @@ public class IntegerFieldBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -307,6 +308,8 @@ public class IntegerFieldBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
@@ -248,6 +248,7 @@ public class NumberFieldBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -277,6 +278,8 @@ public class NumberFieldBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
@@ -248,7 +248,6 @@ public class NumberFieldBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -269,17 +268,6 @@ public class NumberFieldBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
@@ -161,7 +161,6 @@ public class PasswordFieldBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -182,17 +181,6 @@ public class PasswordFieldBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
@@ -161,6 +161,7 @@ public class PasswordFieldBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -190,6 +191,8 @@ public class PasswordFieldBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
@@ -155,7 +155,6 @@ public class TextAreaBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -176,17 +175,6 @@ public class TextAreaBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
@@ -155,6 +155,7 @@ public class TextAreaBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -184,6 +185,8 @@ public class TextAreaBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
@@ -155,6 +155,7 @@ public class TextFieldBasicValidationIT
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -184,6 +185,8 @@ public class TextFieldBasicValidationIT
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
@@ -155,7 +155,6 @@ public class TextFieldBasicValidationIT
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -176,17 +175,6 @@ public class TextFieldBasicValidationIT
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
-import com.vaadin.flow.component.AttachEvent;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.component.shared.internal.ValidationController;
 import com.vaadin.flow.data.binder.ValidationResult;
@@ -134,6 +132,8 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
             SerializableFunction<T, String> formatter, double absoluteMin,
             double absoluteMax) {
         super(null, null, String.class, parser, formatter, true);
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -407,12 +407,6 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
                 .subtract(BigDecimal.valueOf(stepBasis))
                 .remainder(BigDecimal.valueOf(step))
                 .compareTo(BigDecimal.ZERO) == 0;
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -24,13 +24,11 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dependency.Uses;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
 import com.vaadin.flow.component.shared.internal.ValidationController;
@@ -156,6 +154,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
 
         setLocale(Optional.ofNullable(UI.getCurrent()).map(UI::getLocale)
                 .orElse(Locale.ROOT));
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -437,12 +437,6 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         String prop = getElement().getProperty("_decimalSeparator");
         return prop == null || prop.isEmpty() ? '.'
                 : getElement().getProperty("_decimalSeparator").charAt(0);
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -20,11 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
@@ -156,6 +154,8 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     public EmailField() {
         super("", "", false, true);
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -414,12 +414,6 @@ public class EmailField extends TextFieldBase<EmailField, String>
      */
     protected void validate() {
         validationController.validate(getValue());
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -20,11 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
@@ -168,6 +166,8 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
      */
     private PasswordField(boolean isInitialValueOptional) {
         super("", "", false, isInitialValueOptional);
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -443,12 +443,6 @@ public class PasswordField extends TextFieldBase<PasswordField, String>
      */
     protected void validate() {
         validationController.validate(getValue());
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -20,11 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
@@ -168,6 +166,8 @@ public class TextArea extends TextFieldBase<TextArea, String>
      */
     private TextArea(boolean isInitialValueOptional) {
         super("", "", false, isInitialValueOptional);
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -505,12 +505,6 @@ public class TextArea extends TextFieldBase<TextArea, String>
      */
     protected void validate() {
         validationController.validate(getValue());
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -20,11 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.ValidationUtil;
@@ -167,6 +165,8 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     private TextField(boolean isInitialValueOptional) {
         super("", "", false, isInitialValueOptional);
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -438,12 +438,6 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     protected void validate() {
         validationController.validate(getValue());
-    }
-
-    @Override
-    protected void onAttach(AttachEvent attachEvent) {
-        super.onAttach(attachEvent);
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
@@ -216,6 +216,7 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     }
 
     @Test
+<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -245,6 +246,8 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     }
 
     @Test
+=======
+>>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
@@ -216,7 +216,6 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     }
 
     @Test
-<<<<<<< Updated upstream
     public void detach_attachAndInvalidate_preservesInvalidState() {
         detachField();
         attachAndInvalidateField();
@@ -237,17 +236,6 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     }
 
     @Test
-    public void webComponentCanNotModifyInvalidState() {
-        assertWebComponentCanNotModifyInvalidState();
-
-        detachAndReattachField();
-
-        assertWebComponentCanNotModifyInvalidState();
-    }
-
-    @Test
-=======
->>>>>>> Stashed changes
     public void clientSideInvalidStateIsNotPropagatedToServer() {
         // Make the field invalid
         $("button").id(REQUIRED_BUTTON).click();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -40,7 +40,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.shared.ClientValidationUtil;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasAutoOpen;
 import com.vaadin.flow.component.shared.HasClearButton;
@@ -226,6 +225,8 @@ public class TimePicker
                 || !isInitialValueOptional)) {
             setPresentationValue(time);
         }
+
+        getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
@@ -626,7 +627,6 @@ public class TimePicker
         super.onAttach(attachEvent);
         initConnector();
         requestLocaleUpdate();
-        ClientValidationUtil.preventWebComponentFromModifyingInvalidState(this);
     }
 
     private void initConnector() {


### PR DESCRIPTION
## Description

Enables manual validation mode for web components instead of overriding their protected `_shouldSetInvalid` method.

Depends on 
- #6795 

## Type of change

- [x] Refactor
