### PR TITLE
chore: ignore React Router warnings in tests

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -286,6 +286,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 .filter(log -> log.getLevel().equals(Level.WARNING))
                 .filter(log -> !log.getMessage().contains("deprecated"))
                 .filter(log -> !log.getMessage().contains("Lit is in dev mode"))
+                .filter(log -> !log.getMessage()
+                        .contains("React Router Future Flag Warning"))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Ignore future flag warnings from React Router in integration tests.