### PR TITLE
chore: replace deprecated TestBenchElement API in integration tests

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
@@ -78,6 +78,6 @@ public class AvatarGroupIT extends AbstractComponentIT {
 
     private String getAvatarClassName(int index) {
         return $(AvatarGroupElement.class).waitForFirst()
-                .getAvatarElement(index).getAttribute("class");
+                .getAvatarElement(index).getDomAttribute("class");
     }
 }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
@@ -68,7 +68,7 @@ public class AvatarGroupIT extends AbstractComponentIT {
         Assert.assertEquals("red", getAvatarClassName(0));
 
         findElement(By.id("remove-class-names")).click();
-        Assert.assertEquals("", getAvatarClassName(0));
+        Assert.assertNull(getAvatarClassName(0));
     }
 
     private String getAvatarAbbr(int index) {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -128,21 +128,21 @@ public class ButtonIT extends AbstractComponentIT {
     public void clickOnIconButtons_textIsDisplayed() {
         WebElement leftButton = layout.findElement(By.id("left-icon-button"));
         WebElement icon = leftButton.findElement(By.tagName("vaadin-icon"));
-        Assert.assertEquals("vaadin:arrow-left", icon.getAttribute("icon"));
+        Assert.assertEquals("vaadin:arrow-left", icon.getDomAttribute("icon"));
 
         // the icon is before the text
         Assert.assertTrue(getCenterX(leftButton) > getCenterX(icon));
 
         WebElement rightButton = layout.findElement(By.id("right-icon-button"));
         icon = rightButton.findElement(By.tagName("vaadin-icon"));
-        Assert.assertEquals("vaadin:arrow-right", icon.getAttribute("icon"));
+        Assert.assertEquals("vaadin:arrow-right", icon.getDomAttribute("icon"));
 
         // the icon is after the text
         Assert.assertTrue(getCenterX(rightButton) < getCenterX(icon));
 
         WebElement thumbButton = layout.findElement(By.id("thumb-icon-button"));
         icon = thumbButton.findElement(By.tagName("vaadin-icon"));
-        Assert.assertEquals("vaadin:thumbs-up", icon.getAttribute("icon"));
+        Assert.assertEquals("vaadin:thumbs-up", icon.getDomAttribute("icon"));
 
         scrollIntoViewAndClick(leftButton);
         waitUntilMessageIsChangedForClickedButton("Left");
@@ -159,11 +159,10 @@ public class ButtonIT extends AbstractComponentIT {
         WebElement button = layout.findElement(By.id("image-button"));
 
         WebElement img = button.findElement(By.tagName("img"));
-        img.getAttribute("href");
+        img.getDomAttribute("href");
 
-        Assert.assertEquals(getRootURL() + "/img/vaadin-logo.svg",
-                img.getAttribute("src"));
-        Assert.assertEquals("Vaadin logo", img.getAttribute("alt"));
+        Assert.assertEquals("img/vaadin-logo.svg", img.getDomAttribute("src"));
+        Assert.assertEquals("Vaadin logo", img.getDomAttribute("alt"));
 
         scrollIntoViewAndClick(button);
         waitUntilMessageIsChangedForClickedButton("with image");
@@ -172,7 +171,7 @@ public class ButtonIT extends AbstractComponentIT {
     @Test
     public void clickOnAccessibleButton_textIsDisplayed() {
         WebElement button = layout.findElement(By.id("accessible-button"));
-        Assert.assertEquals("Click me", button.getAttribute("aria-label"));
+        Assert.assertEquals("Click me", button.getDomAttribute("aria-label"));
 
         scrollIntoViewAndClick(button);
         waitUntilMessageIsChangedForClickedButton("Accessible");
@@ -181,11 +180,11 @@ public class ButtonIT extends AbstractComponentIT {
     @Test
     public void clickOnTabIndexButtons_textIsDisplayed() {
         WebElement button1 = layout.findElement(By.id("button-tabindex-1"));
-        Assert.assertEquals("1", button1.getAttribute("tabindex"));
+        Assert.assertEquals("1", button1.getDomAttribute("tabindex"));
         WebElement button2 = layout.findElement(By.id("button-tabindex-2"));
-        Assert.assertEquals("2", button2.getAttribute("tabindex"));
+        Assert.assertEquals("2", button2.getDomAttribute("tabindex"));
         WebElement button3 = layout.findElement(By.id("button-tabindex-3"));
-        Assert.assertEquals("3", button3.getAttribute("tabindex"));
+        Assert.assertEquals("3", button3.getDomAttribute("tabindex"));
 
         scrollIntoViewAndClick(button3);
         waitUntilMessageIsChangedForClickedButton("3");
@@ -199,10 +198,10 @@ public class ButtonIT extends AbstractComponentIT {
 
     @Test
     public void clickOnDisabledButton_nothingIsDisplayed() {
-        WebElement button = layout.findElement(By.id("disabled-button"));
-        Assert.assertTrue("The button should contain the 'disabled' attribute",
-                button.getAttribute("disabled").equals("")
-                        || button.getAttribute("disabled").equals("true"));
+        ButtonElement button = layout.$(ButtonElement.class)
+                .id("disabled-button");
+        Assert.assertFalse("The button should contain the 'disabled' attribute",
+                button.isEnabled());
 
         // valo theme adds the pointer-events: none CSS property, which makes
         // the button unclickable by selenium.
@@ -221,11 +220,11 @@ public class ButtonIT extends AbstractComponentIT {
 
     @Test
     public void clickDisableOnClickButton_newClickNotRegistered() {
-        WebElement button = layout
-                .findElement(By.id("disable-on-click-button"));
+        ButtonElement button = layout.$(ButtonElement.class)
+                .id("disable-on-click-button");
         Assert.assertTrue(
                 "The button should not contain the 'disabled' attribute",
-                button.getAttribute("disabled") == null);
+                button.isEnabled());
 
         scrollToElement(button);
         executeScript(
@@ -233,10 +232,9 @@ public class ButtonIT extends AbstractComponentIT {
                 button);
 
         // Check that button is disabled
-        String disabled = button.getAttribute("disabled");
-        Assert.assertTrue(
+        Assert.assertFalse(
                 "The button should contain the 'disabled' attribute after click",
-                disabled != null);
+                button.isEnabled());
 
         String singleClick = "Button Disabled on click was clicked and enabled state was changed to false receiving 1 clicks";
         Assert.assertEquals(
@@ -260,13 +258,14 @@ public class ButtonIT extends AbstractComponentIT {
             // Enable button from server side.
             layout.findElement(By.id("enable-button")).click();
 
-            button = layout.findElement(By.id("disable-on-click-button"));
+            button = layout.$(ButtonElement.class)
+                    .id("disable-on-click-button");
 
             // Check that button is not disabled anymore
             Assert.assertTrue(
                     "The button should not contain the 'disabled' attribute after server side clearing (iteration: "
                             + i + ")",
-                    button.getAttribute("disabled") == null);
+                    button.isEnabled());
 
             Assert.assertEquals(
                     "Button re-enabled message should be the latest message (iteration: "
@@ -277,11 +276,10 @@ public class ButtonIT extends AbstractComponentIT {
             button.click();
 
             // Assert that button gets disabled again on click
-            disabled = button.getAttribute("disabled");
-            Assert.assertTrue(
+            Assert.assertFalse(
                     "The button should contain the 'disabled' attribute after click (iteration: "
                             + i + ")",
-                    disabled != null);
+                    button.isEnabled());
 
             Assert.assertEquals(
                     "Button should have gotten 1 click and become disabled.",
@@ -292,31 +290,30 @@ public class ButtonIT extends AbstractComponentIT {
 
     @Test
     public void removeDisableOnClick_buttonWorksNormally() {
-        WebElement button = layout
-                .findElement(By.id("disable-on-click-button"));
+        ButtonElement button = layout.$(ButtonElement.class)
+                .id("disable-on-click-button");
         Assert.assertTrue(
                 "The button should not contain the 'disabled' attribute",
-                button.getAttribute("disabled") == null);
+                button.isEnabled());
 
         scrollIntoViewAndClick(button);
 
         // Check that button is disabled
-        String disabled = button.getAttribute("disabled");
-        Assert.assertTrue(
+        Assert.assertFalse(
                 "The button should contain the 'disabled' attribute after click",
-                disabled != null);
+                button.isEnabled());
 
         layout.findElement(By.id("enable-button")).click();
         layout.findElement(By.id("toggle-button")).click();
 
-        button = layout.findElement(By.id("disable-on-click-button"));
+        button = layout.$(ButtonElement.class).id("disable-on-click-button");
 
         button.click();
         button.click();
 
-        Assert.assertNull(
-                "The button should not be disabled after " + "click anymore.",
-                button.getAttribute("disabled"));
+        Assert.assertTrue(
+                "The button should not be disabled after click anymore.",
+                button.isEnabled());
 
         String singleClick = "Button Disabled on click was clicked and enabled state was changed to true receiving 2 clicks";
         Assert.assertEquals("Button didn't get expected amount of clicks.",
@@ -357,16 +354,16 @@ public class ButtonIT extends AbstractComponentIT {
 
     @Test
     public void disabledAndPointerEventsAuto_disableOnClick_clientSideButtonIsDisabled() {
-        WebElement button = layout
-                .findElement(By.id("disable-on-click-pointer-events-auto"));
+        ButtonElement button = layout.$(ButtonElement.class)
+                .id("disable-on-click-pointer-events-auto");
 
         scrollToElement(button);
         executeScript("arguments[0].dispatchEvent(new MouseEvent(\"click\"));",
                 button);
 
-        Assert.assertNotNull(
+        Assert.assertFalse(
                 "The button should contain the 'disabled' attribute after click",
-                button.getAttribute("disabled"));
+                button.isEnabled());
     }
 
     @Test
@@ -389,13 +386,13 @@ public class ButtonIT extends AbstractComponentIT {
         firstNameField.sendKeys("text 1");
         lastNamefield.sendKeys("text 2");
 
-        Assert.assertEquals("text 1", firstNameField.getAttribute("value"));
-        Assert.assertEquals("text 2", lastNamefield.getAttribute("value"));
+        Assert.assertEquals("text 1", firstNameField.getDomProperty("value"));
+        Assert.assertEquals("text 2", lastNamefield.getDomProperty("value"));
 
         lastNamefield.sendKeys(Keys.ALT, "l");
 
-        Assert.assertEquals("", firstNameField.getAttribute("value"));
-        Assert.assertEquals("", lastNamefield.getAttribute("value"));
+        Assert.assertEquals("", firstNameField.getDomProperty("value"));
+        Assert.assertEquals("", lastNamefield.getDomProperty("value"));
     }
 
     private void waitUntilMessageIsChangedForClickedButton(
@@ -416,10 +413,10 @@ public class ButtonIT extends AbstractComponentIT {
     @Test
     public void assertVariants() {
         WebElement button = findElement(By.id("button-theme-variants"));
-        Assert.assertEquals("small primary", button.getAttribute("theme"));
+        Assert.assertEquals("small primary", button.getDomAttribute("theme"));
 
         findElement(By.id("remove-theme-variant-button")).click();
-        Assert.assertEquals("primary", button.getAttribute("theme"));
+        Assert.assertEquals("primary", button.getDomAttribute("theme"));
     }
 
     private int getCenterX(WebElement element) {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/IconForButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/IconForButtonIT.java
@@ -31,7 +31,7 @@ public class IconForButtonIT extends AbstractComponentIT {
 
         TestBenchElement button = $("vaadin-button").first();
         TestBenchElement icon = button.$("vaadin-icon").first();
-        String slot = icon.getAttribute("slot");
+        String slot = icon.getDomAttribute("slot");
 
         // self check: this is expected in the initialization and not part of
         // the test
@@ -42,7 +42,7 @@ public class IconForButtonIT extends AbstractComponentIT {
         Assert.assertEquals("Updated text", button.getText());
 
         icon = button.$("vaadin-icon").first();
-        slot = icon.getAttribute("slot");
+        slot = icon.getDomAttribute("slot");
         // slot should have the same value after text update
         Assert.assertEquals("prefix", slot);
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDisabledItemIT.java
@@ -94,9 +94,8 @@ public class CheckboxGroupDisabledItemIT extends AbstractComponentIT {
         // Re-enable group
         toggleEnabledButton.click();
 
-        Assert.assertEquals("Second checkbox should be disabled",
-                Boolean.TRUE.toString(),
-                checkboxes.get(1).getAttribute("disabled"));
+        Assert.assertFalse("Second checkbox should be disabled",
+                checkboxes.get(1).isEnabled());
     }
 
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupIT.java
@@ -88,8 +88,7 @@ public class CheckboxGroupIT extends AbstractComponentIT {
         CheckboxGroupElement group = $(CheckboxGroupElement.class)
                 .id("checkbox-group-disabled");
 
-        Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getAttribute("disabled"));
+        Assert.assertFalse(group.isEnabled());
     }
 
     @Test
@@ -124,10 +123,8 @@ public class CheckboxGroupIT extends AbstractComponentIT {
 
         List<CheckboxElement> checkboxes = group.getCheckboxes();
 
-        Assert.assertEquals(Boolean.TRUE.toString(),
-                checkboxes.get(1).getAttribute("readonly"));
-        Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getAttribute("readonly"));
+        Assert.assertTrue(checkboxes.get(1).hasAttribute("readonly"));
+        Assert.assertTrue(group.hasAttribute("readonly"));
 
         scrollToElement(group);
         getCommandExecutor().executeScript("window.scrollBy(0,50);");
@@ -159,10 +156,10 @@ public class CheckboxGroupIT extends AbstractComponentIT {
                 .id("checkbox-group-theme-variants");
 
         scrollToElement(group);
-        Assert.assertEquals("vertical", group.getAttribute("theme"));
+        Assert.assertEquals("vertical", group.getDomAttribute("theme"));
 
         findElement(By.id("remove-theme-variant-button")).click();
-        Assert.assertNull(group.getAttribute("theme"));
+        Assert.assertNull(group.getDomAttribute("theme"));
     }
 
     @Test
@@ -202,7 +199,7 @@ public class CheckboxGroupIT extends AbstractComponentIT {
         WebElement anchor = checkboxes.get(2).findElement(By.tagName("img"));
 
         Assert.assertEquals("https://vaadin.com/images/vaadin-logo.svg",
-                anchor.getAttribute("src"));
+                anchor.getDomAttribute("src"));
 
         Assert.assertEquals("Bill", checkboxes.get(2).getText());
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxIT.java
@@ -89,8 +89,9 @@ public class CheckboxIT extends AbstractComponentIT {
 
     @Test
     public void disabledCheckbox() {
-        WebElement checkbox = layout.findElement(By.id("disabled-checkbox"));
-        Assert.assertEquals("true", checkbox.getAttribute("disabled"));
+        CheckboxElement checkbox = layout.$(CheckboxElement.class)
+                .id("disabled-checkbox");
+        Assert.assertFalse(checkbox.isEnabled());
         WebElement message = layout
                 .findElement(By.id("disabled-checkbox-message"));
         Assert.assertEquals("", message.getText());
@@ -103,21 +104,21 @@ public class CheckboxIT extends AbstractComponentIT {
 
     @Test
     public void indeterminateCheckbox() {
-        WebElement checkbox = layout
-                .findElement(By.id("indeterminate-checkbox"));
+        CheckboxElement checkbox = layout.$(CheckboxElement.class)
+                .id("indeterminate-checkbox");
         WebElement button = layout.findElement(By.id("reset-indeterminate"));
-        Assert.assertEquals("This checkbox should be in indeterminate state",
-                "true", checkbox.getAttribute("indeterminate"));
+        Assert.assertTrue("This checkbox should be in indeterminate state",
+                checkbox.hasAttribute("indeterminate"));
 
         checkbox.click();
-        Assert.assertNotEquals(
+        Assert.assertFalse(
                 "Checkbox should not be in indeterminate state after clicking it",
-                "true", checkbox.getAttribute("indeterminate"));
+                checkbox.hasAttribute("indeterminate"));
 
         clickElementWithJs(button);
-        Assert.assertEquals(
+        Assert.assertTrue(
                 "This checkbox should be in indeterminate state after resetting",
-                "true", checkbox.getAttribute("indeterminate"));
+                checkbox.hasAttribute("indeterminate"));
     }
 
     @Test
@@ -139,7 +140,7 @@ public class CheckboxIT extends AbstractComponentIT {
                 .findElement(By.cssSelector("[slot=input]"));
         Assert.assertEquals(
                 "Accessible checkbox should have the aria-label attribute",
-                "Click me", inputElement.getAttribute("aria-label"));
+                "Click me", inputElement.getDomAttribute("aria-label"));
     }
 
     @Test

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DataProviderIdPageIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DataProviderIdPageIT.java
@@ -19,8 +19,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
+import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
+import com.vaadin.flow.component.checkbox.testbench.CheckboxGroupElement;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-checkbox/data-provider-id")
@@ -32,10 +33,9 @@ public class DataProviderIdPageIT extends AbstractComponentIT {
 
         findElement(By.id("select-by-id")).click();
 
-        TestBenchElement barCheckboxGroup = $("vaadin-checkbox-group")
-                .id("id-data-provider").$("vaadin-checkbox").all().get(1);
-        String isChecked = barCheckboxGroup.getAttribute("checked");
-        Assert.assertEquals(Boolean.TRUE.toString(), isChecked);
+        CheckboxElement barCheckbox = $(CheckboxGroupElement.class)
+                .id("id-data-provider").$(CheckboxElement.class).all().get(1);
+        Assert.assertTrue(barCheckbox.isChecked());
     }
 
     @Test
@@ -44,10 +44,9 @@ public class DataProviderIdPageIT extends AbstractComponentIT {
 
         findElement(By.id("select-by-equals")).click();
 
-        TestBenchElement barCheckboxGroup = $("vaadin-checkbox-group")
-                .id("standard-equals").$("vaadin-checkbox").all().get(1);
-        String isChecked = barCheckboxGroup.getAttribute("checked");
-        Assert.assertEquals(Boolean.TRUE.toString(), isChecked);
+        CheckboxElement barCheckbox = $(CheckboxGroupElement.class)
+                .id("standard-equals").$(CheckboxElement.class).all().get(1);
+        Assert.assertTrue(barCheckbox.isChecked());
     }
 
     @Test
@@ -56,9 +55,8 @@ public class DataProviderIdPageIT extends AbstractComponentIT {
 
         findElement(By.id("no-selection")).click();
 
-        TestBenchElement barCheckboxGroup = $("vaadin-checkbox-group")
-                .id("id-data-provider").$("vaadin-checkbox").all().get(1);
-        String isChecked = barCheckboxGroup.getAttribute("checked");
-        Assert.assertNull(isChecked);
+        CheckboxElement barCheckbox = $(CheckboxGroupElement.class)
+                .id("id-data-provider").$(CheckboxElement.class).all().get(1);
+        Assert.assertFalse(barCheckbox.isChecked());
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DetachReattachIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DetachReattachIT.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
+import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
@@ -34,11 +34,11 @@ public class DetachReattachIT extends AbstractComponentIT {
         open();
 
         clickButton("setValue");
-        List checkedBeforeDetach = getCheckboxexCheckedState();
+        List<Boolean> checkedBeforeDetach = getCheckboxesCheckedState();
         clickButton("detach");
         clickButton("attach");
         Assert.assertEquals("Checkboxes should remain checked on reattach",
-                checkedBeforeDetach, getCheckboxexCheckedState());
+                checkedBeforeDetach, getCheckboxesCheckedState());
     }
 
     @Test
@@ -51,15 +51,14 @@ public class DetachReattachIT extends AbstractComponentIT {
         clickButton("attach");
         Assert.assertTrue(
                 "Checkboxes should not be checked after deselectAll on reattach",
-                getCheckboxexCheckedState().stream()
-                        .allMatch(checked -> checked == null));
+                getCheckboxesCheckedState().stream()
+                        .noneMatch(checked -> checked));
     }
 
-    private List getCheckboxexCheckedState() {
+    private List<Boolean> getCheckboxesCheckedState() {
         TestBenchElement group = $("vaadin-checkbox-group").first();
-        return group.findElements(By.tagName("vaadin-checkbox")).stream()
-                .map(checkbox -> checkbox.getAttribute("checked"))
-                .collect(Collectors.toList());
+        return group.$(CheckboxElement.class).all().stream()
+                .map(CheckboxElement::isChecked).collect(Collectors.toList());
     }
 
     private void clickButton(String id) {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DisabledItemsPageIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DisabledItemsPageIT.java
@@ -20,8 +20,9 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
+import com.vaadin.flow.component.checkbox.testbench.CheckboxGroupElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
@@ -31,25 +32,22 @@ public class DisabledItemsPageIT extends AbstractComponentIT {
     @Test
     public void set_items_to_disabled_group_should_be_disabled() {
         open();
-        WebElement group = findElement(By.id("checkbox-group"));
+        CheckboxGroupElement group = $(CheckboxGroupElement.class)
+                .id("checkbox-group");
 
-        List<WebElement> checkboxes = group
-                .findElements(By.tagName("vaadin-checkbox"));
+        List<CheckboxElement> checkboxes = group.$(CheckboxElement.class).all();
         Assert.assertTrue("No buttons should be present", checkboxes.isEmpty());
 
         // Click button to add items
         findElement(By.id("add-button")).click();
 
         waitForElementPresent(By.tagName("vaadin-checkbox"));
-        checkboxes = group.findElements(By.tagName("vaadin-checkbox"));
+        checkboxes = group.$(CheckboxElement.class).all();
         Assert.assertEquals("Group should have checkboxes", 2,
                 checkboxes.size());
 
-        // re-get the elements to not get stale element exception.
-        for (WebElement button : group
-                .findElements(By.tagName("vaadin-checkbox"))) {
-            Assert.assertEquals("All checkboxes should be disabled",
-                    Boolean.TRUE.toString(), button.getAttribute("disabled"));
-        }
+        Assert.assertTrue(
+                checkboxes.stream().noneMatch(CheckboxElement::isEnabled));
+
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
@@ -92,7 +92,7 @@ public class HelperIT extends AbstractComponentIT {
         CheckboxElement checkboxHelperComponent = $(CheckboxElement.class)
                 .id("checkbox-helper-component");
         Assert.assertEquals("helper-component", checkboxHelperComponent
-                .getHelperComponent().getAttribute("id"));
+                .getHelperComponent().getDomAttribute("id"));
 
         $("button").id("empty-helper-component").click();
         Assert.assertEquals(null, checkboxHelperComponent.getHelperComponent());

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/InjectedCheckboxIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/InjectedCheckboxIT.java
@@ -32,8 +32,7 @@ public class InjectedCheckboxIT extends AbstractComponentIT {
         TestBenchElement checkbox = $("inject-checkbox").first()
                 .$("vaadin-checkbox").first();
 
-        String isChecked = checkbox.getAttribute("checked");
-        Assert.assertEquals(Boolean.TRUE.toString(), isChecked);
+        Assert.assertTrue(checkbox.getPropertyBoolean("checked"));
 
         Assert.assertEquals("Accept",
                 checkbox.getPropertyString("textContent").trim());

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearValueIT.java
@@ -181,7 +181,7 @@ public class ClearValueIT extends AbstractComponentIT {
         Assert.assertEquals(String.format(
                 "Unexpected 'allowCustomValue' property name for combo box with id '%s'",
                 comboBoxId), Boolean.toString(allowCustomValue),
-                comboBox.getAttribute("allowCustomValue"));
+                comboBox.getPropertyString("allowCustomValue"));
 
         findElement(By.id(buttonId)).click();
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxItemClassNameIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxItemClassNameIT.java
@@ -66,7 +66,7 @@ public class ComboBoxItemClassNameIT extends AbstractComponentIT {
                 .$("vaadin-combo-box-item");
 
         for (int i = 0; i < expectedClassNames.length; i++) {
-            Assert.assertEquals(items.get(i).getAttribute("class"),
+            Assert.assertEquals(items.get(i).getDomAttribute("class"),
                     expectedClassNames[i]);
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/HelperTextPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/HelperTextPageIT.java
@@ -44,8 +44,8 @@ public class HelperTextPageIT extends AbstractComboBoxIT {
     public void assertHelperComponent() {
         ComboBoxElement comboHelperComponent = $(ComboBoxElement.class)
                 .id("combobox-helper-component");
-        Assert.assertEquals("helper-component",
-                comboHelperComponent.getHelperComponent().getAttribute("id"));
+        Assert.assertEquals("helper-component", comboHelperComponent
+                .getHelperComponent().getDomAttribute("id"));
 
         clickButton("empty-helper-component");
         Assert.assertEquals(null, comboHelperComponent.getHelperComponent());

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxItemClassNameIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxItemClassNameIT.java
@@ -100,7 +100,7 @@ public class MultiSelectComboBoxItemClassNameIT extends AbstractComponentIT {
                 .$("vaadin-multi-select-combo-box-item");
 
         for (int i = 0; i < expectedClassNames.length; i++) {
-            Assert.assertEquals(items.get(i).getAttribute("class"),
+            Assert.assertEquals(items.get(i).getDomAttribute("class"),
                     expectedClassNames[i]);
         }
     }
@@ -111,7 +111,7 @@ public class MultiSelectComboBoxItemClassNameIT extends AbstractComponentIT {
 
         for (int i = 0; i < expectedClassNames.length; i++) {
             // Skip first chip as it's used for overflow items
-            Assert.assertEquals(chips.get(i + 1).getAttribute("class"),
+            Assert.assertEquals(chips.get(i + 1).getDomAttribute("class"),
                     expectedClassNames[i]);
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/NullValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/NullValueChangeIT.java
@@ -51,7 +51,7 @@ public class NullValueChangeIT extends AbstractComponentIT {
                 comboBox);
 
         Assert.assertEquals("_inputElementValue must be empty.", "",
-                comboBox.getAttribute("_inputElementValue"));
+                comboBox.getDomProperty("_inputElementValue"));
     }
 
 }

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/StylingIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/StylingIT.java
@@ -91,6 +91,6 @@ public class StylingIT extends AbstractComponentIT {
     }
 
     private String getOverlayClassName() {
-        return getOverlay().getAttribute("class");
+        return getOverlay().getDomAttribute("class");
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/AutoAttachedContextMenuIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/AutoAttachedContextMenuIT.java
@@ -63,7 +63,7 @@ public class AutoAttachedContextMenuIT extends AbstractContextMenuIT {
 
         verifyOpened();
         Assert.assertEquals("Auto-attached context menu",
-                getOverlay().getAttribute("innerText"));
+                getOverlay().getDomProperty("innerText"));
 
         checkLogsForErrors();
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuDemoIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuDemoIT.java
@@ -53,8 +53,8 @@ public class ContextMenuDemoIT extends AbstractComponentIT {
                 "Second menu item", "Disabled menu item" },
                 getMenuItemCaptions());
 
-        Assert.assertEquals("The last item is supposed to be disabled", "true",
-                getMenuItems().get(2).getAttribute("disabled"));
+        Assert.assertFalse("The last item is supposed to be disabled",
+                getMenuItems().get(2).isEnabled());
 
         $("body").first().click();
         verifyClosed();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/OverrideOnBeforeOpenContextMenuIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/OverrideOnBeforeOpenContextMenuIT.java
@@ -48,7 +48,7 @@ public class OverrideOnBeforeOpenContextMenuIT extends AbstractContextMenuIT {
         verifyOpened();
 
         Assert.assertEquals("Dynamic Item",
-                getOverlay().getAttribute("innerText"));
+                getOverlay().getDomProperty("innerText"));
 
         clickBody();
         verifyClosed();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuIT.java
@@ -170,7 +170,7 @@ public class SubMenuIT extends AbstractContextMenuIT {
                 checkableItem.getTagName().toLowerCase(Locale.ENGLISH));
         Assert.assertEquals("checkable", checkableItem.getText());
         Assert.assertEquals("",
-                checkableItem.getAttribute("menu-item-checked"));
+                checkableItem.getDomAttribute("menu-item-checked"));
 
         // uncheck the item
         checkableItem.click();
@@ -192,12 +192,11 @@ public class SubMenuIT extends AbstractContextMenuIT {
         checkableItem = subMenuOverlay.$("vaadin-context-menu-list-box").first()
                 .findElements(By.xpath("./*")).get(1);
 
-        Assert.assertNull(checkableItem.getAttribute("menu-item-checked"));
+        Assert.assertNull(checkableItem.getDomAttribute("menu-item-checked"));
     }
 
     private void assertHasPopup(TestBenchElement item, boolean isParent) {
-        boolean hasPopup = Boolean
-                .parseBoolean(item.getAttribute("aria-haspopup"));
+        boolean hasPopup = item.hasAttribute("aria-haspopup");
         if (isParent) {
             Assert.assertTrue("Item should have aria-haspopup set to true",
                     hasPopup);

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuIT.java
@@ -196,7 +196,8 @@ public class SubMenuIT extends AbstractContextMenuIT {
     }
 
     private void assertHasPopup(TestBenchElement item, boolean isParent) {
-        boolean hasPopup = item.hasAttribute("aria-haspopup");
+        boolean hasPopup = Boolean
+                .parseBoolean(item.getDomAttribute("aria-haspopup"));
         if (isParent) {
             Assert.assertTrue("Item should have aria-haspopup set to true",
                     hasPopup);

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/tests/StylingIT.java
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/src/test/java/com/vaadin/flow/component/cookieconsent/tests/StylingIT.java
@@ -59,6 +59,6 @@ public class StylingIT extends AbstractComponentIT {
     }
 
     private String getBannerClassName() {
-        return getConsentBanner().getAttribute("class");
+        return getConsentBanner().getDomAttribute("class");
     }
 }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/BasicUseIT.java
@@ -91,14 +91,14 @@ public class BasicUseIT extends AbstractComponentIT {
         GridElement grid = $(GridElement.class).waitForFirst();
         Assert.assertEquals("Sort by First Name",
                 grid.getHeaderCellContent(0, 0).$("vaadin-grid-sorter").first()
-                        .getAttribute("aria-label"));
+                        .getDomAttribute("aria-label"));
     }
 
     @Test
     public void filterHasAriaLabel() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         Assert.assertEquals("Filter by First Name",
-                crud.getFilterFields().get(0).getAttribute("aria-label"));
+                crud.getFilterFields().get(0).getDomAttribute("aria-label"));
     }
 
     @Test
@@ -158,22 +158,22 @@ public class BasicUseIT extends AbstractComponentIT {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         GridElement grid = $(GridElement.class).first();
 
-        Assert.assertNotEquals("no-border", crud.getAttribute("theme"));
-        Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
+        Assert.assertNotEquals("no-border", crud.getDomAttribute("theme"));
+        Assert.assertNotEquals("no-border", grid.getDomAttribute("theme"));
 
         getTestButton("toggleBorders").click();
-        Assert.assertEquals("no-border", crud.getAttribute("theme"));
-        Assert.assertEquals("no-border", grid.getAttribute("theme"));
+        Assert.assertEquals("no-border", crud.getDomAttribute("theme"));
+        Assert.assertEquals("no-border", grid.getDomAttribute("theme"));
 
         getTestButton("toggleBorders").click();
-        Assert.assertNotEquals("no-border", crud.getAttribute("theme"));
-        Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
+        Assert.assertNotEquals("no-border", crud.getDomAttribute("theme"));
+        Assert.assertNotEquals("no-border", grid.getDomAttribute("theme"));
     }
 
     @Test
     public void toolbarVisibleByDefault() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
-        Assert.assertNull(crud.getAttribute("no-toolbar"));
+        Assert.assertFalse(crud.hasAttribute("no-toolbar"));
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java
@@ -75,12 +75,12 @@ public class CustomGridIT extends AbstractComponentIT {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         GridElement grid = $(GridElement.class).first();
 
-        Assert.assertNotEquals("no-border", crud.getAttribute("theme"));
-        Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
+        Assert.assertNotEquals("no-border", crud.getDomAttribute("theme"));
+        Assert.assertNotEquals("no-border", grid.getDomAttribute("theme"));
 
         toggleBordersButton().click();
-        Assert.assertEquals("no-border", crud.getAttribute("theme"));
-        Assert.assertNotEquals("no-border", grid.getAttribute("theme"));
+        Assert.assertEquals("no-border", crud.getDomAttribute("theme"));
+        Assert.assertNotEquals("no-border", grid.getDomAttribute("theme"));
     }
 
     @Test

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/CustomHelperIT.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/CustomHelperIT.java
@@ -47,7 +47,7 @@ public class CustomHelperIT extends AbstractComponentIT {
                 CustomFieldElement.class).id("custom-field-helper-component");
 
         Assert.assertEquals("helper-component", customFieldHelperComponent
-                .getHelperComponent().getAttribute("id"));
+                .getHelperComponent().getDomAttribute("id"));
 
         $("button").id("button-clear-helper-component").click();
 
@@ -66,7 +66,7 @@ public class CustomHelperIT extends AbstractComponentIT {
         $("button").id("button-add-helper-component").click();
 
         Assert.assertEquals("helper-component-lazy", customFieldHelperComponent
-                .getHelperComponent().getAttribute("id"));
+                .getHelperComponent().getDomAttribute("id"));
     }
 
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -293,7 +293,7 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
         TestBenchElement input = $(DatePickerElement.class).id(id)
                 .findElement(By.tagName("input"));
 
-        while (!input.getAttribute("value").isEmpty()) {
+        while (!input.getPropertyString("value").isEmpty()) {
             input.sendKeys(Keys.BACK_SPACE);
         }
         input.sendKeys(value);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerHelpersIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerHelpersIT.java
@@ -47,7 +47,7 @@ public class DatePickerHelpersIT extends AbstractComponentIT {
         DatePickerElement dataPickerHelperComponent = $(DatePickerElement.class)
                 .id("data-picker-helper-component");
         Assert.assertEquals("helper-component", dataPickerHelperComponent
-                .getHelperComponent().getAttribute("id"));
+                .getHelperComponent().getDomAttribute("id"));
 
         $("button").id("button-clear-component").click();
         Assert.assertNull(dataPickerHelperComponent.getHelperComponent());

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerHelpersPageIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerHelpersPageIT.java
@@ -48,7 +48,7 @@ public class DateTimePickerHelpersPageIT extends AbstractComponentIT {
         DateTimePickerElement dtp = $(DateTimePickerElement.class)
                 .id("dtp-helper-component");
         Assert.assertEquals("helper-component",
-                dtp.getHelperComponent().getAttribute("id"));
+                dtp.getHelperComponent().getDomAttribute("id"));
 
         $("button").id("button-clear-helper-component").click();
         Assert.assertNull(dtp.getHelperComponent());

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
@@ -183,6 +183,6 @@ public class DateTimePickerIT extends AbstractComponentIT {
         DateTimePickerElement picker = $(DateTimePickerElement.class)
                 .id("date-time-picker-variant");
 
-        Assert.assertEquals("small", picker.getAttribute("theme"));
+        Assert.assertEquals("small", picker.getDomAttribute("theme"));
     }
 }

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/BasicIT.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/src/test/java/com/vaadin/flow/component/details/tests/BasicIT.java
@@ -49,7 +49,7 @@ public class BasicIT extends AbstractComponentIT {
 
         DetailsElement detailsThemed = detailsElements.get(2);
         List<String> themes = Arrays
-                .asList(detailsThemed.getAttribute("theme").split(" "));
+                .asList(detailsThemed.getDomAttribute("theme").split(" "));
         Assert.assertTrue(themes.containsAll(Stream.of(DetailsVariant.values())
                 .map(DetailsVariant::getVariantName)
                 .collect(Collectors.toList())));

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -231,9 +231,9 @@ public class DialogTestPageIT extends AbstractComponentIT {
         findElement(By.id("button-for-dialog-with-div")).click();
         WebElement overlay = getOverlayContent().$("*").id("overlay");
         Assert.assertTrue(
-                overlay.getAttribute("style").contains("width: 100%;"));
+                overlay.getDomAttribute("style").contains("width: 100%;"));
         Assert.assertTrue(
-                overlay.getAttribute("style").contains("height: 100%;"));
+                overlay.getDomAttribute("style").contains("height: 100%;"));
 
         WebElement div = findElement(By.id("div-in-dialog"));
         WebElement content = overlay.findElement(By.id("content"));

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithClassNamesIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithClassNamesIT.java
@@ -45,8 +45,8 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
 
         WebElement overlay = $(DIALOG_OVERLAY_TAG).first();
 
-        String overlayClassNames = overlay.getAttribute("class");
-        String dialogClassNames = dialog.getAttribute("class");
+        String overlayClassNames = overlay.getDomAttribute("class");
+        String dialogClassNames = dialog.getDomAttribute("class");
 
         Assert.assertEquals("custom", dialogClassNames);
         Assert.assertEquals("custom", overlayClassNames);
@@ -63,8 +63,8 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         DialogElement dialog = $(DialogElement.class).first();
         WebElement overlay = $(DIALOG_OVERLAY_TAG).first();
 
-        String overlayClassNames = overlay.getAttribute("class");
-        String dialogClassNames = dialog.getAttribute("class");
+        String overlayClassNames = overlay.getDomAttribute("class");
+        String dialogClassNames = dialog.getDomAttribute("class");
 
         Assert.assertEquals("custom added", dialogClassNames);
         Assert.assertEquals("custom added", overlayClassNames);
@@ -81,8 +81,8 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         DialogElement dialog = $(DialogElement.class).first();
         WebElement overlay = $(DIALOG_OVERLAY_TAG).first();
 
-        String overlayClassNames = overlay.getAttribute("class");
-        String dialogClassNames = dialog.getAttribute("class");
+        String overlayClassNames = overlay.getDomAttribute("class");
+        String dialogClassNames = dialog.getDomAttribute("class");
 
         Assert.assertEquals("", dialogClassNames);
         Assert.assertEquals("", overlayClassNames);
@@ -105,8 +105,8 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         DialogElement dialog = $(DialogElement.class).first();
         WebElement overlay = $(DIALOG_OVERLAY_TAG).first();
 
-        String overlayClassNames = overlay.getAttribute("class");
-        String dialogClassNames = dialog.getAttribute("class");
+        String overlayClassNames = overlay.getDomAttribute("class");
+        String dialogClassNames = dialog.getDomAttribute("class");
 
         Assert.assertEquals("added", dialogClassNames);
         Assert.assertEquals("added", overlayClassNames);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridIT.java
@@ -53,7 +53,7 @@ public class DynamicContextMenuGridIT extends AbstractComponentIT {
         verifyOpened();
 
         Assert.assertEquals("Person 40",
-                $(OVERLAY_TAG).first().getAttribute("innerText"));
+                $(OVERLAY_TAG).first().getDomProperty("innerText"));
 
         $("body").first().click();
         verifyClosed();
@@ -74,7 +74,7 @@ public class DynamicContextMenuGridIT extends AbstractComponentIT {
 
         verifyOpened();
         Assert.assertEquals("Person 40",
-                $(OVERLAY_TAG).first().getAttribute("innerText"));
+                $(OVERLAY_TAG).first().getDomProperty("innerText"));
     }
 
     private void verifyOpened() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DragAndDropGridIT.java
@@ -147,7 +147,7 @@ public class DragAndDropGridIT extends AbstractComponentIT {
         fireDrop(0, "on-top");
         Assert.assertEquals("<b>2</b>",
                 findElement(By.id("drop-data-html-message"))
-                        .getAttribute("innerHTML"));
+                        .getDomProperty("innerHTML"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java
@@ -79,7 +79,7 @@ public class DynamicEditorKBNavigationIT extends AbstractComponentIT {
 
         TestBenchElement emailField = emailCell.$("vaadin-text-field").first();
         String isReadonly = emailField.$("input").first()
-                .getAttribute("readonly");
+                .getDomAttribute("readonly");
 
         Assert.assertEquals(Boolean.TRUE.toString(), isReadonly);
 
@@ -90,9 +90,9 @@ public class DynamicEditorKBNavigationIT extends AbstractComponentIT {
         new Actions(getDriver()).sendKeys(Keys.BACK_SPACE).build().perform();
 
         emailField = emailCell.$("vaadin-text-field").first();
-        Assert.assertNotNull(emailField.getAttribute("focused"));
+        Assert.assertNotNull(emailField.getDomAttribute("focused"));
         Assert.assertEquals("Not a subscriber",
-                emailField.getAttribute("value"));
+                emailField.getDomProperty("value"));
 
         // Change the subscriber status back
         checkbox = subscriberCell.$("vaadin-checkbox").first();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridFilteringIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridFilteringIT.java
@@ -20,7 +20,6 @@ import static com.vaadin.flow.component.grid.it.GridFilteringPage.LAZY_FILTERABL
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
@@ -43,7 +42,7 @@ public class GridFilteringIT extends AbstractComponentIT {
         // Blur input to get value change
         executeScript("arguments[0].blur();", input);
 
-        WebElement grid = findElement(By.id("data-grid"));
+        GridElement grid = $(GridElement.class).id("data-grid");
         // empty Grid content
         Object size = executeScript("return arguments[0].size", grid);
         Assert.assertEquals("0", size.toString());
@@ -56,7 +55,7 @@ public class GridFilteringIT extends AbstractComponentIT {
         waitUntil(driver -> executeScript("return arguments[0].size", grid)
                 .toString().equals("3"));
 
-        waitUntil(driver -> "false".equals(grid.getAttribute("loading")));
+        waitUntil(driver -> !grid.hasAttribute("loading"));
     }
 
     @Test // for https://github.com/vaadin/flow/issues/9988

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -88,11 +88,11 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
             if (haveTemplates) {
                 Assert.assertTrue(
                         templates.stream().allMatch(template -> template
-                                .getAttribute("class").contains(className)));
+                                .getDomAttribute("class").contains(className)));
             } else {
                 Assert.assertTrue(
                         templates.stream().noneMatch(template -> template
-                                .getAttribute("class").contains(className)));
+                                .getDomAttribute("class").contains(className)));
             }
         });
     }
@@ -123,7 +123,7 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         clickButton("append-header-without-content");
         List<WebElement> headerCells = getHeaderCells();
         String lastHeaderContent = headerCells.get(headerCells.size() - 1)
-                .getAttribute("innerHTML");
+                .getDomProperty("innerHTML");
         Assert.assertTrue(
                 "The appended header should be empty, but contained text: '"
                         + lastHeaderContent + "'",
@@ -243,7 +243,7 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
                 2, headerCells.size());
         Assert.assertThat(
                 "The first header cell should contain the multiselection checkbox",
-                headerCells.get(0).getAttribute("innerHTML"),
+                headerCells.get(0).getDomProperty("innerHTML"),
                 CoreMatchers.containsString("vaadin-checkbox"));
         Assert.assertEquals(
                 "The second header cell should contain the set text", "0",
@@ -368,13 +368,13 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
     private void assertHeaderHasGridSorter(int headerIndexFromTop) {
         List<WebElement> headerCells = getHeaderCells();
         WebElement cellWithSorter = headerCells.get(headerIndexFromTop);
-        Assert.assertThat(cellWithSorter.getAttribute("innerHTML"),
+        Assert.assertThat(cellWithSorter.getDomProperty("innerHTML"),
                 CoreMatchers.containsString("vaadin-grid-sorter"));
 
         Assert.assertTrue("Only one header should have the sorting indicators",
                 headerCells.stream()
                         .filter(cell -> !cell.equals(cellWithSorter))
-                        .noneMatch(cell -> cell.getAttribute("innerHTML")
+                        .noneMatch(cell -> cell.getDomProperty("innerHTML")
                                 .contains("vaadin-grid-sorter")));
     }
 
@@ -392,12 +392,12 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         WebElement thead = grid.$("*").id("header");
 
         List<WebElement> headers = thead.findElements(By.tagName("tr")).stream()
-                .filter(tr -> tr.getAttribute("hidden") == null)
+                .filter(tr -> tr.getDomAttribute("hidden") == null)
                 .flatMap(tr -> tr.findElements(By.tagName("th")).stream())
                 .collect(Collectors.toList());
 
         List<String> cellNames = headers.stream().map(header -> header
-                .findElement(By.tagName("slot")).getAttribute("name"))
+                .findElement(By.tagName("slot")).getDomAttribute("name"))
                 .collect(Collectors.toList());
 
         List<WebElement> headerCells = cellNames.stream()
@@ -410,7 +410,7 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
 
     private List<String> getHeaderContents() {
         return getHeaderCells().stream()
-                .map(cell -> cell.getAttribute("innerHTML"))
+                .map(cell -> cell.getDomProperty("innerHTML"))
                 .collect(Collectors.toList());
     }
 
@@ -429,12 +429,12 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         WebElement tfoot = grid.$("*").id("footer");
 
         List<WebElement> footers = tfoot.findElements(By.tagName("tr")).stream()
-                .filter(tr -> tr.getAttribute("hidden") == null)
+                .filter(tr -> tr.getDomAttribute("hidden") == null)
                 .flatMap(tr -> tr.findElements(By.tagName("td")).stream())
                 .collect(Collectors.toList());
 
         List<String> cellNames = footers.stream().map(footer -> footer
-                .findElement(By.tagName("slot")).getAttribute("name"))
+                .findElement(By.tagName("slot")).getDomAttribute("name"))
                 .collect(Collectors.toList());
 
         List<WebElement> footerCells = cellNames.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsIT.java
@@ -51,13 +51,13 @@ public class GridHeaderRowWithComponentsIT extends AbstractComponentIT {
         Assert.assertThat(
                 "The first header cell should contain the component "
                         + "of the first appended header row",
-                headerCells.get(0).getAttribute("innerHTML"),
+                headerCells.get(0).getDomProperty("innerHTML"),
                 CoreMatchers.containsString("<label>foo</label>"));
 
         Assert.assertThat(
                 "The second header cell should contain the component "
                         + "of the second appended header row",
-                headerCells.get(1).getAttribute("innerHTML"),
+                headerCells.get(1).getDomProperty("innerHTML"),
                 CoreMatchers.containsString("<label>bar</label>"));
     }
 
@@ -65,7 +65,7 @@ public class GridHeaderRowWithComponentsIT extends AbstractComponentIT {
     public void prependHeader_setText_setComponent_componentOverridesText() {
         findElement(By.id("set-both-text-and-component")).click();
         String headerContent = getHeaderCells().get(0)
-                .getAttribute("innerHTML");
+                .getDomProperty("innerHTML");
 
         Assert.assertThat(
                 "The header cell should not contain the text after "
@@ -83,7 +83,7 @@ public class GridHeaderRowWithComponentsIT extends AbstractComponentIT {
         List<WebElement> headers = thead.findElements(By.tagName("th"));
 
         List<String> cellNames = headers.stream().map(header -> header
-                .findElement(By.tagName("slot")).getAttribute("name"))
+                .findElement(By.tagName("slot")).getDomAttribute("name"))
                 .collect(Collectors.toList());
 
         List<WebElement> headerCells = cellNames.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -41,7 +41,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 "true",
                 definedItemCountLazyGrid
                         .findElement(By.id(SELECT_ALL_CHECKBOX_ID))
-                        .getAttribute("hidden"));
+                        .getDomAttribute("hidden"));
 
         WebElement unknownItemCountLazyGrid = findElement(By.id(
                 GridMultiSelectionColumnPage.UNKNOWN_ITEM_COUNT_LAZY_GRID_ID));
@@ -50,7 +50,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 "true",
                 unknownItemCountLazyGrid
                         .findElement(By.id(SELECT_ALL_CHECKBOX_ID))
-                        .getAttribute("hidden"));
+                        .getDomAttribute("hidden"));
 
         WebElement grid = findElement(
                 By.id(GridMultiSelectionColumnPage.IN_MEMORY_GRID_ID));
@@ -58,7 +58,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
         Assert.assertNull(
                 "in-memory grid selectAllCheckbox should be visible by default",
-                selectAllCheckbox.getAttribute("hidden"));
+                selectAllCheckbox.getDomAttribute("hidden"));
     }
 
     @Test
@@ -74,10 +74,10 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
 
         // Initial
         Assert.assertNull("Select all checkbox should not be checked initially",
-                selectAllCheckbox.getAttribute("checked"));
+                selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertNull(
                 "Select all checkbox should not be in indeterminate state initially",
-                selectAllCheckbox.getAttribute("indeterminate"));
+                selectAllCheckbox.getDomAttribute("indeterminate"));
 
         // Select single
         // Note that in indeterminate state, the select all checkbox is also
@@ -86,10 +86,10 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         Assert.assertEquals("Selected item count: 1", message.getText());
         Assert.assertEquals(
                 "Select all checkbox is not checked even though an item is selected",
-                "true", selectAllCheckbox.getAttribute("checked"));
+                "true", selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertEquals(
                 "Select all checkbox is not in indeterminate state even though an item is selected",
-                "true", selectAllCheckbox.getAttribute("indeterminate"));
+                "true", selectAllCheckbox.getDomAttribute("indeterminate"));
 
         // Select all
         selectAllCheckbox.click();
@@ -99,10 +99,10 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 message.getText());
         Assert.assertEquals(
                 "Select all checkbox is not checked even though all items selected",
-                "true", selectAllCheckbox.getAttribute("checked"));
+                "true", selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertNull(
                 "Select all checkbox is in indeterminate state even though all items are selected",
-                selectAllCheckbox.getAttribute("indeterminate"));
+                selectAllCheckbox.getDomAttribute("indeterminate"));
 
         // Deselect single
         // Note that in indeterminate state, the select all checkbox is also
@@ -114,10 +114,10 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 message.getText());
         Assert.assertEquals(
                 "Select all checkbox is not checked even though an item is selected",
-                "true", selectAllCheckbox.getAttribute("checked"));
+                "true", selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertEquals(
                 "Select all checkbox is not in indeterminate state even though not all items selected",
-                "true", selectAllCheckbox.getAttribute("indeterminate"));
+                "true", selectAllCheckbox.getDomAttribute("indeterminate"));
 
         // Deselect all, needs to toggle the checkbox twice, first to select all
         // again, then to deselect all
@@ -126,10 +126,10 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         Assert.assertEquals("Selected item count: 0", message.getText());
         Assert.assertNull(
                 "Select all checkbox is checked even though no items selected",
-                selectAllCheckbox.getAttribute("checked"));
+                selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertNull(
                 "Select all checkbox is in indeterminate state even though no items are selected",
-                selectAllCheckbox.getAttribute("indeterminate"));
+                selectAllCheckbox.getDomAttribute("indeterminate"));
     }
 
     @Test
@@ -168,7 +168,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 selectAllCheckbox_selectionMode.isDisplayed());
         selectAllCheckbox_selectionMode.click();
         Assert.assertEquals("true",
-                selectAllCheckbox_selectionMode.getAttribute("checked"));
+                selectAllCheckbox_selectionMode.getDomAttribute("checked"));
         Assert.assertEquals(
                 "Selected item count: "
                         + (GridMultiSelectionColumnPage.ITEM_COUNT),
@@ -181,9 +181,9 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 .findElements(By.tagName("vaadin-checkbox")).get(6);
         selectCheckbox6_multiSelection.click();
         Assert.assertEquals("true",
-                selectCheckbox12_multiSelection.getAttribute("checked"));
+                selectCheckbox12_multiSelection.getDomAttribute("checked"));
         Assert.assertEquals("true",
-                selectCheckbox6_multiSelection.getAttribute("checked"));
+                selectCheckbox6_multiSelection.getDomAttribute("checked"));
     }
 
     @Test
@@ -216,21 +216,21 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
 
         Assert.assertEquals("The selectAllCheckbox should be hidden by default",
-                "true", selectAllCheckbox.getAttribute("hidden"));
+                "true", selectAllCheckbox.getDomAttribute("hidden"));
 
         WebElement inMemory = findElement(By.id("set-in-memory-button"));
         inMemory.click();
 
         Assert.assertNull(
                 "The selectAllCheckbox should be visible with in-memory DataProvider",
-                selectAllCheckbox.getAttribute("hidden"));
+                selectAllCheckbox.getDomAttribute("hidden"));
 
         WebElement backend = findElement(By.id("set-backend-button"));
         backend.click();
 
         Assert.assertEquals(
                 "The selectAllCheckbox should be hidden with backend DataProvider",
-                "true", selectAllCheckbox.getAttribute("hidden"));
+                "true", selectAllCheckbox.getDomAttribute("hidden"));
     }
 
     @Test
@@ -259,7 +259,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         // Test autoWidth of selection column is true
         WebElement gridSelectionMode = grid
                 .findElement(By.tagName("vaadin-grid-flow-selection-column"));
-        String autoWidth = gridSelectionMode.getAttribute("autoWidth");
+        String autoWidth = gridSelectionMode.getDomProperty("autoWidth");
         Assert.assertTrue("autoWidth should be true",
                 Boolean.parseBoolean(autoWidth));
     }
@@ -303,7 +303,8 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 GridMultiSelectionColumnPage.MULTI_SELECT_GRID_ALL_SELECTED_GRID_ID);
         WebElement selectAllCheckbox = grid
                 .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
-        Assert.assertEquals("true", selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals("true",
+                selectAllCheckbox.getDomAttribute("checked"));
     }
 
     @Test
@@ -322,10 +323,10 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
                 .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
         Assert.assertEquals(
                 "Select all checkbox is not checked even though an item is selected",
-                "true", selectAllCheckbox.getAttribute("checked"));
+                "true", selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertEquals(
                 "Select all checkbox is not in indeterminate state even though not all items selected",
-                "true", selectAllCheckbox.getAttribute("indeterminate"));
+                "true", selectAllCheckbox.getDomAttribute("indeterminate"));
     }
 
     @Test
@@ -340,6 +341,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
 
         WebElement selectAllCheckbox = grid
                 .findElement(By.id(SELECT_ALL_CHECKBOX_ID));
-        Assert.assertEquals("true", selectAllCheckbox.getAttribute("checked"));
+        Assert.assertEquals("true",
+                selectAllCheckbox.getDomAttribute("checked"));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridSingleSelectionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridSingleSelectionIT.java
@@ -117,17 +117,16 @@ public class GridSingleSelectionIT extends AbstractComponentIT {
         TestBenchElement table = grid.$("table").first();
         Assert.assertTrue(table.hasAttribute("aria-multiselectable"));
         Assert.assertFalse(Boolean
-                .parseBoolean(table.getAttribute("aria-multiselectable")));
+                .parseBoolean(table.getDomAttribute("aria-multiselectable")));
 
         GridTRElement firstRow = grid.getRow(0);
         firstRow.select();
-        Assert.assertTrue(firstRow.hasAttribute("aria-selected"));
-        Assert.assertTrue(
-                Boolean.parseBoolean(firstRow.getAttribute("aria-selected")));
+        Assert.assertTrue(Boolean
+                .parseBoolean(firstRow.getDomAttribute("aria-selected")));
 
         GridTRElement secondRow = grid.getRow(1);
-        Assert.assertFalse(
-                Boolean.parseBoolean(secondRow.getAttribute("aria-selected")));
+        Assert.assertFalse(Boolean
+                .parseBoolean(secondRow.getDomAttribute("aria-selected")));
     }
 
     // Regression test for: https://github.com/vaadin/flow-components/issues/324

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridStylingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridStylingIT.java
@@ -166,9 +166,9 @@ public class GridStylingIT extends AbstractComponentIT {
         click("column-generator");
 
         Assert.assertEquals("grid0",
-                grid.getRow(0).getDetailsRow().getAttribute("class"));
+                grid.getRow(0).getDetailsRow().getDomAttribute("class"));
         Assert.assertEquals("grid5",
-                grid.getRow(5).getDetailsRow().getAttribute("class"));
+                grid.getRow(5).getDetailsRow().getDomAttribute("class"));
 
         checkLogsForErrors();
     }
@@ -304,7 +304,7 @@ public class GridStylingIT extends AbstractComponentIT {
     static void assertCellClassNames(GridElement grid, int rowIndex,
             int colIndex, String expectedClassNames) {
         String classNames = grid.getCell(rowIndex, colIndex)
-                .getAttribute("class");
+                .getDomAttribute("class");
         Assert.assertEquals(String.format(
                 "Unexpected class names in cell at row %s, col %s.", rowIndex,
                 colIndex), expectedClassNames, classNames);
@@ -322,7 +322,7 @@ public class GridStylingIT extends AbstractComponentIT {
     static void assertCellPartNames(GridElement grid, int rowIndex,
             int colIndex, String expectedPartNames) {
         String partNames = grid.getCell(rowIndex, colIndex)
-                .getAttribute("part");
+                .getDomAttribute("part");
         String customParts = Stream.of(partNames.split(" "))
                 .filter(part -> !part.contains("cell"))
                 .collect(Collectors.joining(" "));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridStylingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridStylingIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -303,8 +304,9 @@ public class GridStylingIT extends AbstractComponentIT {
 
     static void assertCellClassNames(GridElement grid, int rowIndex,
             int colIndex, String expectedClassNames) {
-        String classNames = grid.getCell(rowIndex, colIndex)
-                .getDomAttribute("class");
+        String classNames = Optional.ofNullable(
+                grid.getCell(rowIndex, colIndex).getDomAttribute("class"))
+                .orElse("");
         Assert.assertEquals(String.format(
                 "Unexpected class names in cell at row %s, col %s.", rowIndex,
                 colIndex), expectedClassNames, classNames);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
@@ -92,11 +92,11 @@ public class GridTestPageIT extends AbstractComponentIT {
     public void grid_does_not_loose_data_on_new_property_sync() {
         int size = Integer
                 .valueOf(findElement(By.id("grid-with-component-renderers"))
-                        .getAttribute("size"));
+                        .getDomProperty("size"));
         findElement(By.id("toggle-column-ordering")).click();
         int updatedSize = Integer
                 .valueOf(findElement(By.id("grid-with-component-renderers"))
-                        .getAttribute("size"));
+                        .getDomProperty("size"));
         Assert.assertEquals(
                 "When some property is synced, grid size property should stay the same",
                 size, updatedSize);
@@ -344,9 +344,9 @@ public class GridTestPageIT extends AbstractComponentIT {
                 grid);
 
         invisible.click();
-        waitUntil(driver -> "true".equals(grid.getAttribute("hidden")));
+        waitUntil(driver -> "true".equals(grid.getDomAttribute("hidden")));
         visible.click();
-        waitUntil(driver -> grid.getAttribute("hidden") == null);
+        waitUntil(driver -> grid.getDomAttribute("hidden") == null);
         items = getItems(driver, grid);
         Assert.assertEquals(50, items.size());
         items.forEach((row, map) -> {
@@ -373,9 +373,9 @@ public class GridTestPageIT extends AbstractComponentIT {
         assertSelection(grid, "Item 0");
 
         invisible.click();
-        waitUntil(driver -> "true".equals(grid.getAttribute("hidden")));
+        waitUntil(driver -> "true".equals(grid.getDomAttribute("hidden")));
         visible.click();
-        waitUntil(driver -> grid.getAttribute("hidden") == null);
+        waitUntil(driver -> grid.getDomAttribute("hidden") == null);
         assertSelection(grid, "Item 0");
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewAllRowsVisibleIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewAllRowsVisibleIT.java
@@ -38,8 +38,8 @@ public class GridViewAllRowsVisibleIT extends AbstractComponentIT {
 
     @Test
     public void allRowsVisible_allRowsAreFetched() {
-        Assert.assertEquals("Grid should have allRowsVisible set to true",
-                "true", grid.getAttribute("allRowsVisible"));
+        Assert.assertTrue("Grid should have allRowsVisible set to true",
+                grid.getPropertyBoolean("allRowsVisible"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewConfiguringColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewConfiguringColumnsIT.java
@@ -64,16 +64,16 @@ public class GridViewConfiguringColumnsIT extends AbstractComponentIT {
                 .executeScript(firstCellHiddenScript, grid));
 
         Assert.assertNotEquals("true",
-                grid.getAttribute("columnReorderingAllowed"));
+                grid.getDomProperty("columnReorderingAllowed"));
 
         WebElement toggleUserReordering = findElement(
                 By.id("toggle-user-reordering"));
         clickElementWithJs(toggleUserReordering);
         Assert.assertEquals("true",
-                grid.getAttribute("columnReorderingAllowed"));
+                grid.getDomProperty("columnReorderingAllowed"));
         clickElementWithJs(toggleUserReordering);
         Assert.assertNotEquals("true",
-                grid.getAttribute("columnReorderingAllowed"));
+                grid.getDomProperty("columnReorderingAllowed"));
 
         String frozenStatusScript = "return arguments[0].frozen";
         assertFrozenColumn(grid, frozenStatusScript, "toggle-id-column-frozen",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java
@@ -60,7 +60,7 @@ public class GridViewEditorIT extends AbstractComponentIT {
         TestBenchElement subscriberCheckbox = subscriberCell
                 .$("vaadin-checkbox").first();
         boolean isSubscriber = subscriberCheckbox
-                .getAttribute("checked") != null;
+                .getDomAttribute("checked") != null;
 
         TestBenchElement nameField = nameCell.$("vaadin-text-field").first();
 
@@ -232,14 +232,14 @@ public class GridViewEditorIT extends AbstractComponentIT {
                 .getCell(grid.getAllColumns().get(2)).$("vaadin-button")
                 .first();
         Assert.assertEquals(Boolean.TRUE.toString(),
-                nextEditButton.getAttribute("disabled"));
+                nextEditButton.getDomAttribute("disabled"));
 
         GridTHTDElement subscriberCell = row.getCell(subscriberColumn);
 
         TestBenchElement subscriberCheckbox = subscriberCell
                 .$("vaadin-checkbox").first();
         boolean isSubscriber = subscriberCheckbox
-                .getAttribute("checked") != null;
+                .getDomAttribute("checked") != null;
 
         // Write valid name.
         TestBenchElement nameField = nameCell.$("vaadin-text-field").first();
@@ -296,7 +296,7 @@ public class GridViewEditorIT extends AbstractComponentIT {
         WebElement nextEditButton = grid.getRow(1).getCell(editColumn)
                 .$("vaadin-button").first();
         Assert.assertEquals(Boolean.TRUE.toString(),
-                nextEditButton.getAttribute("disabled"));
+                nextEditButton.getDomAttribute("disabled"));
 
         TestBenchElement nameField = nameCell.$("vaadin-text-field").first();
 
@@ -337,10 +337,10 @@ public class GridViewEditorIT extends AbstractComponentIT {
         emailInput = emailField.$("input").first();
 
         Assert.assertEquals(Boolean.TRUE.toString(),
-                emailInput.getAttribute("readonly"));
+                emailInput.getDomAttribute("readonly"));
 
         Assert.assertEquals("Not a subscriber",
-                emailInput.getAttribute("value"));
+                emailInput.getDomProperty("value"));
 
         // Switch subscriber value on
         checkbox = subscriberCell.$("vaadin-checkbox").first();
@@ -391,9 +391,9 @@ public class GridViewEditorIT extends AbstractComponentIT {
 
         TestBenchElement emailField = row.getCell(grid.getAllColumns().get(2))
                 .$("vaadin-text-field").first();
-        Assert.assertNotNull(emailField.getAttribute("focused"));
+        Assert.assertNotNull(emailField.getDomAttribute("focused"));
         Assert.assertEquals("Not a subscriber",
-                emailField.getAttribute("value"));
+                emailField.getDomProperty("value"));
 
         subscriberCell.$("vaadin-checkbox").first().click();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewHeaderAndFooterRowsIT.java
@@ -115,6 +115,7 @@ public class GridViewHeaderAndFooterRowsIT extends AbstractComponentIT {
         return cells.stream()
                 .map(cell -> cell.findElements(By.tagName(componentTag)))
                 .filter(list -> !list.isEmpty()).map(list -> list.get(0))
-                .anyMatch(cell -> text.equals(cell.getAttribute("innerHTML")));
+                .anyMatch(
+                        cell -> text.equals(cell.getDomProperty("innerHTML")));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
@@ -79,16 +79,16 @@ public class GridViewSelectionIT extends AbstractComponentIT {
         // deselect 1
         getCellContent(grid.getCell(0, 0)).click();
         Assert.assertEquals("Select all should be checked", "true",
-                selectAllCheckbox.getAttribute("checked"));
+                selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertEquals("Select all should be indeterminate", "true",
-                selectAllCheckbox.getAttribute("indeterminate"));
+                selectAllCheckbox.getDomAttribute("indeterminate"));
 
         // reselect 1
         getCellContent(grid.getCell(0, 0)).click();
         Assert.assertEquals("Select all should be checked", "true",
-                selectAllCheckbox.getAttribute("checked"));
+                selectAllCheckbox.getDomAttribute("checked"));
         Assert.assertNull("Select all should not be indeterminate",
-                selectAllCheckbox.getAttribute("indeterminate"));
+                selectAllCheckbox.getDomAttribute("indeterminate"));
     }
 
     /**
@@ -126,18 +126,18 @@ public class GridViewSelectionIT extends AbstractComponentIT {
         TestBenchElement table = grid.$("table").first();
         // table should have aria-multiselectable set to true
         Assert.assertTrue(Boolean
-                .parseBoolean(table.getAttribute("aria-multiselectable")));
+                .parseBoolean(table.getDomAttribute("aria-multiselectable")));
 
         Assert.assertTrue(Boolean
-                .parseBoolean(grid.getRow(0).getAttribute("aria-selected")));
+                .parseBoolean(grid.getRow(0).getDomAttribute("aria-selected")));
         Assert.assertTrue(Boolean
-                .parseBoolean(grid.getRow(1).getAttribute("aria-selected")));
+                .parseBoolean(grid.getRow(1).getDomAttribute("aria-selected")));
         Assert.assertFalse(Boolean
-                .parseBoolean(grid.getRow(2).getAttribute("aria-selected")));
+                .parseBoolean(grid.getRow(2).getDomAttribute("aria-selected")));
 
         grid.select(2);
         Assert.assertTrue(Boolean
-                .parseBoolean(grid.getRow(2).getAttribute("aria-selected")));
+                .parseBoolean(grid.getRow(2).getDomAttribute("aria-selected")));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -147,7 +147,7 @@ public class GridViewSortingIT extends AbstractComponentIT {
 
         WebElement sorter = grid.getHeaderCell(0).$("vaadin-grid-sorter")
                 .first();
-        Assert.assertNull(sorter.getAttribute("direction"));
+        Assert.assertNull(sorter.getDomProperty("direction"));
     }
 
     @Test
@@ -249,7 +249,7 @@ public class GridViewSortingIT extends AbstractComponentIT {
             String directionValue = direction == SortDirection.ASCENDING ? "asc"
                     : "desc";
             Assert.assertEquals(directionValue,
-                    columnSorter.getAttribute("direction"));
+                    columnSorter.getDomProperty("direction"));
 
             // Check order part displays correct order value
             String orderValue = String

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewUsingComponentsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewUsingComponentsIT.java
@@ -123,7 +123,8 @@ public class GridViewUsingComponentsIT extends AbstractComponentIT {
         return cells.stream()
                 .map(cell -> cell.findElements(By.tagName(componentTag)))
                 .filter(list -> !list.isEmpty()).map(list -> list.get(0))
-                .anyMatch(cell -> text.equals(cell.getAttribute("innerHTML")));
+                .anyMatch(
+                        cell -> text.equals(cell.getDomProperty("innerHTML")));
     }
 
     private void assertComponentRendereredDetails(WebElement grid, int rowIndex,
@@ -144,7 +145,7 @@ public class GridViewUsingComponentsIT extends AbstractComponentIT {
 
         Pattern pattern = Pattern.compile("<span>Name:\\s?([\\w\\s]*)</span>");
         Matcher innerHTML = pattern
-                .matcher(layouts.get(0).getAttribute("innerHTML"));
+                .matcher(layouts.get(0).getDomProperty("innerHTML"));
         Assert.assertTrue(
                 "No result found for " + pattern.toString()
                         + " when searching for name: " + personName,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridWithTemplateIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridWithTemplateIT.java
@@ -161,19 +161,19 @@ public class GridWithTemplateIT extends AbstractComponentIT {
 
         Assert.assertEquals(
                 "The flexGrow property should be 2 on the first column", "2",
-                columns.get(0).getAttribute("flexGrow"));
+                columns.get(0).getDomProperty("flexGrow"));
         Assert.assertEquals(
                 "The flexGrow property should be 0 on the second column", "0",
-                columns.get(1).getAttribute("flexGrow"));
+                columns.get(1).getDomProperty("flexGrow"));
         Assert.assertEquals(
                 "The width property should be 20px on the second column",
-                "20px", columns.get(1).getAttribute("width"));
+                "20px", columns.get(1).getDomProperty("width"));
         Assert.assertEquals(
                 "The frozen property should be true on the third column",
-                "true", columns.get(2).getAttribute("frozen"));
+                "true", columns.get(2).getDomProperty("frozen"));
         Assert.assertEquals(
                 "The resizable property should be true on the third column",
-                "true", columns.get(2).getAttribute("resizable"));
+                "true", columns.get(2).getDomProperty("resizable"));
     }
 
     private void clickOnTheButtonInsideTheTestTemplate(TestBenchElement grid,
@@ -197,9 +197,8 @@ public class GridWithTemplateIT extends AbstractComponentIT {
     private TestBenchElement findTestTemplateElement(TestBenchElement grid,
             String id) {
         TestBenchElement list = grid.$("*").id(id);
-        Assert.assertNotNull(
-                "Could not find the <test-template> of id '" + id
-                        + "' inside the grid '" + grid.getAttribute("id") + "'",
+        Assert.assertNotNull("Could not find the <test-template> of id '" + id
+                + "' inside the grid '" + grid.getDomAttribute("id") + "'",
                 list);
         return list;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HiddenEditorButtonsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HiddenEditorButtonsIT.java
@@ -45,21 +45,21 @@ public class HiddenEditorButtonsIT extends AbstractComponentIT {
     @Test
     public void editItem_buttonsAreShown_confirmEdit_buttonsAreHidden() {
         TestBenchElement editButton = grid.findElement(By.id("edit-1"));
-        Assert.assertNull(editButton.getAttribute("hidden"));
+        Assert.assertNull(editButton.getDomAttribute("hidden"));
         editButton.click();
 
         waitForElementPresent(By.id("editor"));
 
-        Assert.assertEquals("true", editButton.getAttribute("hidden"));
+        Assert.assertEquals("true", editButton.getDomAttribute("hidden"));
         waitForElementPresent(By.id("save-1"));
         waitForElementPresent(By.id("cancel-1"));
 
         TestBenchElement editor = grid.findElement(By.id("editor"));
         editor.sendKeys("234");
         TestBenchElement saveButton = grid.findElement(By.id("save-1"));
-        Assert.assertNull(saveButton.getAttribute("hidden"));
+        Assert.assertNull(saveButton.getDomAttribute("hidden"));
         TestBenchElement cancelButton = grid.findElement(By.id("cancel-1"));
-        Assert.assertNull(cancelButton.getAttribute("hidden"));
+        Assert.assertNull(cancelButton.getDomAttribute("hidden"));
         saveButton.click();
 
         waitForElementNotPresent(By.id("editor"));
@@ -67,18 +67,18 @@ public class HiddenEditorButtonsIT extends AbstractComponentIT {
         editButton = grid.findElement(By.id("edit-1"));
         waitForElementNotPresent(By.id("save-1"));
         waitForElementNotPresent(By.id("cancel-1"));
-        Assert.assertNull(editButton.getAttribute("hidden"));
+        Assert.assertNull(editButton.getDomAttribute("hidden"));
     }
 
     @Test
     public void editItem_scrollAway_scrollBack_buttonsAreStillVisible() {
         TestBenchElement editButton = grid.findElement(By.id("edit-1"));
-        Assert.assertNull(editButton.getAttribute("hidden"));
+        Assert.assertNull(editButton.getDomAttribute("hidden"));
         editButton.click();
 
         waitForElementPresent(By.id("editor"));
 
-        Assert.assertEquals("true", editButton.getAttribute("hidden"));
+        Assert.assertEquals("true", editButton.getDomAttribute("hidden"));
         waitForElementPresent(By.id("save-1"));
         waitForElementPresent(By.id("cancel-1"));
 
@@ -90,30 +90,30 @@ public class HiddenEditorButtonsIT extends AbstractComponentIT {
         waitForElementPresent(By.id("editor"));
 
         TestBenchElement saveButton = grid.findElement(By.id("save-1"));
-        Assert.assertNull(saveButton.getAttribute("hidden"));
+        Assert.assertNull(saveButton.getDomAttribute("hidden"));
         TestBenchElement cancelButton = grid.findElement(By.id("cancel-1"));
-        Assert.assertNull(cancelButton.getAttribute("hidden"));
+        Assert.assertNull(cancelButton.getDomAttribute("hidden"));
     }
 
     @Test
     public void editItem_scrollAway_editAnotherItem_scrollBack_buttonsAreHidden() {
         TestBenchElement editButton = grid.findElement(By.id("edit-1"));
-        Assert.assertNull(editButton.getAttribute("hidden"));
+        Assert.assertNull(editButton.getDomAttribute("hidden"));
         editButton.click();
 
         waitForElementPresent(By.id("editor"));
 
-        Assert.assertEquals("true", editButton.getAttribute("hidden"));
+        Assert.assertEquals("true", editButton.getDomAttribute("hidden"));
         waitForElementPresent(By.id("save-1"));
         waitForElementPresent(By.id("cancel-1"));
 
         grid.scrollToRow(1000);
         waitForElementPresent(By.id("edit-1000"));
         editButton = grid.findElement(By.id("edit-1000"));
-        Assert.assertNull(editButton.getAttribute("hidden"));
+        Assert.assertNull(editButton.getDomAttribute("hidden"));
         editButton.click();
 
-        Assert.assertEquals("true", editButton.getAttribute("hidden"));
+        Assert.assertEquals("true", editButton.getDomAttribute("hidden"));
         waitForElementPresent(By.id("save-1000"));
         waitForElementPresent(By.id("cancel-1000"));
 
@@ -124,7 +124,7 @@ public class HiddenEditorButtonsIT extends AbstractComponentIT {
         waitForElementNotPresent(By.id("editor"));
 
         editButton = grid.findElement(By.id("edit-1"));
-        Assert.assertNull(editButton.getAttribute("hidden"));
+        Assert.assertNull(editButton.getDomAttribute("hidden"));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -64,7 +64,7 @@ public class SortingIT extends AbstractComponentIT {
 
         GridElement hiddenGrid = $(GridElement.class).id("hidden-grid");
 
-        waitUntil(driver -> "false".equals(hiddenGrid.getAttribute("loading")));
+        waitUntil(driver -> !hiddenGrid.hasAttribute("loading"));
 
         Assert.assertEquals("B", hiddenGrid.getCell(0, 0).getText());
         Assert.assertEquals("A", hiddenGrid.getCell(1, 0).getText());
@@ -83,9 +83,9 @@ public class SortingIT extends AbstractComponentIT {
         findElement(By.id("sort-by-age")).click();
         List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter").all();
         Assert.assertEquals("Sort by Name",
-                sorters.get(0).getAttribute("aria-label"));
+                sorters.get(0).getDomAttribute("aria-label"));
         Assert.assertEquals("Sort by Age",
-                sorters.get(1).getAttribute("aria-label"));
+                sorters.get(1).getDomAttribute("aria-label"));
     }
 
     @Test
@@ -144,17 +144,17 @@ public class SortingIT extends AbstractComponentIT {
         Assert.assertEquals("asc",
                 sortingGridElement
                         .findElements(By.tagName("vaadin-grid-sorter")).get(0)
-                        .getAttribute("direction"));
+                        .getDomProperty("direction"));
         String sortStateNumberNameColumn = sortingGridElement
                 .findElements(By.tagName("vaadin-grid-sorter")).get(0)
-                .getAttribute("_order");
+                .getDomProperty("_order");
         Assert.assertEquals("asc",
                 sortingGridElement
                         .findElements(By.tagName("vaadin-grid-sorter")).get(1)
-                        .getAttribute("direction"));
+                        .getDomProperty("direction"));
         String sortStateNumberAgeColumn = sortingGridElement
                 .findElements(By.tagName("vaadin-grid-sorter")).get(1)
-                .getAttribute("_order");
+                .getDomProperty("_order");
         // Detach
         btnRemove.click();
         // Reattach
@@ -165,20 +165,20 @@ public class SortingIT extends AbstractComponentIT {
         Assert.assertEquals("asc",
                 sortingGridElement
                         .findElements(By.tagName("vaadin-grid-sorter")).get(0)
-                        .getAttribute("direction"));
+                        .getDomProperty("direction"));
 
         Assert.assertEquals("asc",
                 sortingGridElement
                         .findElements(By.tagName("vaadin-grid-sorter")).get(1)
-                        .getAttribute("direction"));
+                        .getDomProperty("direction"));
 
         String sortStateNumberAgeColumnAfterDetach = sortingGridElement
                 .findElements(By.tagName("vaadin-grid-sorter")).get(1)
-                .getAttribute("_order");
+                .getDomProperty("_order");
 
         String sortStateNumberNameColumnAfterDetach = sortingGridElement
                 .findElements(By.tagName("vaadin-grid-sorter")).get(0)
-                .getAttribute("_order");
+                .getDomProperty("_order");
         String textAgeColumnAfterReattch = sortingGridElement.getCell(0, 1)
                 .getText();
         Assert.assertEquals(textAgeColumnBeforeReattch,
@@ -197,7 +197,7 @@ public class SortingIT extends AbstractComponentIT {
                 1, sorters.size());
         TestBenchElement sorter = sorters.get(0);
         Assert.assertEquals("Expected ascending sort order.", "asc",
-                sorter.getAttribute("direction"));
+                sorter.getDomProperty("direction"));
         Assert.assertTrue(sorter.getText().startsWith(expectedColumnHeader));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/TextRendererIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/TextRendererIT.java
@@ -41,7 +41,7 @@ public class TextRendererIT extends AbstractComponentIT {
 
         // self check: click is handled with a result on the client side
         String classNames = findElement(By.tagName("vaadin-grid"))
-                .getAttribute("class");
+                .getDomAttribute("class");
         Assert.assertThat(classNames, CoreMatchers.containsString("refreshed"));
 
         Set<String> cellsAfterRefresh = findElements(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/UpdateEditorComponentIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/UpdateEditorComponentIT.java
@@ -46,7 +46,7 @@ public class UpdateEditorComponentIT extends AbstractComponentIT {
 
         TestBenchElement textField = nameCell.$("vaadin-text-field").first()
                 .$("input").first();
-        Assert.assertEquals("foo", textField.getAttribute("value"));
+        Assert.assertEquals("foo", textField.getDomProperty("value"));
 
         // close the editor via clicking another cell
         grid.getRow(1).click(10, 10);
@@ -59,6 +59,6 @@ public class UpdateEditorComponentIT extends AbstractComponentIT {
         // Now it should be a text area component
         TestBenchElement textArea = nameCell.$("vaadin-text-area").first()
                 .$("textarea").first();
-        Assert.assertEquals("foo", textArea.getAttribute("value"));
+        Assert.assertEquals("foo", textArea.getDomProperty("value"));
     }
 }

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/src/test/java/com/vaadin/flow/component/icon/tests/IconIT.java
@@ -102,7 +102,7 @@ public class IconIT extends AbstractComponentIT {
     private void assertIconProperty(WebElement icon, String collection,
             String iconName) {
         Assert.assertEquals(collection + ":" + iconName,
-                icon.getAttribute("icon"));
+                icon.getDomAttribute("icon"));
     }
 
     private void assertCssValue(WebElement element, String propertyName,

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxIT.java
@@ -129,8 +129,8 @@ public class ListBoxIT extends AbstractComponentIT {
     }
 
     private void assertItem(WebElement item, String itemName) {
-        Assert.assertEquals("Items should be enabled in the beginning", null,
-                item.getAttribute("disabled"));
+        Assert.assertNull("Items should be enabled in the beginning",
+                item.getDomAttribute("disabled"));
 
         List<WebElement> labels = item.findElements(By.tagName("label"));
         String nameText = labels.get(0).getText();
@@ -156,7 +156,7 @@ public class ListBoxIT extends AbstractComponentIT {
 
         Assert.assertEquals(
                 "Item should be disabled after clicking the button enough times",
-                "true", item.getAttribute("disabled"));
+                "true", item.getDomAttribute("disabled"));
     }
 
     @Test

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayClassNameIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayClassNameIT.java
@@ -96,11 +96,11 @@ public class OverlayClassNameIT extends AbstractComponentIT {
 
     private void assertClassAttribute(LoginOverlayElement overlay,
             String expected) {
-        String className = overlay.getAttribute("class");
+        String className = overlay.getDomAttribute("class");
         Assert.assertEquals(expected, className);
 
         WebElement wrappedElement = overlay.getLoginOverlayWrapper();
-        String cardClassName = wrappedElement.getAttribute("class");
+        String cardClassName = wrappedElement.getDomAttribute("class");
         Assert.assertEquals(expected, cardClassName);
     }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
@@ -100,7 +100,7 @@ public class OverlayIT extends AbstractLoginIT {
 
         title = loginOverlay.getTitleComponent();
         Assert.assertEquals("vaadin:vaadin-h",
-                title.$("vaadin-icon").first().getAttribute("icon"));
+                title.$("vaadin-icon").first().getDomAttribute("icon"));
 
         Assert.assertEquals("Component title", title.$("h3").first().getText());
 

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/src/test/java/com/vaadin/flow/theme/lumo/ExplicitLumoTemplateIT.java
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/src/test/java/com/vaadin/flow/theme/lumo/ExplicitLumoTemplateIT.java
@@ -30,7 +30,7 @@ public class ExplicitLumoTemplateIT extends AbstractThemedTemplateIT {
         open();
 
         WebElement html = findElement(By.tagName("html"));
-        Assert.assertEquals(Lumo.DARK, html.getAttribute("theme"));
+        Assert.assertEquals(Lumo.DARK, html.getDomAttribute("theme"));
     }
 
     @Override

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.menubar.tests;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -383,12 +384,12 @@ public class MenuBarPageIT extends AbstractComponentIT {
         TestBenchElement overflowButton = menuBar.getOverflowButton();
 
         Assert.assertEquals("More options",
-                overflowButton.getAttribute("aria-label"));
+                overflowButton.getDomAttribute("aria-label"));
 
         click("set-i18n");
 
         Assert.assertEquals("more-options",
-                overflowButton.getAttribute("aria-label"));
+                overflowButton.getDomAttribute("aria-label"));
     }
 
     @Test
@@ -400,7 +401,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         TestBenchElement overflowButton = menuBar.getOverflowButton();
 
         Assert.assertEquals("more-options",
-                overflowButton.getAttribute("aria-label"));
+                overflowButton.getDomAttribute("aria-label"));
 
         click("toggle-attached");
         click("toggle-attached");
@@ -409,7 +410,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         overflowButton = menuBar.getOverflowButton();
 
         Assert.assertEquals("more-options",
-                overflowButton.getAttribute("aria-label"));
+                overflowButton.getDomAttribute("aria-label"));
     }
 
     @Test
@@ -424,7 +425,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void toggleMenuBarTheme_themeIsToggled() {
         Assert.assertFalse(menuBar.hasAttribute("theme"));
         click("toggle-theme");
-        Assert.assertEquals(menuBar.getAttribute("theme"),
+        Assert.assertEquals(menuBar.getDomAttribute("theme"),
                 MenuBarTestPage.MENU_BAR_THEME);
         click("toggle-theme");
         Assert.assertFalse(menuBar.hasAttribute("theme"));
@@ -436,7 +437,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         Assert.assertFalse(menuButton1.hasAttribute("theme"));
         click("toggle-item-1-theme");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("theme"),
+        Assert.assertEquals(menuButton1.getDomAttribute("theme"),
                 MenuBarTestPage.MENU_ITEM_THEME);
         click("toggle-item-1-theme");
         menuButton1 = menuBar.getButtons().get(0);
@@ -449,11 +450,11 @@ public class MenuBarPageIT extends AbstractComponentIT {
         Assert.assertFalse(menuButton1.hasAttribute("class"));
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME);
+        Assert.assertEquals(Set.of(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME),
+                menuButton1.getClassNames());
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertFalse(menuButton1.hasAttribute("class"));
+        Assert.assertEquals(Set.of(), menuButton1.getClassNames());
     }
 
     @Test
@@ -462,12 +463,12 @@ public class MenuBarPageIT extends AbstractComponentIT {
         Assert.assertFalse(menuButton1.hasAttribute("class"));
         click("toggle-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME);
+        Assert.assertEquals(Set.of(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME),
+                menuButton1.getClassNames());
         click("set-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME);
+        Assert.assertEquals(Set.of(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME),
+                menuButton1.getClassNames());
     }
 
     @Test
@@ -476,11 +477,11 @@ public class MenuBarPageIT extends AbstractComponentIT {
         Assert.assertFalse(menuButton1.hasAttribute("class"));
         click("set-unset-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME);
+        Assert.assertEquals(Set.of(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME),
+                menuButton1.getClassNames());
         click("set-unset-item1-class-name");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertFalse(menuButton1.hasAttribute("class"));
+        Assert.assertEquals(Set.of(), menuButton1.getClassNames());
     }
 
     @Test
@@ -489,16 +490,13 @@ public class MenuBarPageIT extends AbstractComponentIT {
         Assert.assertFalse(menuButton1.hasAttribute("class"));
         click("add-remove-multiple-classes");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertTrue(menuButton1.getAttribute("class")
-                .contains(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME));
-        Assert.assertTrue(menuButton1.getAttribute("class")
-                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
+        Assert.assertEquals(
+                Set.of(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME,
+                        MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME),
+                menuButton1.getClassNames());
         click("add-remove-multiple-classes");
         menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertFalse(menuButton1.getAttribute("class")
-                .contains(MenuBarTestPage.MENU_ITEM_FIRST_CLASS_NAME));
-        Assert.assertFalse(menuButton1.getAttribute("class")
-                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
+        Assert.assertEquals(Set.of(), menuButton1.getClassNames());
     }
 
     @Test
@@ -568,8 +566,8 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("change-item2-class-name");
         menuBar.getOverflowButton().click();
         TestBenchElement menuItem = menuBar.getSubMenuItems().get(0);
-        Assert.assertEquals(menuItem.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME);
+        Assert.assertEquals(Set.of(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME),
+                menuItem.getClassNames());
     }
 
     @Test
@@ -582,8 +580,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         menuBar.getOverflowButton().click();
         TestBenchElement menuItem = menuBar.getSubMenuItems().get(0);
 
-        Assert.assertFalse(menuItem.getAttribute("class")
-                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
+        Assert.assertEquals(Set.of(), menuItem.getClassNames());
     }
 
     @Test
@@ -596,13 +593,12 @@ public class MenuBarPageIT extends AbstractComponentIT {
         waitForResizeObserver();
         click("change-item2-class-name");
         TestBenchElement menuItem = menuBar.getButtons().get(1);
-        Assert.assertEquals(menuItem.getAttribute("class"),
-                MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME);
+        Assert.assertEquals(Set.of(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME),
+                menuItem.getClassNames());
 
         click("remove-item2-class-name");
         menuItem = menuBar.getButtons().get(1);
-        Assert.assertFalse(menuItem.getAttribute("class")
-                .contains(MenuBarTestPage.MENU_ITEM_SECOND_CLASS_NAME));
+        Assert.assertEquals(Set.of(), menuItem.getClassNames());
     }
 
     @Test
@@ -611,7 +607,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("toggle-item-1-visibility");
         click("toggle-item-1-visibility");
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
-        Assert.assertEquals(menuButton1.getAttribute("theme"),
+        Assert.assertEquals(menuButton1.getDomAttribute("theme"),
                 MenuBarTestPage.MENU_ITEM_THEME);
     }
 
@@ -636,7 +632,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
         menuBar.getButtons().get(0).click();
         Assert.assertEquals(
-                menuBar.getSubMenuItems().get(1).getAttribute("theme"),
+                menuBar.getSubMenuItems().get(1).getDomAttribute("theme"),
                 MenuBarTestPage.SUB_ITEM_THEME);
 
         click("toggle-sub-theme");
@@ -654,7 +650,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
         TestBenchElement menuButton1 = menuBar.getButtons().get(0);
         Assert.assertEquals(MenuBarTestPage.MENU_ITEM_THEME,
-                menuButton1.getAttribute("theme"));
+                menuButton1.getDomAttribute("theme"));
     }
 
     @After
@@ -674,7 +670,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     private void assertButtonContents(String... expectedInnerHTML) {
         String[] contents = menuBar.getButtons().stream().map(button -> button
-                .$("vaadin-menu-bar-item").first().getAttribute("innerHTML"))
+                .$("vaadin-menu-bar-item").first().getDomProperty("innerHTML"))
                 .toArray(String[]::new);
         Assert.assertArrayEquals(expectedInnerHTML, contents);
     }
@@ -716,7 +712,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     private String[] getOverlayMenuItemContents(
             List<TestBenchElement> menuItems) {
-        return menuItems.stream().map(item -> item.getAttribute("innerHTML"))
+        return menuItems.stream().map(item -> item.getDomProperty("innerHTML"))
                 .toArray(String[]::new);
     }
 
@@ -746,7 +742,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         openSubSubMenu();
         verifyOpened();
         TestBenchElement subMenuItem = menuBar.getSubMenuItems().get(2);
-        var subMenuItemClassNames = subMenuItem.getAttribute("class");
+        var subMenuItemClassNames = subMenuItem.getClassNames();
         for (String className : classNames) {
             if (containsClassNames) {
                 Assert.assertTrue(subMenuItemClassNames.contains(className));

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.messages.tests;
 import static org.hamcrest.CoreMatchers.startsWith;
 
 import java.util.List;
+import java.util.Set;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -103,12 +104,12 @@ public class MessageListIT extends AbstractComponentIT {
 
         clickElementWithJs("addClassNames");
         Assert.assertEquals("Unexpected class name after adding class names",
-                "urgent pinned",
-                getFirstMessage(messageList).getAttribute("class"));
+                Set.of("urgent", "pinned"),
+                getFirstMessage(messageList).getClassNames());
 
         clickElementWithJs("removeClassNames");
         Assert.assertEquals("Unexpected class name after removing class names",
-                "pinned", getFirstMessage(messageList).getAttribute("class"));
+                Set.of("pinned"), getFirstMessage(messageList).getClassNames());
     }
 
     @Test

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationWithClassNamesIT.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.notification.tests;
 
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +56,7 @@ public class NotificationWithClassNamesIT extends AbstractComponentIT {
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
         NotificationElement notification = $(NotificationElement.class).first();
-        assertClassAttribute(notification, "custom");
+        assertClassAttribute(notification, Set.of("custom"));
     }
 
     @Test
@@ -65,7 +67,7 @@ public class NotificationWithClassNamesIT extends AbstractComponentIT {
         addClassName.click();
 
         NotificationElement notification = $(NotificationElement.class).first();
-        assertClassAttribute(notification, "custom added");
+        assertClassAttribute(notification, Set.of("custom", "added"));
     }
 
     @Test
@@ -77,7 +79,7 @@ public class NotificationWithClassNamesIT extends AbstractComponentIT {
         clearClassNames.click();
 
         NotificationElement notification = $(NotificationElement.class).first();
-        assertClassAttribute(notification, "");
+        assertClassAttribute(notification, Set.of());
     }
 
     @Test
@@ -95,7 +97,7 @@ public class NotificationWithClassNamesIT extends AbstractComponentIT {
         waitForElementPresent(By.tagName(NOTIFICATION_CARD));
 
         NotificationElement notification = $(NotificationElement.class).first();
-        assertClassAttribute(notification, "added");
+        assertClassAttribute(notification, Set.of("added"));
     }
 
     @Test
@@ -112,20 +114,18 @@ public class NotificationWithClassNamesIT extends AbstractComponentIT {
         addClassName.click();
 
         NotificationElement notification = $(NotificationElement.class).first();
-        assertClassAttribute(notification, "custom added");
+        assertClassAttribute(notification, Set.of("custom", "added"));
 
         NotificationElement otherNotification = $(NotificationElement.class)
                 .get(1);
-        assertClassAttribute(otherNotification, "other");
+        assertClassAttribute(otherNotification, Set.of("other"));
     }
 
     private void assertClassAttribute(TestBenchElement notification,
-            String expected) {
-        String className = notification.getAttribute("class");
-        Assert.assertEquals(expected, className);
+            Set<String> expected) {
+        Assert.assertEquals(expected, notification.getClassNames());
 
         TestBenchElement card = (TestBenchElement) notification.getContext();
-        String cardClassName = card.getAttribute("class");
-        Assert.assertEquals(expected, cardClassName);
+        Assert.assertEquals(expected, card.getClassNames());
     }
 }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/orderedlayout/tests/HorizontalLayoutViewIT.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/orderedlayout/tests/HorizontalLayoutViewIT.java
@@ -44,17 +44,17 @@ public class HorizontalLayoutViewIT extends AbstractComponentIT {
 
         Assert.assertTrue(
                 "By default layout should contain spacing theme in 'theme' attribute",
-                hLayout.getAttribute("theme").contains("spacing"));
+                hLayout.getDomAttribute("theme").contains("spacing"));
         Assert.assertTrue(
                 "By default layout should contain margin theme in 'theme' attribute",
-                hLayout.getAttribute("theme").contains("margin"));
+                hLayout.getDomAttribute("theme").contains("margin"));
 
         checkThemeChanges(hLayout, "spacing", false);
         checkThemeChanges(hLayout, "margin", false);
 
         Assert.assertNull(
                 "After turning off spacing and margin, layout should not contain 'theme' attribute",
-                hLayout.getAttribute("theme"));
+                hLayout.getDomAttribute("theme"));
 
         checkThemeChanges(hLayout, "padding", true);
         checkThemeChanges(hLayout, "margin", true);
@@ -64,7 +64,7 @@ public class HorizontalLayoutViewIT extends AbstractComponentIT {
 
         Assert.assertNull(
                 "After turning off everything, layout should not contain 'theme' attribute",
-                hLayout.getAttribute("theme"));
+                hLayout.getDomAttribute("theme"));
     }
 
     @Test
@@ -200,11 +200,12 @@ public class HorizontalLayoutViewIT extends AbstractComponentIT {
             boolean shouldPresent) {
         findElement(By.id(String.format("toggle-%s", themeName))).click();
         if (shouldPresent) {
-            waitUntil(dr -> layoutToCheck.getAttribute("theme") != null
-                    && layoutToCheck.getAttribute("theme").contains(themeName));
+            waitUntil(dr -> layoutToCheck.getDomAttribute("theme") != null
+                    && layoutToCheck.getDomAttribute("theme")
+                            .contains(themeName));
         } else {
-            waitUntil(dr -> layoutToCheck.getAttribute("theme") == null
-                    || !layoutToCheck.getAttribute("theme")
+            waitUntil(dr -> layoutToCheck.getDomAttribute("theme") == null
+                    || !layoutToCheck.getDomAttribute("theme")
                             .contains(themeName));
         }
     }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/orderedlayout/tests/OrderedLayoutIT.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/orderedlayout/tests/OrderedLayoutIT.java
@@ -77,11 +77,12 @@ public class OrderedLayoutIT extends AbstractComponentIT {
         layoutToCheck.findElement(By.id(String.format("toggle-%s", themeName)))
                 .click();
         if (shouldPresent) {
-            waitUntil(dr -> layoutToCheck.getAttribute("theme") != null
-                    && layoutToCheck.getAttribute("theme").contains(themeName));
+            waitUntil(dr -> layoutToCheck.getDomAttribute("theme") != null
+                    && layoutToCheck.getDomAttribute("theme")
+                            .contains(themeName));
         } else {
-            waitUntil(dr -> layoutToCheck.getAttribute("theme") == null
-                    || !layoutToCheck.getAttribute("theme")
+            waitUntil(dr -> layoutToCheck.getDomAttribute("theme") == null
+                    || !layoutToCheck.getDomAttribute("theme")
                             .contains(themeName));
         }
     }

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/orderedlayout/tests/VerticalLayoutViewIT.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/orderedlayout/tests/VerticalLayoutViewIT.java
@@ -44,17 +44,17 @@ public class VerticalLayoutViewIT extends AbstractComponentIT {
 
         Assert.assertTrue(
                 "By default layout should contain spacing theme in 'theme' attribute",
-                vlayout.getAttribute("theme").contains("spacing"));
+                vlayout.getDomAttribute("theme").contains("spacing"));
         Assert.assertTrue(
                 "By default layout should contain margin theme in 'theme' attribute",
-                vlayout.getAttribute("theme").contains("margin"));
+                vlayout.getDomAttribute("theme").contains("margin"));
 
         checkThemeChanges(vlayout, "spacing", false);
         checkThemeChanges(vlayout, "margin", false);
 
         Assert.assertNull(
                 "After turning off spacing and padding, layout should not contain 'theme' attribute",
-                vlayout.getAttribute("theme"));
+                vlayout.getDomAttribute("theme"));
 
         checkThemeChanges(vlayout, "margin", true);
 
@@ -62,7 +62,7 @@ public class VerticalLayoutViewIT extends AbstractComponentIT {
 
         Assert.assertNull(
                 "After turning off everything, layout should not contain 'theme' attribute",
-                vlayout.getAttribute("theme"));
+                vlayout.getDomAttribute("theme"));
     }
 
     @Test
@@ -197,11 +197,12 @@ public class VerticalLayoutViewIT extends AbstractComponentIT {
         findElement(By.id(String.format("toggle-vertical-%s", themeName)))
                 .click();
         if (shouldPresent) {
-            waitUntil(dr -> layoutToCheck.getAttribute("theme") != null
-                    && layoutToCheck.getAttribute("theme").contains(themeName));
+            waitUntil(dr -> layoutToCheck.getDomAttribute("theme") != null
+                    && layoutToCheck.getDomAttribute("theme")
+                            .contains(themeName));
         } else {
-            waitUntil(dr -> layoutToCheck.getAttribute("theme") == null
-                    || !layoutToCheck.getAttribute("theme")
+            waitUntil(dr -> layoutToCheck.getDomAttribute("theme") == null
+                    || !layoutToCheck.getDomAttribute("theme")
                             .contains(themeName));
         }
     }

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarIT.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarIT.java
@@ -59,13 +59,13 @@ public class ProgressBarIT extends AbstractComponentIT {
         scrollToElement(progressBar);
 
         Assert.assertEquals(ProgressBarVariant.LUMO_ERROR.getVariantName(),
-                progressBar.getAttribute("theme"));
+                progressBar.getDomAttribute("theme"));
 
         findElement(By.id("remove-theme-variant-button")).click();
-        Assert.assertNull(progressBar.getAttribute("theme"));
+        Assert.assertNull(progressBar.getDomAttribute("theme"));
     }
 
     private String valueOf(WebElement progressBar) {
-        return progressBar.getAttribute("value");
+        return progressBar.getDomProperty("value");
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPageIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/DisabledItemsPageIT.java
@@ -48,7 +48,8 @@ public class DisabledItemsPageIT extends AbstractComponentIT {
         for (WebElement button : group
                 .findElements(By.tagName("vaadin-radio-button"))) {
             Assert.assertEquals("All buttons should be disabled",
-                    Boolean.TRUE.toString(), button.getAttribute("disabled"));
+                    Boolean.TRUE.toString(),
+                    button.getDomAttribute("disabled"));
         }
     }
 
@@ -62,7 +63,7 @@ public class DisabledItemsPageIT extends AbstractComponentIT {
                 .findElements(By.tagName("vaadin-radio-button"))) {
             Assert.assertEquals("All buttons should be disabled",
                     Boolean.TRUE.toString(),
-                    radioButton.getAttribute("disabled"));
+                    radioButton.getDomAttribute("disabled"));
         }
 
         // Click button to enable items
@@ -72,9 +73,10 @@ public class DisabledItemsPageIT extends AbstractComponentIT {
         WebElement firstButton = radioButtons.get(0);
         WebElement secondButton = radioButtons.get(1);
         Assert.assertNull("First button should not be disabled",
-                firstButton.getAttribute("disabled"));
+                firstButton.getDomAttribute("disabled"));
         Assert.assertEquals("Second button should be disabled",
-                Boolean.TRUE.toString(), secondButton.getAttribute("disabled"));
+                Boolean.TRUE.toString(),
+                secondButton.getDomAttribute("disabled"));
     }
 
     @Test
@@ -91,9 +93,10 @@ public class DisabledItemsPageIT extends AbstractComponentIT {
         WebElement firstButton = radioButtons.get(0);
         WebElement secondButton = radioButtons.get(1);
         Assert.assertNull("First button should not be disabled",
-                firstButton.getAttribute("disabled"));
+                firstButton.getDomAttribute("disabled"));
         Assert.assertEquals("Second button should be disabled",
-                Boolean.TRUE.toString(), secondButton.getAttribute("disabled"));
+                Boolean.TRUE.toString(),
+                secondButton.getDomAttribute("disabled"));
     }
 
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupIT.java
@@ -75,7 +75,7 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
         WebElement group = findElement(By.id("button-group-disabled"));
 
         Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getAttribute("disabled"));
+                group.getDomAttribute("disabled"));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
         WebElement anchor = buttons.get(0).findElement(By.tagName("a"));
 
         Assert.assertEquals("http://example.com/1",
-                anchor.getAttribute("href"));
+                anchor.getDomAttribute("href"));
 
         Assert.assertEquals("Joe", anchor.getText());
 
@@ -109,7 +109,7 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
         WebElement anchor = buttons.get(2).findElement(By.tagName("img"));
 
         Assert.assertEquals("https://vaadin.com/images/vaadin-logo.svg",
-                anchor.getAttribute("src"));
+                anchor.getDomAttribute("src"));
 
         Assert.assertEquals("Bill", buttons.get(2).getText());
     }
@@ -122,7 +122,7 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
                 .findElements(By.tagName("vaadin-radio-button"));
 
         Assert.assertEquals(Boolean.TRUE.toString(),
-                buttons.get(1).getAttribute("disabled"));
+                buttons.get(1).getDomAttribute("disabled"));
 
         scrollToElement(group);
         getCommandExecutor().executeScript("window.scrollBy(0,50);");
@@ -152,9 +152,9 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
                 .findElements(By.tagName("vaadin-radio-button"));
 
         Assert.assertEquals(Boolean.TRUE.toString(),
-                buttons.get(1).getAttribute("disabled"));
+                buttons.get(1).getDomAttribute("disabled"));
         Assert.assertEquals(Boolean.TRUE.toString(),
-                group.getAttribute("readonly"));
+                group.getDomAttribute("readonly"));
 
         scrollToElement(group);
         getCommandExecutor().executeScript("window.scrollBy(0,50);");
@@ -218,10 +218,10 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
         WebElement group = findElement(By.id("button-group-theme-variant"));
         scrollToElement(group);
         Assert.assertEquals(RadioGroupVariant.LUMO_VERTICAL.getVariantName(),
-                group.getAttribute("theme"));
+                group.getDomAttribute("theme"));
 
         findElement(By.id("remove-theme-variant-button")).click();
-        Assert.assertNull(group.getAttribute("theme"));
+        Assert.assertNull(group.getDomAttribute("theme"));
     }
 
     @Test
@@ -237,7 +237,7 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
                 .getHelperComponent();
         Assert.assertEquals("helperComponent", helperComponent.getText());
         Assert.assertEquals("helper-component",
-                helperComponent.getAttribute("id"));
+                helperComponent.getDomAttribute("id"));
     }
 
     @Test
@@ -255,7 +255,7 @@ public class RadioButtonGroupIT extends AbstractComponentIT {
         WebElement helperComponent = groupWithHelperComponent
                 .getHelperComponent();
         Assert.assertEquals("helper-component",
-                helperComponent.getAttribute("id"));
+                helperComponent.getDomAttribute("id"));
 
         $(TestBenchElement.class).id("clear-helper-component-button").click();
         Assert.assertNull(groupWithHelperComponent.getHelperComponent());

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
@@ -71,7 +71,7 @@ public abstract class AbstractSelectIT extends AbstractComponentIT {
         }
 
         private void clear(TestBenchElement input) {
-            String value = input.getAttribute("value");
+            String value = input.getDomProperty("value");
             if (value.length() > 0) {
                 CharSequence[] clearSequence = new CharSequence[value.length()];
                 for (int i = 0; i < clearSequence.length; i++) {
@@ -181,7 +181,7 @@ public abstract class AbstractSelectIT extends AbstractComponentIT {
 
             Assert.assertEquals(
                     "EmptySelectionItem not selected based on value attribute",
-                    "", selectedItem.getAttribute("value"));
+                    "", selectedItem.getDomProperty("value"));
         }
 
         void valueChangeEvent(String value, String oldValue, boolean fromClient,

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutIT.java
@@ -128,10 +128,10 @@ public class SplitLayoutIT extends AbstractComponentIT {
                 By.id("split-layout-theme-variant"));
         scrollToElement(splitLayout);
         Assert.assertEquals(SplitLayoutVariant.LUMO_SMALL.getVariantName(),
-                splitLayout.getAttribute("theme"));
+                splitLayout.getDomAttribute("theme"));
 
         findElement(By.id("remove-variant-button")).click();
-        Assert.assertNull(splitLayout.getAttribute("theme"));
+        Assert.assertNull(splitLayout.getDomProperty("theme"));
     }
 
     @Element("*")

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutIT.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutIT.java
@@ -131,7 +131,7 @@ public class SplitLayoutIT extends AbstractComponentIT {
                 splitLayout.getDomAttribute("theme"));
 
         findElement(By.id("remove-variant-button")).click();
-        Assert.assertNull(splitLayout.getDomProperty("theme"));
+        Assert.assertNull(splitLayout.getDomAttribute("theme"));
     }
 
     @Element("*")

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -432,8 +432,8 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     public String getSelectionFormula() {
         final var sprElement = getSpreadsheet();
 
-        TestBenchElement selection = $("*").withClassName("sheet-selection")
-                .first();
+        TestBenchElement selection = sprElement.$("*")
+                .withClassName("sheet-selection").first();
         final Set<String> classes = selection.getClassNames();
 
         int startRow = -1;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -238,7 +239,7 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     public boolean isCellActiveWithinSelection(String address) {
         SheetCellElement cell = getSpreadsheet().getCellAt(address);
         return cell.isCellSelected()
-                && !cell.getAttribute("class").contains("cell-range");
+                && !cell.getClassNames().contains("cell-range");
     }
 
     public void clickOnColumnHeader(String columnAddress, Keys... modifiers) {
@@ -407,7 +408,7 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     }
 
     public String getAddressFieldValue() {
-        return getAddressField().getAttribute("value");
+        return getAddressField().getDomProperty("value");
     }
 
     public void setAddressFieldValue(String address) {
@@ -425,15 +426,15 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     }
 
     public String getFormulaFieldValue() {
-        return getFormulaField().getAttribute("value");
+        return getFormulaField().getDomProperty("value");
     }
 
     public String getSelectionFormula() {
         final var sprElement = getSpreadsheet();
 
-        WebElement selection = findElementInShadowRoot(
-                org.openqa.selenium.By.className("sheet-selection"));
-        final String[] classes = selection.getAttribute("class").split(" ");
+        TestBenchElement selection = $("*").withClassName("sheet-selection")
+                .first();
+        final Set<String> classes = selection.getClassNames();
 
         int startRow = -1;
         int startColumn = -1;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ChartsIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ChartsIT.java
@@ -211,7 +211,7 @@ public class ChartsIT extends AbstractSpreadsheetIT {
 
     private TestBenchElement getChartInShadowRoot(WebElement overlayElement) {
         var slot = overlayElement.findElement(By.tagName("slot"));
-        var slotName = slot.getAttribute("name");
+        var slotName = slot.getDomAttribute("name");
         var chart = getSpreadsheet().findElement(
                 By.cssSelector("[slot=\"" + slotName + "\"] vaadin-chart"));
         return chart.$(DivElement.class).first();
@@ -219,7 +219,7 @@ public class ChartsIT extends AbstractSpreadsheetIT {
 
     private TestBenchElement getMinimizeButton(WebElement overlayElement) {
         var slot = overlayElement.findElement(By.tagName("slot"));
-        var slotName = slot.getAttribute("name");
+        var slotName = slot.getDomAttribute("name");
         return getSpreadsheet().findElement(
                 By.cssSelector("[slot=\"" + slotName + "\"] .minimize-button"));
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -39,7 +39,7 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
         Assert.assertEquals(sampleText, getCellValue("B2"));
         clickCell("B2");
         Assert.assertEquals(sampleText,
-                getEditorElement("input").getAttribute("value"));
+                getEditorElement("input").getDomProperty("value"));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
                 getCellValue("D2"));
         clickCell("D2");
         Assert.assertEquals(sampleLocalDateTime,
-                getEditorElement("input").getAttribute("value"));
+                getEditorElement("input").getDomProperty("value"));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
         Assert.assertEquals(sampleText, getCellValue("E2"));
         clickCell("E2");
         Assert.assertEquals(sampleText,
-                getEditorElement("textarea").getAttribute("value").trim());
+                getEditorElement("textarea").getDomProperty("value").trim());
     }
 
     @Test
@@ -137,7 +137,7 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
         Assert.assertEquals(sampleValue, getCellValue("F2"));
         clickCell("F2");
         Assert.assertEquals(sampleValue,
-                getEditorElement("input").getAttribute("value"));
+                getEditorElement("input").getDomProperty("value"));
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/HyperlinkIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/HyperlinkIT.java
@@ -177,7 +177,7 @@ public class HyperlinkIT extends AbstractSpreadsheetIT {
 
     public String getSelectedCell() {
         String elemClass = findElementInShadowRoot(
-                By.cssSelector(".sheet-selection")).getAttribute("class");
+                By.cssSelector(".sheet-selection")).getDomAttribute("class");
 
         int rowStart = elemClass.indexOf("row");
         if (rowStart == -1) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/LeadingQuoteIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/LeadingQuoteIT.java
@@ -91,7 +91,7 @@ public class LeadingQuoteIT extends AbstractSpreadsheetIT {
 
     private String getInlineEditorValue(String cell) {
         WebElement cellEditor = getInlineEditor(cell);
-        return cellEditor.getAttribute("value");
+        return cellEditor.getDomProperty("value");
     }
 
     private String getFormulaBarValue(String cell) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/PreserveOnRefreshIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/PreserveOnRefreshIT.java
@@ -71,7 +71,7 @@ public class PreserveOnRefreshIT extends AbstractSpreadsheetIT {
         spreadsheetElement = getSpreadsheetElement();
         input = spreadsheetElement.findElement(By.cssSelector("input"));
         assertComponentVisible(spreadsheetElement, "vaadin-text-field");
-        Assert.assertEquals(sampleText, input.getAttribute("value"));
+        Assert.assertEquals(sampleText, input.getDomProperty("value"));
     }
 
     @Test

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetTabSheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SheetTabSheetIT.java
@@ -98,6 +98,6 @@ public class SheetTabSheetIT extends AbstractSpreadsheetIT {
 
     private void verifySheetFocused() {
         Assert.assertTrue("Sheet lost focus", getFocusedElement()
-                .getAttribute("class").contains("bottom-right-pane"));
+                .getDomAttribute("class").contains("bottom-right-pane"));
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/WrongHashesOnScrollIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/WrongHashesOnScrollIT.java
@@ -57,9 +57,8 @@ public class WrongHashesOnScrollIT extends AbstractSpreadsheetIT {
                 By.cssSelector(".cell"));
 
         for (WebElement cell : elements) {
-            assertNotEquals(
-                    "Cell with class " + cell.getAttribute("class") + " fails",
-                    "###", cell.getText());
+            assertNotEquals("Cell with class " + cell.getDomAttribute("class")
+                    + " fails", "###", cell.getText());
         }
     }
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/TabsIT.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/TabsIT.java
@@ -65,9 +65,9 @@ public class TabsIT extends AbstractComponentIT {
         WebElement tabs = findElement(By.id("tabs-with-theme"));
         scrollToElement(tabs);
         Assert.assertEquals(TabsVariant.LUMO_SMALL.getVariantName(),
-                tabs.getAttribute("theme"));
+                tabs.getDomAttribute("theme"));
 
         findElement(By.id("remove-theme-variant-button")).click();
-        Assert.assertNull(tabs.getAttribute("theme"));
+        Assert.assertNull(tabs.getDomAttribute("theme"));
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -50,7 +50,7 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
     @Test
     public void shouldHaveInputModeDecimal() {
         Assert.assertEquals("decimal",
-                field.$("input").first().getAttribute("inputmode"));
+                field.$("input").first().getDomAttribute("inputmode"));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
@@ -45,7 +45,7 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
     public void assertReadOnly() {
         WebElement webComponent = findElement(
                 By.tagName("vaadin-password-field"));
-        Assert.assertNull(webComponent.getAttribute("readonly"));
+        Assert.assertNull(webComponent.getDomAttribute("readonly"));
         WebElement button = findElement(By.id("read-only"));
         button.click();
         waitUntil(
@@ -61,7 +61,7 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
         WebElement webComponent = findElement(
                 By.tagName("vaadin-password-field"));
 
-        Assert.assertNull(webComponent.getAttribute("required"));
+        Assert.assertNull(webComponent.getDomAttribute("required"));
 
         WebElement button = findElement(By.id("required"));
         button.click();
@@ -108,22 +108,21 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
     public void assertFocusShortcut() {
         PasswordFieldElement shortcutField = $(PasswordFieldElement.class)
                 .id("shortcut-field");
-        Assert.assertNull(
+        Assert.assertFalse(
                 "TextField should not be focused before the shortcut event is triggered.",
-                shortcutField.getAttribute("focused"));
+                shortcutField.hasAttribute("focused"));
 
         SendKeysHelper.sendKeys(driver, Keys.ALT, "1");
         Assert.assertTrue(
                 "TextField should be focused after the shortcut event is triggered.",
-                shortcutField.getAttribute("focused").equals("true")
-                        || shortcutField.getAttribute("focused").equals(""));
+                shortcutField.hasAttribute("focused"));
     }
 
     @Test
     public void passwordFieldHasPlaceholder() {
         WebElement passwordField = findElement(
                 By.id("password-field-with-value-change-listener"));
-        Assert.assertEquals(passwordField.getAttribute("placeholder"),
+        Assert.assertEquals(passwordField.getDomAttribute("placeholder"),
                 "placeholder text");
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -64,15 +64,14 @@ public class TextAreaPageIT extends AbstractComponentIT {
     public void assertFocusShortcut() {
         TextAreaElement shortcutField = $(TextAreaElement.class)
                 .id("shortcut-field");
-        Assert.assertNull(
+        Assert.assertFalse(
                 "TextArea should not be focused before the shortcut event is triggered.",
-                shortcutField.getAttribute("focused"));
+                shortcutField.hasAttribute("focused"));
 
         SendKeysHelper.sendKeys(driver, Keys.ALT, "1");
         Assert.assertTrue(
                 "TextArea should be focused after the shortcut event is triggered.",
-                shortcutField.getAttribute("focused").equals("true")
-                        || shortcutField.getAttribute("focused").equals(""));
+                shortcutField.hasAttribute("focused"));
     }
 
     @Test
@@ -125,7 +124,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
     public void textAreaHasPlaceholder() {
         WebElement textField = findElement(
                 By.id("text-area-with-value-change-listener"));
-        Assert.assertEquals(textField.getAttribute("placeholder"),
+        Assert.assertEquals(textField.getDomAttribute("placeholder"),
                 "placeholder text");
     }
 
@@ -174,7 +173,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
         TextAreaElement textAreaElement = $(TextAreaElement.class)
                 .id("helper-component-field");
         Assert.assertEquals("helper-component",
-                textAreaElement.getHelperComponent().getAttribute("id"));
+                textAreaElement.getHelperComponent().getDomAttribute("id"));
     }
 
     @Test
@@ -182,7 +181,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
         TextAreaElement textAreaElement = $(TextAreaElement.class)
                 .id("helper-component-field");
         Assert.assertEquals("helper-component",
-                textAreaElement.getHelperComponent().getAttribute("id"));
+                textAreaElement.getHelperComponent().getDomAttribute("id"));
 
         $(TestBenchElement.class).id("clear-helper-component-button").click();
         Assert.assertNull(textAreaElement.getHelperComponent());

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
@@ -49,7 +49,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
     public void assertReadOnly() {
         WebElement webComponent = findElement(By.tagName("vaadin-text-field"));
 
-        Assert.assertNull(webComponent.getAttribute("readonly"));
+        Assert.assertNull(webComponent.getDomAttribute("readonly"));
 
         WebElement button = findElement(By.id("read-only"));
         button.click();
@@ -66,7 +66,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
     @Test
     public void assertRequired() {
         WebElement webComponent = findElement(By.tagName("vaadin-text-field"));
-        Assert.assertNull(webComponent.getAttribute("required"));
+        Assert.assertNull(webComponent.getDomAttribute("required"));
         WebElement button = findElement(By.id("required"));
         button.click();
         waitUntil(
@@ -271,21 +271,21 @@ public class TextFieldPageIT extends AbstractComponentIT {
         WebElement textField = findElement(
                 By.id("text-field-with-value-change-listener"));
         Assert.assertEquals("placeholder text",
-                textField.getAttribute("placeholder"));
+                textField.getDomAttribute("placeholder"));
     }
 
     @Test
     public void assertFocusShortcut() {
-        WebElement shortcutField = findElement(By.id("shortcut-field"));
-        Assert.assertNull(
+        TextFieldElement shortcutField = $(TextFieldElement.class)
+                .id("shortcut-field");
+        Assert.assertFalse(
                 "TextField should not be focused before the shortcut event is triggered.",
-                shortcutField.getAttribute("focused"));
+                shortcutField.hasAttribute("focused"));
 
         SendKeysHelper.sendKeys(driver, Keys.ALT, "1");
         Assert.assertTrue(
                 "TextField should be focused after the shortcut event is triggered.",
-                shortcutField.getAttribute("focused").equals("true")
-                        || shortcutField.getAttribute("focused").equals(""));
+                shortcutField.hasAttribute("focused"));
     }
 
     @Test
@@ -310,7 +310,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
         TextFieldElement textFieldElement = $(TextFieldElement.class)
                 .id("helper-component-field");
         Assert.assertEquals("helper-component",
-                textFieldElement.getHelperComponent().getAttribute("id"));
+                textFieldElement.getHelperComponent().getDomProperty("id"));
     }
 
     @Test
@@ -318,7 +318,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
         TextFieldElement textFieldElement = $(TextFieldElement.class)
                 .id("helper-component-field");
         Assert.assertEquals("helper-component",
-                textFieldElement.getHelperComponent().getAttribute("id"));
+                textFieldElement.getHelperComponent().getDomProperty("id"));
 
         $(TestBenchElement.class).id("clear-helper-component-button").click();
         Assert.assertNull(textFieldElement.getHelperComponent());

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
@@ -137,7 +137,7 @@ public class TimePickerIT extends AbstractComponentIT {
         TimePickerElement picker = $(TimePickerElement.class)
                 .id("time-picker-helper-component");
         Assert.assertEquals("helper-component",
-                picker.getHelperComponent().getAttribute("id"));
+                picker.getHelperComponent().getDomAttribute("id"));
 
         $("button").id("button-clear-helper-component").click();
         Assert.assertNull(picker.getHelperComponent());

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -79,7 +79,7 @@ public class VirtualListIT extends AbstractComponentIT {
         clickElementWithJs("list-with-strings-accessible-name");
 
         Assert.assertEquals("Accessible Item 1",
-                firstChildElement.getAttribute("aria-label"));
+                firstChildElement.getDomAttribute("aria-label"));
 
         var secondChildElement = virtualList
                 .findElement(By.xpath("//*[text()='Item 2']"));
@@ -264,7 +264,7 @@ public class VirtualListIT extends AbstractComponentIT {
 
         assertListContainsMaxItems(items.size(), 25);
 
-        MatcherAssert.assertThat(list.getAttribute("innerText"), CoreMatchers
+        MatcherAssert.assertThat(list.getDomProperty("innerText"), CoreMatchers
                 .not(CoreMatchers.containsString("the-placeholder")));
 
         // Scroll to bottom and set an attribute when a placeholder becomes
@@ -289,14 +289,14 @@ public class VirtualListIT extends AbstractComponentIT {
                 list);
 
         waitUntil(driver -> "true"
-                .equals(list.getAttribute("placeholderWasHere")));
+                .equals(list.getDomAttribute("placeholderWasHere")));
 
-        waitUntil(driver -> list.getAttribute("innerText")
+        waitUntil(driver -> list.getDomProperty("innerText")
                 .contains("Person 100"));
 
         MatcherAssert.assertThat(
                 "The VirtualList shouldn't display any placeholders after the data is loaded",
-                list.getAttribute("innerText"), CoreMatchers
+                list.getDomProperty("innerText"), CoreMatchers
                         .not(CoreMatchers.containsString("the-placeholder")));
 
         assertListContainsMaxItems(items.size(), 25);
@@ -379,9 +379,9 @@ public class VirtualListIT extends AbstractComponentIT {
                 list);
 
         invisible.click();
-        waitUntil(driver -> "true".equals(list.getAttribute("hidden")));
+        waitUntil(driver -> "true".equals(list.getDomAttribute("hidden")));
         visible.click();
-        waitUntil(driver -> list.getAttribute("hidden") == null);
+        waitUntil(driver -> list.getDomAttribute("hidden") == null);
         assertItemsArePresent(list, 20);
         Assert.assertTrue("The $connector instance should be preserved",
                 (Boolean) executeScript(

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
@@ -153,7 +153,7 @@ public class VirtualListViewIT extends AbstractComponentIT {
                 "return Vaadin.Flow.clients.ROOT.getByNodeId(arguments[0]).textContent",
                 nodeId);
         Assert.assertEquals("The placeholder component of the '"
-                + list.getAttribute("id")
+                + list.getDomAttribute("id")
                 + "' virtual-list should have the '-----' as text content",
                 "-----", text);
     }
@@ -168,13 +168,13 @@ public class VirtualListViewIT extends AbstractComponentIT {
 
         List<WebElement> content = list
                 .findElements(By.cssSelector("vaadin-vertical-layout")).stream()
-                .filter(element -> !element.getAttribute("innerHTML")
+                .filter(element -> !element.getDomProperty("innerHTML")
                         .contains("-----")) // placeholders
                 .collect(Collectors.toList());
 
-        waitUntil(driver -> content.get(0).getAttribute("disabled") != null);
+        waitUntil(driver -> content.get(0).getDomAttribute("disabled") != null);
         Optional<WebElement> notDisabled = content.stream()
-                .filter(item -> item.getAttribute("disabled") == null)
+                .filter(item -> item.getDomAttribute("disabled") == null)
                 .findFirst();
 
         if (notDisabled.isPresent()) {
@@ -188,7 +188,7 @@ public class VirtualListViewIT extends AbstractComponentIT {
         JsonArray items = VirtualListIT.getItems(getDriver(), list);
         Assert.assertEquals(
                 "There should be " + expectedSize + " items in the '"
-                        + list.getAttribute("id") + "' virtual-list",
+                        + list.getDomAttribute("id") + "' virtual-list",
                 expectedSize, items.length());
     }
 
@@ -211,7 +211,7 @@ public class VirtualListViewIT extends AbstractComponentIT {
         var keyForFirstName = obj.keySet().stream()
                 .filter(key -> key.endsWith("firstName")).findFirst().get();
         Assert.assertEquals("The placeholderItem object of the '"
-                + list.getAttribute("id")
+                + list.getDomAttribute("id")
                 + "' virtual-list should have the '-----' as firstName property",
                 "-----", obj.get(keyForFirstName));
     }


### PR DESCRIPTION
## Description

Replaces the deprecated `getAttribute` API with `getDomAttribute` or `getDomProperty` respectively.

In some places I also refactored some code to use TestBench APIs where that was easily possible:
- Use `isEnabled` for checking whether an element is enabled / disabled
- Use `getClassNames` for getting an element's class names consistently in a null-safe way

I didn't apply that consistently though. Some tests would require switching to `TestBenchElement` from `WebElement`, and then the PR was already getting quite big in general.

Part of https://github.com/vaadin/flow-components/issues/7105

## Type of change

- Internal