### PR TITLE
feat: add `setAriaLabel` to `Grid`

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3672,6 +3672,30 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
+     * Set the aria-label of the component to the given text.
+     *
+     * @param ariaLabel
+     *            the aria-label text to set or {@code null} to clear
+     */
+    public void setAriaLabel(String ariaLabel) {
+        if (ariaLabel == null) {
+            getElement().removeProperty("accessibleName");
+        } else {
+            getElement().setProperty("accessibleName", ariaLabel);
+        }
+    }
+
+    /**
+     * Gets the aria-label of the component.
+     *
+     * @return an optional aria-label of the component if no aria-label has been
+     *         set
+     */
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    /**
      * Adds a new context-menu for this grid.
      *
      * @return the added context-menu

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -131,6 +131,20 @@ public class GridTest {
         callSetRequestedRange(grid, 0, 600);
     }
 
+    @Test
+    public void setAriaLabel() {
+        final Grid<String> grid = new Grid<>();
+        grid.setAriaLabel("test");
+        Assert.assertTrue(grid.getAriaLabel().isPresent());
+        Assert.assertEquals("test", grid.getAriaLabel().get());
+        Assert.assertEquals("test",
+                grid.getElement().getProperty("accessibleName"));
+
+        grid.setAriaLabel(null);
+        Assert.assertFalse(grid.getAriaLabel().isPresent());
+        Assert.assertFalse(grid.getElement().hasProperty("accessibleName"));
+    }
+
     private void callSetRequestedRange(Grid<String> grid, int start,
             int length) {
         try {


### PR DESCRIPTION
## Description

Add `setAriaLabel`/`getAriaLabel` methods to `Grid` that uses the `accessibleName` property available in the web component to set the `aria-label` attribute on its internal `<table>` element.

Fixes vaadin/web-components#6749

## Type of change

- [ ] Bugfix
- [X] Feature
