### PR TITLE
test: make integration tests work with new headless mode (24.4)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/AbstractItemCountComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/AbstractItemCountComboBoxIT.java
@@ -32,7 +32,7 @@ public abstract class AbstractItemCountComboBoxIT extends AbstractComboBoxIT {
 
     // changing the dimension might get combo box change what it fetches and
     // how many items it shows, so changing this is a bad idea ...
-    private static final Dimension TARGET_SIZE = new Dimension(1000, 900);
+    private static final Dimension TARGET_SIZE = new Dimension(1000, 1100);
     protected ComboBoxElement comboBoxElement;
     protected int countIncreasePageCount = 4;
     protected int pageSize = new ComboBox<String>().getPageSize();

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.tests;
 
-import java.util.List;
-
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
-
 public abstract class AbstractComponentIT
         extends com.vaadin.flow.testutil.AbstractComponentIT {
 
@@ -28,22 +23,10 @@ public abstract class AbstractComponentIT
     }
 
     @Override
-    protected List<DesiredCapabilities> customizeCapabilities(
-            List<DesiredCapabilities> capabilities) {
-        // This method is overridden to force the legacy Chrome headless mode
-        // for the time being. The new `--headless=new` mode has an issue
-        // that doesn't allow tests to adjust the browser window size with
-        // `getDriver().manage().window().setSize(...)`, see more:
-        // https://github.com/SeleniumHQ/selenium/issues/11706
-        ChromeOptions chromeOptions = new ChromeOptions();
-        chromeOptions.addArguments("--headless", "--disable-gpu");
+    public void setup() throws Exception {
+        super.setup();
 
-        capabilities.stream()
-                .filter(cap -> "chrome".equalsIgnoreCase(cap.getBrowserName()))
-                .forEach(cap -> cap.setCapability(ChromeOptions.CAPABILITY,
-                        chromeOptions));
-
-        return capabilities;
+        // Set a default window size
+        testBench().resizeViewPortTo(1024, 800);
     }
-
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ContextMenuIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ContextMenuIT.java
@@ -34,8 +34,9 @@ public class ContextMenuIT extends AbstractSpreadsheetIT {
         // Make sure to use a small enough viewport so that the document needs
         // to be scrolled to see the cell
         getDriver().manage().window().setSize(WINDOW_SIZE_SMALL);
-        // Scroll the document horizontally
-        executeScript("document.documentElement.scrollLeft = 100");
+        // Scroll the document so the cell is visible
+        executeScript(
+                "document.documentElement.scrollLeft = 100;document.documentElement.scrollTop = 200;");
 
         var cell = getSpreadsheet().getCellAt("B2");
         // Open context menu for the cell


### PR DESCRIPTION
Cherry-pick of https://github.com/vaadin/flow-components/pull/6859

Sonar failure is an unrelated issue.