### PR TITLE
chore: remove obsolete license checker from spreadsheet

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/component/spreadsheet/client/ConnectorBundleLoaderFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/component/spreadsheet/client/ConnectorBundleLoaderFactory.java
@@ -43,7 +43,6 @@ import com.vaadin.client.ServerConnector;
 import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.communication.JsonDecoder;
 import com.vaadin.client.metadata.ConnectorBundleLoader;
-import com.vaadin.client.metadata.ConnectorBundleLoader.CValUiInfo;
 import com.vaadin.client.metadata.InvokationHandler;
 import com.vaadin.client.metadata.OnStateChangeMethod;
 import com.vaadin.client.metadata.ProxyHandler;
@@ -65,9 +64,6 @@ import com.vaadin.shared.annotations.DelegateToWidget;
 import com.vaadin.shared.annotations.NoLayout;
 import com.vaadin.shared.ui.Connect;
 import com.vaadin.shared.ui.Connect.LoadStyle;
-import com.vaadin.tools.CvalAddonsChecker;
-import com.vaadin.tools.CvalChecker;
-import com.vaadin.tools.CvalChecker.InvalidCvalException;
 import com.vaadin.tools.ReportUsage;
 
 public class ConnectorBundleLoaderFactory extends Generator {
@@ -214,8 +210,6 @@ public class ConnectorBundleLoaderFactory extends Generator {
         ReportUsage.checkForUpdatesInBackgroundThread();
     }
 
-    private CvalAddonsChecker cvalChecker = new CvalAddonsChecker();
-
     @Override
     public String generate(TreeLogger logger, GeneratorContext context,
             String typeName) throws UnableToCompleteException {
@@ -245,23 +239,6 @@ public class ConnectorBundleLoaderFactory extends Generator {
                 className);
         if (printWriter == null) {
             return;
-        }
-
-        List<CValUiInfo> cvalInfos = null;
-        try {
-            if (cvalChecker != null) {
-                cvalInfos = cvalChecker.run();
-                // Don't run twice
-                cvalChecker = null;
-            }
-        } catch (InvalidCvalException e) {
-            System.err.println("\n\n\n\n" + CvalChecker.LINE);
-            for (String line : e.getMessage().split("\n")) {
-                System.err.println(line);
-            }
-            System.err.println(CvalChecker.LINE + "\n\n\n\n");
-            System.exit(1);
-            throw new UnableToCompleteException();
         }
 
         List<ConnectorBundle> bundles = buildBundles(logger,
@@ -376,18 +353,6 @@ public class ConnectorBundleLoaderFactory extends Generator {
             // Close add(new ...
             w.outdent();
             w.println("});");
-        }
-
-        if (cvalInfos != null && !cvalInfos.isEmpty()) {
-            w.println("{");
-            for (CValUiInfo c : cvalInfos) {
-                if ("evaluation".equals(c.type)) {
-                    w.println("cvals.add(new CValUiInfo(\"" + c.product
-                            + "\", \"" + c.version + "\", \"" + c.widgetset
-                            + "\", null));");
-                }
-            }
-            w.println("}");
         }
 
         w.outdent();


### PR DESCRIPTION
## Description

The Spreadsheet client uses an outdated license checker that has now been removed from Framework in https://github.com/vaadin/framework-es/pull/335. That in turn causes compilation issues when trying to bump the Framework version (https://github.com/vaadin/flow-components/pull/7083).

As I understand it, for the Flow Spreadsheet we build the client at build time, so a license check at that point seems unnecessary. Besides, the actual license check for the Flow Spreadsheet happens here: https://github.com/vaadin/flow-components/blob/a7152f830a9ee775ce7772f8ace53bff4c80da9a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java#L138-L143

Thus I figure we can remove the license check from the client completely.