### PR TITLE
refactor: simplify cache reset logic in gridConnector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -735,19 +735,11 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid.$connector.reset = function () {
     grid.size = 0;
     cache = {};
-    dataProviderController.rootCache.items = [];
+    dataProviderController.clearCache();
     lastRequestedRanges = {};
-    if (ensureSubCacheDebouncer) {
-      ensureSubCacheDebouncer.cancel();
-    }
-    if (parentRequestDebouncer) {
-      parentRequestDebouncer.cancel();
-    }
-    if (rootRequestDebouncer) {
-      rootRequestDebouncer.cancel();
-    }
-    ensureSubCacheDebouncer = undefined;
-    parentRequestDebouncer = undefined;
+    ensureSubCacheDebouncer?.cancel();
+    parentRequestDebouncer?.cancel();
+    rootRequestDebouncer?.cancel();
     ensureSubCacheQueue = [];
     parentRequestQueue = [];
     updateAllGridRowsInDomBasedOnCache();


### PR DESCRIPTION
## Description

Simplifies the `$connector.reset` method in gridConnector.

## Type of change

- [x] Refactor
