### PR TITLE
refactor!(TimePicker): sync value on change event instead of value-changed

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
@@ -90,7 +90,7 @@ public class TimePickerIT extends AbstractComponentIT {
         Assert.assertEquals("Item in the dropdown is not correct", "1:00 AM",
                 picker.getItemText(1));
         picker.closeDropDown();
-        executeScript("arguments[0].value = '12:31'", picker);
+        picker.setValue("12:31");
 
         selectStep("0.5s");
         validatePickerValue(picker, "12:31:00.000");
@@ -100,7 +100,7 @@ public class TimePickerIT extends AbstractComponentIT {
 
         // for the auto formatting of the value to work, it needs to match the
         // new step
-        executeScript("arguments[0].value = '12:30:00'", picker);
+        picker.setValue("12:30:00");
         selectStep("30m"); // using smaller step will cause the drop down to be
                            // big and then drop down iron list does magic that
                            // messes the item indexes

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -230,6 +230,8 @@ public class TimePicker
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
 
+        setSynchronizedEvent("change");
+
         addValueChangeListener(e -> validate());
 
         getElement().addEventListener("unparsable-change", event -> {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.timepicker.testbench;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import org.openqa.selenium.By;
@@ -185,6 +186,12 @@ public class TimePickerElement extends TestBenchElement
     public void scrollToItem(int index) {
         executeScript("arguments[0]._scroller.scrollIntoView(arguments[1])",
                 getTimePickerComboBox(), index);
+    }
+
+    @Override
+    public void setValue(String value) {
+        setProperty("value", value);
+        dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     /**


### PR DESCRIPTION
## Description

For consistency with DatePicker, this PR updates TimePicker to synchronize its value on `change` event instead of `value-changed`.

Related #6797 

## Type of change

- [x] Refactor
