### PR TITLE
fix: update keymapper when refreshing select item

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -1050,6 +1050,7 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
                     .getItem();
             IdentifierProvider<T> identifierProvider = getIdentifierProvider();
             Object updatedItemId = identifierProvider.apply(updatedItem);
+            keyMapper.refresh(updatedItem);
             getItems()
                     .filter(vaadinItem -> updatedItemId.equals(
                             identifierProvider.apply(vaadinItem.getItem())))

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -941,6 +941,29 @@ public class SelectTest {
         Assert.assertEquals(-1, select.getItemPosition("does not exist"));
     }
 
+    @Test
+    public void refreshItem_selectFromClient_valueContainsUpdatedItem() {
+        Select<CustomItem> select = new Select<>();
+        SelectListDataView<CustomItem> dataView = select.setItems(
+                new CustomItem(1L, "foo"), new CustomItem(2L, "bar"),
+                new CustomItem(3L, "baz"));
+        dataView.setIdentifierProvider(CustomItem::getId);
+        selectSupplier = () -> select;
+
+        CustomItem updatedItem = new CustomItem(2L, "updated");
+        dataView.refreshItem(updatedItem);
+
+        AtomicReference<CustomItem> selectedItem = new AtomicReference<>();
+        select.addValueChangeListener(e -> selectedItem.set(e.getValue()));
+
+        // Simulate selecting an item from the client side via key
+        var itemKey = getListBoxChild(1).getProperty("value");
+        select.getElement().setProperty("value", itemKey);
+
+        Assert.assertEquals("updated", selectedItem.get().name);
+        Assert.assertEquals("updated", select.getValue().name);
+    }
+
     private void validateItem(int index, String textContent, String label,
             boolean enabled) {
         Element item = getListBoxChild(index);

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -957,7 +957,7 @@ public class SelectTest {
         select.addValueChangeListener(e -> selectedItem.set(e.getValue()));
 
         // Simulate selecting an item from the client side via key
-        var itemKey = getListBoxChild(1).getProperty("value");
+        String itemKey = getListBoxChild(1).getProperty("value");
         select.getElement().setProperty("value", itemKey);
 
         Assert.assertEquals("updated", selectedItem.get().name);


### PR DESCRIPTION
Since `Select` uses the key mapper for converting presentation value to model value, the key mapper needs to be updated when individual items are refreshed via the data view.

Fixes https://github.com/vaadin/flow-components/issues/6908