### PR TITLE
chore: remove unnecessary formatter instructions

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroupVariant.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroupVariant.java
@@ -21,12 +21,10 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-avatar-group} component.
  */
 public enum AvatarGroupVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_XLARGE("xlarge"),
     LUMO_LARGE("large"),
     LUMO_SMALL("small"),
     LUMO_XSMALL("xsmall");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarVariant.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarVariant.java
@@ -21,12 +21,10 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-avatar} component.
  */
 public enum AvatarVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_XLARGE("xlarge"),
     LUMO_LARGE("large"),
     LUMO_SMALL("small"),
     LUMO_XSMALL("xsmall");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/ButtonVariant.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/ButtonVariant.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-button} component.
  */
 public enum ButtonVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_LARGE("large"),
     LUMO_TERTIARY("tertiary"),
@@ -34,7 +33,6 @@ public enum ButtonVariant implements ThemeVariant {
     LUMO_ICON("icon"),
     MATERIAL_CONTAINED("contained"),
     MATERIAL_OUTLINED("outlined");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/CardVariant.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/CardVariant.java
@@ -21,12 +21,10 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-card} component.
  */
 public enum CardVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_ELEVATED("elevated"),
     LUMO_OUTLINED("outlined"),
     MATERIAL_ELEVATED("elevated"),
     MATERIAL_OUTLINED("outlined");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupVariant.java
@@ -21,11 +21,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-checkbox-group} component.
  */
 public enum CheckboxGroupVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_VERTICAL("vertical"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_VERTICAL("vertical");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxVariant.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxVariant.java
@@ -21,14 +21,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-combo-box} component.
  */
 public enum ComboBoxVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxVariant.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxVariant.java
@@ -22,14 +22,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * component.
  */
 public enum MultiSelectComboBoxVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePickerVariant.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePickerVariant.java
@@ -21,14 +21,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-date-picker} component.
  */
 public enum DatePickerVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerVariant.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerVariant.java
@@ -22,14 +22,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * component.
  */
 public enum DateTimePickerVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -50,7 +50,6 @@ public class Tooltip implements Serializable {
      * Tooltip position in relation to the target element.
      */
     public enum TooltipPosition {
-        //@formatter:off
         TOP_START("top-start"),
         TOP("top"),
         TOP_END("top-end"),
@@ -63,7 +62,6 @@ public class Tooltip implements Serializable {
         END_TOP("end-top"),
         END("end"),
         END_BOTTOM("end-bottom");
-        //@formatter:off
 
         private final String position;
 
@@ -79,12 +77,14 @@ public class Tooltip implements Serializable {
          * Gets the {@link TooltipPosition} for the given position string.
          * Returns {@link TooltipPosition#BOTTOM} if no match is found.
          *
-         * @param position the position string
+         * @param position
+         *            the position string
          * @return the {@link TooltipPosition}
          */
         public static TooltipPosition fromPosition(String position) {
             return Arrays.stream(TooltipPosition.values())
-                .filter(p -> p.getPosition().equals(position)).findFirst().orElse(BOTTOM);
+                    .filter(p -> p.getPosition().equals(position)).findFirst()
+                    .orElse(BOTTOM);
         }
     }
 
@@ -104,7 +104,8 @@ public class Tooltip implements Serializable {
             // Remove the tooltip from its current state tree
             tooltip.tooltipElement.removeFromTree(false);
 
-            // The host under which the <vaadin-tooltip> element is auto-attached
+            // The host under which the <vaadin-tooltip> element is
+            // auto-attached
             var tooltipHost = UI.getCurrent().getElement();
             tooltipHost.appendChild(tooltip.tooltipElement);
             tooltip.tooltipElement.executeJs("this.target = $0;", element);
@@ -122,7 +123,8 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * Creates a tooltip to the given {@code Component} if one hasn't already been created.
+     * Creates a tooltip to the given {@code Component} if one hasn't already
+     * been created.
      *
      * @param component
      *            the component to attach the tooltip to
@@ -150,17 +152,18 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * Creates a tooltip to the given {@link HasTooltip} component
-     * and adds the tooltip element to the component's tooltip slot.
+     * Creates a tooltip to the given {@link HasTooltip} component and adds the
+     * tooltip element to the component's tooltip slot.
      *
      * @param hasTooltip
-     *              the component to attach the tooltip to
+     *            the component to attach the tooltip to
      * @return the tooltip handle
      */
     static Tooltip forHasTooltip(HasTooltip hasTooltip) {
         var tooltip = new Tooltip();
         SlotUtils.setSlot(hasTooltip, "tooltip", tooltip.tooltipElement);
-        var component = ComponentUtil.getInnermostComponent(hasTooltip.getElement());
+        var component = ComponentUtil
+                .getInnermostComponent(hasTooltip.getElement());
         ComponentUtil.setData(component, TOOLTIP_DATA_KEY, tooltip);
         return tooltip;
     }
@@ -196,8 +199,8 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * The delay in milliseconds before the tooltip is opened on keyboard focus, when not
-     * in manual mode.
+     * The delay in milliseconds before the tooltip is opened on keyboard focus,
+     * when not in manual mode.
      *
      * @param focusDelay
      *            the delay in milliseconds
@@ -207,8 +210,8 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * The delay in milliseconds before the tooltip is opened on keyboard focus, when not
-     * in manual mode.
+     * The delay in milliseconds before the tooltip is opened on keyboard focus,
+     * when not in manual mode.
      *
      * @return the delay in milliseconds
      */
@@ -217,8 +220,8 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * The delay in milliseconds before the tooltip is opened on keyboard focus, when not
-     * in manual mode.
+     * The delay in milliseconds before the tooltip is opened on keyboard focus,
+     * when not in manual mode.
      *
      * @param focusDelay
      *            the delay in milliseconds
@@ -312,7 +315,8 @@ public class Tooltip implements Serializable {
     public TooltipPosition getPosition() {
         var positionString = tooltipElement.getProperty("position");
         return Arrays.stream(TooltipPosition.values())
-            .filter(p -> p.getPosition().equals(positionString)).findFirst().orElse(null);
+                .filter(p -> p.getPosition().equals(positionString)).findFirst()
+                .orElse(null);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridVariant.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridVariant.java
@@ -19,16 +19,13 @@ package com.vaadin.flow.component.grid;
  * Set of theme variants applicable for {@code vaadin-grid} component.
  */
 public enum GridVariant {
-    //@formatter:off
     LUMO_NO_BORDER("no-border"),
     LUMO_NO_ROW_BORDERS("no-row-borders"),
     LUMO_COLUMN_BORDERS("column-borders"),
     LUMO_ROW_STRIPES("row-stripes"),
     LUMO_COMPACT("compact"),
     LUMO_WRAP_CELL_CONTENT("wrap-cell-content"),
-    MATERIAL_COLUMN_DIVIDERS( "column-dividers");
-
-    //@formatter:on
+    MATERIAL_COLUMN_DIVIDERS("column-dividers");
 
     private final String variant;
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridProVariant.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridProVariant.java
@@ -12,7 +12,6 @@ package com.vaadin.flow.component.gridpro;
  * Set of theme variants applicable for {@code vaadin-grid-pro} component.
  */
 public enum GridProVariant {
-    //@formatter:off
     LUMO_NO_BORDER("no-border"),
     LUMO_NO_ROW_BORDERS("no-row-borders"),
     LUMO_COLUMN_BORDERS("column-borders"),
@@ -22,8 +21,6 @@ public enum GridProVariant {
     MATERIAL_COLUMN_DIVIDERS("column-dividers"),
     LUMO_HIGHLIGHT_EDITABLE_CELLS("highlight-editable-cells"),
     LUMO_HIGHLIGHT_READ_ONLY_CELLS("highlight-read-only-cells");
-
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarVariant.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarVariant.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-menu-bar} component.
  */
 public enum MenuBarVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_LARGE("large"),
     LUMO_TERTIARY("tertiary"),
@@ -34,7 +33,6 @@ public enum MenuBarVariant implements ThemeVariant {
     MATERIAL_CONTAINED("contained"),
     MATERIAL_OUTLINED("outlined"),
     MATERIAL_END_ALIGNED("end-aligned");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverPosition.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverPosition.java
@@ -19,7 +19,6 @@ package com.vaadin.flow.component.popover;
  * Popover position in relation to the target element.
  */
 public enum PopoverPosition {
-    //@formatter:off
     TOP_START("top-start"),
     TOP("top"),
     TOP_END("top-end"),
@@ -32,7 +31,6 @@ public enum PopoverPosition {
     END_TOP("end-top"),
     END("end"),
     END_BOTTOM("end-bottom");
-    //@formatter:off
 
     private final String position;
 

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/PopoverVariant.java
@@ -21,11 +21,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for the {@link Popover} component.
  */
 public enum PopoverVariant implements ThemeVariant {
-    //@formatter:off
     ARROW("arrow"),
     LUMO_NO_PADDING("no-padding"),
     MATERIAL_NO_PADDING("no-padding");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioGroupVariant.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioGroupVariant.java
@@ -21,11 +21,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-radio-group} component.
  */
 public enum RadioGroupVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_VERTICAL("vertical"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_VERTICAL("vertical");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditorVariant.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditorVariant.java
@@ -15,11 +15,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * component.
  */
 public enum RichTextEditorVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_NO_BORDER("no-border"),
     LUMO_COMPACT("compact"),
     MATERIAL_NO_BORDER("no-border");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/SelectVariant.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/SelectVariant.java
@@ -21,14 +21,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-select} component.
  */
 public enum SelectVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
@@ -21,9 +21,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-tabsheet} component.
  */
 public enum TabSheetVariant implements ThemeVariant {
-    //@formatter:off
     /**
-     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} on individual {@code Tab} instances instead.
+     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} on individual
+     *             {@code Tab} instances instead.
      */
     @Deprecated
     LUMO_TABS_ICON_ON_TOP("icon-on-top"),
@@ -31,12 +31,11 @@ public enum TabSheetVariant implements ThemeVariant {
     LUMO_TABS_SMALL("small"),
     LUMO_TABS_MINIMAL("minimal"),
     LUMO_TABS_HIDE_SCROLL_BUTTONS("hide-scroll-buttons"),
-    LUMO_TABS_EQUAL_WIDTH_TABS( "equal-width-tabs"),
+    LUMO_TABS_EQUAL_WIDTH_TABS("equal-width-tabs"),
     LUMO_BORDERED("bordered"),
     LUMO_NO_PADDING("no-padding"),
     MATERIAL_TABS_FIXED("fixed"),
     MATERIAL_BORDERED("bordered");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
@@ -21,9 +21,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-tabs} component.
  */
 public enum TabsVariant implements ThemeVariant {
-    //@formatter:off
     /**
-     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} on individual {@code Tab} instances instead.
+     * @deprecated Use {@code TabVariant.LUMO_ICON_ON_TOP} on individual
+     *             {@code Tab} instances instead.
      */
     @Deprecated
     LUMO_ICON_ON_TOP("icon-on-top"),
@@ -33,7 +33,6 @@ public enum TabsVariant implements ThemeVariant {
     LUMO_HIDE_SCROLL_BUTTONS("hide-scroll-buttons"),
     LUMO_EQUAL_WIDTH_TABS("equal-width-tabs"),
     MATERIAL_FIXED("fixed");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
@@ -21,13 +21,11 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-text-area} component.
  */
 public enum TextAreaVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
@@ -22,13 +22,11 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * as other components based on it.
  */
 public enum TextFieldVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePickerVariant.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePickerVariant.java
@@ -21,14 +21,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-time-picker} component.
  */
 public enum TimePickerVariant implements ThemeVariant {
-    //@formatter:off
     LUMO_SMALL("small"),
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
-    //@formatter:on
 
     private final String variant;
 


### PR DESCRIPTION
Since https://github.com/vaadin/flow-components/pull/7010 enum values are automatically put on individual lines, so the formatter instructions have become unnecessary.