### PR TITLE
fix: ensure invalid state is correctly set on slotted pickers

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -401,6 +401,13 @@ public class DateTimePicker
         timePicker.setReadOnly(readOnly);
     }
 
+    @Override
+    public void setInvalid(boolean invalid) {
+        HasValidationProperties.super.setInvalid(invalid);
+        datePicker.setInvalid(invalid);
+        timePicker.setInvalid(invalid);
+    }
+
     /**
      * Sets the label for this field.
      *

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.component.timepicker.TimePicker;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
@@ -124,6 +125,13 @@ public class BasicValidationTest
         Assert.assertEquals("Field is required", testField.getErrorMessage());
     }
 
+    @Test
+    public void setInvalid_nestedPickersAreInvalid() {
+        testField.setInvalid(true);
+        Assert.assertTrue(getDatePicker().isInvalid());
+        Assert.assertTrue(getTimePicker().isInvalid());
+    }
+
     @Override
     protected DateTimePicker createTestField() {
         return new DateTimePicker();
@@ -131,6 +139,10 @@ public class BasicValidationTest
 
     private DatePicker getDatePicker() {
         return (DatePicker) SlotUtils.getChildInSlot(testField, "date-picker");
+    }
+
+    private TimePicker getTimePicker() {
+        return (TimePicker) SlotUtils.getChildInSlot(testField, "time-picker");
     }
 
     private void fireValidatedDomEvent() {


### PR DESCRIPTION
## Description

Fixes #7073

Due to the change in #6922, the component always sets `invalid` property on `isInvalid()` on attach. While this makes sense in general, it turns out that calling `setInvalid(true)` on the DateTimePicker does not update corresponding state on its slotted pickers and they end up sending `invalid = false` to the client on initialisation.

Note: I'm not sure if this needs an IT since the problem is that `isInvalid()` returns wrong value and that's now covered with a unit test. Just to clarify, this problem can't be reproduced in the web component  (without `ClientValidationUtil` logic).

## Type of change

- Bugfix