### PR TITLE
feat: make haswidgets api also accept collections

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.dashboard;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -133,14 +134,11 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
     }
 
     @Override
-    public void add(DashboardWidget... widgets) {
+    public void add(Collection<DashboardWidget> widgets) {
         Objects.requireNonNull(widgets, "Widgets to add cannot be null.");
-        List<DashboardWidget> toAdd = new ArrayList<>(widgets.length);
-        for (DashboardWidget widget : widgets) {
-            Objects.requireNonNull(widget, "Widget to add cannot be null.");
-            toAdd.add(widget);
-        }
-        toAdd.forEach(this::doAddWidget);
+        widgets.forEach(widget -> Objects.requireNonNull(widget,
+                "Widget to add cannot be null."));
+        widgets.forEach(this::doAddWidget);
         updateClient();
     }
 
@@ -181,9 +179,9 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
     }
 
     @Override
-    public void remove(DashboardWidget... widgets) {
+    public void remove(Collection<DashboardWidget> widgets) {
         Objects.requireNonNull(widgets, "Widgets to remove cannot be null.");
-        List<DashboardWidget> toRemove = new ArrayList<>(widgets.length);
+        List<DashboardWidget> toRemove = new ArrayList<>(widgets.size());
         for (DashboardWidget widget : widgets) {
             Objects.requireNonNull(widget, "Widget to remove cannot be null.");
             Element parent = widget.getElement().getParent();

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -20,7 +21,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.dom.Element;
 
 /**
  * DashboardSection is a container for organizing multiple
@@ -91,14 +91,11 @@ public class DashboardSection extends Component implements HasWidgets {
     }
 
     @Override
-    public void add(DashboardWidget... widgets) {
+    public void add(Collection<DashboardWidget> widgets) {
         Objects.requireNonNull(widgets, "Widgets to add cannot be null.");
-        List<DashboardWidget> toAdd = new ArrayList<>(widgets.length);
-        for (DashboardWidget widget : widgets) {
-            Objects.requireNonNull(widget, "Widget to add cannot be null.");
-            toAdd.add(widget);
-        }
-        toAdd.forEach(this::doAddWidget);
+        widgets.forEach(widget -> Objects.requireNonNull(widget,
+                "Widget to add cannot be null."));
+        widgets.forEach(this::doAddWidget);
         updateClient();
     }
 
@@ -119,12 +116,12 @@ public class DashboardSection extends Component implements HasWidgets {
     }
 
     @Override
-    public void remove(DashboardWidget... widgets) {
+    public void remove(Collection<DashboardWidget> widgets) {
         Objects.requireNonNull(widgets, "Widgets to remove cannot be null.");
-        List<DashboardWidget> toRemove = new ArrayList<>(widgets.length);
+        var toRemove = new ArrayList<DashboardWidget>(widgets.size());
         for (DashboardWidget widget : widgets) {
             Objects.requireNonNull(widget, "Widget to remove cannot be null.");
-            Element parent = widget.getElement().getParent();
+            var parent = widget.getElement().getParent();
             if (parent == null) {
                 LoggerFactory.getLogger(getClass()).debug(
                         "Removal of a widget with no parent does nothing.");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/HasWidgets.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/HasWidgets.java
@@ -9,7 +9,10 @@
 package com.vaadin.flow.component.dashboard;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * HasWidgets is an interface for components that can contain and manage
@@ -35,7 +38,18 @@ public interface HasWidgets extends Serializable {
      * @param widgets
      *            the widgets to add, not {@code null}
      */
-    void add(DashboardWidget... widgets);
+    default void add(DashboardWidget... widgets) {
+        Objects.requireNonNull(widgets, "Widgets to add cannot be null.");
+        add(Arrays.asList(widgets));
+    }
+
+    /**
+     * Adds the given widgets to this component.
+     *
+     * @param widgets
+     *            the widgets to add, not {@code null}
+     */
+    void add(Collection<DashboardWidget> widgets);
 
     /**
      * Adds the given widget as child of this component at the specific index.
@@ -60,7 +74,21 @@ public interface HasWidgets extends Serializable {
      *             if there is a widget whose non {@code null} parent is not
      *             this component
      */
-    void remove(DashboardWidget... widgets);
+    default void remove(DashboardWidget... widgets) {
+        Objects.requireNonNull(widgets, "Widgets to remove cannot be null.");
+        remove(Arrays.asList(widgets));
+    }
+
+    /**
+     * Removes the given widgets from this component.
+     *
+     * @param widgets
+     *            the widgets to remove, not {@code null}
+     * @throws IllegalArgumentException
+     *             if there is a widget whose non {@code null} parent is not
+     *             this component
+     */
+    void remove(Collection<DashboardWidget> widgets);
 
     /**
      * Removes all widgets from this component.

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.dashboard;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,10 +36,19 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
-    public void addWidget_widgetIsAdded() {
-        DashboardWidget widget1 = getNewWidget();
-        DashboardWidget widget2 = getNewWidget();
+    public void addWidgetInArray_widgetIsAdded() {
+        var widget1 = getNewWidget();
+        var widget2 = getNewWidget();
         dashboard.add(widget1, widget2);
+        fakeClientCommunication();
+        assertChildComponents(dashboard, widget1, widget2);
+    }
+
+    @Test
+    public void addWidgetInCollection_widgetIsAdded() {
+        var widget1 = getNewWidget();
+        var widget2 = getNewWidget();
+        dashboard.add(List.of(widget1, widget2));
         fakeClientCommunication();
         assertChildComponents(dashboard, widget1, widget2);
     }
@@ -50,10 +60,30 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
+    public void addNullCollection_exceptionIsThrown() {
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.add((Collection<DashboardWidget>) null));
+    }
+
+    @Test
     public void addNullWidgetInArray_noWidgetIsAdded() {
         DashboardWidget widget = getNewWidget();
         try {
             dashboard.add(widget, null);
+        } catch (NullPointerException e) {
+            // Do nothing
+        }
+        fakeClientCommunication();
+        assertChildComponents(dashboard);
+    }
+
+    @Test
+    public void addNullWidgetInCollection_noWidgetIsAdded() {
+        var widgets = new ArrayList<DashboardWidget>();
+        widgets.add(getNewWidget());
+        widgets.add(null);
+        try {
+            dashboard.add(widgets);
         } catch (NullPointerException e) {
             // Do nothing
         }
@@ -101,9 +131,9 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
-    public void removeWidget_widgetIsRemoved() {
-        DashboardWidget widget1 = getNewWidget();
-        DashboardWidget widget2 = getNewWidget();
+    public void removeWidgetInArray_widgetIsRemoved() {
+        var widget1 = getNewWidget();
+        var widget2 = getNewWidget();
         dashboard.add(widget1, widget2);
         fakeClientCommunication();
         dashboard.remove(widget1);
@@ -112,9 +142,26 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
+    public void removeWidgetInCollection_widgetIsRemoved() {
+        var widget1 = getNewWidget();
+        var widget2 = getNewWidget();
+        dashboard.add(widget1, widget2);
+        fakeClientCommunication();
+        dashboard.remove(List.of(widget1));
+        fakeClientCommunication();
+        assertChildComponents(dashboard, widget2);
+    }
+
+    @Test
     public void removeNullWidget_exceptionIsThrown() {
         Assert.assertThrows(NullPointerException.class,
                 () -> dashboard.remove((DashboardWidget) null));
+    }
+
+    @Test
+    public void removeNullWidgetCollection_exceptionIsThrown() {
+        Assert.assertThrows(NullPointerException.class,
+                () -> dashboard.remove((Collection<DashboardWidget>) null));
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds 2 new API to `HasWidgets`:
- `void add(Collection<DashboardWidget> widgets)`
- `void remove(Collection<DashboardWidget> widgets)`

Fixes [the project board issue](https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=87240740).

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.