### PR TITLE
refactor: separate spacing into gap and padding

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizePage.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/src/main/java/com/vaadin/flow/component/dashboard/tests/DashboardItemResizePage.java
@@ -26,8 +26,8 @@ public class DashboardItemResizePage extends Div {
         dashboard.setMinimumRowHeight("200px");
         dashboard.setMinimumColumnWidth("250px");
         dashboard.setMaximumColumnWidth("250px");
-        // Use setSpacing when it is made public
-        getStyle().set("--vaadin-dashboard-spacing", "0px");
+        dashboard.setGap("0px");
+        dashboard.setPadding("0px");
 
         DashboardWidget widget = new DashboardWidget();
         widget.setTitle("Widget");

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -313,26 +313,47 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
     }
 
     /**
-     * Returns the spacing of the dashboard. This value adjusts the spacing
-     * between elements within the component and the space around its outer
-     * edges.
+     * Returns the gap of the dashboard. This value adjusts the gap between
+     * elements within the dashboard.
      *
-     * @return the spacing of the dashboard
+     * @return the gap of the dashboard
      */
-    String getSpacing() {
-        return getStyle().get("--vaadin-dashboard-spacing");
+    public String getGap() {
+        return getStyle().get("--vaadin-dashboard-gap");
     }
 
     /**
-     * Sets the spacing of the dashboard. This value adjusts the spacing between
-     * elements within the component and the space around its outer edges.
+     * Sets the gap of the dashboard. This value adjusts the gap between
+     * elements within the dashboard.
      *
-     * @param spacing
-     *            the new spacing. Pass in {@code null} to set the spacing back
+     * @param gap
+     *            the new gap. Pass in {@code null} to set the gap back to the
+     *            default value.
+     */
+    public void setGap(String gap) {
+        getStyle().set("--vaadin-dashboard-gap", gap);
+    }
+
+    /**
+     * Returns the padding of the dashboard. This value adjusts the space around
+     * the outer edges of the dashboard.
+     *
+     * @return the padding of the dashboard
+     */
+    public String getPadding() {
+        return getStyle().get("--vaadin-dashboard-padding");
+    }
+
+    /**
+     * Sets the padding of the dashboard. This value adjusts the space around
+     * the outer edges of the dashboard.
+     *
+     * @param padding
+     *            the new padding. Pass in {@code null} to set the padding back
      *            to the default value.
      */
-    void setSpacing(String spacing) {
-        getStyle().set("--vaadin-dashboard-spacing", spacing);
+    public void setPadding(String padding) {
+        getStyle().set("--vaadin-dashboard-padding", padding);
     }
 
     /**

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
@@ -794,41 +794,78 @@ public class DashboardTest extends DashboardTestBase {
     }
 
     @Test
-    public void setSpacing_valueIsCorrectlySet() {
-        String propertyName = "--vaadin-dashboard-spacing";
+    public void setGap_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-gap";
         String valueToSet = "10px";
         Assert.assertNull(dashboard.getStyle().get(propertyName));
-        dashboard.setSpacing(valueToSet);
+        dashboard.setGap(valueToSet);
         Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
-        dashboard.setSpacing(null);
+        dashboard.setGap(null);
         Assert.assertNull(dashboard.getStyle().get(propertyName));
     }
 
     @Test
-    public void setSpacingNull_propertyIsRemoved() {
-        dashboard.setSpacing("10px");
-        dashboard.setSpacing(null);
-        Assert.assertNull(
-                dashboard.getStyle().get("--vaadin-dashboard-spacing"));
+    public void setGapNull_propertyIsRemoved() {
+        dashboard.setGap("10px");
+        dashboard.setGap(null);
+        Assert.assertNull(dashboard.getStyle().get("--vaadin-dashboard-gap"));
     }
 
     @Test
-    public void defaultSpacingValueIsCorrectlyRetrieved() {
-        Assert.assertNull(dashboard.getSpacing());
+    public void defaultGapValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getGap());
     }
 
     @Test
-    public void setSpacing_valueIsCorrectlyRetrieved() {
+    public void setGap_valueIsCorrectlyRetrieved() {
         String valueToSet = "10px";
-        dashboard.setSpacing(valueToSet);
-        Assert.assertEquals(valueToSet, dashboard.getSpacing());
+        dashboard.setGap(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getGap());
     }
 
     @Test
-    public void setSpacingNull_valueIsCorrectlyRetrieved() {
-        dashboard.setSpacing("10px");
-        dashboard.setSpacing(null);
-        Assert.assertNull(dashboard.getSpacing());
+    public void setGapNull_valueIsCorrectlyRetrieved() {
+        dashboard.setGap("10px");
+        dashboard.setGap(null);
+        Assert.assertNull(dashboard.getGap());
+    }
+
+    @Test
+    public void setPadding_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-padding";
+        String valueToSet = "10px";
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+        dashboard.setPadding(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getStyle().get(propertyName));
+        dashboard.setPadding(null);
+        Assert.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    public void setPaddingNull_propertyIsRemoved() {
+        dashboard.setPadding("10px");
+        dashboard.setPadding(null);
+        Assert.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-padding"));
+    }
+
+    @Test
+    public void defaultPaddingValueIsCorrectlyRetrieved() {
+        Assert.assertNull(dashboard.getPadding());
+    }
+
+    @Test
+    public void setPadding_valueIsCorrectlyRetrieved() {
+        String valueToSet = "10px";
+        dashboard.setPadding(valueToSet);
+        Assert.assertEquals(valueToSet, dashboard.getPadding());
+    }
+
+    @Test
+    public void setPaddingNull_valueIsCorrectlyRetrieved() {
+        dashboard.setPadding("10px");
+        dashboard.setPadding(null);
+        Assert.assertNull(dashboard.getPadding());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR splits the current spacing API to gap and dashboard.

Depends on https://github.com/vaadin/web-components/pull/8205.

The new API:
- `String getGap()`
- `void setGap(String gap)`
- `String getPadding()`
- `void setPadding(String padding)`

Fixes [the related project board issue](https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=88099241).

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.