### PR TITLE
refactor: rename header component to header content

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetPage.java
@@ -29,7 +29,7 @@ public class DashboardWidgetPage extends Div {
         DashboardWidget widget1 = new DashboardWidget();
         widget1.setTitle("Widget 1");
         widget1.setContent(new Div("Some content"));
-        widget1.setHeaderComponent(new Span("Some header"));
+        widget1.setHeaderContent(new Span("Some header"));
         widget1.setId("widget-1");
 
         DashboardWidget widget2 = new DashboardWidget();
@@ -89,7 +89,7 @@ public class DashboardWidgetPage extends Div {
         updateHeaderOfTheFirstWidget.addClickListener(click -> {
             List<DashboardWidget> widgets = dashboard.getWidgets();
             if (!widgets.isEmpty()) {
-                widgets.get(0).setHeaderComponent(new Span("Updated header"));
+                widgets.get(0).setHeaderContent(new Span("Updated header"));
             }
         });
         updateHeaderOfTheFirstWidget.setId("update-header-of-the-first-widget");
@@ -99,7 +99,7 @@ public class DashboardWidgetPage extends Div {
         removeHeaderOfTheFirstWidget.addClickListener(click -> {
             List<DashboardWidget> widgets = dashboard.getWidgets();
             if (!widgets.isEmpty()) {
-                widgets.get(0).setHeaderComponent(null);
+                widgets.get(0).setHeaderContent(null);
             }
         });
         removeHeaderOfTheFirstWidget.setId("remove-header-of-the-first-widget");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.component.shared.SlotUtils;
 /**
  * DashboardWidget represents a customizable widget that can be placed within a
  * {@link Dashboard}. It supports layout options such as colspan and rowspan,
- * and allows setting content and a header component.
+ * and allows setting content and header content.
  *
  * @see Dashboard
  *
@@ -140,24 +140,24 @@ public class DashboardWidget extends Component {
     }
 
     /**
-     * Gets the component in the header content slot of this widget.
+     * Gets the content in the header content slot of this widget.
      *
-     * @return the header component of this widget, or {@code null} if no header
-     *         component has been set
+     * @return the header content of this widget, or {@code null} if no header
+     *         content has been set
      */
-    public Component getHeaderComponent() {
+    public Component getHeaderContent() {
         return SlotUtils.getChildInSlot(this, "header-content");
     }
 
     /**
-     * Sets the component in the header content slot of this widget, replacing
-     * any existing header component.
+     * Sets the content in the header content slot of this widget, replacing any
+     * existing header content.
      *
      * @param header
-     *            the component to set, can be {@code null} to remove existing
-     *            header component
+     *            the content to set, can be {@code null} to remove existing
+     *            header content
      */
-    public void setHeaderComponent(Component header) {
+    public void setHeaderContent(Component header) {
         SlotUtils.setSlot(this, "header-content", header);
     }
 

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/tests/DashboardWidgetTest.java
@@ -173,41 +173,41 @@ public class DashboardWidgetTest extends DashboardTestBase {
     @Test
     public void defaultHeaderIsNull() {
         DashboardWidget widget = new DashboardWidget();
-        Assert.assertNull(widget.getHeaderComponent());
+        Assert.assertNull(widget.getHeaderContent());
     }
 
     @Test
     public void setHeaderToEmptyWidget_correctHeaderIsSet() {
         Div header = new Div();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeaderComponent(header);
-        Assert.assertEquals(header, widget.getHeaderComponent());
+        widget.setHeaderContent(header);
+        Assert.assertEquals(header, widget.getHeaderContent());
     }
 
     @Test
     public void setAnotherHeaderToNonEmptyWidget_correctHeaderIsSet() {
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeaderComponent(new Div());
+        widget.setHeaderContent(new Div());
         Span newHeader = new Span();
-        widget.setHeaderComponent(newHeader);
-        Assert.assertEquals(newHeader, widget.getHeaderComponent());
+        widget.setHeaderContent(newHeader);
+        Assert.assertEquals(newHeader, widget.getHeaderContent());
     }
 
     @Test
     public void setTheSameHeaderToNonEmptyWidget_correctHeaderIsSet() {
         Div header = new Div();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeaderComponent(header);
-        widget.setHeaderComponent(header);
-        Assert.assertEquals(header, widget.getHeaderComponent());
+        widget.setHeaderContent(header);
+        widget.setHeaderContent(header);
+        Assert.assertEquals(header, widget.getHeaderContent());
     }
 
     @Test
     public void setNullHeaderToNonEmptyWidget_headerIsRemoved() {
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeaderComponent(new Div());
-        widget.setHeaderComponent(null);
-        Assert.assertNull(widget.getHeaderComponent());
+        widget.setHeaderContent(new Div());
+        widget.setHeaderContent(null);
+        Assert.assertNull(widget.getHeaderContent());
     }
 
     @Test
@@ -215,7 +215,7 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Div content = new Div();
         DashboardWidget widget = new DashboardWidget();
         widget.setContent(content);
-        widget.setHeaderComponent(null);
+        widget.setHeaderContent(null);
         Assert.assertEquals(content, widget.getContent());
     }
 
@@ -223,9 +223,9 @@ public class DashboardWidgetTest extends DashboardTestBase {
     public void setNullContentToWidgetWithHeader_headerIsNotRemoved() {
         Div header = new Div();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeaderComponent(header);
+        widget.setHeaderContent(header);
         widget.setContent(null);
-        Assert.assertEquals(header, widget.getHeaderComponent());
+        Assert.assertEquals(header, widget.getHeaderContent());
     }
 
     @Test
@@ -234,9 +234,9 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Span header = new Span();
         DashboardWidget widget = new DashboardWidget();
         widget.setContent(content);
-        widget.setHeaderComponent(header);
+        widget.setHeaderContent(header);
         Assert.assertEquals(content, widget.getContent());
-        Assert.assertEquals(header, widget.getHeaderComponent());
+        Assert.assertEquals(header, widget.getHeaderContent());
     }
 
     @Test
@@ -244,10 +244,10 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Div content = new Div();
         Span header = new Span();
         DashboardWidget widget = new DashboardWidget();
-        widget.setHeaderComponent(header);
+        widget.setHeaderContent(header);
         widget.setContent(content);
         Assert.assertEquals(content, widget.getContent());
-        Assert.assertEquals(header, widget.getHeaderComponent());
+        Assert.assertEquals(header, widget.getHeaderContent());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR renames header component related API to use "header content" instead.

Fixes #[8149](https://github.com/vaadin/web-components/issues/8149)

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.