### PR TITLE
chore: upgrade spreadsheet dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
         <spring-data-commons.version>3.4.2</spring-data-commons.version>
 
         <!-- spreadsheet -->
-        <poi.version>5.2.5</poi.version>
-        <javaparser.version>3.25.3</javaparser.version>
+        <poi.version>5.4.0</poi.version>
+        <javaparser.version>3.26.3</javaparser.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
@@ -88,6 +88,10 @@
                     <groupId>com.github.javaparser</groupId>
                     <artifactId>javaparser-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
exclude `log4j-api` dependency, as poi uses different log4j-api versions in its modules. 

```
[ERROR] Dependency convergence error for org.apache.logging.log4j:log4j-api:jar:2.24.3 paths to dependency are:
[ERROR] +-com.vaadin:vaadin:jar:24.7-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spreadsheet-flow:jar:24.7-SNAPSHOT:compile
[ERROR]     +-org.apache.poi:poi:jar:5.4.0:compile
[ERROR]       +-org.apache.logging.log4j:log4j-api:jar:2.24.3:compile
[ERROR] and
[ERROR] +-com.vaadin:vaadin:jar:24.7-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spreadsheet-flow:jar:24.7-SNAPSHOT:compile
[ERROR]     +-org.apache.poi:poi-ooxml:jar:5.4.0:compile
[ERROR]       +-org.apache.xmlbeans:xmlbeans:jar:5.3.0:compile
[ERROR]         +-org.apache.logging.log4j:log4j-api:jar:2.24.2:compile
[ERROR] and
[ERROR] +-com.vaadin:vaadin:jar:24.7-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spreadsheet-flow:jar:24.7-SNAPSHOT:compile
[ERROR]     +-org.apache.poi:poi-ooxml:jar:5.4.0:compile
[ERROR]       +-org.apache.logging.log4j:log4j-api:jar:2.24.3:compile
[ERROR] and
[ERROR] +-com.vaadin:vaadin:jar:24.7-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spreadsheet-flow:jar:24.7-SNAPSHOT:compile
[ERROR]     +-org.apache.poi:poi-scratchpad:jar:5.4.0:compile
[ERROR]       +-org.apache.logging.log4j:log4j-api:jar:2.24.3:compile

```

