### PR TITLE
chore: improve license header formatting

### DIFF
--- a/scripts/templates/apache2-license-header.txt
+++ b/scripts/templates/apache2-license-header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2025 Vaadin Ltd.
+ * Copyright 2000-$YEAR Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/scripts/templates/vaadin-commercial-license-header.txt
+++ b/scripts/templates/vaadin-commercial-license-header.txt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2000-2025 Vaadin Ltd.
+ * Copyright 2000-$YEAR Vaadin Ltd.
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *


### PR DESCRIPTION
## Description

The current license header formatting enforces a specific year, which results in formatter checks failing in older version branches where we have not updated the copyright.

This updates the formatting to:
- Use the current year when adding a new license header
- Accept any year when checking an existing license header

## Type of change

- Internal change