### PR TITLE
fix: ignore row details cells when applying cell update animation

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/GridProItemDetailsPage.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/GridProItemDetailsPage.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.gridpro.tests;
+
+import java.util.List;
+
+import com.vaadin.flow.component.gridpro.GridPro;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "gridpro-item-details")
+public class GridProItemDetailsPage extends Div {
+
+    public GridProItemDetailsPage() {
+        List<SamplePerson> persons = List.of(new SamplePerson("Henry"),
+                new SamplePerson("Indiana"), new SamplePerson("Jones"));
+
+        GridPro<SamplePerson> grid = new GridPro<>();
+        grid.addColumn(SamplePerson::getName).setHeader("Readonly Name");
+        grid.addEditColumn(SamplePerson::getName)
+                .custom(new TextField(), SamplePerson::setName)
+                .setHeader("Editable Name");
+        grid.setItemDetailsRenderer(new TextRenderer<>(
+                person -> "Details for " + person.getName()));
+        grid.setItems(persons);
+
+        add(grid);
+    }
+
+    public static class SamplePerson {
+        private String name;
+
+        public SamplePerson(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/GridProItemDetailsIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/GridProItemDetailsIT.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.gridpro.tests;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.gridpro.testbench.GridProElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("gridpro-item-details")
+public class GridProItemDetailsIT extends AbstractComponentIT {
+
+    @Before
+    public void before() {
+        open();
+        $(GridProElement.class).waitForFirst();
+    }
+
+    @Test
+    public void noErrorsLogged() {
+        checkLogsForErrors();
+    }
+}

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -54,11 +54,10 @@ window.Vaadin.Flow.gridProConnector = {
 
     // Not needed in case of custom editor as value is set on server-side.
     // Overridden in order to avoid blinking of the cell content.
-    column._setEditorValue = function(editor, value) {
-    };
+    column._setEditorValue = function (editor, value) {};
 
     const stopCellEdit = column._stopCellEdit;
-    column._stopCellEdit = function() {
+    column._stopCellEdit = function () {
       stopCellEdit.apply(this, arguments);
       this._grid.toggleAttribute(LOADING_EDITOR_CELL_ATTRIBUTE, false);
     };
@@ -82,7 +81,7 @@ window.Vaadin.Flow.gridProConnector = {
   },
 
   initCellEditableProvider(column) {
-    column.isCellEditable = function(model) {
+    column.isCellEditable = function (model) {
       // If there is no cell editable data, assume the cell is editable
       const isEditable = model.item.cellEditable && model.item.cellEditable[column._flowId];
       return isEditable === undefined || isEditable;
@@ -106,11 +105,12 @@ window.Vaadin.Flow.gridProConnector = {
 
     // Override the method to add the updating-cell part to the cell when it's being updated.
     const generateCellPartNames = grid._generateCellPartNames;
-    grid._generateCellPartNames = function(row, model) {
+    grid._generateCellPartNames = function (row, model) {
       generateCellPartNames.apply(this, arguments);
 
       iterateRowCells(row, (cell) => {
-        const isUpdating = model && grid.__pendingCellUpdate === `${model.item.key}:${cell._column.path}`;
+        const isUpdating =
+          model && cell._column && grid.__pendingCellUpdate === `${model.item.key}:${cell._column.path}`;
         const target = cell._focusButton || cell;
         updatePart(target, isUpdating, 'updating-cell');
       });


### PR DESCRIPTION
## Description

Adds an additional check for whether `cell._column` is defined to ignore row details cells when applying cell update animations.

Fixes https://github.com/vaadin/web-components/issues/8609

## Type of change

- Bugfix