### PR TITLE
test: refactor AppLayout IT to use AbstractComponentIT

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/applayout/tests/AppLayoutIT.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/applayout/tests/AppLayoutIT.java
@@ -24,16 +24,16 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.applayout.testbench.AppLayoutElement;
 import com.vaadin.flow.component.applayout.testbench.DrawerToggleElement;
+import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.tests.AbstractParallelTest;
+import com.vaadin.tests.AbstractComponentIT;
 
-public class AppLayoutIT extends AbstractParallelTest {
+@TestPath("vaadin-app-layout")
+public class AppLayoutIT extends AbstractComponentIT {
 
     @Before
     public void init() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-app-layout");
-        getDriver().get(url);
+        open();
     }
 
     @Test
@@ -66,8 +66,7 @@ public class AppLayoutIT extends AbstractParallelTest {
 
     @Test
     public void navigateToNotFound() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-app-layout") + "/nonexistingpage";
+        String url = getRootURL() + getTestPath() + "/nonexistingpage";
         getDriver().get(url);
         Assert.assertTrue($(AppLayoutElement.class).waitForFirst().getContent()
                 .getText().contains("Could not navigate to"));


### PR DESCRIPTION
## Description

Same as #6801 but for `AppLayout`.

This component was initially using the setup of "Pro" components, let's change it to use `AbstractComponentIT`.
Note: there's a second IT test file that is already using it, so it makes sense to align these.

## Type of change

- Test