### PR TITLE
Revert "feat: create side nav from menu entries (#6957)"

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/pom.xml
@@ -22,11 +22,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-icons-flow</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <scope>test</scope>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.sidenav;
 
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.Objects;
 
 import com.vaadin.flow.component.HasSize;
@@ -27,8 +26,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JsonSerializer;
-import com.vaadin.flow.server.menu.MenuConfiguration;
-import com.vaadin.flow.server.menu.MenuEntry;
 
 /**
  * A side navigation menu with support for hierarchical and flat menus.
@@ -62,24 +59,6 @@ public class SideNav extends SideNavItemContainer implements HasSize, HasStyle {
      */
     public SideNav(String label) {
         setLabel(label);
-    }
-
-    /**
-     * Creates a new menu from the given menu entries, which can be retrieved
-     * from {@link MenuConfiguration}.
-     *
-     * @param menuEntries
-     *            the menu entries to add
-     * @see MenuConfiguration
-     * @see MenuEntry
-     * @see SideNavItem#SideNavItem(MenuEntry)
-     */
-    public SideNav(Collection<MenuEntry> menuEntries) {
-        Objects.requireNonNull(menuEntries, "menuEntries cannot be null");
-
-        for (MenuEntry menuEntry : menuEntries) {
-            addItem(new SideNavItem(menuEntry));
-        }
     }
 
     /**

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
@@ -33,9 +31,6 @@ import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.icon.AbstractIcon;
-import com.vaadin.flow.component.icon.Icon;
-import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.dom.Element;
@@ -48,8 +43,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.internal.ConfigureRoutes;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
-import com.vaadin.flow.server.menu.MenuConfiguration;
-import com.vaadin.flow.server.menu.MenuEntry;
 
 import elemental.json.JsonArray;
 
@@ -202,66 +195,6 @@ public class SideNavItem extends SideNavItemContainer
         setPath(view, routeParameters);
         setLabel(label);
         setPrefixComponent(prefixComponent);
-    }
-
-    /**
-     * Creates a new menu item from the given {@link MenuEntry}.
-     * <p>
-     * If the entry has an icon string, creates an instance of {@link Icon} or
-     * {@link SvgIcon} based on the icon string and sets it as prefix component.
-     * Note that only the following icon types are supported:
-     * <ul>
-     * <li>Icon set: the icon string contains ":" and is in the format
-     * "icon-set:icon-name", for example "vaadin:file"</li>
-     * <li>SVG icon: the icon string ends with ".svg"</li>
-     * </ul>
-     *
-     * @param entry
-     *            the menu entry to create the item from
-     * @see MenuEntry
-     * @see MenuConfiguration
-     */
-    public SideNavItem(MenuEntry entry) {
-        Objects.requireNonNull(entry, "Menu entry cannot be null");
-
-        setLabel(entry.title());
-
-        // If there is a menu class, use it as the path to also add path aliases
-        // Client routes have no menu class, so use the path as fallback
-        if (entry.menuClass() != null) {
-            setPath(entry.menuClass());
-        } else {
-            setPath(entry.path());
-        }
-
-        AbstractIcon<?> icon = createIconFromMenuEntry(entry);
-        if (icon != null) {
-            setPrefixComponent(icon);
-        }
-    }
-
-    private AbstractIcon<? extends AbstractIcon<?>> createIconFromMenuEntry(
-            MenuEntry entry) {
-        // No icon
-        if (entry.icon() == null) {
-            return null;
-        }
-
-        // Icon set
-        if (entry.icon().contains(":") && entry.icon().split(":").length == 2) {
-            return new Icon(entry.icon());
-        }
-
-        // SVG icon
-        if (entry.icon().endsWith(".svg")) {
-            return new SvgIcon(entry.icon());
-        }
-
-        // Icon component doesn't support other types of icons, log a warning
-        LoggerFactory.getLogger(SideNavItem.class)
-                .warn("Icon type not supported: {}", entry.icon());
-
-        return null;
     }
 
     @Override

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -31,8 +31,6 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.icon.Icon;
-import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.BeforeEvent;
@@ -45,7 +43,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.menu.MenuEntry;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 
 import elemental.json.JsonArray;
@@ -219,75 +216,6 @@ public class SideNavItemTest {
 
         assertPath("test-path");
         Assert.assertEquals(prefixComponent, sideNavItem.getPrefixComponent());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void createFromMenuEntry_entryIsNull_throws() {
-        new SideNavItem((MenuEntry) null);
-    }
-
-    @Test
-    public void createFromMenuEntry_setsLabelAndPath() {
-        MenuEntry entry = new MenuEntry("path", "Test label", 0.0, null, null);
-        SideNavItem sideNavItem = new SideNavItem(entry);
-
-        Assert.assertEquals("Test label", sideNavItem.getLabel());
-        Assert.assertEquals("path", sideNavItem.getPath());
-    }
-
-    @Test
-    public void createFromMenuEntry_withMenuClass_setsRouteAndAliases() {
-        runWithMockRouter(() -> {
-            MenuEntry entry = new MenuEntry("path", "Test label", 0.0, null,
-                    TestRouteWithAliases.class);
-            SideNavItem sideNavItem = new SideNavItem(entry);
-
-            Assert.assertEquals("Test label", sideNavItem.getLabel());
-            Assert.assertEquals("foo/bar", sideNavItem.getPath());
-            Assert.assertEquals(Set.of("foo/baz", "foo/qux"),
-                    sideNavItem.getPathAliases());
-        }, TestRouteWithAliases.class);
-    }
-
-    @Test
-    public void createFromMenuEntry_withIconSetIcon_setsIcon() {
-        MenuEntry entry = new MenuEntry("path", "Test label", 0.0,
-                "vaadin:icon", null);
-        SideNavItem sideNavItem = new SideNavItem(entry);
-
-        Assert.assertNotNull(sideNavItem.getPrefixComponent());
-        Assert.assertTrue(sideNavItem.getPrefixComponent() instanceof Icon);
-        Assert.assertEquals("vaadin:icon",
-                ((Icon) sideNavItem.getPrefixComponent()).getIcon());
-    }
-
-    @Test
-    public void createFromMenuEntry_withSvgIcon_setsIcon() {
-        MenuEntry entry = new MenuEntry("path", "Test label", 0.0,
-                "assets/globe.svg", null);
-        SideNavItem sideNavItem = new SideNavItem(entry);
-
-        Assert.assertNotNull(sideNavItem.getPrefixComponent());
-        Assert.assertTrue(sideNavItem.getPrefixComponent() instanceof SvgIcon);
-        Assert.assertEquals("assets/globe.svg",
-                ((SvgIcon) sideNavItem.getPrefixComponent()).getSrc());
-    }
-
-    @Test
-    public void createFromMenuEntry_withoutIcon_noIconSet() {
-        MenuEntry entry = new MenuEntry("path", "Test label", 0.0, null, null);
-        SideNavItem sideNavItem = new SideNavItem(entry);
-
-        Assert.assertNull(sideNavItem.getPrefixComponent());
-    }
-
-    @Test
-    public void createFromMenuEntry_unsupportedIcon_noIconSet() {
-        MenuEntry entry = new MenuEntry("path", "Test label", 0.0,
-                "assets/globe.png", null);
-        SideNavItem sideNavItem = new SideNavItem(entry);
-
-        Assert.assertNull(sideNavItem.getPrefixComponent());
     }
 
     // EXPAND AND COLLAPSE TESTS

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavTest.java
@@ -21,7 +21,6 @@ import static com.vaadin.flow.component.sidenav.tests.SideNavTest.SetLabelOption
 import static com.vaadin.flow.component.sidenav.tests.SideNavTest.SetLabelOption.SET_NO_LABEL;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,7 +31,6 @@ import org.junit.Test;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.server.menu.MenuEntry;
 
 public class SideNavTest {
 
@@ -399,29 +397,6 @@ public class SideNavTest {
         sideNav.remove(new SideNavItem("Foreign item"));
 
         Assert.assertEquals(sideNav.getItems(), sideNavItems);
-    }
-
-    @Test
-    public void createFromMenuEntries_menuEntriesAdded() {
-        MenuEntry entry1 = new MenuEntry("path1", "Item 1", 0.0, null, null);
-        MenuEntry entry2 = new MenuEntry("path2", "Item 2", 1.0, null, null);
-        MenuEntry entry3 = new MenuEntry("path3", "Item 3", 2.0, null, null);
-        List<MenuEntry> menuEntries = List.of(entry1, entry2, entry3);
-
-        SideNav nav = new SideNav(menuEntries);
-
-        Assert.assertEquals(3, nav.getItems().size());
-        Assert.assertEquals("Item 1", nav.getItems().get(0).getLabel());
-        Assert.assertEquals("path1", nav.getItems().get(0).getPath());
-        Assert.assertEquals("Item 2", nav.getItems().get(1).getLabel());
-        Assert.assertEquals("path2", nav.getItems().get(1).getPath());
-        Assert.assertEquals("Item 3", nav.getItems().get(2).getLabel());
-        Assert.assertEquals("path3", nav.getItems().get(2).getPath());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void createFromNullMenuEntries_throws() {
-        new SideNav((Collection<MenuEntry>) null);
     }
 
     enum SetLabelOption {


### PR DESCRIPTION
This reverts commit e3cb174e2cba7195c36ab1c521f3c0d95741ae57.

The import for `com.vaadin.flow.component.icon.Icon` results in adding the Vaadin iconset to the frontend bundle even if you never use icons from that iconset.