### PR TITLE
feat: add wrap API to HorizontalLayout/VerticalLayout

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/ThemableLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/ThemableLayout.java
@@ -106,6 +106,38 @@ public interface ThemableLayout extends HasElement {
     }
 
     /**
+     * Sets whether items should wrap to new lines/columns when they exceed the
+     * layout's boundaries. When enabled, items maintain their size and create
+     * new rows or columns as needed, depending on the layout's orientation.
+     * <p>
+     * When disabled, items will be compressed to fit within a single
+     * row/column.
+     *
+     * @param wrap
+     *            true to enable wrapping, false to force items into a single
+     *            row/column
+     */
+    default void setWrap(boolean wrap) {
+        getThemeList().set("wrap", wrap);
+    }
+
+    /**
+     * Gets whether items will wrap to new lines/columns when they exceed the
+     * layout's boundaries.
+     * <p>
+     * When wrapping is enabled, items maintain their defined dimensions by
+     * creating new rows or columns as needed. When disabled, items may be
+     * compressed to fit within the available space.
+     *
+     * @return true if wrapping is enabled, false if items are forced into a
+     *         single row/column
+     * @see #setWrap(boolean)
+     */
+    default boolean isWrap() {
+        return getThemeList().contains("wrap");
+    }
+
+    /**
      * Gets the set of the theme names applied to the corresponding element in
      * {@code theme} attribute. The set returned can be modified to add or
      * remove the theme names, changes to the set will be reflected in the

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ThemableLayoutTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ThemableLayoutTest.java
@@ -64,6 +64,11 @@ public class ThemableLayoutTest {
         checkThemeToggling("spacing", layout::isSpacing, layout::setSpacing);
     }
 
+    @Test
+    public void checkWrap() {
+        checkThemeToggling("wrap", layout::isWrap, layout::setWrap);
+    }
+
     private void checkThemeToggling(String themeName,
             Supplier<Boolean> themeGetter, Consumer<Boolean> themeSetter) {
         assertFalse(String.format(


### PR DESCRIPTION
## Description

This pull request introduces new functionality to the `ThemableLayout` class in the `vaadin-ordered-layout-flow` package, adding support for item wrapping within the layout. Additionally, it includes corresponding test cases to ensure the new functionality works as expected.

New functionality:

* [`vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/ThemableLayout.java`](diffhunk://#diff-652e2ed58d8825aa2bbddc2a86f3c6eb8b29d76e81c7c3af6ebdca36578e9d19R108-R139): Added `setWrap` and `isWrap` methods to control and check whether items should wrap to new lines or columns when they exceed the layout's boundaries.

Testing:

* [`vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/ThemableLayoutTest.java`](diffhunk://#diff-7f4d4a238e59ca76934df86d15ad313798e6787fffb29a116c2f10e59eb37daaR67-R71): Added `checkWrap` test to verify the behavior of the new wrapping functionality by toggling the "wrap" theme.

Fixes https://github.com/vaadin/web-components/issues/7949

## Type of change

- [ ] Bugfix
- [X] Feature
