### PR TITLE
fix: make Popover static methods thread-safe

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -67,7 +67,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     private static Integer defaultHideDelay;
     private static Integer defaultFocusDelay;
     private static Integer defaultHoverDelay;
-    private static boolean uiInitListenerRegistered = false;
+    static boolean uiInitListenerRegistered = false;
 
     private Component target;
     private Registration targetAttachRegistration;
@@ -111,7 +111,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * @param defaultFocusDelay
      *            the default focus delay
      */
-    public static void setDefaultFocusDelay(int defaultFocusDelay) {
+    public synchronized static void setDefaultFocusDelay(
+            int defaultFocusDelay) {
         Popover.defaultFocusDelay = defaultFocusDelay;
         applyConfiguration();
     }
@@ -124,7 +125,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * @param defaultHideDelay
      *            the default hide delay
      */
-    public static void setDefaultHideDelay(int defaultHideDelay) {
+    public synchronized static void setDefaultHideDelay(int defaultHideDelay) {
         Popover.defaultHideDelay = defaultHideDelay;
         applyConfiguration();
     }
@@ -137,7 +138,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * @param defaultHoverDelay
      *            the default hover delay
      */
-    public static void setDefaultHoverDelay(int defaultHoverDelay) {
+    public synchronized static void setDefaultHoverDelay(
+            int defaultHoverDelay) {
         Popover.defaultHoverDelay = defaultHoverDelay;
         applyConfiguration();
     }


### PR DESCRIPTION
## Description

Add `synchronized` to `setDefault*` methods in `Popover` to ensure that multiple calls originating from different threads will add only one listener to the UI instance.

Fixes #6838

## Type of change

- [X] Bugfix
- [ ] Feature
