### PR TITLE
Revert "feat: allow passing HierarchyColumnComponentRenderer to addComponentHierarchyColumn (#7120)"

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -681,9 +681,8 @@ public class TreeGrid<T> extends Grid<T>
      */
     public <V extends Component> Column<T> addComponentHierarchyColumn(
             ValueProvider<T, V> componentProvider) {
-        return addColumn(new HierarchyColumnComponentRenderer<V, T>(
-                componentProvider, this).withProperty("children",
-                        item -> getDataCommunicator().hasChildren(item)));
+        return addColumn(new HierarchyColumnComponentRenderer<>(
+                componentProvider, this));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -681,29 +681,9 @@ public class TreeGrid<T> extends Grid<T>
      */
     public <V extends Component> Column<T> addComponentHierarchyColumn(
             ValueProvider<T, V> componentProvider) {
-        return addColumn(new HierarchyColumnComponentRenderer<>(
-                componentProvider, this));
-    }
-
-    /**
-     * Adds a new Hierarchy column that shows components.
-     * <p>
-     * <em>NOTE:</em> Using {@link ComponentRenderer} is not as efficient as the
-     * built in renderers.
-     * </p>
-     *
-     * @param componentRenderer
-     *            the renderer used to create a component for the given item
-     * @param <V>
-     *            the component type
-     * @return the new column
-     * @see #addColumn(Renderer)
-     * @see #removeColumn(Column)
-     */
-    public <V extends Component> Column<T> addComponentHierarchyColumn(
-            HierarchyColumnComponentRenderer<V, T> componentRenderer) {
-        return addColumn(componentRenderer.withProperty("children",
-                item -> getDataCommunicator().hasChildren(item)));
+        return addColumn(new HierarchyColumnComponentRenderer<V, T>(
+                componentProvider, this).withProperty("children",
+                        item -> getDataCommunicator().hasChildren(item)));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
@@ -19,10 +19,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.grid.Grid.Column;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.treegrid.HierarchyColumnComponentRenderer;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
@@ -75,15 +71,6 @@ public class TreeGridTest {
                 treeGrid.getDataCommunicator().getKeyMapper().get("key 1"));
         Assert.assertNotNull(
                 treeGrid.getDataCommunicator().getKeyMapper().get("key 2"));
-    }
-
-    @Test
-    public void addHierarchyColumn_withRenderer() {
-        HierarchyColumnComponentRenderer<Component, Item> renderer = new HierarchyColumnComponentRenderer<>(
-                item -> new Span(), treeGrid);
-        Column<Item> column = treeGrid.addComponentHierarchyColumn(renderer);
-
-        Assert.assertEquals(renderer, column.getRenderer());
     }
 
     private void fakeClientCommunication() {


### PR DESCRIPTION
Reverts https://github.com/vaadin/flow-components/pull/7120

The intent of the feature was to allow passing a `HierarchyColumnComponentRenderer` to `addComponentHierarchyColumn`. The only thing the new overload did was to define the `children` property on the renderer, however that is unnecessary as `HierarchyColumnComponentRenderer` sets that already in the constructor:
https://github.com/vaadin/flow-components/blob/a04f1e7942bb0248265a61b1209985447414bb65/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/HierarchyColumnComponentRenderer.java#L48-L49

So the overload isn't actually necessary, as the only thing it does is `addColumn(renderer)`, so you can call that directly instead.

In addition to reverting the PR, this adds a commit that removes the `withProperty` call from the original `addComponentHierarchyColumn` method: https://github.com/vaadin/flow-components/commit/80c5dc100029facbf05a926869300ec42e385fe2 (this doesn't show up in the PR diff with the overall changes).