### PR TITLE
refactor: remove duplicate withProperty call

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -702,8 +702,7 @@ public class TreeGrid<T> extends Grid<T>
      */
     public <V extends Component> Column<T> addComponentHierarchyColumn(
             HierarchyColumnComponentRenderer<V, T> componentRenderer) {
-        return addColumn(componentRenderer.withProperty("children",
-                item -> getDataCommunicator().hasChildren(item)));
+        return addColumn(componentRenderer);
     }
 
     /**


### PR DESCRIPTION
## Description

Removes a duplicate `withProperty` call that is already part of `HierarchyColumnComponentRenderer`:
https://github.com/vaadin/flow-components/blob/a04f1e7942bb0248265a61b1209985447414bb65/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/HierarchyColumnComponentRenderer.java#L48-L49

## Type of change

- Refactor