### PR TITLE
refactor: move disable on click to menu item base

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.contextmenu;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.shared.internal.DisableOnClickController;
 import com.vaadin.flow.function.SerializableRunnable;
 
 /**
@@ -33,42 +32,11 @@ public class MenuItem extends MenuItemBase<ContextMenu, MenuItem, SubMenu>
         implements ClickNotifier<MenuItem> {
 
     private final SerializableRunnable contentReset;
-    private final DisableOnClickController<MenuItem> disableOnClickController = new DisableOnClickController<>(
-            this);
 
     public MenuItem(ContextMenu contextMenu,
             SerializableRunnable contentReset) {
         super(contextMenu);
         this.contentReset = contentReset;
-    }
-
-    /**
-     * Sets whether the item should be disabled when clicked.
-     * <p>
-     * When set to {@code true}, the item will be immediately disabled on the
-     * client-side when clicked, preventing further clicks until re-enabled from
-     * the server-side.
-     *
-     * @param disableOnClick
-     *            whether the item should be disabled when clicked
-     */
-    public void setDisableOnClick(boolean disableOnClick) {
-        disableOnClickController.setDisableOnClick(disableOnClick);
-    }
-
-    /**
-     * Gets whether the item is set to be disabled when clicked.
-     *
-     * @return whether the item is set to be disabled on click
-     */
-    public boolean isDisableOnClick() {
-        return disableOnClickController.isDisableOnClick();
-    }
-
-    @Override
-    public void setEnabled(boolean enabled) {
-        super.setEnabled(enabled);
-        disableOnClickController.onSetEnabled(enabled);
     }
 
     @Override

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.internal.DisableOnClickController;
 
 /**
  * Base class for item component used inside {@link ContextMenu}s.
@@ -58,6 +59,9 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     private boolean checkable = false;
 
     private Set<String> themeNames = new LinkedHashSet<>();
+
+    private final DisableOnClickController<MenuItemBase<C, I, S>> disableOnClickController = new DisableOnClickController<>(
+            this);
 
     /**
      * Default constructor
@@ -215,6 +219,35 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
      */
     public boolean isKeepOpen() {
         return getElement().getProperty("_keepOpen", false);
+    }
+
+    /**
+     * Sets whether the item should be disabled when clicked.
+     * <p>
+     * When set to {@code true}, the item will be immediately disabled on the
+     * client-side when clicked, preventing further clicks until re-enabled from
+     * the server-side.
+     *
+     * @param disableOnClick
+     *            whether the item should be disabled when clicked
+     */
+    public void setDisableOnClick(boolean disableOnClick) {
+        disableOnClickController.setDisableOnClick(disableOnClick);
+    }
+
+    /**
+     * Gets whether the item is set to be disabled when clicked.
+     *
+     * @return whether the item is set to be disabled on click
+     */
+    public boolean isDisableOnClick() {
+        return disableOnClickController.isDisableOnClick();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        HasComponents.super.setEnabled(enabled);
+        disableOnClickController.onSetEnabled(enabled);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -18,8 +18,10 @@ package com.vaadin.flow.component.shared.internal;
 import java.io.Serializable;
 import java.util.Objects;
 
-import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.dependency.JsModule;
 
@@ -32,14 +34,13 @@ import com.vaadin.flow.component.dependency.JsModule;
  * to prevent multiple clicks or submissions while the server processes the
  * event.
  * <p>
- * This controller requires that the component implements both
- * {@link HasEnabled} and {@link ClickNotifier}.
+ * This controller requires that the component implements {@link HasEnabled}.
  *
  * @param <C>
  *            Type of the component that uses this controller.
  */
 @JsModule("./disableOnClickFunctions.js")
-public class DisableOnClickController<C extends Component & HasEnabled & ClickNotifier<C>>
+public class DisableOnClickController<C extends Component & HasEnabled>
         implements Serializable {
 
     private final C component;
@@ -52,13 +53,16 @@ public class DisableOnClickController<C extends Component & HasEnabled & ClickNo
      * @param component
      *            the component to control, not {@code null}
      */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public DisableOnClickController(C component) {
         this.component = Objects.requireNonNull(component);
-        component.addClickListener(event -> {
-            if (isDisableOnClick()) {
-                component.setEnabled(false);
-            }
-        });
+
+        ComponentUtil.addListener(component, ClickEvent.class,
+                (ComponentEventListener) (event -> {
+                    if (isDisableOnClick()) {
+                        component.setEnabled(false);
+                    }
+                }));
     }
 
     /**


### PR DESCRIPTION
Moves the disable on click logic to `MenuItemBase`, which also makes it available for `GridMenuItem`.