### PR TITLE
refactor: import TextField class from @vaadin/text-field

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import { TextField } from '@vaadin/text-field';
+import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 
 let memoizedTemplate;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
@@ -13,57 +13,58 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+import { TextField } from '@vaadin/text-field';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+
 let memoizedTemplate;
 
-customElements.whenDefined('vaadin-text-field').then(() => {
-  class BigDecimalFieldElement extends customElements.get('vaadin-text-field') {
-    static get template() {
-      if (!memoizedTemplate) {
-        memoizedTemplate = super.template.cloneNode(true);
-        memoizedTemplate.innerHTML += `<style>
-                :host {
-                  width: 8em;
-                }
+class BigDecimalField extends TextField {
+  static get template() {
+    if (!memoizedTemplate) {
+      memoizedTemplate = super.template.cloneNode(true);
+      memoizedTemplate.innerHTML += `<style>
+              :host {
+                width: 8em;
+              }
 
-                :host([dir="rtl"]) [part="input-field"] {
-                  direction: ltr;
-                }
+              :host([dir="rtl"]) [part="input-field"] {
+                direction: ltr;
+              }
 
-                :host([dir="rtl"]) [part="input-field"] ::slotted(input) {
-                  --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em) !important;
-                }
-          </style>`;
-      }
-      return memoizedTemplate;
+              :host([dir="rtl"]) [part="input-field"] ::slotted(input) {
+                --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em) !important;
+              }
+        </style>`;
     }
-
-    static get is() {
-      return 'vaadin-big-decimal-field';
-    }
-
-    static get properties() {
-      return {
-        _decimalSeparator: {
-          type: String,
-          value: '.',
-          observer: '__decimalSeparatorChanged'
-        }
-      };
-    }
-
-    ready() {
-      super.ready();
-      this.inputElement.setAttribute('inputmode', 'decimal');
-    }
-
-    __decimalSeparatorChanged(separator, oldSeparator) {
-      this.allowedCharPattern = '[-+\\d' + separator + ']';
-
-      if (this.value && oldSeparator) {
-        this.value = this.value.split(oldSeparator).join(separator);
-      }
-    }
+    return memoizedTemplate;
   }
 
-  customElements.define(BigDecimalFieldElement.is, BigDecimalFieldElement);
-});
+  static get is() {
+    return 'vaadin-big-decimal-field';
+  }
+
+  static get properties() {
+    return {
+      _decimalSeparator: {
+        type: String,
+        value: '.',
+        observer: '__decimalSeparatorChanged'
+      }
+    };
+  }
+
+  ready() {
+    super.ready();
+    this.inputElement.setAttribute('inputmode', 'decimal');
+  }
+
+  __decimalSeparatorChanged(separator, oldSeparator) {
+    this.allowedCharPattern = '[-+\\d' + separator + ']';
+
+    if (this.value && oldSeparator) {
+      this.value = this.value.split(oldSeparator).join(separator);
+    }
+  }
+}
+
+defineCustomElement(BigDecimalField);


### PR DESCRIPTION
## Description

The PR refactors the `vaadin-big-decimal-field` web component to import the TextField class from `@vaadin/text-field` instead of using `customElements.get`.

## Type of change

- [x] Refactor
