### PR TITLE
feat: add constructor overloads for dashboard widget

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -40,6 +40,51 @@ public class DashboardWidget extends Component {
     private boolean featureFlagEnabled;
 
     /**
+     * Creates an empty widget.
+     */
+    public DashboardWidget() {
+        this(null, null);
+    }
+
+    /**
+     * Creates a widget with the specified title.
+     *
+     * @param title
+     *            the title to set
+     */
+    public DashboardWidget(String title) {
+        this(title, null);
+    }
+
+    /**
+     * Creates a widget with the specified content.
+     *
+     * @param content
+     *            the content to set
+     */
+    public DashboardWidget(Component content) {
+        this(null, content);
+    }
+
+    /**
+     * Creates a widget with the specified title and content.
+     *
+     * @param title
+     *            the title to set
+     * @param content
+     *            the content to set
+     */
+    public DashboardWidget(String title, Component content) {
+        super();
+        if (title != null) {
+            setTitle(title);
+        }
+        if (content != null) {
+            setContent(content);
+        }
+    }
+
+    /**
      * Returns the title of the widget.
      *
      * @return the {@code widgetTitle} property from the web component

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardWidgetTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardWidgetTest.java
@@ -31,6 +31,15 @@ public class DashboardWidgetTest extends DashboardTestBase {
     }
 
     @Test
+    public void setTitleInConstructor_returnsCorrectTitle() {
+        var valueToSet = "New title";
+        var widget = new DashboardWidget(valueToSet);
+        widget.setFeatureFlagEnabled(true);
+        widget.setTitle(valueToSet);
+        Assert.assertEquals(valueToSet, widget.getTitle());
+    }
+
+    @Test
     public void setTitleNull_returnsEmptyTitle() {
         DashboardWidget widget = getNewWidget();
         widget.setTitle("New title");
@@ -140,6 +149,24 @@ public class DashboardWidgetTest extends DashboardTestBase {
         Div content = new Div();
         DashboardWidget widget = getNewWidget();
         widget.setContent(content);
+        Assert.assertEquals(content, widget.getContent());
+    }
+
+    @Test
+    public void setContentInConstructor_correctContentIsSet() {
+        var content = new Div();
+        var widget = new DashboardWidget(content);
+        widget.setFeatureFlagEnabled(true);
+        Assert.assertEquals(content, widget.getContent());
+    }
+
+    @Test
+    public void setTitleAndContentInConstructor_correctValuesAreSet() {
+        var title = "New title";
+        var content = new Div();
+        var widget = new DashboardWidget(title, content);
+        widget.setFeatureFlagEnabled(true);
+        Assert.assertEquals(title, widget.getTitle());
         Assert.assertEquals(content, widget.getContent());
     }
 


### PR DESCRIPTION
## Description

This PR adds the following convenience constructors for the `DashboardWidget`:
- `DashboardWidget(String title)`
- `DashboardWidget(Component content)`
- `DashboardWidget(String title, Component content)`

Fixes [the related project board issue](https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=87240651).

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.