### PR TITLE
chore: Revert "chore: fix compilation errors (#7149)"

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/LitRenderer.java
@@ -41,7 +41,6 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
 import com.vaadin.flow.shared.Registration;
 
-import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
@@ -196,10 +195,9 @@ public class LitRenderer<SOURCE> extends Renderer<SOURCE> {
                 .getFeature(ReturnChannelMap.class)
                 .registerChannel(arguments -> {
                     // Invoked when the client calls one of the client callables
-                    String handlerName = arguments.get(0).textValue();
-                    String itemKey = arguments.get(1).textValue();
-                    JsonArray args = Json.instance()
-                            .parse(arguments.get(2).toString());
+                    String handlerName = arguments.getString(0);
+                    String itemKey = arguments.getString(1);
+                    JsonArray args = arguments.getArray(2);
 
                     SerializableBiConsumer<SOURCE, JsonArray> handler = clientCallables
                             .get(handlerName);


### PR DESCRIPTION
as flow has reverted the "feat: RpcHandlers to use Jackson (vaadin/flow#20985)" 
This reverts commit b828fcbdaba9009f6e0e65c4b7f39a64a1ea3038.

