### PR TITLE
fix: Files map is transient that needs to be restored if null

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.upload.MultiFileReceiver;
  * For a custom file the constructor {@link AbstractFileBuffer(FileFactory)}
  * should be used.
  */
+@SuppressWarnings("serial")
 public class MultiFileBuffer extends AbstractFileBuffer
         implements MultiFileReceiver {
 
@@ -67,7 +68,8 @@ public class MultiFileBuffer extends AbstractFileBuffer
     @Override
     public OutputStream receiveUpload(String fileName, String mimeType) {
         FileOutputStream outputBuffer = createFileOutputStream(fileName);
-        files.put(fileName, new FileData(fileName, mimeType, outputBuffer));
+        getFilesMap().put(fileName,
+                new FileData(fileName, mimeType, outputBuffer));
 
         return outputBuffer;
     }
@@ -78,7 +80,15 @@ public class MultiFileBuffer extends AbstractFileBuffer
      * @return files stored
      */
     public Set<String> getFiles() {
-        return files.keySet();
+        return getFilesMap().keySet();
+    }
+
+    private Map<String, FileData> getFilesMap() {
+        if (files == null) {
+            // Restore transient map if it is null
+            files = new HashMap<>();
+        }
+        return files;
     }
 
     /**
@@ -89,7 +99,7 @@ public class MultiFileBuffer extends AbstractFileBuffer
      * @return file data for filename or null if not found
      */
     public FileData getFileData(String fileName) {
-        return files.get(fileName);
+        return getFilesMap().get(fileName);
     }
 
     /**
@@ -100,9 +110,9 @@ public class MultiFileBuffer extends AbstractFileBuffer
      * @return file output stream or null if not available
      */
     public FileDescriptor getFileDescriptor(String fileName) {
-        if (files.containsKey(fileName)) {
+        if (getFilesMap().containsKey(fileName)) {
             try {
-                return ((FileOutputStream) files.get(fileName)
+                return ((FileOutputStream) getFilesMap().get(fileName)
                         .getOutputBuffer()).getFD();
             } catch (IOException e) {
                 getLogger().log(Level.WARNING,
@@ -121,9 +131,10 @@ public class MultiFileBuffer extends AbstractFileBuffer
      * @return input stream for file or empty stream if file not found
      */
     public InputStream getInputStream(String fileName) {
-        if (files.containsKey(fileName)) {
+        if (getFilesMap().containsKey(fileName)) {
             try {
-                return new FileInputStream(files.get(fileName).getFile());
+                return new FileInputStream(
+                        getFilesMap().get(fileName).getFile());
             } catch (IOException e) {
                 getLogger().log(Level.WARNING,
                         "Failed to create InputStream for: '" + fileName + "'",

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
@@ -38,7 +38,6 @@ import com.vaadin.flow.component.upload.MultiFileReceiver;
  * For a custom file the constructor {@link AbstractFileBuffer(FileFactory)}
  * should be used.
  */
-@SuppressWarnings("serial")
 public class MultiFileBuffer extends AbstractFileBuffer
         implements MultiFileReceiver {
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSerializableTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadSerializableTest.java
@@ -63,4 +63,17 @@ public class UploadSerializableTest extends ClassesSerializableTest {
 
         serializeAndDeserialize(multiFileBuffer);
     }
+
+    @Test
+    public void serializeMultiFileBuffer_restoreFileMap() {
+        MultiFileBuffer multiFileBuffer = new MultiFileBuffer();
+        try {
+            multiFileBuffer = serializeAndDeserialize(multiFileBuffer);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+
+        // Verifies that internal file map is restored, would throw otherwise
+        multiFileBuffer.receiveUpload("bar.txt", "text/plain");
+    }
 }


### PR DESCRIPTION
The files will be null after de-serialization, which will lead to NPE.

