### PR TITLE
refactor!: do not generate data for hidden columns

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -73,12 +73,9 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     /**
      * {@inheritDoc}
      * <p>
-     * Note that column related data is sent to the client side even if the
-     * column is invisible. Use {@link Grid#removeColumn(Column)} to remove
-     * column (or don't add the column all) and avoid sending extra data.
+     * Note that column data is not generated or sent to the client while the
+     * column is hidden.
      * </p>
-     *
-     * @see Grid#removeColumn(Column)
      */
     @Override
     public void setVisible(boolean visible) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -70,18 +70,6 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         return grid;
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Note that column data is not generated or sent to the client while the
-     * column is hidden.
-     * </p>
-     */
-    @Override
-    public void setVisible(boolean visible) {
-        super.setVisible(visible);
-    }
-
     private void scheduleHeaderRendering() {
         if (headerRenderingScheduled) {
             return;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -545,7 +545,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             return this;
         }
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
+        @SuppressWarnings({ "unchecked" })
         private void setupRenderer(Renderer<T> renderer) {
             this.renderer = Objects.requireNonNull(renderer,
                     "Renderer must not be null.");
@@ -560,8 +560,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                             .getKeyMapper());
 
             rendering.getDataGenerator().ifPresent(dataGenerator -> {
-                rendererRegistrations.add(compositeDataGenerator
-                        .addDataGenerator((DataGenerator) dataGenerator));
+                rendererRegistrations.add(
+                        compositeDataGenerator.addDataGenerator(dataGenerator));
             });
 
             rendererRegistrations.add(rendering.getRegistration());
@@ -1133,7 +1133,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
                         columnInternalId);
                 editorRendererRegistration = compositeDataGenerator
-                        .addDataGenerator((DataGenerator) editorRenderer);
+                        .addDataGenerator(editorRenderer);
             }
 
             editorRenderer.render(getElement(), null);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -450,6 +450,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     super.generateData(item, jsonObject);
                 }
             }
+
+            @Override
+            public void refreshData(T item) {
+                if (Column.this.isVisible()) {
+                    super.refreshData(item);
+                }
+            }
         };
         private Registration compositeDataGeneratorRegistration;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -417,12 +417,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     /**
      * Server-side component for the {@code <vaadin-grid-column>} element.
      *
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
-     *
      * @param <T>
      *            type of the underlying grid this column is compatible with
      */
@@ -449,6 +443,16 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         private SerializableComparator<T> comparator;
 
+        private final CompositeDataGenerator<T> compositeDataGenerator = new CompositeDataGenerator<>() {
+            @Override
+            public void generateData(T item, ObjectNode jsonObject) {
+                if (Column.this.isVisible()) {
+                    super.generateData(item, jsonObject);
+                }
+            }
+        };
+        private Registration compositeDataGeneratorRegistration;
+
         private Renderer<T> renderer;
         private List<Registration> rendererRegistrations = new ArrayList<>();
 
@@ -470,7 +474,18 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             super(grid);
             this.columnInternalId = columnId;
             comparator = (a, b) -> 0;
+            compositeDataGeneratorRegistration = grid
+                    .addDataGenerator(compositeDataGenerator);
             setupRenderer(renderer);
+        }
+
+        @Override
+        public void setVisible(boolean visible) {
+            boolean refreshViewport = visible && !isVisible();
+            super.setVisible(visible);
+            if (refreshViewport) {
+                getGrid().refreshViewport();
+            }
         }
 
         protected void destroyDataGenerators() {
@@ -482,6 +497,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             if (editorRendererRegistration != null) {
                 editorRendererRegistration.remove();
                 editorRendererRegistration = null;
+            }
+
+            if (compositeDataGeneratorRegistration != null) {
+                compositeDataGeneratorRegistration.remove();
+                compositeDataGeneratorRegistration = null;
             }
         }
 
@@ -540,8 +560,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                             .getKeyMapper());
 
             rendering.getDataGenerator().ifPresent(dataGenerator -> {
-                rendererRegistrations.add(
-                        grid.addDataGenerator((DataGenerator) dataGenerator));
+                rendererRegistrations.add(compositeDataGenerator
+                        .addDataGenerator((DataGenerator) dataGenerator));
             });
 
             rendererRegistrations.add(rendering.getRegistration());
@@ -1112,7 +1132,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             if (editorRenderer == null) {
                 editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
                         columnInternalId);
-                editorRendererRegistration = grid
+                editorRendererRegistration = compositeDataGenerator
                         .addDataGenerator((DataGenerator) editorRenderer);
             }
 
@@ -1747,11 +1767,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * see {@link #addColumn(Renderer)}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
-     * <p>
      * <em>NOTE:</em> This method is a shorthand for
      * {@link #addColumn(ValueProvider, BiFunction)}
      * </p>
@@ -1778,11 +1793,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <em>NOTE:</em> For displaying components, see
      * {@link #addComponentColumn(ValueProvider)}. For using built-in renderers,
      * see {@link #addColumn(Renderer)}.
-     * </p>
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
      * </p>
      *
      * @param valueProvider
@@ -1842,11 +1852,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <em>NOTE:</em> Using {@link ComponentRenderer} is not as efficient as the
      * built in renderers or using {@link LitRenderer}.
      * </p>
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
      *
      * @param componentProvider
      *            a value provider that will return a component for the given
@@ -1869,12 +1874,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * to configure backend sorting for this column. In-memory sorting is
      * automatically configured using the return type of the given
      * {@link ValueProvider}.
-     *
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
      *
      * @see Column#setComparator(ValueProvider)
      * @see Column#setSortProperty(String...)
@@ -1910,11 +1909,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * or using {@link LitRenderer}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
-     * <p>
      * <em>NOTE:</em> This method is a shorthand for
      * {@link #addColumn(Renderer, BiFunction)}
      * </p>
@@ -1946,11 +1940,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * {@link #addComponentColumn(ValueProvider)}, but using
      * {@link ComponentRenderer} is not as efficient as the built in renderers
      * or using {@link LitRenderer}.
-     * </p>
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
      * </p>
      *
      * @param renderer
@@ -2055,12 +2044,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * from a bean type with {@link #Grid(Class)}.
      *
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
-     *
-     * <p>
      * <strong>Note:</strong> This method is a shorthand for
      * {@link #addColumn(String, BiFunction)}
      * </p>
@@ -2094,12 +2077,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <p>
      * <strong>Note:</strong> This method can only be used for a Grid created
      * from a bean type with {@link #Grid(Class)}.
-     *
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
      *
      * @see #addColumn(String)
      * @see #removeColumn(Column)
@@ -2171,12 +2148,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <p>
      * <strong>Note:</strong> This method can only be used for a Grid created
      * from a bean type with {@link #Grid(Class)}.
-     *
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
-     * </p>
      *
      * @param propertyNames
      *            the property names of the new columns, not <code>null</code>
@@ -4367,6 +4338,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         idToColumnMap.forEach((id, column) -> {
+            if (!column.isVisible()) {
+                return;
+            }
             String cellTooltip = column.tooltipGenerator.apply(item);
             if (cellTooltip != null) {
                 tooltips.put(id, cellTooltip);
@@ -4387,6 +4361,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         idToColumnMap.forEach((id, column) -> {
+            if (!column.isVisible()) {
+                return;
+            }
             String cellPartName = column.getPartNameGenerator().apply(item);
             if (cellPartName != null) {
                 part.put(id, cellPartName);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridHiddenColumnRenderingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridHiddenColumnRenderingTest.java
@@ -41,7 +41,8 @@ class GridHiddenColumnRenderingTest {
     private AtomicInteger dataProviderFetchCallCount = new AtomicInteger(0);
     private AtomicInteger dataProviderSizeCallCount = new AtomicInteger(0);
     private AtomicInteger columnValueProviderCallCount = new AtomicInteger(0);
-    private AtomicInteger columnTooltipGeneratorSpy = new AtomicInteger(0);
+    private AtomicInteger columnTooltipGeneratorCallCount = new AtomicInteger(
+            0);
     private AtomicInteger columnPartNameGeneratorCallCount = new AtomicInteger(
             0);
 
@@ -69,7 +70,7 @@ class GridHiddenColumnRenderingTest {
         });
 
         column.setTooltipGenerator(s -> {
-            columnTooltipGeneratorSpy.incrementAndGet();
+            columnTooltipGeneratorCallCount.incrementAndGet();
             return "tooltip";
         });
 
@@ -193,21 +194,22 @@ class GridHiddenColumnRenderingTest {
 
     private void resetColumnDataSpies() {
         columnValueProviderCallCount.set(0);
-        columnTooltipGeneratorSpy.set(0);
+        columnTooltipGeneratorCallCount.set(0);
         columnPartNameGeneratorCallCount.set(0);
     }
 
     private void assertColumnDataSent() {
         Assertions.assertEquals(ITEMS.size(),
                 columnValueProviderCallCount.get());
-        Assertions.assertEquals(ITEMS.size(), columnTooltipGeneratorSpy.get());
+        Assertions.assertEquals(ITEMS.size(),
+                columnTooltipGeneratorCallCount.get());
         Assertions.assertEquals(ITEMS.size(),
                 columnPartNameGeneratorCallCount.get());
     }
 
     private void assertColumnDataNotSent() {
         Assertions.assertEquals(0, columnValueProviderCallCount.get());
-        Assertions.assertEquals(0, columnTooltipGeneratorSpy.get());
+        Assertions.assertEquals(0, columnTooltipGeneratorCallCount.get());
         Assertions.assertEquals(0, columnPartNameGeneratorCallCount.get());
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridHiddenColumnRenderingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridHiddenColumnRenderingTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.tests.MockUIExtension;
+
+class GridHiddenColumnRenderingTest {
+
+    private static List<String> ITEMS = IntStream.range(0, 10)
+            .mapToObj(i -> "Item " + i).toList();
+
+    @RegisterExtension
+    private MockUIExtension ui = new MockUIExtension();
+
+    private Grid<String> grid;
+
+    private Grid.Column<String> column;
+
+    private AtomicInteger dataProviderFetchCallCount = new AtomicInteger(0);
+    private AtomicInteger dataProviderSizeCallCount = new AtomicInteger(0);
+    private AtomicInteger columnValueProviderCallCount = new AtomicInteger(0);
+    private AtomicInteger columnTooltipGeneratorSpy = new AtomicInteger(0);
+    private AtomicInteger columnPartNameGeneratorCallCount = new AtomicInteger(
+            0);
+
+    @BeforeEach
+    void setup() {
+        grid = new Grid<>();
+
+        grid.setItems(query -> {
+            dataProviderFetchCallCount.incrementAndGet();
+            return ITEMS.stream().skip(query.getOffset())
+                    .limit(query.getLimit());
+        }, query -> {
+            dataProviderSizeCallCount.incrementAndGet();
+            return ITEMS.size();
+        });
+
+        column = grid.addColumn(s -> {
+            columnValueProviderCallCount.incrementAndGet();
+            return s;
+        });
+
+        column.setPartNameGenerator(s -> {
+            columnPartNameGeneratorCallCount.incrementAndGet();
+            return "part";
+        });
+
+        column.setTooltipGenerator(s -> {
+            columnTooltipGeneratorSpy.incrementAndGet();
+            return "tooltip";
+        });
+
+        ui.add(grid);
+    }
+
+    @Test
+    void initiallyVisibleColumn_columnDataSent() {
+        ui.fakeClientCommunication();
+        assertColumnDataSent();
+    }
+
+    @Test
+    void initiallyVisibleColumn_detachAndAttachGrid_columnDataSentOnReattach() {
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        ui.remove(grid);
+        ui.add(grid);
+        ui.fakeClientCommunication();
+        assertColumnDataSent();
+    }
+
+    @Test
+    void initiallyHiddenColumn_columnDataNotSent() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        assertColumnDataNotSent();
+    }
+
+    @Test
+    void initiallyHiddenColumn_detachAndAttachGrid_columnDataNotSentOnReattach() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        ui.remove(grid);
+        ui.add(grid);
+        ui.fakeClientCommunication();
+        assertColumnDataNotSent();
+    }
+
+    @Test
+    void hideColumn_columnDataNotSent() {
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        assertColumnDataNotSent();
+    }
+
+    @Test
+    void hideAndImmediatelyShowColumn_columnDataSent() {
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        column.setVisible(false);
+        column.setVisible(true);
+        ui.fakeClientCommunication();
+        assertColumnDataSent();
+    }
+
+    @Test
+    void showColumn_columnDataSent() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        column.setVisible(true);
+        ui.fakeClientCommunication();
+        assertColumnDataSent();
+    }
+
+    @Test
+    void showAndImmediatelyHideColumn_columnDataNotSent() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        column.setVisible(true);
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        assertColumnDataNotSent();
+    }
+
+    @Test
+    void hiddenColumn_setRenderer_columnDataNotSent() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        resetColumnDataSpies();
+
+        column.setRenderer(new ColumnPathRenderer<>("value", s -> {
+            columnValueProviderCallCount.incrementAndGet();
+            return s;
+        }));
+        ui.fakeClientCommunication();
+        assertColumnDataNotSent();
+    }
+
+    @Test
+    void hideColumn_dataProviderNotCalled() {
+        ui.fakeClientCommunication();
+        resetDataProviderSpies();
+
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        assertDataProviderNotCalled();
+    }
+
+    @Test
+    void showColumn_dataProviderNotCalled() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        resetDataProviderSpies();
+
+        column.setVisible(true);
+        ui.fakeClientCommunication();
+        assertDataProviderNotCalled();
+    }
+
+    private void resetColumnDataSpies() {
+        columnValueProviderCallCount.set(0);
+        columnTooltipGeneratorSpy.set(0);
+        columnPartNameGeneratorCallCount.set(0);
+    }
+
+    private void assertColumnDataSent() {
+        Assertions.assertEquals(ITEMS.size(),
+                columnValueProviderCallCount.get());
+        Assertions.assertEquals(ITEMS.size(), columnTooltipGeneratorSpy.get());
+        Assertions.assertEquals(ITEMS.size(),
+                columnPartNameGeneratorCallCount.get());
+    }
+
+    private void assertColumnDataNotSent() {
+        Assertions.assertEquals(0, columnValueProviderCallCount.get());
+        Assertions.assertEquals(0, columnTooltipGeneratorSpy.get());
+        Assertions.assertEquals(0, columnPartNameGeneratorCallCount.get());
+    }
+
+    private void resetDataProviderSpies() {
+        dataProviderFetchCallCount.set(0);
+        dataProviderSizeCallCount.set(0);
+    }
+
+    private void assertDataProviderNotCalled() {
+        Assertions.assertEquals(0, dataProviderFetchCallCount.get());
+        Assertions.assertEquals(0, dataProviderSizeCallCount.get());
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridHiddenColumnRenderingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridHiddenColumnRenderingTest.java
@@ -15,32 +15,37 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.vaadin.flow.data.provider.DataGenerator;
+import com.vaadin.flow.data.provider.DataKeyMapper;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.renderer.Rendering;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.tests.MockUIExtension;
 
-class GridHiddenColumnRenderingTest {
+import tools.jackson.databind.node.ObjectNode;
 
-    private static List<String> ITEMS = IntStream.range(0, 10)
-            .mapToObj(i -> "Item " + i).toList();
+class GridHiddenColumnRenderingTest {
 
     @RegisterExtension
     private MockUIExtension ui = new MockUIExtension();
 
     private Grid<String> grid;
-
     private Grid.Column<String> column;
 
     private AtomicInteger dataProviderFetchCallCount = new AtomicInteger(0);
     private AtomicInteger dataProviderSizeCallCount = new AtomicInteger(0);
-    private AtomicInteger columnValueProviderCallCount = new AtomicInteger(0);
+    private AtomicInteger columnGenerateDataCallCount = new AtomicInteger(0);
+    private AtomicInteger columnRefreshDataCallCount = new AtomicInteger(0);
     private AtomicInteger columnTooltipGeneratorCallCount = new AtomicInteger(
             0);
     private AtomicInteger columnPartNameGeneratorCallCount = new AtomicInteger(
@@ -52,17 +57,14 @@ class GridHiddenColumnRenderingTest {
 
         grid.setItems(query -> {
             dataProviderFetchCallCount.incrementAndGet();
-            return ITEMS.stream().skip(query.getOffset())
+            return Stream.of("Item 0").skip(query.getOffset())
                     .limit(query.getLimit());
         }, query -> {
             dataProviderSizeCallCount.incrementAndGet();
-            return ITEMS.size();
+            return 1;
         });
 
-        column = grid.addColumn(s -> {
-            columnValueProviderCallCount.incrementAndGet();
-            return s;
-        });
+        column = grid.addColumn(createSpyRenderer());
 
         column.setPartNameGenerator(s -> {
             columnPartNameGeneratorCallCount.incrementAndGet();
@@ -78,139 +80,166 @@ class GridHiddenColumnRenderingTest {
     }
 
     @Test
-    void initiallyVisibleColumn_columnDataSent() {
+    void initiallyVisibleColumn_columnDataGenerated() {
         ui.fakeClientCommunication();
-        assertColumnDataSent();
+        assertColumnDataGenerated();
     }
 
     @Test
-    void initiallyVisibleColumn_detachAndAttachGrid_columnDataSentOnReattach() {
+    void initiallyHiddenColumn_columnDataNotGenerated() {
+        column.setVisible(false);
         ui.fakeClientCommunication();
-        resetColumnDataSpies();
-
-        ui.remove(grid);
-        ui.add(grid);
-        ui.fakeClientCommunication();
-        assertColumnDataSent();
+        assertColumnDataNotGenerated();
     }
 
-    @Test
-    void initiallyHiddenColumn_columnDataNotSent() {
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        assertColumnDataNotSent();
+    @Nested
+    class InitiallyVisibleColumnClass {
+        @BeforeEach
+        void setup() {
+            ui.fakeClientCommunication();
+            resetColumnDataSpies();
+            resetDataProviderSpies();
+        }
+
+        @Test
+        void refreshItem_columnDataRefreshed() {
+            grid.getDataProvider().refreshItem("Item 0");
+            ui.fakeClientCommunication();
+            assertColumnDataRefreshed();
+        }
+
+        @Test
+        void detachAndAttachGrid_columnDataGenerated() {
+            ui.remove(grid);
+            ui.add(grid);
+            ui.fakeClientCommunication();
+            assertColumnDataGenerated();
+        }
+
+        @Test
+        void hideColumn_columnDataNotGenerated() {
+            column.setVisible(false);
+            ui.fakeClientCommunication();
+            assertColumnDataNotGenerated();
+        }
+
+        @Test
+        void hideColumn_dataProviderNotCalled() {
+            column.setVisible(false);
+            ui.fakeClientCommunication();
+            assertDataProviderNotCalled();
+        }
+
+        @Test
+        void hideAndImmediatelyShowColumn_columnDataGenerated() {
+            column.setVisible(false);
+            column.setVisible(true);
+            ui.fakeClientCommunication();
+            assertColumnDataGenerated();
+        }
     }
 
-    @Test
-    void initiallyHiddenColumn_detachAndAttachGrid_columnDataNotSentOnReattach() {
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        resetColumnDataSpies();
+    @Nested
+    class InitiallyHiddenColumnClass {
+        @BeforeEach
+        void setup() {
+            column.setVisible(false);
+            ui.fakeClientCommunication();
+            resetColumnDataSpies();
+            resetDataProviderSpies();
+        }
 
-        ui.remove(grid);
-        ui.add(grid);
-        ui.fakeClientCommunication();
-        assertColumnDataNotSent();
+        @Test
+        void refreshItem_columnDataNotRefreshed() {
+            grid.getDataProvider().refreshItem("Item 0");
+            ui.fakeClientCommunication();
+            assertColumnDataNotRefreshed();
+        }
+
+        @Test
+        void detachAndAttachGrid_columnDataNotGenerated() {
+            ui.remove(grid);
+            ui.add(grid);
+            ui.fakeClientCommunication();
+            assertColumnDataNotGenerated();
+        }
+
+        @Test
+        void setRenderer_columnDataNotGenerated() {
+            column.setRenderer(createSpyRenderer());
+            ui.fakeClientCommunication();
+            assertColumnDataNotGenerated();
+        }
+
+        @Test
+        void showColumn_columnDataGenerated() {
+            column.setVisible(true);
+            ui.fakeClientCommunication();
+            assertColumnDataGenerated();
+        }
+
+        @Test
+        void showColumn_dataProviderNotCalled() {
+            column.setVisible(true);
+            ui.fakeClientCommunication();
+            assertDataProviderNotCalled();
+        }
+
+        @Test
+        void showAndImmediatelyHideColumn_columnDataNotGenerated() {
+            column.setVisible(true);
+            column.setVisible(false);
+            ui.fakeClientCommunication();
+            assertColumnDataNotGenerated();
+        }
     }
 
-    @Test
-    void hideColumn_columnDataNotSent() {
-        ui.fakeClientCommunication();
-        resetColumnDataSpies();
+    private Renderer<String> createSpyRenderer() {
+        return new Renderer<>() {
+            @Override
+            public Rendering<String> render(Element container,
+                    DataKeyMapper<String> keyMapper, String rendererName) {
+                return () -> Optional.of(new DataGenerator<String>() {
+                    @Override
+                    public void generateData(String item,
+                            ObjectNode jsonObject) {
+                        columnGenerateDataCallCount.incrementAndGet();
+                    }
 
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        assertColumnDataNotSent();
-    }
-
-    @Test
-    void hideAndImmediatelyShowColumn_columnDataSent() {
-        ui.fakeClientCommunication();
-        resetColumnDataSpies();
-
-        column.setVisible(false);
-        column.setVisible(true);
-        ui.fakeClientCommunication();
-        assertColumnDataSent();
-    }
-
-    @Test
-    void showColumn_columnDataSent() {
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        resetColumnDataSpies();
-
-        column.setVisible(true);
-        ui.fakeClientCommunication();
-        assertColumnDataSent();
-    }
-
-    @Test
-    void showAndImmediatelyHideColumn_columnDataNotSent() {
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        resetColumnDataSpies();
-
-        column.setVisible(true);
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        assertColumnDataNotSent();
-    }
-
-    @Test
-    void hiddenColumn_setRenderer_columnDataNotSent() {
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        resetColumnDataSpies();
-
-        column.setRenderer(new ColumnPathRenderer<>("value", s -> {
-            columnValueProviderCallCount.incrementAndGet();
-            return s;
-        }));
-        ui.fakeClientCommunication();
-        assertColumnDataNotSent();
-    }
-
-    @Test
-    void hideColumn_dataProviderNotCalled() {
-        ui.fakeClientCommunication();
-        resetDataProviderSpies();
-
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        assertDataProviderNotCalled();
-    }
-
-    @Test
-    void showColumn_dataProviderNotCalled() {
-        column.setVisible(false);
-        ui.fakeClientCommunication();
-        resetDataProviderSpies();
-
-        column.setVisible(true);
-        ui.fakeClientCommunication();
-        assertDataProviderNotCalled();
+                    @Override
+                    public void refreshData(String item) {
+                        columnRefreshDataCallCount.incrementAndGet();
+                    }
+                });
+            }
+        };
     }
 
     private void resetColumnDataSpies() {
-        columnValueProviderCallCount.set(0);
+        columnRefreshDataCallCount.set(0);
+        columnGenerateDataCallCount.set(0);
         columnTooltipGeneratorCallCount.set(0);
         columnPartNameGeneratorCallCount.set(0);
     }
 
-    private void assertColumnDataSent() {
-        Assertions.assertEquals(ITEMS.size(),
-                columnValueProviderCallCount.get());
-        Assertions.assertEquals(ITEMS.size(),
-                columnTooltipGeneratorCallCount.get());
-        Assertions.assertEquals(ITEMS.size(),
-                columnPartNameGeneratorCallCount.get());
+    private void assertColumnDataGenerated() {
+        Assertions.assertEquals(1, columnGenerateDataCallCount.get());
+        Assertions.assertEquals(1, columnTooltipGeneratorCallCount.get());
+        Assertions.assertEquals(1, columnPartNameGeneratorCallCount.get());
     }
 
-    private void assertColumnDataNotSent() {
-        Assertions.assertEquals(0, columnValueProviderCallCount.get());
+    private void assertColumnDataNotGenerated() {
+        Assertions.assertEquals(0, columnGenerateDataCallCount.get());
         Assertions.assertEquals(0, columnTooltipGeneratorCallCount.get());
         Assertions.assertEquals(0, columnPartNameGeneratorCallCount.get());
+    }
+
+    private void assertColumnDataRefreshed() {
+        Assertions.assertEquals(1, columnRefreshDataCallCount.get());
+    }
+
+    private void assertColumnDataNotRefreshed() {
+        Assertions.assertEquals(0, columnRefreshDataCallCount.get());
     }
 
     private void resetDataProviderSpies() {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -527,9 +527,10 @@ public class GridPro<E> extends Grid<E> {
     }
 
     private void generateCellEditableData(E item, ObjectNode jsonObject) {
-        // Get edit columns with cell editable providers
+        // Get visible edit columns with cell editable providers
         List<EditColumn<E>> editColumns = getColumns().stream()
                 .filter(column -> column instanceof EditColumn<E> editColumn
+                        && editColumn.isVisible()
                         && editColumn.cellEditableProvider != null)
                 .map(column -> (EditColumn<E>) column).toList();
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -187,11 +187,6 @@ public class GridPro<E> extends Grid<E> {
     /**
      * Server-side component for the {@code <vaadin-grid-edit-column>} element.
      *
-     * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link GridPro#removeColumn(Column)} to avoid sending extra data.
-     *
      * @param <T>
      *            type of the underlying grid this column is compatible with
      */

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProHiddenColumnCellEditableTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProHiddenColumnCellEditableTest.java
@@ -24,8 +24,7 @@ class GridProHiddenColumnCellEditableTest {
 
     private GridPro<String> grid;
     private GridPro.EditColumn<String> column;
-    private AtomicInteger cellEditableProviderCallCount = new AtomicInteger(
-            0);
+    private AtomicInteger cellEditableProviderCallCount = new AtomicInteger(0);
 
     @BeforeEach
     void setup() {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProHiddenColumnCellEditableTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProHiddenColumnCellEditableTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.gridpro;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.tests.MockUIExtension;
+
+class GridProHiddenColumnCellEditableTest {
+
+    @RegisterExtension
+    private MockUIExtension ui = new MockUIExtension();
+
+    private GridPro<String> grid;
+    private GridPro.EditColumn<String> column;
+    private AtomicInteger cellEditableProviderCallCount = new AtomicInteger(
+            0);
+
+    @BeforeEach
+    void setup() {
+        grid = new GridPro<>();
+        grid.setItems("Item 0");
+
+        column = (GridPro.EditColumn<String>) grid.addEditColumn(item -> item)
+                .text((item, newValue) -> {
+                });
+        column.setCellEditableProvider(item -> {
+            cellEditableProviderCallCount.incrementAndGet();
+            return true;
+        });
+
+        ui.add(grid);
+    }
+
+    @Test
+    void visibleColumn_cellEditableProviderCalled() {
+        ui.fakeClientCommunication();
+        Assertions.assertEquals(1, cellEditableProviderCallCount.get());
+    }
+
+    @Test
+    void hiddenColumn_cellEditableProviderNotCalled() {
+        column.setVisible(false);
+        ui.fakeClientCommunication();
+        Assertions.assertEquals(0, cellEditableProviderCallCount.get());
+    }
+}


### PR DESCRIPTION
## Description

Value providers, tooltip generators, and part name generators run for every row regardless of column visibility. This adds unnecessary load when these callbacks do expensive work.

Each column's data generators are now wrapped in a `CompositeDataGenerator` that only runs them while the column is visible, and the row-level tooltip and part name generation are skipped for hidden columns too. Showing a previously hidden column refreshes the viewport so its data is generated again (but not reloaded from the data provider).

Depends on
- https://github.com/vaadin/flow/pull/24895
- https://github.com/vaadin/flow-components/pull/9661

> [!WARNING]
> Hidden columns no longer send data to the client side.

Fixes #6737

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
