### PR TITLE
feat: add support for views with HasUrlParameter to SideNavItem

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -36,11 +36,13 @@ import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.internal.ConfigureRoutes;
+import com.vaadin.flow.router.internal.HasUrlParameterFormat;
 
 import elemental.json.JsonArray;
 
@@ -101,6 +103,26 @@ public class SideNavItem extends SideNavItemContainer
     public SideNavItem(String label, Class<? extends Component> view) {
         setPath(view);
         setLabel(label);
+    }
+
+    /**
+     * Creates a new menu item using the given label that links to the given
+     * view, which must implement {@link HasUrlParameter}.
+     *
+     * @param label
+     *            the label for the item
+     * @param view
+     *            the view to link to, must implement {@link HasUrlParameter}
+     * @param parameter
+     *            the URL parameter for the view
+     * @param <T>
+     *            the type of the URL parameter
+     * @param <C>
+     *            the type of the view
+     */
+    public <T, C extends Component & HasUrlParameter<T>> SideNavItem(
+            String label, Class<? extends C> view, T parameter) {
+        this(label, view, HasUrlParameterFormat.getParameters(parameter));
     }
 
     /**
@@ -260,6 +282,33 @@ public class SideNavItem extends SideNavItemContainer
      */
     public void setPath(Class<? extends Component> view) {
         setPath(view, RouteParameters.empty());
+    }
+
+    /**
+     * Retrieves {@link com.vaadin.flow.router.Route} and
+     * {@link com.vaadin.flow.router.RouteAlias} annotations from the specified
+     * view, and then sets the corresponding path and path aliases for this
+     * item.
+     * <p>
+     * Note: Vaadin Router will be used to determine the URL path of the view
+     * and this URL will be then set to this navigation item using
+     * {@link SideNavItem#setPath(String)}.
+     *
+     * @param view
+     *            The view to link to. The view should be annotated with the
+     *            {@link com.vaadin.flow.router.Route} annotation and must
+     *            implement {@link HasUrlParameter}. Set to null to disable
+     *            navigation for this item.
+     * @param parameter
+     *            the URL parameter for the view
+     * @param <T>
+     *            the type of the URL parameter
+     * @param <C>
+     *            the type of the view
+     */
+    public <T, C extends Component & HasUrlParameter<T>> void setPath(
+            Class<? extends C> view, T parameter) {
+        setPath(view, HasUrlParameterFormat.getParameters(parameter));
     }
 
     /**

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -33,6 +33,8 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
@@ -606,6 +608,25 @@ public class SideNavItemTest {
     }
 
     @Test
+    public void createFromComponentWithHasUrlParameter_pathContainsParameters() {
+        runWithMockRouter(() -> {
+            sideNavItem = new SideNavItem("test",
+                    TestRouteWithHasUrlParameter.class, "bar/baz");
+
+            assertPath("foo/bar/baz");
+        }, TestRouteWithHasUrlParameter.class);
+    }
+
+    @Test
+    public void setPathAsComponentWithHasUrlParameter_pathContainsParameters() {
+        runWithMockRouter(() -> {
+            sideNavItem.setPath(TestRouteWithHasUrlParameter.class, "bar/baz");
+
+            assertPath("foo/bar/baz");
+        }, TestRouteWithHasUrlParameter.class);
+    }
+
+    @Test
     public void setTarget_hasTarget() {
         sideNavItem.setTarget("_blank");
         Assert.assertEquals("_blank",
@@ -777,6 +798,15 @@ public class SideNavItemTest {
     @Route("foo/:k1/:k2/bar")
     private static class TestRouteWithRouteParams extends Component {
 
+    }
+
+    @Route("foo")
+    private static class TestRouteWithHasUrlParameter extends Component
+            implements HasUrlParameter<String> {
+        @Override
+        public void setParameter(BeforeEvent event, String parameter) {
+
+        }
     }
 
     @Route("foo/bar")


### PR DESCRIPTION
Allows setting `SideNavItem` paths using views that implement `HasUrlParameter`.

The implementation is adapted from `RouterLink`.

Closes https://github.com/vaadin/flow-components/issues/6949