### PR TITLE
fix: dispatch change event in setChecked

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/CheckboxElement.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/CheckboxElement.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.checkbox.testbench;
 
+import java.util.Collections;
+
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.TestBenchElement;
@@ -46,6 +48,7 @@ public class CheckboxElement extends TestBenchElement
      */
     public void setChecked(boolean checked) {
         setProperty("checked", checked);
+        dispatchEvent("change", Collections.singletonMap("bubbles", true));
     }
 
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
@@ -61,7 +62,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void selectAllCheckbox_state() {
+    public void selectAllCheckbox_click_state() {
         open();
         WebElement grid = findElement(
                 By.id(GridMultiSelectionColumnPage.IN_MEMORY_GRID_ID));
@@ -129,6 +130,26 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         Assert.assertNull(
                 "Select all checkbox is in indeterminate state even though no items are selected",
                 selectAllCheckbox.getAttribute("indeterminate"));
+    }
+
+    @Test
+    public void selectAllCheckbox_setChecked_selectsAndDeselectsItems() {
+        open();
+
+        GridElement grid = $(GridElement.class)
+                .id(GridMultiSelectionColumnPage.IN_MEMORY_GRID_ID);
+        CheckboxElement selectAllCheckbox = grid.$(CheckboxElement.class)
+                .id(SELECT_ALL_CHECKBOX_ID);
+        WebElement message = findElement(By.id("selected-item-count"));
+
+        selectAllCheckbox.setChecked(true);
+        Assert.assertEquals(
+                "Selected item count: "
+                        + GridMultiSelectionColumnPage.ITEM_COUNT,
+                message.getText());
+
+        selectAllCheckbox.setChecked(false);
+        Assert.assertEquals("Selected item count: 0", message.getText());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -62,7 +62,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void selectAllCheckbox_click_state() {
+    public void selectAllCheckbox_state() {
         open();
         WebElement grid = findElement(
                 By.id(GridMultiSelectionColumnPage.IN_MEMORY_GRID_ID));


### PR DESCRIPTION
## Description

The PR updates the `setChecked` method of `CheckboxElement` to dispatch a change event, allowing applications to use this method for selecting grid checkboxes after they were refactored to listen to the change event in https://github.com/vaadin/web-components/pull/8239.

## Type of change

- [x] Bugfix
