### PR TITLE
chore: replace deprecated api in testbench elements

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
@@ -53,9 +53,9 @@ public class AccordionElement extends TestBenchElement {
      * @return the index of the opened panel or null if closed.
      */
     public OptionalInt getOpenedIndex() {
-        final String openedAttribute = getAttribute(OPENED_PROPERTY);
-        return openedAttribute == null ? OptionalInt.empty()
-                : OptionalInt.of(Integer.valueOf(openedAttribute));
+        Integer openedIndex = getPropertyInteger(OPENED_PROPERTY);
+        return openedIndex == null ? OptionalInt.empty()
+                : OptionalInt.of(openedIndex);
     }
 
     /**

--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
@@ -65,7 +65,7 @@ public class AccordionElement extends TestBenchElement {
      */
     public Optional<AccordionPanelElement> getOpenedPanel() {
         final ElementQuery<AccordionPanelElement> openedPanels = $(
-                AccordionPanelElement.class).attribute(OPENED_PROPERTY, "");
+                AccordionPanelElement.class).withAttribute(OPENED_PROPERTY);
 
         return !openedPanels.exists() ? Optional.empty()
                 : Optional.of(openedPanels.first());

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutElement.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutElement.java
@@ -21,14 +21,12 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("vaadin-app-layout")
 public class AppLayoutElement extends TestBenchElement {
 
-    @SuppressWarnings("unchecked")
     public TestBenchElement getContent() {
-        TestBenchElement contentPlaceholder = $(TestBenchElement.class)
-                .attribute("content", "").first();
+        TestBenchElement contentSlot = $("slot").withoutAttribute("name")
+                .first();
 
         return (TestBenchElement) executeScript(
-                "return arguments[0].firstElementChild.assignedNodes()[0];",
-                contentPlaceholder);
+                "return arguments[0].assignedNodes()[0];", contentSlot);
     }
 
     public boolean isDrawerFirst() {

--- a/vaadin-avatar-flow-parent/vaadin-avatar-testbench/src/main/java/com/vaadin/flow/component/avatar/testbench/AvatarElement.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-testbench/src/main/java/com/vaadin/flow/component/avatar/testbench/AvatarElement.java
@@ -36,7 +36,7 @@ public class AvatarElement extends TestBenchElement {
      * @return the tooltip text
      */
     public String getTitle() {
-        return getAttribute("title");
+        return getDomAttribute("title");
     }
 
     /**

--- a/vaadin-avatar-flow-parent/vaadin-avatar-testbench/src/main/java/com/vaadin/flow/component/avatar/testbench/AvatarGroupElement.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-testbench/src/main/java/com/vaadin/flow/component/avatar/testbench/AvatarGroupElement.java
@@ -47,7 +47,7 @@ public class AvatarGroupElement extends TestBenchElement {
      * @return the aria label
      */
     public String getAriaLabel() {
-        return getAttribute("aria-label");
+        return getDomAttribute("aria-label");
     }
 
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/CheckboxGroupElement.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/CheckboxGroupElement.java
@@ -142,6 +142,6 @@ public class CheckboxGroupElement extends TestBenchElement
      * @return the slotted component or {@code null} if there is no component
      */
     public TestBenchElement getErrorMessageComponent() {
-        return $("div").attributeContains("slot", "error-message").first();
+        return $("div").withAttribute("slot", "error-message").first();
     }
 }

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-testbench/src/main/java/com/vaadin/flow/component/cookieconsent/testbench/CookieConsentElement.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-testbench/src/main/java/com/vaadin/flow/component/cookieconsent/testbench/CookieConsentElement.java
@@ -30,27 +30,27 @@ public class CookieConsentElement extends TestBenchElement {
     }
 
     public String getMessage() {
-        return getAttribute("message");
+        return getDomProperty("message");
     }
 
     public String getDismissLabel() {
-        return getAttribute("dismiss");
+        return getDomProperty("dismiss");
     }
 
     public String getLearnMoreLabel() {
-        return getAttribute("learnMore");
+        return getDomProperty("learnMore");
     }
 
     public String getLearnMoreLink() {
-        return getAttribute("learnMoreLink");
+        return getDomProperty("learnMoreLink");
     }
 
     public String getCookieName() {
-        return getAttribute("cookieName");
+        return getDomProperty("cookieName");
     }
 
     public Position getPosition() {
-        return Optional.ofNullable(getAttribute("position"))
+        return Optional.ofNullable(getDomProperty("position"))
                 .map(value -> value.replace('-', '_')).map(String::toUpperCase)
                 .map(Position::valueOf).orElse(null);
     }

--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
@@ -44,7 +44,7 @@ public class CrudElement extends TestBenchElement {
      */
     public Optional<TestBenchElement> getNewItemButton() {
         ElementQuery<TestBenchElement> newButtonQuery = this
-                .$(TestBenchElement.class).attribute("slot", "new-button");
+                .$(TestBenchElement.class).withAttribute("slot", "new-button");
         return newButtonQuery.exists() ? Optional.of(newButtonQuery.last())
                 : Optional.empty();
     }
@@ -56,8 +56,8 @@ public class CrudElement extends TestBenchElement {
      * @return the filter field for each column
      */
     public List<TextFieldElement> getFilterFields() {
-        return this.$(TextFieldElement.class).attribute("crud-role", "Search")
-                .all();
+        return this.$(TextFieldElement.class)
+                .withAttribute("crud-role", "Search").all();
     }
 
     /**
@@ -66,7 +66,7 @@ public class CrudElement extends TestBenchElement {
      * @return the toolbar content
      */
     public List<TestBenchElement> getToolbar() {
-        return this.$(TestBenchElement.class).attribute("slot", "toolbar")
+        return this.$(TestBenchElement.class).withAttribute("slot", "toolbar")
                 .all();
     }
 
@@ -129,7 +129,7 @@ public class CrudElement extends TestBenchElement {
     public boolean isEditorOpen() {
         if (getEditorPosition().isEmpty()) {
             return $("vaadin-crud-dialog-overlay").onPage()
-                    .attribute("opened", "").exists();
+                    .withAttribute("opened").exists();
         }
         return getPropertyBoolean("editorOpened");
     }
@@ -161,7 +161,7 @@ public class CrudElement extends TestBenchElement {
     public TestBenchElement getEditor() {
         if (getEditorPosition().isEmpty()) {
             return $("vaadin-crud-dialog-overlay").onPage()
-                    .attribute("opened", "").first();
+                    .withAttribute("opened").first();
         }
         return this;
     }

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/src/main/java/com/vaadin/flow/component/customfield/testbench/CustomFieldElement.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/src/main/java/com/vaadin/flow/component/customfield/testbench/CustomFieldElement.java
@@ -39,7 +39,7 @@ public class CustomFieldElement extends TestBenchElement implements HasHelper {
     @Override
     public TestBenchElement getHelperComponent() {
         final ElementQuery<TestBenchElement> query = $(TestBenchElement.class)
-                .attribute("slot", "helper");
+                .withAttribute("slot", "helper");
         if (query.exists()) {
             TestBenchElement last = query.last();
             // To avoid getting the "slot" element, for components with slotted

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/src/main/java/com/vaadin/flow/component/dashboard/testbench/DashboardElement.java
@@ -45,7 +45,7 @@ public class DashboardElement extends TestBenchElement {
 
     private Float getSortIndex(TestBenchElement element) {
         var wrapper = element.getPropertyElement("parentElement");
-        var slotName = wrapper.getAttribute("slot");
+        var slotName = wrapper.getDomAttribute("slot");
         var slotNumber = Float.parseFloat(slotName.split("-")[1]);
         var wrapperParent = wrapper.getPropertyElement("parentElement");
         if ($(DashboardSectionElement.class).all().contains(wrapperParent)) {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -56,8 +56,8 @@ public class DatePickerElement extends TestBenchElement
          * @return
          */
         public ButtonElement getTodayButton() {
-            return this.$(ButtonElement.class).attribute("slot", "today-button")
-                    .first();
+            return this.$(ButtonElement.class)
+                    .withAttribute("slot", "today-button").first();
         }
 
         /**
@@ -67,7 +67,7 @@ public class DatePickerElement extends TestBenchElement
          */
         public ButtonElement getCancelButton() {
             return this.$(ButtonElement.class)
-                    .attribute("slot", "cancel-button").first();
+                    .withAttribute("slot", "cancel-button").first();
         }
     }
 
@@ -79,7 +79,7 @@ public class DatePickerElement extends TestBenchElement
          */
         public String getHeaderText() {
             return this.$(TestBenchElement.class)
-                    .attribute("part", "month-header").first().getText();
+                    .withAttribute("part", "month-header").first().getText();
         }
 
         /**
@@ -88,7 +88,7 @@ public class DatePickerElement extends TestBenchElement
          * @return
          */
         public List<WeekdayElement> getWeekdays() {
-            return this.$(WeekdayElement.class).attribute("part", "weekday")
+            return this.$(WeekdayElement.class).withAttribute("part", "weekday")
                     .all();
         }
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/src/main/java/com/vaadin/flow/component/datetimepicker/testbench/DateTimePickerElement.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/src/main/java/com/vaadin/flow/component/datetimepicker/testbench/DateTimePickerElement.java
@@ -248,11 +248,13 @@ public class DateTimePickerElement extends TestBenchElement
     }
 
     private TestBenchElement getDatePicker() {
-        return $("vaadin-date-picker").attribute("slot", "date-picker").first();
+        return $("vaadin-date-picker").withAttribute("slot", "date-picker")
+                .first();
     }
 
     private TestBenchElement getTimePicker() {
-        return $("vaadin-time-picker").attribute("slot", "time-picker").first();
+        return $("vaadin-time-picker").withAttribute("slot", "time-picker")
+                .first();
     }
 
     /**
@@ -263,7 +265,7 @@ public class DateTimePickerElement extends TestBenchElement
     @Override
     public TestBenchElement getHelperComponent() {
         final ElementQuery<TestBenchElement> query = $(TestBenchElement.class)
-                .attribute("slot", "helper");
+                .withAttribute("slot", "helper");
         if (query.exists()) {
             TestBenchElement last = query.last();
             // To avoid getting the "slot" element, for components with slotted

--- a/vaadin-details-flow-parent/vaadin-details-testbench/src/main/java/com/vaadin/flow/component/details/testbench/DetailsElement.java
+++ b/vaadin-details-flow-parent/vaadin-details-testbench/src/main/java/com/vaadin/flow/component/details/testbench/DetailsElement.java
@@ -39,12 +39,11 @@ public class DetailsElement extends TestBenchElement {
      * Returns content element
      */
     public TestBenchElement getContent() {
-        TestBenchElement contentPlaceholder = $(TestBenchElement.class)
-                .attribute("part", "content").first();
+        TestBenchElement contentSlot = $("slot").withoutAttribute("name")
+                .first();
 
         return (TestBenchElement) executeScript(
-                "return arguments[0].firstElementChild.assignedNodes()[0];",
-                contentPlaceholder);
+                "return arguments[0].assignedNodes()[0];", contentSlot);
     }
 
     /**
@@ -65,7 +64,8 @@ public class DetailsElement extends TestBenchElement {
      * Returns a wrapper of the summary component
      */
     public TestBenchElement getSummaryWrapper() {
-        return $(TestBenchElement.class).attribute("slot", "summary").first();
+        return $(TestBenchElement.class).withAttribute("slot", "summary")
+                .first();
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -348,7 +348,7 @@ public class GridElement extends TestBenchElement {
         List<WebElement> headerCells = headerRows.get(rowIndex)
                 .findElements(By.tagName("th"));
         String slotName = headerCells.get(columnIndex)
-                .findElement(By.tagName("slot")).getAttribute("name");
+                .findElement(By.tagName("slot")).getDomAttribute("name");
 
         return findElement(By.cssSelector(
                 "vaadin-grid-cell-content[slot='" + slotName + "']"));

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -177,7 +177,7 @@ public class TreeGridElement extends GridElement {
         WebElement expandElement = getExpandToggleElement(rowIndex,
                 hierarchyColumnIndex);
         return expandElement != null
-                && !"false".equals(expandElement.getAttribute("expanded"));
+                && !"false".equals(expandElement.getDomProperty("expanded"));
     }
 
     /**
@@ -208,7 +208,7 @@ public class TreeGridElement extends GridElement {
             WebElement expandElement = getExpandToggleElement(rowIndex,
                     hierarchyColumnIndex);
             return expandElement != null && expandElement.isDisplayed()
-                    && "false".equals(expandElement.getAttribute("leaf"));
+                    && "false".equals(expandElement.getDomProperty("leaf"));
         } catch (NoSuchElementException e) {
             return false;
         }

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/src/main/java/com/vaadin/flow/component/gridpro/testbench/GridProElement.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/src/main/java/com/vaadin/flow/component/gridpro/testbench/GridProElement.java
@@ -130,7 +130,7 @@ public class GridProElement extends TestBenchElement {
         List<WebElement> headerCells = headerRows.get(rowIndex)
                 .findElements(By.tagName("th"));
         String slotName = headerCells.get(columnIndex)
-                .findElement(By.tagName("slot")).getAttribute("name");
+                .findElement(By.tagName("slot")).getDomAttribute("name");
 
         return findElement(By.cssSelector(
                 "vaadin-grid-cell-content[slot='" + slotName + "']"));

--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
@@ -44,7 +44,7 @@ public class ListBoxElement extends TestBenchElement
 
     @Override
     public String getSelectedText() {
-        return getItems().filter(i -> i.getAttribute("selected") != null)
+        return getItems().filter(i -> i.getDomAttribute("selected") != null)
                 .findFirst().map(WebElement::getText).orElse(null);
     }
 

--- a/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginOverlayElement.java
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/src/main/java/com/vaadin/flow/component/login/testbench/LoginOverlayElement.java
@@ -94,7 +94,7 @@ public class LoginOverlayElement extends TestBenchElement implements Login {
             return getTitleComponent().getText();
         }
         return getLoginOverlayWrapper().$(TestBenchElement.class)
-                .attribute("part", "title").first()
+                .withAttribute("part", "title").first()
                 // Using textContent, since getText() works unpredictable in
                 // Edge
                 .getPropertyString("textContent");
@@ -105,7 +105,8 @@ public class LoginOverlayElement extends TestBenchElement implements Login {
      */
     public String getDescription() {
         return getLoginOverlayWrapper().$(TestBenchElement.class)
-                .attribute("part", "brand").first().$("p").first().getText();
+                .withAttribute("part", "brand").first().$("p").first()
+                .getText();
     }
 
     /**
@@ -113,7 +114,7 @@ public class LoginOverlayElement extends TestBenchElement implements Login {
      */
     public boolean hasTitleComponent() {
         return getLoginOverlayWrapper().$(TestBenchElement.class)
-                .attribute("slot", "title").exists();
+                .withAttribute("slot", "title").exists();
     }
 
     /**
@@ -125,7 +126,7 @@ public class LoginOverlayElement extends TestBenchElement implements Login {
             return null;
         }
         return getLoginOverlayWrapper().$(TestBenchElement.class)
-                .attribute("slot", "title").first();
+                .withAttribute("slot", "title").first();
     }
 
     @Override

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -107,7 +107,8 @@ public class MapElement extends TestBenchElement {
      * @return attribution container div
      */
     public TestBenchElement getAttributionContainer() {
-        return $("div").attributeContains("class", "ol-attribution").first();
+        return $("div").withAttributeContaining("class", "ol-attribution")
+                .first();
     }
 
     /**

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -107,7 +107,7 @@ public class MapElement extends TestBenchElement {
      * @return attribution container div
      */
     public TestBenchElement getAttributionContainer() {
-        return $("div").withAttributeContaining("class", "ol-attribution")
+        return $("div").withAttributeContainingWord("class", "ol-attribution")
                 .first();
     }
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.menubar.testbench;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
@@ -62,7 +63,7 @@ public class MenuBarElement extends TestBenchElement {
     }
 
     private boolean isOverflowButton(TestBenchElement element) {
-        return element.getAttribute("slot").contains("overflow");
+        return Objects.equals("overflow", element.getDomAttribute("slot"));
     }
 
     private boolean isVisible(TestBenchElement element) {

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageElement.java
@@ -88,7 +88,7 @@ public class MessageElement extends TestBenchElement {
      * @return the {@code theme} attribute
      */
     public String getTheme() {
-        return getAttribute("theme");
+        return getDomAttribute("theme");
     }
 
 }

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/src/main/java/com/vaadin/flow/component/richtexteditor/testbench/RichTextEditorElement.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/src/main/java/com/vaadin/flow/component/richtexteditor/testbench/RichTextEditorElement.java
@@ -18,12 +18,13 @@ import com.vaadin.testbench.elementsbase.Element;
 public class RichTextEditorElement extends TestBenchElement {
 
     public TestBenchElement getEditor() {
-        return $("div").attributeContains("class", "ql-editor").first();
+        return $("div").withAttributeContainingWord("class", "ql-editor")
+                .first();
     }
 
     public List getTitles() {
-        TestBenchElement toolbar = $("div").attributeContains("part", "toolbar")
-                .first();
+        TestBenchElement toolbar = $("div")
+                .withAttributeContainingWord("part", "toolbar").first();
         List<TestBenchElement> buttonTooltips = toolbar
                 .$("button + vaadin-tooltip").all();
         return buttonTooltips.stream()

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -35,7 +35,7 @@ import com.vaadin.testbench.elementsbase.Element;
 public class SideNavElement extends TestBenchElement {
 
     public String getLabel() {
-        return $("span").attributeContains("slot", "label").first().getText();
+        return $("span").withAttribute("slot", "label").first().getText();
     }
 
     public boolean isCollapsible() {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -52,7 +52,7 @@ public class SideNavItemElement extends TestBenchElement {
     }
 
     public String getPath() {
-        return getAttribute("path");
+        return getDomAttribute("path");
     }
 
     public boolean isExpanded() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.spreadsheet.testbench;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -90,7 +91,8 @@ public class SheetCellElement extends TestBenchElement {
 
     private boolean noneOfTheElementsIsWidget(List<WebElement> children) {
         for (WebElement e : children) {
-            if (e.getAttribute("class").contains("v-widget")) {
+            if (Optional.ofNullable(e.getDomAttribute("class")).orElse("")
+                    .contains("v-widget")) {
                 return false;
             }
         }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
@@ -312,7 +312,8 @@ public class SpreadsheetElement extends TestBenchElement {
     private boolean isNonCoherentlySelected(WebElement element) {
         // an element is non-coherently selected if the class attribute
         // contains "cell-range"
-        return element.getAttribute("class").contains("cell-range")
+        return Optional.ofNullable(element.getDomAttribute("class")).orElse("")
+                .contains("cell-range")
                 || "solid".equals(element.getCssValue("outline-style"));
     }
 


### PR DESCRIPTION
## Description

Remove usage of deprecated API in TestBench elements:
- Replace `TestBenchElement.getAttribute` with `TestBenchElement.getDOMAttribute` or `TestBenchElement.getDOM Property` respectively
- Replace `ElementQuery.attribute`, `ElementQuery.attributeContains` with respective replacements

Part of https://github.com/vaadin/flow-components/issues/7105

## Type of change

- Internal