### PR TITLE
feat: allow passing HierarchyColumnComponentRenderer to addComponentHierarchyColumn

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -663,7 +663,6 @@ public class TreeGrid<T> extends Grid<T>
         return column;
     }
     
-
     /**
      * Adds a new Hierarchy column that shows components.
      * <p>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -662,7 +662,7 @@ public class TreeGrid<T> extends Grid<T>
 
         return column;
     }
-    
+
     /**
      * Adds a new Hierarchy column that shows components.
      * <p>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -681,7 +681,7 @@ public class TreeGrid<T> extends Grid<T>
      */
     public <V extends Component> Column<T> addComponentHierarchyColumn(
             ValueProvider<T, V> componentProvider) {
-        return addColumn(new HierarchyColumnComponentRenderer<V, T>(
+        return addColumn(new HierarchyColumnComponentRenderer<>(
                 componentProvider, this));
     }
 
@@ -692,8 +692,8 @@ public class TreeGrid<T> extends Grid<T>
      * built in renderers.
      * </p>
      *
-     * @param componentProvider
-     *            the renderer used to create the grid cell structure
+     * @param componentRenderer
+     *            the renderer used to create a component for the given item
      * @param <V>
      *            the component type
      * @return the new column
@@ -703,7 +703,7 @@ public class TreeGrid<T> extends Grid<T>
     public <V extends Component> Column<T> addComponentHierarchyColumn(
             HierarchyColumnComponentRenderer<V, T> componentRenderer) {
         return addColumn(componentRenderer.withProperty("children",
-                        item -> getDataCommunicator().hasChildren(item)));
+                item -> getDataCommunicator().hasChildren(item)));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -662,6 +662,7 @@ public class TreeGrid<T> extends Grid<T>
 
         return column;
     }
+    
 
     /**
      * Adds a new Hierarchy column that shows components.
@@ -682,7 +683,27 @@ public class TreeGrid<T> extends Grid<T>
     public <V extends Component> Column<T> addComponentHierarchyColumn(
             ValueProvider<T, V> componentProvider) {
         return addColumn(new HierarchyColumnComponentRenderer<V, T>(
-                componentProvider, this).withProperty("children",
+                componentProvider, this));
+    }
+
+    /**
+     * Adds a new Hierarchy column that shows components.
+     * <p>
+     * <em>NOTE:</em> Using {@link ComponentRenderer} is not as efficient as the
+     * built in renderers.
+     * </p>
+     *
+     * @param componentProvider
+     *            the renderer used to create the grid cell structure
+     * @param <V>
+     *            the component type
+     * @return the new column
+     * @see #addColumn(Renderer)
+     * @see #removeColumn(Column)
+     */
+    public <V extends Component> Column<T> addComponentHierarchyColumn(
+            HierarchyColumnComponentRenderer<V, T> componentRenderer) {
+        return addColumn(componentRenderer.withProperty("children",
                         item -> getDataCommunicator().hasChildren(item)));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
@@ -19,11 +19,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.treegrid.HierarchyColumnComponentRenderer;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.flow.function.ValueProvider;
 
 public class TreeGridTest {
 
@@ -71,6 +75,23 @@ public class TreeGridTest {
                 treeGrid.getDataCommunicator().getKeyMapper().get("key 1"));
         Assert.assertNotNull(
                 treeGrid.getDataCommunicator().getKeyMapper().get("key 2"));
+    }
+
+    private interface TestInterface {}
+
+    private class TestRenderer extends HierarchyColumnComponentRenderer<Span, Item> implements TestInterface {
+        public TestRenderer(ValueProvider<Item, Span> componentProvider, TreeGrid<Item> grid) {
+            super(componentProvider, grid);
+        }
+    }
+
+    @Test
+    public void addHierarchyColumn_usesGivenRenderer() {
+        TestRenderer renderer = new TestRenderer(item -> new Span(item.getKey()), treeGrid);
+        Column<Item> column = treeGrid.addComponentHierarchyColumn(renderer);
+
+        Assert.assertTrue(
+            column.getRenderer() instanceof TestRenderer);
     }
 
     private void fakeClientCommunication() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.treegrid.HierarchyColumnComponentRenderer;
@@ -27,7 +28,6 @@ import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
-import com.vaadin.flow.function.ValueProvider;
 
 public class TreeGridTest {
 
@@ -77,21 +77,13 @@ public class TreeGridTest {
                 treeGrid.getDataCommunicator().getKeyMapper().get("key 2"));
     }
 
-    private interface TestInterface {}
-
-    private class TestRenderer extends HierarchyColumnComponentRenderer<Span, Item> implements TestInterface {
-        public TestRenderer(ValueProvider<Item, Span> componentProvider, TreeGrid<Item> grid) {
-            super(componentProvider, grid);
-        }
-    }
-
     @Test
-    public void addHierarchyColumn_usesGivenRenderer() {
-        TestRenderer renderer = new TestRenderer(item -> new Span(item.getKey()), treeGrid);
+    public void addHierarchyColumn_withRenderer() {
+        HierarchyColumnComponentRenderer<Component, Item> renderer = new HierarchyColumnComponentRenderer<>(
+                item -> new Span(), treeGrid);
         Column<Item> column = treeGrid.addComponentHierarchyColumn(renderer);
 
-        Assert.assertTrue(
-            column.getRenderer() instanceof TestRenderer);
+        Assert.assertEquals(renderer, column.getRenderer());
     }
 
     private void fakeClientCommunication() {


### PR DESCRIPTION
## Description

As mentioned in the issue, unlike with the Grid you can not pass a Renderer into a TreeGrid to add a Column. To enhance the API and make it possible to do type matching on Renderers passed into the method, I have overloaded the "addComponentHierarchyColumn"-method.

Fixes #7107 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
