### PR TITLE
fix: apply colors from conditional formatting

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ColorConverterUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ColorConverterUtil.java
@@ -14,16 +14,19 @@ public class ColorConverterUtil implements Serializable {
 
     public static String toRGBA(byte[] argb) {
         int rgba[] = new int[3];
-        for (int i = 1; i < argb.length; i++) {
+        boolean hasAlpha = argb.length == 4;
+        float alpha = hasAlpha ? argb[0] : 1.0f;
+        int channelOffset = hasAlpha ? 1 : 0;
+
+        for (int i = channelOffset; i < argb.length; i++) {
             int x = argb[i];
             if (x < 0) {
                 x += 256;
             }
-            rgba[i - 1] = x;
+            rgba[i - channelOffset] = x;
         }
 
-        float x = argb[0];
-        return buildRgba(rgba, x);
+        return buildRgba(rgba, alpha);
     }
 
     public static String toRGBA(String hexARGB) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/XSSFColorConverterTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/XSSFColorConverterTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import org.apache.poi.ss.usermodel.ComparisonOperator;
+import org.apache.poi.ss.usermodel.ConditionalFormattingRule;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.XSSFColorConverter;
+
+public class XSSFColorConverterTest {
+
+    private Spreadsheet spreadsheet;
+    private XSSFColorConverter converter;
+
+    @Before
+    public void setUp() {
+        spreadsheet = new Spreadsheet();
+        converter = new XSSFColorConverter(
+                (XSSFWorkbook) spreadsheet.getWorkbook());
+    }
+
+    @Test
+    public void getFontColorCSS_withIndexedColor() {
+        var rule = createRule();
+        var font = rule.createFontFormatting();
+        font.setFontColorIndex(IndexedColors.RED.index);
+
+        var cssColor = converter.getFontColorCSS(rule);
+
+        Assert.assertEquals("rgba(255, 0, 0, 1.0);", cssColor);
+    }
+
+    @Test
+    public void getFontColorCSS_withRgbColor() {
+        var rule = createRule();
+        var font = rule.createFontFormatting();
+        var color = new XSSFColor(
+                new byte[] { (byte) 255, (byte) 128, (byte) 64 });
+        font.setFontColor(color);
+
+        var cssColor = converter.getFontColorCSS(rule);
+
+        Assert.assertEquals("rgba(255, 128, 64, 1.0);", cssColor);
+    }
+
+    @Test
+    public void getBackgroundColorCSS_withIndexedColor() {
+        var rule = createRule();
+        var pattern = rule.createPatternFormatting();
+        pattern.setFillBackgroundColor(IndexedColors.RED.index);
+
+        var cssColor = converter.getBackgroundColorCSS(rule);
+
+        Assert.assertEquals("rgba(255, 0, 0, 1.0);", cssColor);
+    }
+
+    @Test
+    public void getBackgroundColorCSS_withRgbColor() {
+        var rule = createRule();
+        var pattern = rule.createPatternFormatting();
+        var color = new XSSFColor(
+                new byte[] { (byte) 255, (byte) 128, (byte) 64 });
+        pattern.setFillBackgroundColor(color);
+
+        var cssColor = converter.getBackgroundColorCSS(rule);
+
+        Assert.assertEquals("rgba(255, 128, 64, 1.0);", cssColor);
+    }
+
+    private ConditionalFormattingRule createRule() {
+        var conditionalFormatting = spreadsheet.getActiveSheet()
+                .getSheetConditionalFormatting();
+        return conditionalFormatting
+                .createConditionalFormattingRule(ComparisonOperator.LT, "0");
+    }
+}


### PR DESCRIPTION
Fixes logic for retrieving text and background color from formatting rules and adds handling of indexed and RGB colors.

Fixes https://github.com/vaadin/flow-components/issues/6819