### PR TITLE
fix: check wether HTML values contains user content

### DIFF
--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.jsoup.nodes.Document;
+
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEvent;
@@ -262,6 +264,16 @@ public class RichTextEditor
     private static String modelToPresentation(String htmlValue) {
         // Sanitize HTML sent to client
         return sanitize(htmlValue);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        Document document = org.jsoup.Jsoup.parse(getValue());
+        String text = document.body().text();
+        boolean hasText = !text.trim().isEmpty();
+        boolean hasImages = document.selectFirst("img") != null;
+
+        return !hasText && !hasImages;
     }
 
     /**
@@ -1004,6 +1016,11 @@ public class RichTextEditor
         @Override
         public String getEmptyValue() {
             return "";
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return RichTextEditor.this.isEmpty();
         }
     }
 

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -266,12 +266,29 @@ public class RichTextEditor
         return sanitize(htmlValue);
     }
 
+    /**
+     * Returns whether the value is considered to be empty.
+     * <p>
+     * As the editor's HTML value always contains a minimal markup, this does
+     * not check if the value is an empty string. Instead, this method considers
+     * the value to not be empty if the user has added some content, which can
+     * be:
+     * <ul>
+     * <li>Text, whitespaces or line breaks</li>
+     * <li>An image</li>
+     * </ul>
+     * <p>
+     * Note that a single empty HTML tag, such as a heading, blockquote, etc.,
+     * is not considered as content.
+     *
+     * @return {@code true} if considered empty; {@code false} if not
+     */
     @Override
     public boolean isEmpty() {
         Document document = org.jsoup.Jsoup.parse(getValue());
 
         // Get non-normalized text including spaces and newlines
-        // <br>s count as newlines
+        // Note that <br>s count as newlines
         String text = document.body().wholeText();
 
         // Remove first newline occurrence as Quill editor adds a single <br> in
@@ -1026,6 +1043,23 @@ public class RichTextEditor
             return "";
         }
 
+        /**
+         * Returns whether the value is considered to be empty.
+         * <p>
+         * As the editor's HTML value always contains a minimal markup, this does
+         * not check if the value is an empty string. Instead, this method considers
+         * the value to not be empty if the user has added some content, which can
+         * be:
+         * <ul>
+         * <li>Text, whitespaces or line breaks</li>
+         * <li>An image</li>
+         * </ul>
+         * <p>
+         * Note that a single empty HTML tag, such as a heading, blockquote, etc.,
+         * is not considered as content.
+         *
+         * @return {@code true} if considered empty; {@code false} if not
+         */
         @Override
         public boolean isEmpty() {
             return RichTextEditor.this.isEmpty();

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -269,8 +269,16 @@ public class RichTextEditor
     @Override
     public boolean isEmpty() {
         Document document = org.jsoup.Jsoup.parse(getValue());
-        String text = document.body().text();
-        boolean hasText = !text.trim().isEmpty();
+
+        // Get non-normalized text including spaces and newlines
+        // <br>s count as newlines
+        String text = document.body().wholeText();
+
+        // Remove first newline occurrence as Quill editor adds a single <br> in
+        // every element even without the user having typed anything
+        text = text.replaceFirst("\n", "");
+
+        boolean hasText = !text.isEmpty();
         boolean hasImages = document.selectFirst("img") != null;
 
         return !hasText && !hasImages;

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -1046,17 +1046,17 @@ public class RichTextEditor
         /**
          * Returns whether the value is considered to be empty.
          * <p>
-         * As the editor's HTML value always contains a minimal markup, this does
-         * not check if the value is an empty string. Instead, this method considers
-         * the value to not be empty if the user has added some content, which can
-         * be:
+         * As the editor's HTML value always contains a minimal markup, this
+         * does not check if the value is an empty string. Instead, this method
+         * considers the value to not be empty if the user has added some
+         * content, which can be:
          * <ul>
          * <li>Text, whitespaces or line breaks</li>
          * <li>An image</li>
          * </ul>
          * <p>
-         * Note that a single empty HTML tag, such as a heading, blockquote, etc.,
-         * is not considered as content.
+         * Note that a single empty HTML tag, such as a heading, blockquote,
+         * etc., is not considered as content.
          *
          * @return {@code true} if considered empty; {@code false} if not
          */

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorHtmlIsEmptyTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorHtmlIsEmptyTest.java
@@ -12,7 +12,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RichTextEditorIsEmptyTest {
+public class RichTextEditorHtmlIsEmptyTest {
     private RichTextEditor editor;
 
     @Before
@@ -27,7 +27,7 @@ public class RichTextEditorIsEmptyTest {
     }
 
     @Test
-    public void quillDefaultHtml_isEmpty() {
+    public void hasQuillDefaultHtml_isEmpty() {
         // This is the default value of the Quill editor when there is no text
         editor.setValue("<p><br></p>");
         Assert.assertTrue(editor.isEmpty());
@@ -35,7 +35,7 @@ public class RichTextEditorIsEmptyTest {
     }
 
     @Test
-    public void singleLineBreak_isEmpty() {
+    public void hasSingleLineBreak_isEmpty() {
         editor.setValue("<h1><br></h1>");
         Assert.assertTrue(editor.isEmpty());
         Assert.assertTrue(editor.asHtml().isEmpty());
@@ -96,7 +96,7 @@ public class RichTextEditorIsEmptyTest {
 
     @Test
     public void hasImage_notEmpty() {
-        editor.setValue("<img src='https://vaadin.com'>");
+        editor.setValue("<img>");
         Assert.assertFalse(editor.isEmpty());
         Assert.assertFalse(editor.asHtml().isEmpty());
     }

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorIsEmptyTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorIsEmptyTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.richtexteditor;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RichTextEditorIsEmptyTest {
+    private RichTextEditor editor;
+
+    @Before
+    public void init() {
+        editor = new RichTextEditor();
+    }
+
+    @Test
+    public void initialValue_isEmpty() {
+        Assert.assertTrue(editor.isEmpty());
+        Assert.assertTrue(editor.asHtml().isEmpty());
+    }
+
+    @Test
+    public void quillDefaultHtml_isEmpty() {
+        // This is the default value of the Quill editor when there is no text
+        editor.setValue("<p><br></p>");
+        Assert.assertTrue(editor.isEmpty());
+        Assert.assertTrue(editor.asHtml().isEmpty());
+    }
+
+    @Test
+    public void emptyHtmlTags_isEmpty() {
+        editor.setValue("""
+                <h1> </h1>
+                <p> </p>
+                <h2> </h2>
+                <ol>
+                    <li> </li>
+                    <li> </li>
+                    <li> </li>
+                </ol>
+                <ul>
+                    <li> </li>
+                    <li> </li>
+                    <li> </li>
+                </ul>
+                <blockquote> </blockquote>
+                <pre>
+
+                </pre>
+                <a href="https://vaadin.com"> </a>
+                """);
+        Assert.assertTrue(editor.isEmpty());
+        Assert.assertTrue(editor.asHtml().isEmpty());
+    }
+
+    @Test
+    public void hasTextNode_notEmpty() {
+        editor.setValue("value");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+    }
+
+    @Test
+    public void hasNestedTextNodes_notEmpty() {
+        editor.setValue("""
+                <h1>value</h1>
+                """);
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        editor.setValue("""
+                <ol>
+                    <li>value</li>
+                    <li>value</li>
+                    <li>value</li>
+                </ol>
+                """);
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+    }
+
+    @Test
+    public void hasImage_notEmpty() {
+        editor.setValue("<img src='https://vaadin.com'>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+    }
+}

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorIsEmptyTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorIsEmptyTest.java
@@ -35,53 +35,61 @@ public class RichTextEditorIsEmptyTest {
     }
 
     @Test
-    public void emptyHtmlTags_isEmpty() {
-        editor.setValue("""
-                <h1> </h1>
-                <p> </p>
-                <h2> </h2>
-                <ol>
-                    <li> </li>
-                    <li> </li>
-                    <li> </li>
-                </ol>
-                <ul>
-                    <li> </li>
-                    <li> </li>
-                    <li> </li>
-                </ul>
-                <blockquote> </blockquote>
-                <pre>
+    public void singleLineBreak_isEmpty() {
+        editor.setValue("<h1><br></h1>");
+        Assert.assertTrue(editor.isEmpty());
+        Assert.assertTrue(editor.asHtml().isEmpty());
 
-                </pre>
-                <a href="https://vaadin.com"> </a>
-                """);
+        editor.setValue("<blockquote><br></blockquote>");
+        Assert.assertTrue(editor.isEmpty());
+        Assert.assertTrue(editor.asHtml().isEmpty());
+
+        editor.setValue("<ul><li><br></li></ul>");
         Assert.assertTrue(editor.isEmpty());
         Assert.assertTrue(editor.asHtml().isEmpty());
     }
 
     @Test
-    public void hasTextNode_notEmpty() {
-        editor.setValue("value");
+    public void hasText_notEmpty() {
+        editor.setValue("<p>foo<br></p>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        editor.setValue("<blockquote>foo<br></blockquote>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        editor.setValue("<ul><li>foo<br></li></ul>");
         Assert.assertFalse(editor.isEmpty());
         Assert.assertFalse(editor.asHtml().isEmpty());
     }
 
     @Test
-    public void hasNestedTextNodes_notEmpty() {
-        editor.setValue("""
-                <h1>value</h1>
-                """);
+    public void hasWhitespace_notEmpty() {
+        // Space character
+        editor.setValue("<p> <br></p>");
         Assert.assertFalse(editor.isEmpty());
         Assert.assertFalse(editor.asHtml().isEmpty());
 
-        editor.setValue("""
-                <ol>
-                    <li>value</li>
-                    <li>value</li>
-                    <li>value</li>
-                </ol>
-                """);
+        editor.setValue("<blockquote> <br></blockquote>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        editor.setValue("<ul><li> <br></li></ul>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        // Multiple newlines
+        editor.setValue("<p><br></p><p><br></p>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        editor.setValue(
+                "<blockquote><br></blockquote><blockquote><br></blockquote>");
+        Assert.assertFalse(editor.isEmpty());
+        Assert.assertFalse(editor.asHtml().isEmpty());
+
+        editor.setValue("<ul><li><br></li><li><br></li></ul>");
         Assert.assertFalse(editor.isEmpty());
         Assert.assertFalse(editor.asHtml().isEmpty());
     }


### PR DESCRIPTION
## Description

Make `isEmpty` for the RichTextEditor HTML value check whether a user has actually added some content which can be:
- Text, whitespace and line breaks
- Images

Fixes https://github.com/vaadin/web-components/issues/8453

## Type of change

- Bugfix