### PR TITLE
fix: make auto-added Popover work with PreserveOnRefresh

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -726,6 +726,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         if (target != null) {
             ui.beforeClientResponse(ui, context -> {
                 if (getElement().getNode().getParent() == null) {
+                    // Remove the popover from its current state tree
+                    getElement().removeFromTree(false);
                     ui.addToModalComponent(this);
                     autoAddedToTheUi = true;
                 }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -30,12 +30,13 @@ import com.vaadin.flow.server.VaadinSession;
  */
 public class PopoverAutoAddTest {
     private UI ui = new UI();
+    private VaadinSession session;
 
     @Before
     public void setup() {
         UI.setCurrent(ui);
 
-        VaadinSession session = Mockito.mock(VaadinSession.class);
+        session = Mockito.mock(VaadinSession.class);
         Mockito.when(session.hasLock()).thenReturn(true);
         ui.getInternals().setSession(session);
     }
@@ -131,6 +132,25 @@ public class PopoverAutoAddTest {
         fakeClientResponse();
 
         Assert.assertNull(popover.getElement().getParent());
+    }
+
+    @Test
+    public void setTarget_changeUI_autoAdded() {
+        Popover popover = new Popover();
+        Div target = new Div();
+        popover.setTarget(target);
+        ui.add(target);
+        fakeClientResponse();
+
+        // Create a new UI and move the component to it (@PreserveOnRefresh)
+        ui = new UI();
+        UI.setCurrent(ui);
+        ui.getInternals().setSession(session);
+        target.getElement().removeFromTree(false);
+        ui.add(target);
+
+        fakeClientResponse();
+        Assert.assertEquals(ui.getElement(), popover.getElement().getParent());
     }
 
     private void fakeClientResponse() {


### PR DESCRIPTION
## Description

Fixes #6752

Based on https://github.com/vaadin/flow-components/pull/4289 previously implemented for `Tooltip`. See also https://github.com/vaadin/flow-components/pull/5514 for an explanation why we need to pass `false`.

## Type of change

- Bugfix