### PR TITLE
fix: ensure that invalid state is set from the server 

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxInitialValueValidationPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxInitialValueValidationPage.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test.validation;
+
+import java.util.List;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.router.Route;
+import com.vaadin.tests.validation.AbstractValidationPage;
+
+@Route("vaadin-combo-box/validation/initial-value")
+public class ComboBoxInitialValueValidationPage
+        extends AbstractValidationPage<ComboBox<String>> {
+    public static final String SET_NULL = "set-null-button";
+    public static final String SET_EMPTY_STRING = "set-empty-string-button";
+    public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
+
+    public ComboBoxInitialValueValidationPage() {
+        testField.setI18n(new ComboBox.ComboBoxI18n()
+                .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE));
+
+        add(createButton(SET_NULL, "Set null", event -> {
+            testField.setValue(null);
+        }));
+
+        add(createButton(SET_EMPTY_STRING, "Set empty string", event -> {
+            testField.setValue("");
+        }));
+    }
+
+    @Override
+    protected ComboBox<String> createTestField() {
+        ComboBox<String> comboBox = new ComboBox<>() {
+            @Override
+            protected void validate() {
+                super.validate();
+                incrementServerValidationCounter();
+            }
+        };
+        comboBox.setItems(List.of("foo", "bar", "baz"));
+        comboBox.setRequired(true);
+
+        return comboBox;
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxInitialValueValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxInitialValueValidationIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test.validation;
+
+import static com.vaadin.flow.component.combobox.test.validation.ComboBoxInitialValueValidationPage.REQUIRED_ERROR_MESSAGE;
+import static com.vaadin.flow.component.combobox.test.validation.ComboBoxInitialValueValidationPage.SET_EMPTY_STRING;
+import static com.vaadin.flow.component.combobox.test.validation.ComboBoxInitialValueValidationPage.SET_NULL;
+import static com.vaadin.tests.validation.AbstractValidationPage.ATTACH_FIELD_BUTTON;
+import static com.vaadin.tests.validation.AbstractValidationPage.DETACH_FIELD_BUTTON;
+
+import org.junit.Test;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.validation.AbstractValidationIT;
+
+@TestPath("vaadin-combo-box/validation/initial-value")
+public class ComboBoxInitialValueValidationIT
+        extends AbstractValidationIT<ComboBoxElement> {
+
+    @Test
+    public void fieldWithEmptyString_fieldIsValid() {
+        detachButton();
+
+        clickButton(SET_EMPTY_STRING);
+
+        attachButton();
+        assertClientValid();
+        assertServerValid();
+    }
+
+    @Test
+    public void requiredFieldWithNull_fieldIsInvalid() {
+        detachButton();
+
+        // Need to "force" value change on the field
+        clickButton(SET_EMPTY_STRING);
+        clickButton(SET_NULL);
+
+        attachButton();
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(REQUIRED_ERROR_MESSAGE);
+    }
+
+    private void attachButton() {
+        clickButton(ATTACH_FIELD_BUTTON);
+        // Retrieve new element instance
+        testField = getTestField();
+    }
+
+    private void detachButton() {
+        clickButton(DETACH_FIELD_BUTTON);
+        // Verify element has been removed
+        waitUntil(ExpectedConditions.stalenessOf(testField));
+    }
+
+    private void clickButton(String buttonId) {
+        $("button").id(buttonId).click();
+    }
+
+    @Override
+    protected ComboBoxElement getTestField() {
+        return $(ComboBoxElement.class).first();
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
@@ -35,14 +35,13 @@ public final class ClientValidationUtil {
         StringBuilder expression = new StringBuilder(
                 "this._shouldSetInvalid = function (invalid) { return false };");
 
-        if (component.isInvalid()) {
-            /*
-             * By default the invalid flag is set to false. Workaround the case
-             * where the client side validation overrides the invalid state
-             * before the `_shouldSetInvalid` method is overridden above.
-             */
-            expression.append("this.invalid = true;");
-        }
+        /*
+         * Workaround the case where the client side validation overrides the
+         * invalid state before the `_shouldSetInvalid` method is overridden
+         * above.
+         */
+        expression.append("this.invalid = ").append(component.isInvalid())
+                .append(";");
 
         component.getElement().executeJs(expression.toString());
     }


### PR DESCRIPTION
## Description

Change the `preventWebComponentFromModifyingInvalidState` method in `ClientValidationUtil` class to always set the invalid state of the component on the client to override any client-side validation that may happen before the `_shouldSetInvalid` is overridden.

That's the root cause of the linked issue where a `ComboBox` can stay stuck in the invalid state on the client when the user calls `setValue("")` on the initialization of the component instance.

Fixes https://github.com/vaadin/flow-components/issues/6881

## Type of change

- [X] Bugfix