### PR TITLE
fix: restore disableOnClick attribute

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -77,9 +77,9 @@ public class DisableOnClickController<C extends Component & HasEnabled>
     public void setDisableOnClick(boolean disableOnClick) {
         this.disableOnClick = disableOnClick;
         if (disableOnClick) {
-            component.getElement().setProperty("disableOnClick", "true");
+            component.getElement().setAttribute("disableOnClick", "true");
         } else {
-            component.getElement().removeProperty("disableOnClick");
+            component.getElement().removeAttribute("disableOnClick");
         }
     }
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/disableOnClickFunctions.js
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/resources/META-INF/resources/frontend/disableOnClickFunctions.js
@@ -1,5 +1,5 @@
 document.addEventListener('click', (event) => {
-  const target = event.composedPath().find((node) => node.disableOnClick);
+  const target = event.composedPath().find((node) => node.hasAttribute && node.hasAttribute('disableOnClick'));
   if (target) {
     target.disabled = true;
   }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
@@ -51,6 +51,17 @@ public class DisableOnClickControllerTest {
     }
 
     @Test
+    public void setDisableOnClick_updatesAttribute() {
+        component.setDisableOnClick(true);
+        Assert.assertTrue(
+                component.getElement().hasAttribute("disableOnClick"));
+
+        component.setDisableOnClick(false);
+        Assert.assertFalse(
+                component.getElement().hasAttribute("disableOnClick"));
+    }
+
+    @Test
     public void disableOnClickNotSetUp_click_componentIsStillEnabled() {
         var componentIsEnabled = new AtomicBoolean(true);
         component.addClickListener(


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description

https://github.com/vaadin/flow-components/pull/6815 extracted the disable on click logic into a controller and as part of that changed the implementation to use a property instead of an attribute. However, customers have been using the attribute for targeting styles (https://github.com/vaadin/web-components/issues/842#issuecomment-1007331620), which now doesn't work anymore. 

This reverts the implementation back to use an attribute.

## Type of change

- Bugfix
