### PR TITLE
chore: add shared Vite config

### DIFF
--- a/shared/shared-vite-config.ts
+++ b/shared/shared-vite-config.ts
@@ -7,10 +7,10 @@ export const mergeConfigs = (...configs: UserConfigFn[]) => {
 
 export const sharedConfig: UserConfigFn = (env) => ({
   plugins: [
-    // Use local version of web-components, disabled by default
-    // To use this un-comment the lines below and change the path to
-    // the absolute path of your web-components repo's node_modules
-    // folder
+    // Use local version of web-components, disabled by default.
+    // To use this, uncomment the lines below and change the path
+    // to your local web-components folder if needed (absolute or
+    // relative to this shared config).
     // DO NOT COMMIT THESE CHANGES!
     // useLocalWebComponents('../../web-components')
   ]

--- a/shared/shared-vite-config.ts
+++ b/shared/shared-vite-config.ts
@@ -1,0 +1,17 @@
+import { UserConfigFn, mergeConfig } from 'vite';
+import { useLocalWebComponents } from './web-components-vite-plugin';
+
+export const mergeConfigs = (...configs: UserConfigFn[]) => {
+  return configs.reduce((acc, config) => mergeConfig(acc, config));
+};
+
+export const sharedConfig: UserConfigFn = (env) => ({
+  plugins: [
+    // Use local version of web-components, disabled by default
+    // To use this un-comment the lines below and change the path to
+    // the absolute path of your web-components repo's node_modules
+    // folder
+    // DO NOT COMMIT THESE CHANGES!
+    // useLocalWebComponents('../../web-components')
+  ]
+});

--- a/shared/web-components-vite-plugin.ts
+++ b/shared/web-components-vite-plugin.ts
@@ -4,24 +4,31 @@ import { PluginOption } from 'vite';
 /**
  * Vite plugin that resolves Vaadin component JS modules to a
  * local checkout of the web-components repository
- * @param webComponentsNodeModulesPath
+ *
+ * @param webComponentsRepoPath
  */
-export function useLocalWebComponents(webComponentsNodeModulesPath: string): PluginOption {
+export function useLocalWebComponents(webComponentsRepoPath: string): PluginOption {
+  const nodeModulesPath = path.resolve(__dirname, `${webComponentsRepoPath}/node_modules`);
+
   return {
     name: 'use-local-web-components',
     enforce: 'pre',
-    config(config) {
-      config.server = config.server ?? {};
-      config.server.fs = config.server.fs ?? {};
-      config.server.fs.allow = config.server.fs.allow ?? [];
-      config.server.fs.allow.push(webComponentsNodeModulesPath);
-      config.server.watch = config.server.watch ?? {};
-      config.server.watch.ignored = [`!${webComponentsNodeModulesPath}/**`];
+    config() {
+      return {
+        server: {
+          fs: {
+            allow: [nodeModulesPath]
+          },
+          watch: {
+            ignored: [`!${nodeModulesPath}/**`]
+          }
+        }
+      };
     },
     resolveId(id) {
       if (/^(@polymer|@vaadin)/.test(id)) {
-        return this.resolve(path.join(webComponentsNodeModulesPath, id));
+        return this.resolve(path.join(nodeModulesPath, id));
       }
-    },
-  }
+    }
+  };
 }

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/vite.config.ts
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/vite.config.ts
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/vite.config.ts
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/vite.config.ts
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/vite.config.ts
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/vite.config.ts
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/vite.config.ts
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/vite.config.ts
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/vite.config.ts
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/vite.config.ts
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/vite.config.ts
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/vite.config.ts
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/vite.config.ts
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/vite.config.ts
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/vite.config.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/vite.config.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/vite.config.ts
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/vite.config.ts
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/vite.config.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/vite.config.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/vite.config.ts
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/vite.config.ts
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/vite.config.ts
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/vite.config.ts
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/vite.config.ts
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/vite.config.ts
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/vite.config.ts
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/vite.config.ts
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/vite.config.ts
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/vite.config.ts
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/vite.config.ts
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/vite.config.ts
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/vite.config.ts
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/vite.config.ts
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/vite.config.ts
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/vite.config.ts
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/vite.config.ts
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/vite.config.ts
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/vite.config.ts
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/vite.config.ts
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/vite.config.ts
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/vite.config.ts
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/vite.config.ts
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/vite.config.ts
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/vite.config.ts
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/vite.config.ts
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/vite.config.ts
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/vite.config.ts
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/vite.config.ts
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/vite.config.ts
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/vite.config.ts
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/vite.config.ts
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/vite.config.ts
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/vite.config.ts
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/vite.config.ts
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/vite.config.ts
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/vite.config.ts
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/vite.config.ts
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/vite.config.ts
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/vite.config.ts
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/vite.config.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/vite.config.ts
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/vite.config.ts
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/vite.config.ts
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/vite.config.ts
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/vite.config.ts
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/vite.config.ts
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/vite.config.ts
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/vite.config.ts
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/vite.config.ts
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/vite.config.ts
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/vite.config.ts
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/vite.config.ts
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/vite.config.ts
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/vite.config.ts
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/vite.config.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/vite.config.ts
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/vite.config.ts
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/vite.config.ts
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/vite.config.ts
@@ -9,4 +9,8 @@ const customConfig: UserConfigFn = (env) => ({
   // https://vitejs.dev/config/
 });
 
-export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env),
+  customConfig(env)
+));

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/vite.config.ts
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/vite.config.ts
@@ -1,23 +1,12 @@
 // @ts-ignore can not be resolved until NPM packages are installed
-import { UserConfigFn } from 'vite';
+import { defineConfig, UserConfigFn } from 'vite';
 // @ts-ignore can not be resolved until Flow generates base Vite config
-import { overrideVaadinConfig } from './vite.generated';
-// import { useLocalWebComponents } from '../../shared/web-components-vite-plugin';
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../../shared/shared-vite-config';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-
-  // Use local version of web-components, disabled by default
-  // To use this un-comment the lines below and change the path to
-  // the absolute path of your web-components repo's node_modules
-  // folder
-  // DO NOT COMMIT THESE CHANGES!
-  /*
-  plugins: [
-    useLocalWebComponents('/path/to/web-components/node_modules')
-  ]
-   */
 });
 
-export default overrideVaadinConfig(customConfig);
+export default defineConfig((env) => mergeConfigs(vaadinConfig(env), sharedConfig(env), customConfig(env)));


### PR DESCRIPTION
## Description

Enabling `useLocalWebComponents` for each component individually can be tedious. This PR introduces a shared Vite config to allow you to add Vite plugins that will apply to all components automatically.

## Type of change

- [x] Internal
