### PR TITLE
fix: remove size reset to allow data provider calls to resolve

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderPage.java
@@ -86,6 +86,7 @@ public class GridUpdateDataProviderPage extends Div {
      */
     public GridUpdateDataProviderPage() {
         createBasicGrid();
+        createEmptyGrid();
         createBeanGrid();
     }
 
@@ -111,6 +112,22 @@ public class GridUpdateDataProviderPage extends Div {
         updateProvider.setId("update-basic-provider");
 
         add(new H2("Basic grid"), grid, updateProvider);
+    }
+
+    private void createEmptyGrid() {
+        Grid<String> grid = new Grid<>();
+        grid.setId("empty-grid");
+
+        grid.addColumn(i -> i).setHeader("text");
+
+        NativeButton setItemsAndPageSize = new NativeButton(
+                "Set items and page size", event -> {
+                    grid.setItems("foo", "bar", "baz");
+                    grid.setPageSize(10);
+                });
+        setItemsAndPageSize.setId("set-items-and-page-size");
+
+        add(new H2("Empty grid"), grid, setItemsAndPageSize);
     }
 
     private void createBeanGrid() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderIT.java
@@ -75,6 +75,15 @@ public class GridUpdateDataProviderIT extends AbstractComponentIT {
     }
 
     @Test
+    public void emptyGrid_setItemsAndPageSize() {
+        WebElement grid = findElement(By.id("empty-grid"));
+        findElement(By.id("set-items-and-page-size")).click();
+
+        waitUntil(driver -> hasCell(grid, "foo"));
+        waitUntil(driver -> hasCell(grid, "bar"));
+    }
+
+    @Test
     public void beanGrid_changeDataProvider() {
         WebElement grid = findElement(By.id("bean-grid"));
         waitUntil(driver -> hasCell(grid, "foo"));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -542,6 +542,27 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
   };
 
+  /**
+   * Update the given page of items in the DOM, if the items are visible
+   */
+  const updatePageInDom = function (pageItems) {
+    const firstItem = pageItems[0];
+    if (!firstItem) {
+      return;
+    }
+
+    // Item might not be in grid cache yet if there is a pending request for that page
+    const firstItemContext = dataProviderController.getItemContext(firstItem);
+    if (!firstItemContext) {
+      return;
+    }
+
+    // Update the visible rows in the grid
+    const flatStartIndex = firstItemContext.flatIndex;
+    const flatEndIndex = flatStartIndex + pageItems.length - 1;
+    grid.__updateVisibleRows(flatStartIndex, flatEndIndex);
+  };
+
   grid.$connector.set = function (index, items, parentKey) {
     if (index % grid.pageSize != 0) {
       throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
@@ -567,11 +588,9 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       grid.$connector.doSelection(slice.filter((item) => item.selected));
       grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
 
-      const updatedItems = updateGridCache(page, pkey);
-      if (updatedItems) {
-        itemsUpdated(updatedItems);
-        updateGridItemsInDomBasedOnCache(updatedItems);
-      }
+      updateGridCache(page, pkey);
+      itemsUpdated(slice);
+      updatePageInDom(slice);
     }
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -542,27 +542,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
   };
 
-  /**
-   * Update the given page of items in the DOM, if the items are visible
-   */
-  const updatePageInDom = function (pageItems) {
-    const firstItem = pageItems[0];
-    if (!firstItem) {
-      return;
-    }
-
-    // Item might not be in grid cache yet if there is a pending request for that page
-    const firstItemContext = dataProviderController.getItemContext(firstItem);
-    if (!firstItemContext) {
-      return;
-    }
-
-    // Update the visible rows in the grid
-    const flatStartIndex = firstItemContext.flatIndex;
-    const flatEndIndex = flatStartIndex + pageItems.length - 1;
-    grid.__updateVisibleRows(flatStartIndex, flatEndIndex);
-  };
-
   grid.$connector.set = function (index, items, parentKey) {
     if (index % grid.pageSize != 0) {
       throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
@@ -588,9 +567,11 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       grid.$connector.doSelection(slice.filter((item) => item.selected));
       grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
 
-      updateGridCache(page, pkey);
-      itemsUpdated(slice);
-      updatePageInDom(slice);
+      const updatedItems = updateGridCache(page, pkey);
+      if (updatedItems) {
+        itemsUpdated(updatedItems);
+        updateGridItemsInDomBasedOnCache(updatedItems);
+      }
     }
   };
 
@@ -752,7 +733,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   };
 
   grid.$connector.reset = function () {
-    grid.size = 0;
     cache = {};
     dataProviderController.rootCache.items = [];
     lastRequestedRanges = {};


### PR DESCRIPTION
Removes an extra `size` property change in `reset`, which would otherwise clear pending data provider requests.

When setting items and the page size at once, the Flow component does this:
- Set `size` property to the number of items, for example `3`
- Calls `reset`, which reverts `size` to `0`
- Calls `updateSize`, which changes `size` to `3` again

Reverting `size` to `0` causes `DataProviderController` to clear pending requests, and as such the connector can not resolve them in `confirm`, so the grid does not render the updated items automatically. In addition there is some issue with the virtualizer, where resetting the size does not clear rendered items, so that increasing the size again will not result in updates / new data provider requests. Combined those result in the grid not rendering the new items.

Removing the `size` reset seems safe. It is only called when changing the page size, and is always followed by other connector calls that update the size and clear and set data. Virtualizer could use a fix too, but that is more challenging due to some caching logic on which rows need updates.

Fixes https://github.com/vaadin/web-components/issues/8693