### PR TITLE
refactor: do not rely on _hasInputValue for detecting bad input

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -759,7 +759,7 @@ public class DatePicker
         boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
         boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
         boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
-        boolean isInputValuePresent = isInputValuePresent();
+        String oldInputElementValue = getInputElementValue();
 
         // When the value is cleared programmatically, there is no change event
         // that would synchronize _inputElementValue, so we reset it ourselves
@@ -772,7 +772,7 @@ public class DatePicker
 
         // Revalidate if setValue(null) didn't result in a value change but
         // cleared bad input
-        if (isValueRemainedEmpty && isInputValuePresent) {
+        if (isValueRemainedEmpty && !oldInputElementValue.isEmpty()) {
             validate();
             fireValidationStatusChangeEvent();
         }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
@@ -15,13 +15,14 @@
  */
 package com.vaadin.flow.component.textfield.validation;
 
-import java.lang.reflect.Method;
 import java.math.BigDecimal;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 public class BigDecimalFieldBasicValidationTest
@@ -34,14 +35,15 @@ public class BigDecimalFieldBasicValidationTest
         });
 
         // Trigger ValidationStatusChangeEvent
-        simulateBadInput();
+        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
+        fakeClientPropertyChange(testField, "value", "foo");
         testField.clear();
     }
 
     @Test
     public void badInput_validate_emptyErrorMessageDisplayed() {
-        testField.getElement().setProperty("_hasInputValue", true);
-        simulateBadInput();
+        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
+        fakeClientPropertyChange(testField, "value", "foo");
         Assert.assertEquals("", testField.getErrorMessage());
     }
 
@@ -49,8 +51,8 @@ public class BigDecimalFieldBasicValidationTest
     public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setI18n(new BigDecimalField.BigDecimalFieldI18n()
                 .setBadInputErrorMessage("Value has invalid format"));
-        testField.getElement().setProperty("_hasInputValue", true);
-        simulateBadInput();
+        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
+        fakeClientPropertyChange(testField, "value", "foo");
         Assert.assertEquals("Value has invalid format",
                 testField.getErrorMessage());
     }
@@ -104,16 +106,10 @@ public class BigDecimalFieldBasicValidationTest
         return new BigDecimalField();
     }
 
-    private void simulateBadInput() {
-        testField.getElement().setProperty("_hasInputValue", true);
-
-        try {
-            Method validateMethod = BigDecimalField.class
-                    .getDeclaredMethod("validate");
-            validateMethod.setAccessible(true);
-            validateMethod.invoke(testField);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private void fakeClientPropertyChange(Component component, String property,
+            String value) {
+        Element element = component.getElement();
+        element.getStateProvider().setProperty(element.getNode(), property,
+                value, false);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/validation/BigDecimalFieldBasicValidationTest.java
@@ -35,14 +35,12 @@ public class BigDecimalFieldBasicValidationTest
         });
 
         // Trigger ValidationStatusChangeEvent
-        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
         fakeClientPropertyChange(testField, "value", "foo");
         testField.clear();
     }
 
     @Test
     public void badInput_validate_emptyErrorMessageDisplayed() {
-        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
         fakeClientPropertyChange(testField, "value", "foo");
         Assert.assertEquals("", testField.getErrorMessage());
     }
@@ -51,7 +49,6 @@ public class BigDecimalFieldBasicValidationTest
     public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setI18n(new BigDecimalField.BigDecimalFieldI18n()
                 .setBadInputErrorMessage("Value has invalid format"));
-        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
         fakeClientPropertyChange(testField, "value", "foo");
         Assert.assertEquals("Value has invalid format",
                 testField.getErrorMessage());

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.timepicker;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
@@ -367,7 +366,7 @@ public class TimePicker
         boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
         boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
         boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
-        boolean isInputValuePresent = isInputValuePresent();
+        String oldInputElementValue = getInputElementValue();
 
         // When the value is cleared programmatically, there is no change event
         // that would synchronize _inputElementValue, so we reset it ourselves
@@ -380,7 +379,7 @@ public class TimePicker
 
         // Revalidate if setValue(null) didn't result in a value change but
         // cleared bad input
-        if (isValueRemainedEmpty && isInputValuePresent) {
+        if (isValueRemainedEmpty && !oldInputElementValue.isEmpty()) {
             validate();
             fireValidationStatusChangeEvent();
         }
@@ -454,7 +453,7 @@ public class TimePicker
     /**
      * Gets the value of the input element. This value is updated on the server
      * when the web component dispatches a `change` or `unparsable-change`
-     * event. Except when clearing the value, {@link #setValue(LocalDate)} does
+     * event. Except when clearing the value, {@link #setValue(LocalTime)} does
      * not update the input element value on the server because it requires date
      * formatting, which is implemented on the web component's side.
      *

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
@@ -20,8 +20,10 @@ import java.time.LocalTime;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
@@ -37,14 +39,15 @@ public class BasicValidationTest
         });
 
         // Trigger ValidationStatusChangeEvent
-        testField.getElement().setProperty("_hasInputValue", true);
+        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
         testField.clear();
     }
 
     @Test
     public void badInput_validate_emptyErrorMessageDisplayed() {
         testField.getElement().setProperty("_hasInputValue", true);
-        fireUnparsableChangeDomEvent();
+        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
+        fakeClientDomEvent(testField, "unparsable-change");
         Assert.assertEquals("", testField.getErrorMessage());
     }
 
@@ -52,8 +55,8 @@ public class BasicValidationTest
     public void badInput_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setI18n(new TimePicker.TimePickerI18n()
                 .setBadInputErrorMessage("Time has invalid format"));
-        testField.getElement().setProperty("_hasInputValue", true);
-        fireUnparsableChangeDomEvent();
+        fakeClientPropertyChange(testField, "_inputElementValue", "foo");
+        fakeClientDomEvent(testField, "unparsable-change");
         Assert.assertEquals("Time has invalid format",
                 testField.getErrorMessage());
     }
@@ -138,10 +141,16 @@ public class BasicValidationTest
         return new TimePicker();
     }
 
-    private void fireUnparsableChangeDomEvent() {
-        DomEvent unparsableChangeDomEvent = new DomEvent(testField.getElement(),
-                "unparsable-change", Json.createObject());
-        testField.getElement().getNode().getFeature(ElementListenerMap.class)
-                .fireEvent(unparsableChangeDomEvent);
+    private void fakeClientDomEvent(Component component, String eventName) {
+        Element element = component.getElement();
+        DomEvent event = new DomEvent(element, eventName, Json.createObject());
+        element.getNode().getFeature(ElementListenerMap.class).fireEvent(event);
+    }
+
+    private void fakeClientPropertyChange(Component component, String property,
+            String value) {
+        Element element = component.getElement();
+        element.getStateProvider().setProperty(element.getNode(), property,
+                value, false);
     }
 }


### PR DESCRIPTION
## Description

The PR follows up on #6743 and updates TimePicker and BigDecimalField to not rely on `_hasInputValue` for detecting bad input. This change will allow us to remove some overrides in the [date-picker](https://github.com/vaadin/web-components/blob/0f883924dc1bc039c67d5b78091290a388ec33b6/packages/date-picker/src/vaadin-date-picker-mixin.js#L407-L421) and [time-picker](https://github.com/vaadin/web-components/blob/0f883924dc1bc039c67d5b78091290a388ec33b6/packages/time-picker/src/vaadin-time-picker-combo-box.js#L84-L95) web components.

Part of https://github.com/vaadin/web-components/issues/5639

## Type of change

- [x] Refactor
