### PR TITLE
fix: replace requestAnimationFrame with global click listener

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -332,8 +332,6 @@ public class ButtonIT extends AbstractComponentIT {
         var button = findElement(By.id(itemId));
         for (int i = 0; i < 3; i++) {
             button.click();
-            getCommandExecutor().getDriver()
-                    .executeAsyncScript("requestAnimationFrame(arguments[0])");
             Assert.assertFalse(button.isEnabled());
             waitUntil(driver -> button.isEnabled());
         }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/MenuItemDisableOnClickIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/MenuItemDisableOnClickIT.java
@@ -98,8 +98,6 @@ public class MenuItemDisableOnClickIT extends AbstractContextMenuIT {
         var menuItem = findElement(By.id(itemId));
         for (int i = 0; i < 3; i++) {
             menuItem.click();
-            getCommandExecutor().getDriver()
-                    .executeAsyncScript("requestAnimationFrame(arguments[0])");
             Assert.assertFalse(menuItem.isEnabled());
             waitUntil(driver -> menuItem.isEnabled());
         }
@@ -197,8 +195,6 @@ public class MenuItemDisableOnClickIT extends AbstractContextMenuIT {
         // Test whether the item is still disable on click
         getCommandExecutor().disableWaitForVaadin();
         menuItem.click();
-        getCommandExecutor().getDriver()
-                .executeAsyncScript("requestAnimationFrame(arguments[0])");
         Assert.assertFalse(menuItem.isEnabled());
         waitUntil(ExpectedConditions.elementToBeClickable(menuItem), 2);
         Assert.assertTrue(menuItem.isEnabled());

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -45,7 +45,6 @@ public class DisableOnClickController<C extends Component & HasEnabled>
 
     private final C component;
     private boolean disableOnClick = false;
-    private boolean disableOnClickInitialized;
 
     /**
      * Creates a new controller for the given component.
@@ -79,7 +78,6 @@ public class DisableOnClickController<C extends Component & HasEnabled>
         this.disableOnClick = disableOnClick;
         if (disableOnClick) {
             component.getElement().setProperty("disableOnClick", "true");
-            ensureDisableOnClickInitialized();
         } else {
             component.getElement().removeProperty("disableOnClick");
         }
@@ -109,25 +107,5 @@ public class DisableOnClickController<C extends Component & HasEnabled>
         // round trip, Flow will not detect any changes and the client side
         // component would not be enabled again.
         component.getElement().executeJs("this.disabled = $0", !enabled);
-    }
-
-    /**
-     * Initialize client side disabling so disabled if immediate on click even
-     * if server-side handling takes some time.
-     */
-    private void ensureDisableOnClickInitialized() {
-        if (disableOnClickInitialized) {
-            return;
-        }
-        disableOnClickInitialized = true;
-        if (component.isAttached()) {
-            initDisableOnClick();
-        }
-        component.addAttachListener(event -> initDisableOnClick());
-    }
-
-    private void initDisableOnClick() {
-        component.getElement().executeJs(
-                "window.Vaadin.Flow.disableOnClick.initDisableOnClick(this);");
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/disableOnClickFunctions.js
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/disableOnClickFunctions.js
@@ -1,14 +1,6 @@
-function disableOnClickListener({currentTarget: element}) {
-  if (element.disableOnClick) {
-    requestAnimationFrame(() => element.disabled = true);
+document.addEventListener('click', (event) => {
+  const target = event.composedPath().find((node) => node.disableOnClick);
+  if (target) {
+    target.disabled = true;
   }
-}
-
-window.Vaadin.Flow.disableOnClick = {
-  initDisableOnClick: (element) => {
-    if (!element.__hasDisableOnClickListener) {
-      element.addEventListener('click', disableOnClickListener);
-      element.__hasDisableOnClickListener = true;
-    }
-  }
-}
+});

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
@@ -20,22 +20,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
-import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinSession;
 
 public class DisableOnClickControllerTest {
-
-    private static final String INIT_DISABLE_ON_CLICK_JS = "window.Vaadin.Flow.disableOnClick.initDisableOnClick(this);";
 
     private TestComponent component;
 
@@ -82,78 +75,6 @@ public class DisableOnClickControllerTest {
         component.setDisableOnClick(true);
         component.click();
         Assert.assertTrue(component.isEnabled());
-    }
-
-    @Test
-    public void itemNotDisableOnClick_attach_initNotCalled() {
-        var spiedElement = getSpiedElement();
-
-        var ui = initUi();
-        ui.add(component);
-        fakeClientCommunication(ui);
-        Assert.assertTrue(component.isAttached());
-
-        Mockito.verify(spiedElement, Mockito.never())
-                .executeJs(INIT_DISABLE_ON_CLICK_JS);
-    }
-
-    @Test
-    public void itemDisableOnClick_notAttached_initNotCalled() {
-        var spiedElement = getSpiedElement();
-
-        component.setDisableOnClick(true);
-
-        var ui = initUi();
-        fakeClientCommunication(ui);
-
-        Mockito.verify(spiedElement, Mockito.never())
-                .executeJs(INIT_DISABLE_ON_CLICK_JS);
-    }
-
-    @Test
-    public void itemAlreadyAttached_setDisableOnClickMultipleTimesInRoundTrip_initCalledOnce() {
-        var spiedElement = getSpiedElement();
-
-        var ui = initUi();
-        ui.add(component);
-        fakeClientCommunication(ui);
-        Assert.assertTrue(component.isAttached());
-
-        component.setDisableOnClick(true);
-        component.setDisableOnClick(false);
-        component.setDisableOnClick(true);
-        fakeClientCommunication(ui);
-
-        Mockito.verify(spiedElement, Mockito.times(1))
-                .executeJs(INIT_DISABLE_ON_CLICK_JS);
-    }
-
-    private UI initUi() {
-        var ui = new UI();
-        UI.setCurrent(ui);
-        var session = Mockito.mock(VaadinSession.class);
-        ui.getInternals().setSession(session);
-        var service = Mockito.mock(VaadinService.class);
-        Mockito.when(session.getService()).thenReturn(service);
-        return ui;
-    }
-
-    private void fakeClientCommunication(UI ui) {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
-    }
-
-    private Element getSpiedElement() {
-        var spiedElement = Mockito.spy(component.getElement());
-        try {
-            var elementField = Component.class.getDeclaredField("element");
-            elementField.setAccessible(true);
-            elementField.set(component, spiedElement);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return spiedElement;
     }
 
     @Tag("test")


### PR DESCRIPTION
## Description

This PR replaces the requestAnimationFrame approach with a global click listener for disabling components when `disableOnClick` is set to true. This ensures the disabling happens synchronously, avoiding race conditions with server requests, and only after all other click listeners have been executed, allowing the context menu to properly close after a disable-on-click item was clicked.

Fixes https://github.com/vaadin/flow-components/issues/7009

## Type of change

- [x] Bugfix
