### PR TITLE
test: refactor Details IT to use AbstractComponentIT

### DIFF
--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/BasicIT.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/BasicIT.java
@@ -26,17 +26,17 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.details.DetailsVariant;
 import com.vaadin.flow.component.details.testbench.DetailsElement;
-import com.vaadin.tests.AbstractParallelTest;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 
-public class BasicIT extends AbstractParallelTest {
+@TestPath("vaadin-details")
+public class BasicIT extends AbstractComponentIT {
 
     private List<DetailsElement> detailsElements;
 
     @Before
     public void init() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-details");
-        getDriver().get(url);
+        open();
         detailsElements = $(DetailsElement.class).all();
 
         Assert.assertEquals(3, detailsElements.size());


### PR DESCRIPTION
## Description

Same as #6682 but for `Details`.

This component was initially using the setup of "Pro" components, let's change it to use `AbstractComponentIT`.
Note: there's a second IT test file that is already using it, so it makes sense to align these.

## Type of change

- Test