### PR TITLE
refactor: deprecate ClientValidatedEvent and HasClientValidation

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
@@ -28,7 +28,10 @@ import com.vaadin.flow.shared.Registration;
 /**
  * Mixin interface for subscribing to the client-side `validated` event from a
  * component.
+ *
+ * @deprecated This interface is no longer supported and will be removed in 24.7.
  */
+@Deprecated
 public interface HasClientValidation extends Serializable {
     /**
      * Adds a listener for the {@code validated} event fired by the web
@@ -37,7 +40,9 @@ public interface HasClientValidation extends Serializable {
      * @param listener
      *            the listener, not null.
      * @return a {@link Registration} for removing the event listener.
+     * @deprecated This event is no longer supported and will be removed in 24.7.
      */
+    @Deprecated
     default Registration addClientValidatedEventListener(
             ComponentEventListener<ClientValidatedEvent> listener) {
         return ComponentUtil.addListener((Component) this,
@@ -47,8 +52,11 @@ public interface HasClientValidation extends Serializable {
     /**
      * An event fired by the web component whenever it is validated on the
      * client-side.
+     *
+     * @deprecated This event is no longer supported and will be removed in 24.7.
      */
     @DomEvent("validated")
+    @Deprecated
     public static class ClientValidatedEvent extends ComponentEvent<Component> {
 
         private final boolean valid;

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.shared.Registration;
  * Mixin interface for subscribing to the client-side `validated` event from a
  * component.
  *
- * @deprecated This interface is no longer supported and will be removed in 24.7.
+ * @deprecated This interface is no longer supported and will be removed in 25.0
  */
 @Deprecated
 public interface HasClientValidation extends Serializable {
@@ -40,7 +40,7 @@ public interface HasClientValidation extends Serializable {
      * @param listener
      *            the listener, not null.
      * @return a {@link Registration} for removing the event listener.
-     * @deprecated This event is no longer supported and will be removed in 24.7.
+     * @deprecated This event is no longer supported and will be removed in 25.0
      */
     @Deprecated
     default Registration addClientValidatedEventListener(
@@ -53,7 +53,7 @@ public interface HasClientValidation extends Serializable {
      * An event fired by the web component whenever it is validated on the
      * client-side.
      *
-     * @deprecated This event is no longer supported and will be removed in 24.7.
+     * @deprecated This event is no longer supported and will be removed in 25.0
      */
     @DomEvent("validated")
     @Deprecated

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClientValidation.java
@@ -23,13 +23,17 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.HasValidation;
+import com.vaadin.flow.data.binder.HasValidator;
+import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.shared.Registration;
 
 /**
  * Mixin interface for subscribing to the client-side `validated` event from a
  * component.
  *
- * @deprecated This interface is no longer supported and will be removed in 25.0
+ * @deprecated Since 24.6, this interface is no longer supported. Consider
+ *             {@link HasValidation} or {@link HasValidator} as an alternative.
  */
 @Deprecated
 public interface HasClientValidation extends Serializable {
@@ -40,7 +44,9 @@ public interface HasClientValidation extends Serializable {
      * @param listener
      *            the listener, not null.
      * @return a {@link Registration} for removing the event listener.
-     * @deprecated This event is no longer supported and will be removed in 25.0
+     * @deprecated Since 24.6, this event is no longer supported. Consider
+     *             subscribing to {@link ValidationStatusChangeEvent} to get
+     *             notified when the user enters input that cannot be parsed.
      */
     @Deprecated
     default Registration addClientValidatedEventListener(
@@ -53,7 +59,9 @@ public interface HasClientValidation extends Serializable {
      * An event fired by the web component whenever it is validated on the
      * client-side.
      *
-     * @deprecated This event is no longer supported and will be removed in 25.0
+     * @deprecated Since 24.6, this event is no longer supported. Consider
+     *             subscribing to {@link ValidationStatusChangeEvent} to get
+     *             notified when the user enters input that cannot be parsed.
      */
     @DomEvent("validated")
     @Deprecated

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractBasicValidationTest.java
@@ -24,6 +24,10 @@ import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.shared.HasClientValidation.ClientValidatedEvent;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+
+import elemental.json.Json;
 
 /**
  * An abstract class that provides tests verifying that a component correctly
@@ -44,6 +48,15 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
 
         ComponentUtil.fireEvent(testField, new ComponentValueChangeEvent<>(
                 testField, testField, testField.getEmptyValue(), false));
+        Assert.assertFalse(testField.isInvalid());
+    }
+
+    @Test
+    public void setRequired_setManualValidation_fireUnparsableChangeEvent_noValidation() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setManualValidation(true);
+
+        fireUnparsableChangeDomEvent();
         Assert.assertFalse(testField.isInvalid());
     }
 
@@ -82,4 +95,11 @@ public abstract class AbstractBasicValidationTest<C extends AbstractField<C, V> 
     }
 
     protected abstract C createTestField();
+
+    private void fireUnparsableChangeDomEvent() {
+        DomEvent unparsableChangeDomEvent = new DomEvent(testField.getElement(),
+                "unparsable-change", Json.createObject());
+        testField.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(unparsableChangeDomEvent);
+    }
 }


### PR DESCRIPTION
## Description

The PR deprecates `ClientValidatedEvent` and `HasClientValidation`, with plans to remove them in the next major where web components will stop dispatching `validated` events when used as part of their Flow counterparts, see https://github.com/vaadin/flow-components/pull/6792


## Type of change

- [x] Refactor
