### PR TITLE
fix: make waitForUploads poll for upload processing until completion or timeout

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -18,15 +18,21 @@ package com.vaadin.flow.component.upload.tests;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.devtools.DevTools;
+import org.openqa.selenium.devtools.HasDevTools;
+import org.openqa.selenium.devtools.v130.network.Network;
 import org.openqa.selenium.logging.LogEntry;
 
 import com.vaadin.flow.component.upload.testbench.UploadElement;
@@ -159,6 +165,32 @@ public class UploadIT extends AbstractUploadIT {
         List<LogEntry> logList2 = getLogEntries(Level.SEVERE);
         assertThat("There should have no severe message in the console",
                 logList2.size(), CoreMatchers.is(0));
+    }
+
+    @Test
+    public void slowUpload_waitForUpload_pollsUntilUploadFinishes()
+            throws Exception {
+        Assume.assumeTrue("Current driver does not support Dev Tools",
+                driver instanceof HasDevTools);
+
+        // Slow down upload to 100 kb/sec
+        DevTools devTools = ((HasDevTools) driver).getDevTools();
+        devTools.createSessionIfThereIsNotOne();
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(),
+                Optional.empty()));
+        devTools.send(Network.emulateNetworkConditions(false, 40, 900000,
+                100000, Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty()));
+
+        File tempFile = createTempFile("txt");
+        Files.write(tempFile.toPath(), new byte[1024 * 300]);
+
+        getUpload().upload(tempFile, 10);
+
+        $("button").id("print-file-count").click();
+
+        Assert.assertEquals("File list should contain one file", 1,
+                getFileCount());
     }
 
     private int getFileCount() {

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -154,9 +154,11 @@ public class UploadElement extends TestBenchElement {
                 + "var upload = arguments[0];" + "let intervalId;"
                 + "intervalId = window.setInterval(function() {"
                 + "  var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;"
-                + "  if (!inProgress) { "
-                + "    window.clearInterval(intervalId);" + "    callback();"
-                + "  }" + "}, 500);";
+                + "  if (!inProgress) { " //
+                + "    window.clearInterval(intervalId);" //
+                + "    callback();" //
+                + "  }" //
+                + "}, 500);";
         getCommandExecutor().getDriver().executeAsyncScript(script, this);
 
     }

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -147,8 +147,8 @@ public class UploadElement extends TestBenchElement {
     private void waitForUploads(int maxSeconds) {
         String script = "return arguments[0].files.every((file) => !file.uploading);";
 
-        waitUntil(driver -> (Boolean) getCommandExecutor().getDriver()
-                .executeScript(script, UploadElement.this), maxSeconds);
+        waitUntil(driver -> (Boolean) executeScript(script, UploadElement.this),
+                maxSeconds);
     }
 
     private void startUpload() {

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -151,11 +151,12 @@ public class UploadElement extends TestBenchElement {
         timeouts.setScriptTimeout(maxSeconds, TimeUnit.SECONDS);
 
         String script = "var callback = arguments[arguments.length - 1];"
-                + "var upload = arguments[0];"
-                + "window.setTimeout(function() {"
+                + "var upload = arguments[0];" + "let intervalId;"
+                + "intervalId = window.setInterval(function() {"
                 + "  var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;"
-                + "  if (!inProgress) callback();" //
-                + "}, 500);";
+                + "  if (!inProgress) { "
+                + "    window.clearInterval(intervalId);" + "    callback();"
+                + "  }" + "}, 500);";
         getCommandExecutor().getDriver().executeAsyncScript(script, this);
 
     }

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -17,10 +17,8 @@ package com.vaadin.flow.component.upload.testbench;
 
 import java.io.File;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebDriver.Timeouts;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
@@ -147,20 +145,15 @@ public class UploadElement extends TestBenchElement {
      *            the number of seconds to wait for the upload to finish
      */
     private void waitForUploads(int maxSeconds) {
-        Timeouts timeouts = getDriver().manage().timeouts();
-        timeouts.setScriptTimeout(maxSeconds, TimeUnit.SECONDS);
-
         String script = "var callback = arguments[arguments.length - 1];"
-                + "var upload = arguments[0];" + "let intervalId;"
-                + "intervalId = window.setInterval(function() {"
-                + "  var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;"
-                + "  if (!inProgress) { " //
-                + "    window.clearInterval(intervalId);" //
-                + "    callback();" //
-                + "  }" //
-                + "}, 500);";
-        getCommandExecutor().getDriver().executeAsyncScript(script, this);
+                + "var upload = arguments[0];" //
+                + "var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;"
+                + "callback(!inProgress);";
 
+        waitUntil(
+                driver -> (Boolean) getCommandExecutor().getDriver()
+                        .executeAsyncScript(script, UploadElement.this),
+                maxSeconds);
     }
 
     private void startUpload() {

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -151,10 +151,8 @@ public class UploadElement extends TestBenchElement {
                 return !inProgress;
                 """;
 
-        waitUntil(
-                driver -> (Boolean) getCommandExecutor().getDriver()
-                        .executeScript(script, UploadElement.this),
-                maxSeconds);
+        waitUntil(driver -> (Boolean) getCommandExecutor().getDriver()
+                .executeScript(script, UploadElement.this), maxSeconds);
     }
 
     private void startUpload() {

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -145,11 +145,7 @@ public class UploadElement extends TestBenchElement {
      *            the number of seconds to wait for the upload to finish
      */
     private void waitForUploads(int maxSeconds) {
-        String script = """
-                var upload = arguments[0];
-                var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;
-                return !inProgress;
-                """;
+        String script = "return arguments[0].files.every((file) => !file.uploading);";
 
         waitUntil(driver -> (Boolean) getCommandExecutor().getDriver()
                 .executeScript(script, UploadElement.this), maxSeconds);

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -146,7 +146,6 @@ public class UploadElement extends TestBenchElement {
      */
     private void waitForUploads(int maxSeconds) {
         String script = """
-                var callback = arguments[arguments.length - 1];
                 var upload = arguments[0];
                 var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;
                 return !inProgress;

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -145,14 +145,16 @@ public class UploadElement extends TestBenchElement {
      *            the number of seconds to wait for the upload to finish
      */
     private void waitForUploads(int maxSeconds) {
-        String script = "var callback = arguments[arguments.length - 1];"
-                + "var upload = arguments[0];" //
-                + "var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;"
-                + "callback(!inProgress);";
+        String script = """
+                var callback = arguments[arguments.length - 1];
+                var upload = arguments[0];
+                var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;
+                return !inProgress;
+                """;
 
         waitUntil(
                 driver -> (Boolean) getCommandExecutor().getDriver()
-                        .executeAsyncScript(script, UploadElement.this),
+                        .executeScript(script, UploadElement.this),
                 maxSeconds);
     }
 


### PR DESCRIPTION
## Description

Currently UploadElement.waitForUploads checks for in-progress uploads only once causing the test to fail if the upload does not complete in 500 milliseconds. This change repeats the check every 500 milliseconds, until the condition is verified or the script execution times out.

Fixes #3646

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
