### PR TITLE
chore: replace deprecated ElementQuery APIs in integration tests

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/applayout/tests/AppLayoutIT.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/applayout/tests/AppLayoutIT.java
@@ -44,12 +44,12 @@ public class AppLayoutIT extends AbstractComponentIT {
 
         Assert.assertNotNull(layout.getDrawerToggle());
 
-        layout.$("a").attribute("href", "vaadin-app-layout/Page1").first()
+        layout.$("a").withAttribute("href", "vaadin-app-layout/Page1").first()
                 .click();
         Assert.assertEquals("This is Page 1", $(AppLayoutElement.class)
                 .waitForFirst().getContent().getText());
 
-        layout.$("a").attribute("href", "vaadin-app-layout/Page2").first()
+        layout.$("a").withAttribute("href", "vaadin-app-layout/Page2").first()
                 .click();
         Assert.assertEquals("This is Page 2", $(AppLayoutElement.class)
                 .waitForFirst().getContent().getText());

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/BasicChartIT.java
@@ -30,23 +30,23 @@ public class BasicChartIT extends AbstractTBTest {
     @Test
     public void Chart_TitleDisplayed() {
         final TestBenchElement chart = getChartElement();
-        final WebElement title = chart.$("*")
-                .attributeContains("class", "highcharts-title").first();
+        final WebElement title = chart.$("*").withClassName("highcharts-title")
+                .first();
         assertTrue(title.getText().contains("First Chart for Flow"));
     }
 
     @Test
     public void Chart_TitleCanBeChanged() {
         final TestBenchElement chart = getChartElement();
-        final WebElement title = chart.$("*")
-                .attributeContains("class", "highcharts-title").first();
+        final WebElement title = chart.$("*").withClassName("highcharts-title")
+                .first();
         assertTrue(title.getText().contains("First Chart for Flow"));
 
         final WebElement changeTitleButton = findElement(By.id("change_title"));
         changeTitleButton.click();
 
         final WebElement titleChanged = chart.$("*")
-                .attributeContains("class", "highcharts-title").first();
+                .withClassName("highcharts-title").first();
         assertTrue(titleChanged.getText()
                 .contains("First Chart for Flow - title changed"));
     }
@@ -55,7 +55,7 @@ public class BasicChartIT extends AbstractTBTest {
     public void Chart_SeriesNameIsSet() {
         final TestBenchElement chart = getChartElement();
         final WebElement series = chart.$("*")
-                .attributeContains("class", "highcharts-legend-item").first();
+                .withClassName("highcharts-legend-item").first();
         assertTrue(series.getText().contains("Tokyo"));
     }
 
@@ -64,7 +64,7 @@ public class BasicChartIT extends AbstractTBTest {
         final TestBenchElement chart = getChartElement();
         waitUntil(driver -> {
             List<TestBenchElement> labels = chart.$("*")
-                    .attributeContains("class", "highcharts-label").all();
+                    .withClassName("highcharts-label").all();
             return !labels.isEmpty()
                     && labels.stream().map(TestBenchElement::getText)
                             .anyMatch("Sample label"::equals);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/PieWithLegendEventsIT.java
@@ -58,7 +58,7 @@ public class PieWithLegendEventsIT extends AbstractTBTest {
     }
 
     private WebElement getLegendElement() {
-        return getChartElement().$("*")
-                .attributeContains("class", "highcharts-legend-item").first();
+        return getChartElement().$("*").withClassName("highcharts-legend-item")
+                .first();
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -267,8 +267,8 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findLegendItem() {
-        return getChartElement().$("*")
-                .attributeContains("class", "highcharts-legend-item").first();
+        return getChartElement().$("*").withClassName("highcharts-legend-item")
+                .first();
     }
 
     private WebElement findCheckBox() {
@@ -280,8 +280,8 @@ public class ServerSideEventsIT extends AbstractTBTest {
     }
 
     private WebElement findCheckBox(int index) {
-        return getChartElement().$("input")
-                .attributeContains("type", "checkbox").get(index);
+        return getChartElement().$("input").withAttribute("type", "checkbox")
+                .get(index);
     }
 
     private WebElement findDisableVisibityToggle() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
@@ -44,7 +44,7 @@ public class HelperIT extends AbstractComponentIT {
         TestBenchElement checkboxGroup = $("vaadin-checkbox-group").first();
 
         TestBenchElement helperComponent = checkboxGroup.$("span")
-                .attributeContains("slot", "helper").first();
+                .withAttribute("slot", "helper").first();
         Assert.assertEquals("Helper text", helperComponent.getText());
 
     }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
@@ -72,7 +72,7 @@ public class HelperIT extends AbstractComponentIT {
                 .id("checkbox-helper-text");
 
         String helperText = checkboxHelperText.$(TestBenchElement.class)
-                .attribute("slot", "helper").first().getText();
+                .withAttribute("slot", "helper").first().getText();
 
         Assert.assertEquals("Helper text", helperText);
     }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CompositeIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CompositeIT.java
@@ -35,10 +35,10 @@ public class CompositeIT extends AbstractComponentIT {
         Assert.assertFalse(crud.getEditorSaveButton().isEnabled());
 
         $("vaadin-crud-dialog-overlay").first().$("div")
-                .attribute("editor-role", "language").first()
+                .withAttribute("editor-role", "language").first()
                 .$(ButtonElement.class).first().click();
 
-        $(TextFieldElement.class).attribute("editor-role", "language-field")
+        $(TextFieldElement.class).withAttribute("editor-role", "language-field")
                 .first().setValue("English");
 
         $(TestBenchElement.class).withId("overlay").last()

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java
@@ -36,8 +36,8 @@ public class CustomGridIT extends AbstractComponentIT {
         crud.openRowForEditing(0);
         Assert.assertTrue(crud.isEditorOpen());
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
 
         Assert.assertEquals("Sayo", lastNameField.getValue());
 
@@ -56,8 +56,8 @@ public class CustomGridIT extends AbstractComponentIT {
         crud.openRowForEditing(0);
         Assert.assertTrue(crud.isEditorOpen());
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
 
         Assert.assertEquals("Sayo", lastNameField.getValue());
         lastNameField.setValue("Otto");
@@ -120,7 +120,7 @@ public class CustomGridIT extends AbstractComponentIT {
 
     private String getEditorHeaderText(CrudElement crud) {
         return crud.getEditor().$(TestBenchElement.class)
-                .attribute("slot", "header").first().getText();
+                .withAttribute("slot", "header").first().getText();
     }
 
     private ButtonElement customGridClickToEditButton() {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/DetachAttachIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/DetachAttachIT.java
@@ -48,8 +48,8 @@ public class DetachAttachIT extends AbstractComponentIT {
         crud = $(CrudElement.class).waitForFirst();
         crud.openRowForEditing(0);
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
     }
 }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EditorButtonsIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EditorButtonsIT.java
@@ -46,8 +46,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
         CrudElement crud = getCrud();
         crud.openRowForEditing(0);
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
 
         Assert.assertFalse(crud.getEditorSaveButton().isEnabled());
@@ -61,8 +61,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
         assertTrue(crud.isEditorOpen());
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
 
         ButtonElement saveButton = crud.getEditorSaveButton();
@@ -80,8 +80,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
         assertFalse(saveButton.isEnabled());
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
 
         assertTrue(saveButton.isEnabled());
@@ -99,8 +99,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
         assertFalse("Save button should be disabled", saveButton.isEnabled());
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
 
         assertFalse("Save button should remain disabled",
@@ -123,8 +123,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
                 cancelButton.isEnabled());
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
 
         assertFalse("Cancel button should remain disabled",
@@ -147,8 +147,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
                 deleteButton.isEnabled());
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
 
         assertFalse("Delete button should remain disabled",
@@ -168,8 +168,8 @@ public class EditorButtonsIT extends AbstractComponentIT {
         getTestButton("add-enter-shortcut-button").click();
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue(lastNameExpected);
 
         // invoke shortcut

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EventHandlingIT.java
@@ -89,10 +89,10 @@ public class EventHandlingIT extends AbstractComponentIT {
                 getLastEvent());
 
         Assert.assertEquals("Guille", crud.getEditor().$(TextFieldElement.class)
-                .attribute("editor-role", "first-name").first().getValue());
+                .withAttribute("editor-role", "first-name").first().getValue());
 
         Assert.assertEquals("Guille", crud.getEditor().$(TextFieldElement.class)
-                .attribute("editor-role", "last-name").first().getValue());
+                .withAttribute("editor-role", "last-name").first().getValue());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class EventHandlingIT extends AbstractComponentIT {
         // Ensure editor is marked dirty on edit
         getTestButton("editServerItem").click();
         crud.getEditor().$(TextFieldElement.class)
-                .attribute("editor-role", "first-name").first()
+                .withAttribute("editor-role", "first-name").first()
                 .setValue("Vaadin");
 
         dismissDialog();
@@ -151,8 +151,8 @@ public class EventHandlingIT extends AbstractComponentIT {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         crud.openRowForEditing(0);
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         Assert.assertTrue(lastNameField.hasAttribute("invalid"));
 
         // Invalid input
@@ -181,14 +181,14 @@ public class EventHandlingIT extends AbstractComponentIT {
 
         TextFieldElement firstNameField = crud.getEditor()
                 .$(TextFieldElement.class)
-                .attribute("editor-role", "first-name").first();
+                .withAttribute("editor-role", "first-name").first();
 
         Assert.assertFalse(firstNameField.hasAttribute("invalid"));
 
         // To avoid editor being dirty
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Oladeji");
 
         crud.getEditorSaveButton().click();
@@ -202,8 +202,8 @@ public class EventHandlingIT extends AbstractComponentIT {
         crud.openRowForEditing(1);
 
         TextFieldElement lastNameField = crud.getEditor()
-                .$(TextFieldElement.class).attribute("editor-role", "last-name")
-                .first();
+                .$(TextFieldElement.class)
+                .withAttribute("editor-role", "last-name").first();
 
         Assert.assertFalse(lastNameField.hasAttribute("invalid"));
 
@@ -222,9 +222,9 @@ public class EventHandlingIT extends AbstractComponentIT {
 
         TestBenchElement editor = crud.getEditor();
         TextFieldElement firstNameField = editor.$(TextFieldElement.class)
-                .attribute("editor-role", "first-name").first();
+                .withAttribute("editor-role", "first-name").first();
         TextFieldElement lastNameField = editor.$(TextFieldElement.class)
-                .attribute("editor-role", "last-name").first();
+                .withAttribute("editor-role", "last-name").first();
 
         Assert.assertEquals("firstName", firstNameField.getValue());
         Assert.assertEquals("lastName", lastNameField.getValue());

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/NewButtonIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/NewButtonIT.java
@@ -11,8 +11,6 @@ package com.vaadin.flow.component.crud.tests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.crud.testbench.CrudElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -41,11 +39,6 @@ public class NewButtonIT extends AbstractComponentIT {
     }
 
     private boolean verifyButtonRendered(CrudElement crud) {
-        try {
-            WebElement el = crud.$("*").attribute("slot", "new-button").first();
-        } catch (NoSuchElementException e) {
-            return false;
-        }
-        return true;
+        return crud.$("*").withAttribute("slot", "new-button").exists();
     }
 }

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/BasicIT.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/BasicIT.java
@@ -36,7 +36,7 @@ public class BasicIT extends AbstractComponentIT {
         final CustomFieldElement customField = $(CustomFieldElement.class)
                 .waitForFirst();
         Assert.assertEquals("",
-                $("div").attribute("id", "result").get(0).getText());
+                $("div").withAttribute("id", "result").first().getText());
         TextFieldElement field1 = getById(customField, "field1");
         field1.setValue("1");
         TextFieldElement field2 = getById(customField, "field2");
@@ -44,13 +44,13 @@ public class BasicIT extends AbstractComponentIT {
         $("button").waitForFirst().click();
         executeScript(
                 "!!document.activeElement ? document.activeElement.blur() : 0");
-        waitUntil(e -> "3"
-                .equals($("div").attribute("id", "result").get(0).getText()));
+        waitUntil(e -> "3".equals(
+                $("div").withAttribute("id", "result").first().getText()));
     }
 
     private TextFieldElement getById(CustomFieldElement customField,
             String id) {
-        return customField.$(TextFieldElement.class).attribute("id", id)
+        return customField.$(TextFieldElement.class).withAttribute("id", id)
                 .waitForFirst();
     }
 }

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/BasicIT.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/customfield/tests/BasicIT.java
@@ -35,8 +35,7 @@ public class BasicIT extends AbstractComponentIT {
     public void valueIsUpdated() {
         final CustomFieldElement customField = $(CustomFieldElement.class)
                 .waitForFirst();
-        Assert.assertEquals("",
-                $("div").withAttribute("id", "result").first().getText());
+        Assert.assertEquals("", $("div").id("result").getText());
         TextFieldElement field1 = getById(customField, "field1");
         field1.setValue("1");
         TextFieldElement field2 = getById(customField, "field2");
@@ -44,13 +43,11 @@ public class BasicIT extends AbstractComponentIT {
         $("button").waitForFirst().click();
         executeScript(
                 "!!document.activeElement ? document.activeElement.blur() : 0");
-        waitUntil(e -> "3".equals(
-                $("div").withAttribute("id", "result").first().getText()));
+        waitUntil(e -> "3".equals($("div").id("result").getText()));
     }
 
     private TextFieldElement getById(CustomFieldElement customField,
             String id) {
-        return customField.$(TextFieldElement.class).withAttribute("id", id)
-                .waitForFirst();
+        return customField.$(TextFieldElement.class).id(id);
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/InjectedDatePickerI18nIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/InjectedDatePickerI18nIT.java
@@ -33,7 +33,8 @@ public class InjectedDatePickerI18nIT extends AbstractComponentIT {
                 .$("input").first().click();
 
         TestBenchElement cancelButton = $("vaadin-date-picker-overlay").first()
-                .$("vaadin-button").attribute("slot", "cancel-button").first();
+                .$("vaadin-button").withAttribute("slot", "cancel-button")
+                .first();
 
         Assert.assertEquals("peruuta", cancelButton.getText());
     }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
@@ -70,7 +70,7 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
         Assert.assertFalse("Backdrop was not removed from dom",
                 $(TestBenchElement.class).id("overlay").$(DivElement.class)
-                        .attributeContains("id", "backdrop").exists());
+                        .withAttribute("id", "backdrop").exists());
 
         $(NativeButtonElement.class).id("log").click();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java
@@ -154,8 +154,7 @@ public class GridViewEditorIT extends AbstractComponentIT {
         nameInput.sendKeys(Keys.ENTER);
 
         GridTHTDElement editColumn = row.getCell(grid.getAllColumns().get(2));
-        editColumn.$("vaadin-button").withAttribute("class", "save").first()
-                .click();
+        editColumn.$("vaadin-button").withClassName("save").first().click();
 
         String validation = findElement(By.id("validation")).getText();
         // There is an error in the status message
@@ -165,8 +164,7 @@ public class GridViewEditorIT extends AbstractComponentIT {
         // No save events
         Assert.assertEquals("", msg.getText());
 
-        editColumn.$("vaadin-button").withAttribute("class", "cancel").first()
-                .click();
+        editColumn.$("vaadin-button").withClassName("cancel").first().click();
 
         Assert.assertEquals(personName, nameCell.getText());
         // Still no any save events

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java
@@ -154,7 +154,7 @@ public class GridViewEditorIT extends AbstractComponentIT {
         nameInput.sendKeys(Keys.ENTER);
 
         GridTHTDElement editColumn = row.getCell(grid.getAllColumns().get(2));
-        editColumn.$("vaadin-button").attribute("class", "save").first()
+        editColumn.$("vaadin-button").withAttribute("class", "save").first()
                 .click();
 
         String validation = findElement(By.id("validation")).getText();
@@ -165,7 +165,7 @@ public class GridViewEditorIT extends AbstractComponentIT {
         // No save events
         Assert.assertEquals("", msg.getText());
 
-        editColumn.$("vaadin-button").attribute("class", "cancel").first()
+        editColumn.$("vaadin-button").withAttribute("class", "cancel").first()
                 .click();
 
         Assert.assertEquals(personName, nameCell.getText());

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSortingIT.java
@@ -255,7 +255,7 @@ public class GridViewSortingIT extends AbstractComponentIT {
             String orderValue = String
                     .valueOf(querySortOrders.indexOf(querySortOrder) + 1);
             TestBenchElement orderElement = columnSorter.$("*")
-                    .attribute("part", "order").first();
+                    .withAttribute("part", "order").first();
             Assert.assertEquals(orderValue, orderElement.getText());
         });
     }

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/src/test/java/com/vaadin/flow/theme/lumo/LumoIconIT.java
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/src/test/java/com/vaadin/flow/theme/lumo/LumoIconIT.java
@@ -50,7 +50,7 @@ public class LumoIconIT extends AbstractComponentIT {
 
     private void assertIconExists(String iconName) {
         ElementQuery<TestBenchElement> icon = $(TestBenchElement.class)
-                .attribute("icon", iconName);
+                .withAttribute("icon", iconName);
 
         Assert.assertTrue("Could not find icon: " + iconName, icon.exists());
     }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/PreserveOnRefreshIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/PreserveOnRefreshIT.java
@@ -73,7 +73,7 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
         getDriver().navigate().refresh();
         TestBenchElement notification = $(NOTIFICATION_TAG).first();
         boolean containsComponentContent = notification.$("span")
-                .attribute("id", "component-content").exists();
+                .withAttribute("id", "component-content").exists();
         Assert.assertTrue(
                 "Notification card does not contain added component anymore",
                 containsComponentContent);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/HelperIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/HelperIT.java
@@ -35,7 +35,7 @@ public class HelperIT extends AbstractComponentIT {
         TestBenchElement radioGroup = $("vaadin-radio-group").first();
 
         TestBenchElement helperComponent = radioGroup.$("span")
-                .attributeContains("slot", "helper").first();
+                .withAttribute("slot", "helper").first();
         Assert.assertEquals("Helper text", helperComponent.getText());
 
     }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
@@ -158,7 +158,7 @@ public abstract class AbstractSelectIT extends AbstractComponentIT {
             Assert.assertEquals("Invalid placeholder text", expectedItemText,
                     selectedItem.getText());
             TestBenchElement valueButton = selectElement
-                    .$(TestBenchElement.class).attribute("slot", "value")
+                    .$(TestBenchElement.class).withAttribute("slot", "value")
                     .first();
             Assert.assertTrue(valueButton.hasAttribute("placeholder"));
         }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ChartsIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ChartsIT.java
@@ -94,8 +94,8 @@ public class ChartsIT extends AbstractSpreadsheetIT {
 
         // Get any element from the shadow root of the minimize button
         var shadowRootElement = $("vaadin-button")
-                .withAttribute("class", "minimize-button").first().$("div")
-                .withAttribute("class", "vaadin-button-container").first();
+                .withClassName("minimize-button").first().$("div")
+                .withClassName("vaadin-button-container").first();
 
         // Dispatch a mouseover event to the shadow root element
         executeScript(
@@ -112,8 +112,8 @@ public class ChartsIT extends AbstractSpreadsheetIT {
 
         // Get any element from the shadow root of the minimize button
         var shadowRootElement = $("vaadin-button")
-                .withAttribute("class", "minimize-button").first().$("div")
-                .withAttribute("class", "vaadin-button-container").first();
+                .withClassName("minimize-button").first().$("div")
+                .withClassName("vaadin-button-container").first();
 
         // Dispatch a dblclick event to the shadow root element
         executeScript(

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ChartsIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ChartsIT.java
@@ -94,8 +94,8 @@ public class ChartsIT extends AbstractSpreadsheetIT {
 
         // Get any element from the shadow root of the minimize button
         var shadowRootElement = $("vaadin-button")
-                .attribute("class", "minimize-button").first().$("div")
-                .attribute("class", "vaadin-button-container").first();
+                .withAttribute("class", "minimize-button").first().$("div")
+                .withAttribute("class", "vaadin-button-container").first();
 
         // Dispatch a mouseover event to the shadow root element
         executeScript(
@@ -112,8 +112,8 @@ public class ChartsIT extends AbstractSpreadsheetIT {
 
         // Get any element from the shadow root of the minimize button
         var shadowRootElement = $("vaadin-button")
-                .attribute("class", "minimize-button").first().$("div")
-                .attribute("class", "vaadin-button-container").first();
+                .withAttribute("class", "minimize-button").first().$("div")
+                .withAttribute("class", "vaadin-button-container").first();
 
         // Dispatch a dblclick event to the shadow root element
         executeScript(

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -168,7 +168,7 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
         blur();
 
         TestBenchElement clearButton = field.$(TestBenchElement.class)
-                .attributeContains("part", "clear-button").first();
+                .withAttributeContainingWord("part", "clear-button").first();
         clearButton.click();
 
         assertValueChange(2, 300, null);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldPageIT.java
@@ -119,7 +119,7 @@ public class EmailFieldPageIT extends AbstractComponentIT {
         blur();
 
         WebElement clearButton = field.$("*")
-                .attributeContains("part", "clear-button").first();
+                .withAttributeContainingWord("part", "clear-button").first();
         clearButton.click();
 
         String value = findElement(By.id("clear-message")).getText();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPageIT.java
@@ -125,7 +125,7 @@ public class IntegerFieldPageIT extends AbstractComponentIT {
         blur();
 
         TestBenchElement clearButton = field.$(TestBenchElement.class)
-                .attributeContains("part", "clear-button").first();
+                .withAttributeContainingWord("part", "clear-button").first();
         clearButton.click();
 
         assertValueChange(2, 300, null);
@@ -136,7 +136,7 @@ public class IntegerFieldPageIT extends AbstractComponentIT {
         field = $(IntegerFieldElement.class).id("step-integer-field");
 
         TestBenchElement increaseButton = field.$(TestBenchElement.class)
-                .attributeContains("part", "increase-button").first();
+                .withAttributeContainingWord("part", "increase-button").first();
 
         increaseButton.click();
         assertValueChange(1, null, 4);

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
@@ -126,7 +126,7 @@ public class NumberFieldPageIT extends AbstractComponentIT {
         blur();
 
         WebElement clearButton = field.$("*")
-                .attributeContains("part", "clear-button").first();
+                .withAttributeContainingWord("part", "clear-button").first();
         clearButton.click();
 
         String value = findElement(By.id("clear-message")).getText();
@@ -138,7 +138,7 @@ public class NumberFieldPageIT extends AbstractComponentIT {
         TestBenchElement field = $("*").id("step-number-field");
 
         WebElement increaseButton = field.$("*")
-                .attributeContains("part", "increase-button").first();
+                .withAttributeContainingWord("part", "increase-button").first();
         increaseButton.click();
 
         String value = findElement(By.id("step-message")).getText();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
@@ -80,7 +80,7 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
         field.setValue("foo");
 
         WebElement clearButton = field.$("*")
-                .attributeContains("part", "clear-button").first();
+                .withAttributeContainingWord("part", "clear-button").first();
         clearButton.click();
 
         String value = findElement(By.id("clear-message")).getText();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -53,7 +53,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
         blur();
 
         WebElement clearButton = field.$("*")
-                .attributeContains("part", "clear-button").first();
+                .withAttributeContainingWord("part", "clear-button").first();
         clearButton.click();
 
         String value = findElement(By.id("clear-message")).getText();

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadI18nIT.java
@@ -40,9 +40,9 @@ public class UploadI18nIT extends AbstractUploadIT {
         open();
 
         UploadElement upload = $(UploadElement.class).id("upload-full-i18n");
-        WebElement addButton = upload.$("*").attribute("slot", "add-button")
+        WebElement addButton = upload.$("*").withAttribute("slot", "add-button")
                 .first();
-        WebElement dropLabel = upload.$("*").attribute("slot", "drop-label")
+        WebElement dropLabel = upload.$("*").withAttribute("slot", "drop-label")
                 .first();
 
         Assert.assertEquals(UploadTestsI18N.RUSSIAN_FULL.getAddFiles().getOne(),
@@ -80,9 +80,9 @@ public class UploadI18nIT extends AbstractUploadIT {
         open();
 
         UploadElement upload = $(UploadElement.class).id("upload-partial-i18n");
-        WebElement addButton = upload.$("*").attribute("slot", "add-button")
+        WebElement addButton = upload.$("*").withAttribute("slot", "add-button")
                 .first();
-        WebElement dropLabel = upload.$("*").attribute("slot", "drop-label")
+        WebElement dropLabel = upload.$("*").withAttribute("slot", "drop-label")
                 .first();
 
         // This label should still be the default one
@@ -136,7 +136,7 @@ public class UploadI18nIT extends AbstractUploadIT {
         UploadElement upload = $(UploadElement.class)
                 .id("upload-detach-reattach-i18n");
 
-        WebElement dropLabel = upload.$("*").attribute("slot", "drop-label")
+        WebElement dropLabel = upload.$("*").withAttribute("slot", "drop-label")
                 .first();
 
         Assert.assertEquals(


### PR DESCRIPTION
## Description

Replace usages of the deprecated `attribute` and `attributeContains` APIs.

Part of https://github.com/vaadin/flow-components/issues/7105

## Type of change

- Internal