### PR TITLE
fix: prevent error with addComponentAtIndex without children

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
@@ -325,7 +325,9 @@ public class HorizontalLayout extends Component implements ThemableLayout,
 
     @Override
     public void addComponentAtIndex(int index, Component component) {
-        Component oldComponent = getComponentAt(index);
+        Component oldComponent = getComponentCount() > index
+                ? getComponentAt(index)
+                : null;
         String slotName = oldComponent != null
                 ? oldComponent.getElement().getAttribute("slot")
                 : null;

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/HorizontalLayoutSlotsTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/HorizontalLayoutSlotsTest.java
@@ -304,6 +304,14 @@ public class HorizontalLayoutSlotsTest {
         Assert.assertEquals(div1.getElement().getAttribute("slot"), "end");
     }
 
+    @Test
+    public void addComponentAtIndex_firstComponentAdded() {
+        Div div1 = new Div();
+        layout.addComponentAtIndex(0, div1);
+
+        Assert.assertEquals(div1, layout.getComponentAt(0));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void addToMiddle_textNodeAsComponent_throws() {
         Text textNode = new Text("Text");


### PR DESCRIPTION
## Description

Follow-up to #7051 

Added check for `getComponentCount()` to avoid following error with `addComponentAtIndex(0)`:

```
java.lang.IllegalArgumentException: The 'index' argument should not be greater than or equals to the number of children components. It was: 0
```

## Type of change

- Bugfix