### PR TITLE
fix: update keymapper when refreshing radio button item

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -856,10 +856,9 @@ public class RadioButtonGroup<T>
     }
 
     private void handleDataChange(DataChangeEvent<T> dataChangeEvent) {
-        if (dataChangeEvent instanceof DataChangeEvent.DataRefreshEvent) {
-            resetRadioButton(
-                    ((DataChangeEvent.DataRefreshEvent<T>) dataChangeEvent)
-                            .getItem());
+        if (dataChangeEvent instanceof DataChangeEvent.DataRefreshEvent<T> refreshEvent) {
+            keyMapper.refresh(refreshEvent.getItem());
+            resetRadioButton(refreshEvent.getItem());
         } else {
             keyMapper.removeAll();
             selectionPreservationHandler.handleDataChange(dataChangeEvent);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -601,4 +601,27 @@ public class RadioButtonGroupTest {
         Assert.assertEquals(selectedItem, group.getValue());
         Assert.assertTrue(events.isEmpty());
     }
+
+    @Test
+    public void refreshItem_selectFromClient_valueContainsUpdatedItem() {
+        RadioButtonGroup<CustomItem> group = new RadioButtonGroup<>();
+        RadioButtonGroupListDataView<CustomItem> dataView = group.setItems(
+                new CustomItem(1L, "foo"), new CustomItem(2L, "bar"),
+                new CustomItem(3L, "baz"));
+        dataView.setIdentifierProvider(CustomItem::getId);
+
+        CustomItem updatedItem = new CustomItem(2L, "updated");
+        dataView.refreshItem(updatedItem);
+
+        AtomicReference<CustomItem> selectedItem = new AtomicReference<>();
+        group.addValueChangeListener(e -> selectedItem.set(e.getValue()));
+
+        // Simulate selecting an item from the client side via key
+        var itemKey = group.getChildren().skip(1).findFirst().get().getElement()
+                .getProperty("value");
+        group.getElement().setProperty("value", itemKey);
+
+        Assert.assertEquals("updated", selectedItem.get().getName());
+        Assert.assertEquals("updated", group.getValue().getName());
+    }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -617,8 +617,8 @@ public class RadioButtonGroupTest {
         group.addValueChangeListener(e -> selectedItem.set(e.getValue()));
 
         // Simulate selecting an item from the client side via key
-        var itemKey = group.getChildren().skip(1).findFirst().get().getElement()
-                .getProperty("value");
+        String itemKey = group.getChildren().skip(1).findFirst().orElseThrow()
+                .getElement().getProperty("value");
         group.getElement().setProperty("value", itemKey);
 
         Assert.assertEquals("updated", selectedItem.get().getName());


### PR DESCRIPTION
Since `RadioButtonGroup` uses the key mapper for converting presentation value to model value, the key mapper needs to be updated when individual items are refreshed via the data view.

Related to https://github.com/vaadin/flow-components/issues/6908