### PR TITLE
test: cleanup UI instances created in unit tests

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hamcrest.collection.IsEmptyCollection;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,6 +63,11 @@ public class CheckboxGroupTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void hasEmptySetAsDefaultValue() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.checkbox.tests;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -33,6 +34,11 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 public class CheckboxUnitTest {
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void initialValue() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.combobox;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -60,6 +61,11 @@ public class ComboBoxTest extends ComboBoxBaseTest {
     protected <TItem> ComboBoxBase<?, TItem, ?> createComboBox(
             Class<TItem> itemClass) {
         return new ComboBox<>();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.datepicker;
 import java.time.LocalDate;
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,11 @@ public class DatePickerLocaleTest {
     public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -48,6 +49,11 @@ import net.jcip.annotations.NotThreadSafe;
 public class DatePickerTest {
 
     private static final String OPENED_PROPERTY_NOT_UPDATED = "The server-side \"opened\"-property was not updated synchronously";
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.datetimepicker;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,11 @@ public class DateTimePickerLocaleTest {
     public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.shared;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,11 @@ public class HasTooltipTest {
         component = new TestComponent();
         ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.shared;
 
 import java.util.Optional;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,11 @@ public class TooltipTest {
         component = new TestComponent();
         ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,6 +61,11 @@ public class GridColumnTest {
         fourthColumn = grid.addColumn(renderer);
 
         UI.setCurrent(new UI());
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,6 +62,11 @@ public class HeaderFooterTest {
         addColumns();
 
         UI.setCurrent(new UI());
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     private void addColumns() {

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.icon.tests;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,6 +27,11 @@ import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.server.StreamResource;
 
 public class SvgIconTest {
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
     @Test
     public void emptyConstructor_hasNoSrc() {
         var icon = new SvgIcon();

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/serialization/MapSerializerTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/serialization/MapSerializerTest.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,6 +51,11 @@ public class MapSerializerTest {
                 .thenReturn(streamRegistrationMock);
         Mockito.when(streamRegistrationMock.getResourceUri())
                 .thenReturn(new URI("https://example.com"));
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.hamcrest.MatcherAssert;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class MessageListTest {
         messageList = new MessageList();
         item1 = new MessageListItem();
         item2 = new MessageListItem();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,6 +55,11 @@ public class RadioButtonGroupTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void setReadOnlyRadioGroup_groupIsReadOnly() {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonSerializableTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonSerializableTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.radiobutton.tests;
 
+import org.junit.After;
 import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
@@ -22,6 +23,11 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
 public class RadioButtonSerializableTest extends ClassesSerializableTest {
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
     @Test
     public void setItems_addToUI_radioButtonGroupIsSerializable()
             throws Throwable {

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.data.renderer;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +28,11 @@ public class LitRendererTest {
     public void setup() {
         UI ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +37,11 @@ public class RichTextEditorTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void setValueNull() {

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,6 +65,11 @@ public class SelectTest {
     @Before
     public void setup() {
         select = new Select<>();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/BuiltinFormatsTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/BuiltinFormatsTest.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.DataFormat;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class BuiltinFormatsTest {
 
         cell = spreadsheet.createCell(0, 0, null);
         cell.setCellStyle(cellStyle);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ClipboardTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/ClipboardTest.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.spreadsheet.tests;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +31,11 @@ public class ClipboardTest {
         spreadsheet.setLocale(Locale.US);
         var ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/CustomDataFormatterTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/CustomDataFormatterTest.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.spreadsheet.tests;
 import java.util.Locale;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,11 @@ public class CustomDataFormatterTest {
         this.threePartDataFormatCell = createThreePartDataFormatCell(
                 spreadsheet);
         this.generalFormatCell = createGeneralFormatCell(spreadsheet);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     private Cell createFourPartDataFormatCell(Spreadsheet spreadsheet) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FormulasTest.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.spreadsheet.tests;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -33,6 +34,11 @@ public class FormulasTest {
         // loaded
         TestHelper.fireClientEvent(spreadsheet, "onSheetScroll",
                 "[1, 1, 1, 1]");
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/LocaleTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/LocaleTest.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.spreadsheet.tests;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,11 @@ public class LocaleTest {
         UI.setCurrent(ui);
 
         spreadsheet = new Spreadsheet();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/charts/ChartFeatureTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/charts/ChartFeatureTest.java
@@ -11,7 +11,6 @@ package com.vaadin.flow.component.spreadsheet.tests.charts;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.DataSeries;
@@ -53,7 +52,6 @@ public class ChartFeatureTest extends ChartTestBase {
         String fileName = "Tagetik 6.xlsx";
         Configuration conf = getChartFromSampleFile(fileName, "J13")
                 .getConfiguration();
-        UI.setCurrent(new UI());
         Spreadsheet spreadsheet = TestHelper.createSpreadsheet(fileName);
 
         Assert.assertEquals(spreadsheet.getCell("B14").getStringCellValue(),

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNull;
 import java.math.BigDecimal;
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +48,11 @@ public class BigDecimalFieldTest extends TextFieldTest {
     public void setup() {
         field = new BigDecimalField();
         field.setLocale(Locale.US);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/ComponentFromTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/ComponentFromTest.java
@@ -58,5 +58,7 @@ class ComponentFromTest {
 
         Component field = Component.from(element, componentClass);
         Assert.assertEquals(value, field.getElement().getPropertyRaw("value"));
+
+        UI.setCurrent(null);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class EmailFieldTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void setValueNull() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class IntegerFieldTest extends TextFieldTest {
     @Before
     public void setup() {
         field = new IntegerField();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +49,11 @@ public class NumberFieldTest extends TextFieldTest {
     @Before
     public void setup() {
         field = new NumberField();
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class PasswordFieldTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void setValueNull() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class TextAreaTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void setValueNull() {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class TextFieldTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void setValueNull() {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocaleTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocaleTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.timepicker.tests;
 
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,11 @@ public class TimePickerLocaleTest {
     public void setup() {
         ui = new UI();
         UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -24,6 +24,7 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -46,6 +47,11 @@ import com.vaadin.flow.server.VaadinSession;
 
 public class TimePickerTest {
     private static final String PROP_AUTO_OPEN_DISABLED = "autoOpenDisabled";
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
 
     @Test
     public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadDropLabelTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadDropLabelTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.upload.tests;
 
+import org.junit.After;
 import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
@@ -25,6 +26,11 @@ import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class UploadDropLabelTest {
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+    }
+
     // Regression test for:
     // https://github.com/vaadin/flow-components/issues/3053
     @Test


### PR DESCRIPTION
Adds a teardown method for clearing the current UI, to every test suite that in some form sets the current UI. While we didn't have any specific issues with not cleaning up the UI so far it seems safer to remove it to avoid possible side effects in other tests.