### PR TITLE
refactor: preload items on grid scroll to index

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -55,7 +55,22 @@ public class GridScrollToPage extends Div {
                 });
         addRowsAndScrollToEnd.setId("add-row-and-scroll-to-end");
 
+        NativeButton addRowAndScrollToIndex = new NativeButton(
+                "Add row and scroll to index", e -> {
+                    items.add(String.valueOf(items.size()));
+                    grid.getDataProvider().refreshAll();
+                    grid.scrollToIndex(items.size() - 1);
+                });
+        addRowAndScrollToIndex.setId("add-row-and-scroll-to-index");
+
+        NativeButton setSmallPageSize = new NativeButton(
+                "Set small page size (5)", e -> {
+                    grid.setPageSize(5);
+                });
+        setSmallPageSize.setId("set-small-page-size");
+
         add(grid, scrollToStart, scrollToEnd, scrollToRow500, grid2,
-                addRowsAndScrollToEnd);
+                addRowsAndScrollToEnd, addRowAndScrollToIndex,
+                setSmallPageSize);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridScrollToIT.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 /**
@@ -75,6 +76,42 @@ public class GridScrollToIT extends AbstractComponentIT {
         button.click();
         Assert.assertEquals(0, grid.getFirstVisibleRowIndex());
         Assert.assertEquals(3, grid.getLastVisibleRowIndex());
+    }
+
+    @Test
+    public void grid_addItem_scrollToIndex_twice() {
+        $("button").id("add-row-and-scroll-to-index").click();
+        // Wait until finished loading
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
+
+        $("button").id("add-row-and-scroll-to-index").click();
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
+
+        // Find the content element of the first visible row cell
+        TestBenchElement slot = grid.getCell(grid.getFirstVisibleRowIndex(), 0)
+                .findElement(By.tagName("slot"));
+        TestBenchElement content = grid
+                .findElement(By.cssSelector("vaadin-grid-cell-content[slot='"
+                        + slot.getPropertyString("name") + "']"));
+        // Expect the content element to be displayed
+        Assert.assertTrue(content.isDisplayed());
+    }
+
+    @Test
+    public void grid_smallPageSize_addItem_scrollToIndex_twice() {
+        // Set page size to 5
+        $("button").id("set-small-page-size").click();
+
+        $("button").id("add-row-and-scroll-to-index").click();
+        // Wait until finished loading
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
+
+        $("button").id("add-row-and-scroll-to-index").click();
+        waitUntil(e -> !grid.getRow(grid.getFirstVisibleRowIndex())
+                .hasAttribute("loading"));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4036,7 +4036,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         // Preload the items
         setRequestedRange(targetPageStartIndex, preloadedItemsCount);
 
-        // Scroll to the requested index            
+        // Scroll to the requested index
         getElement().callJsFunction("scrollToIndex", rowIndex);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4012,6 +4012,31 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
+        // Grid's page size
+        int pageSize = getPageSize();
+        // A rough approximation of the viewport size in rows. This affects the
+        // count of preloaded rows.
+        int viewportSizeEstimate = 40;
+
+        // Get the index of the first item on the page that contains the
+        // requested index
+        int targetPageStartIndex = rowIndex - rowIndex % pageSize;
+
+        // The last index we want to include in the preloaded range
+        int lastIndex = rowIndex + viewportSizeEstimate;
+
+        // Get the index of the last item on the page that contains the last
+        // index we want to preload
+        int lastIndexPageStartIndex = lastIndex - lastIndex % pageSize;
+        int lastIndexPageEndIndex = lastIndexPageStartIndex + pageSize - 1;
+
+        // Preloaded items count
+        int preloadedItemsCount = lastIndexPageEndIndex - targetPageStartIndex
+                + 1;
+        // Preload the items
+        setRequestedRange(targetPageStartIndex, preloadedItemsCount);
+
+        // Scroll to the requested index            
         getElement().callJsFunction("scrollToIndex", rowIndex);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -930,6 +930,18 @@
           }
         }
 
+        if (Object.keys(rootPageCallbacks).length) {
+          // There are still unresolved callbacks waiting for data to the root level,
+          // which means that the range grid requested items for was only partially filled.
+          //
+          // This can happen for example if you preload some items without knowing exactly
+          // how many items the grid web component is going to request.
+          //
+		      // Clear the last requested range for the root level to unblock
+          // any possible data requests for the same range in fetchPage.
+          delete lastRequestedRanges[root];
+        }
+
         // Let server know we're done
         grid.$server.confirmUpdate(id);
       })


### PR DESCRIPTION
Back-port of https://github.com/vaadin/flow-components/pull/5459

Make Grid's `scrollToIndex` method preload the items for the target index so another server roundtrip wouldn't be needed for fetching the items.