### PR TITLE
fix: update keymapper when refreshing checkbox item

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -389,10 +389,10 @@ public class CheckboxGroup<T>
     }
 
     private void handleDataChange(DataChangeEvent<T> dataChangeEvent) {
-        if (dataChangeEvent instanceof DataChangeEvent.DataRefreshEvent) {
-            T otherItem = ((DataChangeEvent.DataRefreshEvent<T>) dataChangeEvent)
-                    .getItem();
+        if (dataChangeEvent instanceof DataChangeEvent.DataRefreshEvent<T> dataRefreshEvent) {
+            T otherItem = dataRefreshEvent.getItem();
             Object otherItemId = getItemId(otherItem);
+            keyMapper.refresh(otherItem);
             getCheckboxItems().filter(
                     item -> Objects.equals(getItemId(item.item), otherItemId))
                     .findFirst().ifPresent(this::updateCheckbox);

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -724,6 +724,33 @@ public class CheckboxGroupTest {
         Assert.assertTrue(events.isEmpty());
     }
 
+    @Test
+    public void refreshItem_selectFromClient_valueContainsUpdatedItem() {
+        CheckboxGroup<CustomItem> group = new CheckboxGroup<>();
+        CheckboxGroupListDataView<CustomItem> dataView = group.setItems(
+                new CustomItem(1L, "foo"), new CustomItem(2L, "bar"),
+                new CustomItem(3L, "baz"));
+        dataView.setIdentifierProvider(CustomItem::getId);
+
+        CustomItem updatedItem = new CustomItem(2L, "updated");
+        dataView.refreshItem(updatedItem);
+
+        AtomicReference<Set<CustomItem>> selectedItems = new AtomicReference<>();
+        group.addValueChangeListener(e -> selectedItems.set(e.getValue()));
+
+        // Simulate selecting an item from the client side via key
+        String itemKey = group.getChildren().skip(1).findFirst().orElseThrow()
+                .getElement().getProperty("value");
+        JsonArray selection = Json.createArray();
+        selection.set(0, itemKey);
+        group.getElement().setPropertyJson("value", selection);
+
+        Assert.assertEquals("updated",
+                selectedItems.get().stream().findFirst().orElseThrow().name);
+        Assert.assertEquals("updated",
+                group.getValue().stream().findFirst().orElseThrow().name);
+    }
+
     /**
      * Used in the tests {@link #singleDataRefreshEvent()} and
      * {@link #allDataRefreshEvent()}


### PR DESCRIPTION
Since `CheckboxGroup` uses the key mapper for converting presentation value to model value, the key mapper needs to be updated when individual items are refreshed via the data view.

Related to https://github.com/vaadin/flow-components/issues/6908