### PR TITLE
test: update loginform element to use part names

### DIFF
--- a/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginFormElement.java
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginFormElement.java
@@ -48,7 +48,7 @@ public class LoginFormElement extends TestBenchElement implements Login {
 
     @Override
     public ButtonElement getForgotPasswordButton() {
-        return $(ButtonElement.class).attribute("slot", "forgot-password")
+        return $(ButtonElement.class).withAttribute("slot", "forgot-password")
                 .first();
     }
 
@@ -65,18 +65,19 @@ public class LoginFormElement extends TestBenchElement implements Login {
     @Override
     public String getFormTitle() {
         return getFormWrapper().$(TestBenchElement.class)
-                .attribute("part", "form").first().$("h2").first().getText();
+                .withAttribute("part", "form-title").first().getText();
     }
 
     @Override
     public TestBenchElement getErrorComponent() {
         return getFormWrapper().$(TestBenchElement.class)
-                .attribute("part", "error-message").first();
+                .withAttribute("part", "error-message").first();
     }
 
     @Override
     public String getErrorMessageTitle() {
-        return getErrorComponent().$("h5").first().getText();
+        return getErrorComponent().$(TestBenchElement.class)
+                .withAttribute("part", "error-message-title").first().getText();
     }
 
     @Override
@@ -87,7 +88,8 @@ public class LoginFormElement extends TestBenchElement implements Login {
     @Override
     public String getAdditionalInformation() {
         return getFormWrapper().$(TestBenchElement.class)
-                .attribute("part", "footer").first().$("p").first().getText();
+                .withAttribute("part", "footer").first().$("p").first()
+                .getText();
     }
 
     @Override


### PR DESCRIPTION
## Description

As part of https://github.com/vaadin/web-components/pull/8438 and https://github.com/vaadin/web-components/pull/8441, the Login component no longer uses `<h*>` elements internally, but the `LoginFormElement` references these elements tag names to find them. This updates the selectors to use part names instead.

This issue was first noticed from test failures at https://github.com/vaadin/flow-components/pull/7003
