### PR TITLE
Avoid obsolete filter syncing [2 days]

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyComboBoxFilterIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyComboBoxFilterIT.java
@@ -15,10 +15,14 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import org.junit.Assert;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -35,7 +39,10 @@ public class LazyComboBoxFilterIT extends AbstractComponentIT {
         comboBox.openPopup();
 
         WebElement query = findElement(By.id("query"));
-        Assert.assertTrue(query.getText().contains("Filter: 1"));
-        Assert.assertTrue(query.getText().contains("Count: 10"));
+
+        WebDriverWait wait = new WebDriverWait(driver,
+                Duration.of(2, ChronoUnit.SECONDS));
+        wait.until(ExpectedConditions.textToBePresentInElement(query,
+                "Filter: 1 Count: 10"));
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -99,6 +99,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
         HasValidationProperties, HasValidator<TValue>, HasPlaceholder {
     private static final int DEFAULT_FILTER_TIMEOUT = 500;
 
+    private String lastKnownFilter;
+
     /**
      * Registration for custom value listeners that disallows entering custom
      * values as soon as there are no more listeners for the custom value event
@@ -346,9 +348,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      *
      * @return the filter string
      */
-    @Synchronize(property = "filter", value = "filter-changed")
     protected String getFilter() {
-        return getElement().getProperty("filter");
+        return lastKnownFilter;
     }
 
     /**
@@ -359,7 +360,11 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * @param filter
      *            the String value to set
      */
+    @Deprecated
     protected void setFilter(String filter) {
+        lastKnownFilter = filter;
+        // MT 20250-02-21 I assume client side never uses this, probably the
+        // whole method is obsolete
         getElement().setProperty("filter", filter == null ? "" : filter);
     }
 
@@ -1367,6 +1372,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      */
     @ClientCallable
     private void setViewportRange(int start, int length, String filter) {
+        this.lastKnownFilter = filter;
         dataController.setViewportRange(start, length, filter);
     }
 


### PR DESCRIPTION
That appears to be obsolete as the filter is anyways sent to the @ClientCallable method when the filtering should actually be done. After this change there is a lot less XHRs/server-visits happening  aka reduces "chattiness" (although there still is some that I don't really know what they are related to (opened changed and some "confirm" requests).

Opening as draft as somebody involved in the current implementation really should look into this (and couldn't run the tests locally).

See also #6863 and #7133 