### PR TITLE
fix: update panes positions on Spreadsheet resize 

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -852,6 +852,7 @@ public class SheetWidget extends Panel {
             // vaadin does bunch of layout phases so this needs to be done in
             // case the comment overlay position should be updated
             refreshAlwaysVisibleCellCommentOverlays();
+            updateSheetPanePositions();
         }
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SizingPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SizingPage.java
@@ -73,6 +73,8 @@ public class SizingPage extends Div {
                         e -> layout.setHeight(null))));
 
         layoutList.add(new ListItem(new Span("Display: "),
+                getButton("none", "layoutDisplayNone",
+                        e -> layout.getStyle().set("display", "none")),
                 getButton("flex", "layoutDisplayFlex",
                         e -> layout.getStyle().set("display", "flex")),
                 getButton("Default (block)", "layoutDisplayDefault",
@@ -89,7 +91,27 @@ public class SizingPage extends Div {
 
         add(layoutList);
 
+        add(new H2("Logs"));
+
+        var logList = new UnorderedList();
+        var messageLog = new Span();
+        messageLog.setId("messageLog");
+        logList.add(new ListItem(new Span("Message: "), messageLog));
+
+        logList.add(new ListItem(new Span("Panel"),
+                getButton("Panel position", "logPanelPosition", e -> {
+                    spreadsheet.getElement().executeJs(
+                            "return this.shadowRoot.querySelector('.bottom-right-pane').style.top")
+                            .then(message -> {
+                                var stringMessage = message.asString();
+                                messageLog.setText(stringMessage);
+                            });
+                })));
+
+        add(logList);
+
         add(layout);
+
     }
 
     private NativeButton getButton(String title, String id,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SizingIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SizingIT.java
@@ -126,6 +126,26 @@ public class SizingIT extends AbstractComponentIT {
         waitUntil(e -> spreadsheet.getCellAt("A20") != null);
     }
 
+    @Test
+    public void containerInitiallyHidden_containerIsShown_panelsPositionsAreCorrect() {
+        // Detach spreadsheet
+        findElement(By.id("spreadsheetAttachedToggle")).click();
+        // Hide layout
+        findElement(By.id("layoutDisplayNone")).click();
+        // Attach spreadsheet
+        findElement(By.id("spreadsheetAttachedToggle")).click();
+        // Get reference to the new spreadsheet
+        var spreadsheet = $(SpreadsheetElement.class).first();
+        // Show layout
+        findElement(By.id("layoutDisplayDefault")).click();
+
+        // Print panel position
+        findElement(By.id("logPanelPosition")).click();
+
+        var messageLog = findElement(By.id("messageLog")).getText();
+        Assert.assertNotEquals("0px", messageLog);
+    }
+
     private void assertSpreadsheetHeight(int height) {
         var internal = spreadsheet.$(DivElement.class).first();
         Assert.assertEquals(height, internal.getSize().getHeight());


### PR DESCRIPTION
## Description

Recalculate sheet position as part of the method triggered by the `ResizeObserver` configured on the Spreadsheet component. It fixes an issue where the pane's positions are wrongly calculated when the component is attached to a hidden parent.

Fixes #6932

## Type of change

- [X] Bugfix
