### PR TITLE
test: refactor Login ITs to use AbstractComponentIT

### DIFF
--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/AbstractLoginIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/AbstractLoginIT.java
@@ -16,42 +16,24 @@
 package com.vaadin.flow.component.login.tests;
 
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.Ignore;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.login.testbench.LoginFormElement;
 import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
-import com.vaadin.testbench.parallel.BrowserUtil;
-import com.vaadin.tests.AbstractParallelTest;
+import com.vaadin.tests.AbstractComponentIT;
 
-public abstract class BasicIT extends AbstractParallelTest {
+@Ignore
+public abstract class AbstractLoginIT extends AbstractComponentIT {
 
-    @Before
-    public void init() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login");
-        getDriver().get(url);
-    }
-
-    public abstract LoginFormElement getLoginForm();
-
-    @Test
-    public void testDefaults() {
-        LoginFormElement login = getLoginForm();
-
+    protected void checkLoginFormDefaults(LoginFormElement login) {
         Assert.assertEquals("Log in", login.getFormTitle());
-        if (!BrowserUtil.isEdge(getDesiredCapabilities())
-                && !BrowserUtil.isSafari(getDesiredCapabilities())) {
-            // Error message should be hidden by default, however Safari and
-            // Edge drivers return the innerHTML content
-            Assert.assertEquals("", login.getErrorMessageTitle());
-            Assert.assertEquals("", login.getErrorMessage());
-        }
+        Assert.assertEquals("", login.getErrorMessageTitle());
+        Assert.assertEquals("", login.getErrorMessage());
         Assert.assertEquals("Forgot password",
                 login.getForgotPasswordButton().getText().trim());
-        Assert.assertFalse(getLoginForm().getForgotPasswordButton()
+        Assert.assertFalse(login.getForgotPasswordButton()
                 .hasAttribute("hidden"));
         Assert.assertEquals("", login.getAdditionalInformation());
     }
@@ -70,15 +52,4 @@ public abstract class BasicIT extends AbstractParallelTest {
         submit.run();
         Assert.assertEquals("Successful login", $("div").id("info").getText());
     }
-
-    @Test
-    public void testNoForgotPasswordButton() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login") + "/no-forgot-password";
-        getDriver().get(url);
-
-        Assert.assertTrue(getLoginForm().getForgotPasswordButton()
-                .hasAttribute("hidden"));
-    }
-
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/AbstractLoginIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/AbstractLoginIT.java
@@ -33,8 +33,8 @@ public abstract class AbstractLoginIT extends AbstractComponentIT {
         Assert.assertEquals("", login.getErrorMessage());
         Assert.assertEquals("Forgot password",
                 login.getForgotPasswordButton().getText().trim());
-        Assert.assertFalse(login.getForgotPasswordButton()
-                .hasAttribute("hidden"));
+        Assert.assertFalse(
+                login.getForgotPasswordButton().hasAttribute("hidden"));
         Assert.assertEquals("", login.getAdditionalInformation());
     }
 

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/I18nIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/I18nIT.java
@@ -20,15 +20,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
-import com.vaadin.tests.AbstractParallelTest;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 
-public class I18nIT extends AbstractParallelTest {
+@TestPath("vaadin-login/overlay/ptbr")
+public class I18nIT extends AbstractComponentIT {
 
     @Before
     public void init() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login") + "/overlay/ptbr";
-        getDriver().get(url);
+        open();
     }
 
     @Test

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/LoginFormIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/LoginFormIT.java
@@ -16,24 +16,23 @@
 package com.vaadin.flow.component.login.tests;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.component.login.testbench.LoginFormElement;
+import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.parallel.BrowserUtil;
 
-public class LoginFormIT extends BasicIT {
+@TestPath("vaadin-login")
+public class LoginFormIT extends AbstractLoginIT {
 
-    @Override
+    @Before
     public void init() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login");
-        getDriver().get(url);
+        open();
     }
 
-    @Override
-    public LoginFormElement getLoginForm() {
+    private LoginFormElement getLoginForm() {
         return $(LoginFormElement.class).waitForFirst();
     }
 
@@ -44,10 +43,10 @@ public class LoginFormIT extends BasicIT {
                 () -> login.submit());
     }
 
-    @Override
+    @Test
     public void testDefaults() {
-        super.testDefaults();
         LoginFormElement login = getLoginForm();
+        checkLoginFormDefaults(login);
         checkLoginForm(login.getUsernameField(), login.getPasswordField(),
                 login.getSubmitButton());
     }
@@ -65,8 +64,7 @@ public class LoginFormIT extends BasicIT {
 
     @Test
     public void disabledLogin() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login") + "/disable-login";
+        String url = getRootURL() + getTestPath() + "/disable-login";
         getDriver().get(url);
         LoginFormElement login = getLoginForm();
         login.getUsernameField().setValue("username");
@@ -76,7 +74,7 @@ public class LoginFormIT extends BasicIT {
         Assert.assertTrue("Login notification was shown",
                 $("div").id("info").getText().isEmpty());
 
-        sendKeys(login.getPasswordField(), Keys.ENTER);
+        login.getPasswordField().sendKeys(Keys.ENTER);
         Assert.assertTrue("Login notification was shown",
                 $("div").id("info").getText().isEmpty());
 
@@ -86,21 +84,12 @@ public class LoginFormIT extends BasicIT {
         checkForgotPassword(login);
     }
 
-    private void sendKeys(TestBenchElement textField, CharSequence... keys) {
-        if (BrowserUtil.isEdge(getDesiredCapabilities())
-                || BrowserUtil.isFirefox(getDesiredCapabilities())) {
-            // Firefox and Edge don't send keys to the slotted input
-            textField = textField.$("input").attribute("slot", "input").first();
-        }
-        textField.sendKeys(keys);
-    }
-
     @Test
     public void passwordEnterKeyLogin() {
         LoginFormElement login = getLoginForm();
         checkSuccessfulLogin(login.getUsernameField(), login.getPasswordField(),
                 () -> {
-                    sendKeys(login.getPasswordField(), Keys.ENTER);
+                    login.getPasswordField().sendKeys(Keys.ENTER);
                 });
     }
 
@@ -109,7 +98,7 @@ public class LoginFormIT extends BasicIT {
         LoginFormElement login = getLoginForm();
         checkSuccessfulLogin(login.getUsernameField(), login.getPasswordField(),
                 () -> {
-                    sendKeys(login.getUsernameField(), Keys.ENTER);
+                    login.getUsernameField().sendKeys(Keys.ENTER);
                 });
     }
 
@@ -146,8 +135,7 @@ public class LoginFormIT extends BasicIT {
 
     @Test
     public void actionLogin() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login") + "/action";
+        String url = getRootURL() + getTestPath() + "/action";
         getDriver().get(url);
         LoginFormElement login = getLoginForm();
 
@@ -156,5 +144,15 @@ public class LoginFormIT extends BasicIT {
         login.submit();
         Assert.assertTrue("Redirect didn't happened on login",
                 getDriver().getCurrentUrl().endsWith("process-login-here"));
+    }
+
+    @Test
+    public void testNoForgotPasswordButton() {
+        String url = getRootURL() + getTestPath() + "/no-forgot-password";
+        getDriver().get(url);
+
+        LoginFormElement login = getLoginForm();
+        Assert.assertTrue(login.getForgotPasswordButton()
+                .hasAttribute("hidden"));
     }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/LoginFormIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/LoginFormIT.java
@@ -152,7 +152,7 @@ public class LoginFormIT extends AbstractLoginIT {
         getDriver().get(url);
 
         LoginFormElement login = getLoginForm();
-        Assert.assertTrue(login.getForgotPasswordButton()
-                .hasAttribute("hidden"));
+        Assert.assertTrue(
+                login.getForgotPasswordButton().hasAttribute("hidden"));
     }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
@@ -19,7 +19,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.login.testbench.LoginFormElement;
 import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
@@ -132,7 +131,8 @@ public class OverlayIT extends AbstractLoginIT {
     }
 
     public void testTitleAndDescriptionStrings() {
-        String url = getRootURL() + getTestPath() + "/property-title-description";
+        String url = getRootURL() + getTestPath()
+                + "/property-title-description";
         getDriver().get(url);
         openOverlay();
 

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
@@ -16,23 +16,20 @@
 package com.vaadin.flow.component.login.tests;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.login.testbench.LoginFormElement;
 import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
+import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
-public class OverlayIT extends BasicIT {
+@TestPath("vaadin-login/overlay")
+public class OverlayIT extends AbstractLoginIT {
 
-    @Override
-    protected String getBaseURL() {
-        return super.getBaseURL() + "/overlay";
-    }
-
-    @Override
-    public LoginFormElement getLoginForm() {
-        openOverlay();
-        return $(LoginOverlayElement.class).waitForFirst().getLoginForm();
+    @Before
+    public void init() {
+        open();
     }
 
     private void openOverlay() {
@@ -48,14 +45,17 @@ public class OverlayIT extends BasicIT {
                 overlay.getPasswordField(), () -> overlay.submit());
     }
 
-    @Override
+    @Test
     public void testDefaults() {
-        super.testDefaults();
+        openOverlay();
         LoginOverlayElement loginOverlay = $(LoginOverlayElement.class)
                 .waitForFirst();
         Assert.assertEquals("App name", loginOverlay.getTitle());
         Assert.assertEquals("Application description",
                 loginOverlay.getDescription());
+
+        checkLoginFormDefaults(loginOverlay.getLoginForm());
+
         checkLoginForm(loginOverlay.getUsernameField(),
                 loginOverlay.getPasswordField(),
                 loginOverlay.getSubmitButton());
@@ -63,8 +63,8 @@ public class OverlayIT extends BasicIT {
 
     @Test
     public void testOverlaySelfAttached() {
-        getDriver()
-                .get(super.getBaseURL() + "/vaadin-login/overlayselfattached");
+        String url = getRootURL() + "/vaadin-login/overlayselfattached";
+        getDriver().get(url);
 
         Assert.assertFalse($(LoginOverlayElement.class).exists());
         openOverlay();
@@ -82,8 +82,7 @@ public class OverlayIT extends BasicIT {
 
     @Test
     public void testTitleComponent() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login") + "/component-title";
+        String url = getRootURL() + getTestPath() + "/component-title";
         getDriver().get(url);
         openOverlay();
 
@@ -115,8 +114,7 @@ public class OverlayIT extends BasicIT {
 
     @Test
     public void testResetTitleComponent() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login") + "/component-title";
+        String url = getRootURL() + getTestPath() + "/component-title";
         getDriver().get(url);
         checkTitleComponentWasReset();
     }
@@ -134,9 +132,7 @@ public class OverlayIT extends BasicIT {
     }
 
     public void testTitleAndDescriptionStrings() {
-        String url = getBaseURL().replace(super.getBaseURL(),
-                super.getBaseURL() + "/vaadin-login")
-                + "/property-title-description";
+        String url = getRootURL() + getTestPath() + "/property-title-description";
         getDriver().get(url);
         openOverlay();
 


### PR DESCRIPTION
## Description

Same as #6801 but for `LoginOverlay` and `LoginForm`.

This component was initially using the setup of "Pro" components, let's change it to use `AbstractComponentIT`.
Note: there are some IT test files that are already using it, so it makes sense to align these.

## Type of change

- Test