### PR TITLE
feat(FormLayout): add autoResponsive API in FormLayout

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -491,6 +491,113 @@ public class FormLayout extends Component
     }
 
     /**
+     * Sets the gap between the label and the field when labels are positioned
+     * aside. The value must be defined in CSS length units, e.g., {@code 1em}
+     * or {@code 10px}.
+     *
+     * @param labelSpacing the gap between the label and the field
+     * @see #setLabelSpacing(float, Unit)
+     */
+    public void setLabelSpacing(String labelSpacing) {
+        this.getStyle().set("--vaadin-form-layout-label-spacing", labelSpacing);
+    }
+
+    /**
+     * Sets the gap between the label and the field when labels are positioned
+     * aside. The value must be defined with a {@link Unit}, e.g., {@code 1} and
+     * {@link Unit#EM}.
+     *
+     * @param labelSpacing the gap between the label and the field
+     * @param unit the CSS unit of the gap
+     * @see #setLabelSpacing(String)
+     */
+    public void setLabelSpacing(float labelSpacing, Unit unit) {
+        setLabelSpacing(labelSpacing + unit.toString());
+    }
+
+    /**
+     * Returns the gap between the label and the field when labels are positioned
+     * aside. It always returns the string value with the CSS length unit.
+     *
+     * @return the gap between the label and the field
+     * @see #setLabelSpacing(String)
+     * @see #setLabelSpacing(float, Unit)
+     */
+    public String getLabelSpacing() {
+        return this.getStyle().get("--vaadin-form-layout-label-spacing");
+    }
+
+    /**
+     * Sets the gap between the columns. The value must be defined in CSS length
+     * units, e.g., {@code 1em} or {@code 10px}.
+     *
+     * @param columnSpacing the gap between the columns
+     * @see #setColumnSpacing(float, Unit)
+     */
+    public void setColumnSpacing(String columnSpacing) {
+        this.getStyle().set("--vaadin-form-layout-column-spacing", columnSpacing);
+    }
+
+    /**
+     * Sets the gap between the columns. The value must be defined with a
+     * {@link Unit}, e.g., {@code 1} and {@link Unit#EM}.
+     *
+     * @param columnSpacing the gap between the columns
+     * @param unit the CSS unit of the gap
+     * @see #setColumnSpacing(String)
+     */
+    public void setColumnSpacing(float columnSpacing, Unit unit) {
+        setColumnSpacing(columnSpacing + unit.toString());
+    }
+
+    /**
+     * Returns the gap between the columns. It always returns the string value
+     * with the CSS length unit.
+     *
+     * @return the gap between the columns
+     * @see #setColumnSpacing(String)
+     * @see #setColumnSpacing(float, Unit)
+     */
+    public String getColumnSpacing() {
+        return this.getStyle().get("--vaadin-form-layout-column-spacing");
+    }
+
+    /**
+     * Sets the gap between the rows. The value must be defined in CSS length
+     * units, e.g., {@code 1em} or {@code 10px}.
+     *
+     * @param rowSpacing the gap between the rows
+     * @see #setRowSpacing(float, Unit)
+     */
+    public void setRowSpacing(String rowSpacing) {
+        this.getStyle().set("--vaadin-form-layout-row-spacing", rowSpacing);
+    }
+
+    /**
+     * Sets the gap between the rows. The value must be defined with a
+     * {@link Unit}, e.g., {@code 1} and {@link Unit#EM}.
+     *
+     * @param rowSpacing the gap between the rows
+     * @param unit the CSS unit of the gap
+     * @see #setRowSpacing(String)
+     */
+    public void setRowSpacing(float rowSpacing, Unit unit) {
+        setRowSpacing(rowSpacing + unit.toString());
+    }
+
+    /**
+     * Returns the gap between the rows. It always returns the string value with
+     * the CSS length unit.
+     *
+     * @return the gap between the rows
+     * @see #setRowSpacing(String)
+     * @see #setRowSpacing(float, Unit)
+     */
+    public String getRowSpacing() {
+        return this.getStyle().get("--vaadin-form-layout-row-spacing");
+    }
+
+    /**
      * Enables the auto responsive mode where the component automatically
      * creates and adjusts columns based on the container's width. Columns have
      * a fixed width defined by {@link #setColumnWidth(String)} and their number
@@ -666,13 +773,23 @@ public class FormLayout extends Component
     }
 
     /**
+     * <p>
      * When enabled with {@link #setAutoResponsive(boolean)}, {@link FormItem}
      * prefers positioning labels beside the fields. If the layout is too narrow
      * to fit a single column with side labels, they revert to their default
      * position above the fields.
+     * </p>
      * <p>
      * To customize the label width and the gap between the label and the field,
-     * use the following CSS properties:
+     * use the following methods:
+     * </p>
+     * <ul>
+     *     <li>{@link #setLabelWidth(String)}</li>
+     *     <li>{@link #setLabelSpacing(String)}</li>
+     * </ul>
+     * <p>
+     *     Alternatively, you can use the following CSS custom properties:
+     * </p>
      * <ul>
      * <li>{@code --vaadin-form-layout-label-width}</li>
      * <li>{@code --vaadin-form-layout-label-spacing}</li>
@@ -696,4 +813,5 @@ public class FormLayout extends Component
     public boolean isLabelsAside() {
         return getElement().getProperty("labelsAside", false);
     }
+
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -453,7 +453,7 @@ public class FormLayout extends Component
     }
 
     /**
-     * Set the width of side-positioned label.
+     * Sets the width of side-positioned label.
      *
      * @param width
      *            the value and CSS unit as a string
@@ -462,11 +462,11 @@ public class FormLayout extends Component
      *      position</a>
      */
     public void setLabelWidth(String width) {
-        this.getStyle().set("--vaadin-form-layout-label-width", width);
+        getStyle().set("--vaadin-form-layout-label-width", width);
     }
 
     /**
-     * Set the width of side-positioned label.
+     * Sets the width of side-positioned label.
      *
      * @param width
      *            the value of the width
@@ -475,11 +475,12 @@ public class FormLayout extends Component
      * @see #setLabelWidth(String)
      */
     public void setLabelWidth(float width, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
         setLabelWidth(width + unit.toString());
     }
 
     /**
-     * Get the width of side-positioned label.
+     * Gets the width of side-positioned label.
      *
      * @return the value and CSS unit as a string
      * @see <a href=
@@ -487,26 +488,26 @@ public class FormLayout extends Component
      *      position</a>
      */
     public String getLabelWidth() {
-        return this.getStyle().get("--vaadin-form-layout-label-width");
+        return getStyle().get("--vaadin-form-layout-label-width");
     }
 
     /**
-     * Sets the gap between the label and the field when labels are positioned
-     * aside. The value must be defined in CSS length units, e.g., {@code 1em}
-     * or {@code 10px}.
+     * Sets the gap between the label and the field which is used when labels
+     * are positioned aside. The value must be provided in CSS length units,
+     * e.g. {@code 1em}.
      *
      * @param labelSpacing
      *            the gap between the label and the field
      * @see #setLabelSpacing(float, Unit)
      */
     public void setLabelSpacing(String labelSpacing) {
-        this.getStyle().set("--vaadin-form-layout-label-spacing", labelSpacing);
+        getStyle().set("--vaadin-form-layout-label-spacing", labelSpacing);
     }
 
     /**
-     * Sets the gap between the label and the field when labels are positioned
-     * aside. The value must be defined with a {@link Unit}, e.g., {@code 1} and
-     * {@link Unit#EM}.
+     * Sets the gap between the label and the field which is used when labels
+     * are positioned aside. The value must be provided with a {@link Unit},
+     * e.g., {@code 1} and {@link Unit#EM}.
      *
      * @param labelSpacing
      *            the gap between the label and the field
@@ -515,38 +516,37 @@ public class FormLayout extends Component
      * @see #setLabelSpacing(String)
      */
     public void setLabelSpacing(float labelSpacing, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
         setLabelSpacing(labelSpacing + unit.toString());
     }
 
     /**
-     * Returns the gap between the label and the field when labels are
-     * positioned aside. It always returns the string value with the CSS length
-     * unit.
+     * Gets the gap between the label and the field which is used when labels
+     * are positioned aside.
      *
-     * @return the gap between the label and the field
+     * @return the value and CSS unit as a string
      * @see #setLabelSpacing(String)
      * @see #setLabelSpacing(float, Unit)
      */
     public String getLabelSpacing() {
-        return this.getStyle().get("--vaadin-form-layout-label-spacing");
+        return getStyle().get("--vaadin-form-layout-label-spacing");
     }
 
     /**
-     * Sets the gap between the columns. The value must be defined in CSS length
-     * units, e.g., {@code 1em} or {@code 10px}.
+     * Sets the gap between the columns. The value must be provided in CSS
+     * length units, e.g. {@code 1em}.
      *
      * @param columnSpacing
      *            the gap between the columns
      * @see #setColumnSpacing(float, Unit)
      */
     public void setColumnSpacing(String columnSpacing) {
-        this.getStyle().set("--vaadin-form-layout-column-spacing",
-                columnSpacing);
+        getStyle().set("--vaadin-form-layout-column-spacing", columnSpacing);
     }
 
     /**
-     * Sets the gap between the columns. The value must be defined with a
-     * {@link Unit}, e.g., {@code 1} and {@link Unit#EM}.
+     * Sets the gap between the columns. The value must be provided with a
+     * {@link Unit}, e.g. {@code 1} and {@link Unit#EM}.
      *
      * @param columnSpacing
      *            the gap between the columns
@@ -555,35 +555,35 @@ public class FormLayout extends Component
      * @see #setColumnSpacing(String)
      */
     public void setColumnSpacing(float columnSpacing, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
         setColumnSpacing(columnSpacing + unit.toString());
     }
 
     /**
-     * Returns the gap between the columns. It always returns the string value
-     * with the CSS length unit.
+     * Gets the gap between the columns.
      *
-     * @return the gap between the columns
+     * @return the value and CSS unit as a string
      * @see #setColumnSpacing(String)
      * @see #setColumnSpacing(float, Unit)
      */
     public String getColumnSpacing() {
-        return this.getStyle().get("--vaadin-form-layout-column-spacing");
+        return getStyle().get("--vaadin-form-layout-column-spacing");
     }
 
     /**
-     * Sets the gap between the rows. The value must be defined in CSS length
-     * units, e.g., {@code 1em} or {@code 10px}.
+     * Sets the gap between the rows. The value must be provided in CSS length
+     * units, e.g. {@code 1em}.
      *
      * @param rowSpacing
      *            the gap between the rows
      * @see #setRowSpacing(float, Unit)
      */
     public void setRowSpacing(String rowSpacing) {
-        this.getStyle().set("--vaadin-form-layout-row-spacing", rowSpacing);
+        getStyle().set("--vaadin-form-layout-row-spacing", rowSpacing);
     }
 
     /**
-     * Sets the gap between the rows. The value must be defined with a
+     * Sets the gap between the rows. The value must be provided with a
      * {@link Unit}, e.g., {@code 1} and {@link Unit#EM}.
      *
      * @param rowSpacing
@@ -593,23 +593,23 @@ public class FormLayout extends Component
      * @see #setRowSpacing(String)
      */
     public void setRowSpacing(float rowSpacing, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
         setRowSpacing(rowSpacing + unit.toString());
     }
 
     /**
-     * Returns the gap between the rows. It always returns the string value with
-     * the CSS length unit.
+     * Gets the gap between the rows.
      *
-     * @return the gap between the rows
+     * @return the value and CSS unit as a string
      * @see #setRowSpacing(String)
      * @see #setRowSpacing(float, Unit)
      */
     public String getRowSpacing() {
-        return this.getStyle().get("--vaadin-form-layout-row-spacing");
+        return getStyle().get("--vaadin-form-layout-row-spacing");
     }
 
     /**
-     * Enables the auto responsive mode where the component automatically
+     * Enables the auto responsive mode in which the component automatically
      * creates and adjusts columns based on the container's width. Columns have
      * a fixed width defined by {@link #setColumnWidth(String)} and their number
      * increases up to the limit set by {@link #setMaxColumns(int)}. The
@@ -620,12 +620,11 @@ public class FormLayout extends Component
      * By default, each field is placed on a new row. To organize fields into
      * rows, there are two options:
      * <ol>
-     * <li>Use {@link FormRow} to explicitly group fields into rows.</li>
-     *
+     * <li>Use {@link FormRow} to explicitly group fields into rows.
      * <li>Enable the {@link #setAutoRows(boolean)} property to automatically
      * arrange fields in available columns, wrapping to a new row when
      * necessary. {@link ElementFactory#createBr()} elements can be used to
-     * force a new row.</li>
+     * force a new row.
      * </ol>
      *
      * @param autoResponsive
@@ -637,7 +636,7 @@ public class FormLayout extends Component
     }
 
     /**
-     * Returns whether the auto responsive mode is enabled.
+     * Gets whether the auto responsive mode is enabled.
      *
      * @return {@code true} if auto responsive mode is enabled, {@code false}
      *         otherwise
@@ -648,11 +647,16 @@ public class FormLayout extends Component
     }
 
     /**
-     * When enabled with {@link #setAutoResponsive(boolean)}, distributes fields
-     * across columns by placing each field in the next available column and
-     * wrapping to the next row when the current row is full.
+     * Sets whether the component should automatically distribute fields across
+     * columns by placing each field in the next available column and wrapping
+     * to the next row when the current row is full.
      * {@link ElementFactory#createBr()} elements can be used to force a new
-     * row. Default is {@code false}.
+     * row.
+     * <p>
+     * The default value is {@code false}.
+     * <p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @param autoRows
      *            {@code true} to enable auto rows mode, {@code false} otherwise
@@ -662,7 +666,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Returns whether the auto rows mode is enabled.
+     * Gets whether the component is set to automatically distribute fields
+     * across columns when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if auto rows mode is enabled, {@code false}
      *         otherwise
@@ -673,36 +678,53 @@ public class FormLayout extends Component
     }
 
     /**
-     * When {@link #setAutoResponsive(boolean)} is enabled, defines the width of
-     * each column. The value must be defined in CSS length units, e.g.,
-     * {@code 100px} or {@code 13em}. The default value is {@code 13em}.
+     * Sets the width of columns that the component should use when
+     * {@link #setAutoResponsive(boolean)} is enabled. The value must be
+     * provided in CSS length units, e.g. {@code 100px}.
+     * <p>
+     * By default, the web component uses a width of {@code 13em}.
+     * <p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @param columnWidth
-     *            the width of each column
+     *            the width of columns
      */
     public void setColumnWidth(String columnWidth) {
+        Objects.requireNonNull(columnWidth, "Column width cannot be null");
+        if (columnWidth.isBlank()) {
+            throw new IllegalArgumentException("Column width cannot be empty");
+        }
+
         getElement().setProperty("columnWidth", columnWidth);
     }
 
     /**
-     * When {@link #setAutoResponsive(boolean)} is enabled, defines the width of
-     * each column. The value must be defined with a {@link Unit}, e.g.,
-     * {@code 100} and {@link Unit#PIXELS}.
+     * Sets the width of columns that the component should use when
+     * {@link #setAutoResponsive(boolean)} is enabled. The value must be
+     * provided with a {@link Unit}, e.g. {@code 100} and {@link Unit#PIXELS}.
+     * <p>
+     * By default, the web component uses a width of {@code 13em}.
+     * <p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @param columnWidth
-     *            the width of each column
+     *            the width of columns
      * @param unit
      *            the CSS unit of the width
      */
     public void setColumnWidth(float columnWidth, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
         setColumnWidth(columnWidth + unit.toString());
     }
 
     /**
-     * Returns the defined width of each column. It always returns the string
-     * value with the CSS length unit.
+     * Gets the width of columns that is used when
+     * {@link #setAutoResponsive(boolean)} is enabled.
      *
-     * @return the width of each column
+     * @return the value and CSS unit as a string, or an empty string if not
+     *         explicitly set
      * @see #setColumnWidth(String)
      * @see #setColumnWidth(float, Unit)
      */
@@ -711,10 +733,14 @@ public class FormLayout extends Component
     }
 
     /**
-     * When {@code #setAutoResponsive(boolean)} is enabled, defines the maximum
-     * number of columns that the layout can create. The layout will create
-     * columns up to this limit based on the available container width. The
-     * default value is {@code 10}.
+     * Sets the maximum number of columns that the component can create The
+     * component will create columns up to this limit based on the available
+     * container width.
+     * <p>
+     * By default, the web component uses a maximum of 10 columns.
+     * <p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @param maxColumns
      *            the maximum number of columns
@@ -724,9 +750,10 @@ public class FormLayout extends Component
     }
 
     /**
-     * Returns the maximum number of columns that the layout can create.
+     * Gets the maximum number of columns that the component can create when
+     * {@code #setAutoResponsive(boolean)} is enabled.
      *
-     * @return the maximum number of columns
+     * @return the maximum number of columns or 0 if not explicitly set
      * @see #setMaxColumns(int)
      */
     public int getMaxColumns() {
@@ -734,11 +761,15 @@ public class FormLayout extends Component
     }
 
     /**
-     * When {@link #setAutoResponsive(boolean)} is enabled, specifies whether
-     * the columns should expand in width to evenly fill any remaining space
-     * after the layout has created as many fixed-width
+     * Sets whether the columns should expand in width to evenly fill any
+     * remaining space after the component has created as many fixed-width
      * ({@link #setColumnWidth(String)}) columns as possible within the
-     * {@link #setMaxColumns(int)} limit. The default value is {@code false}.
+     * {@link #setMaxColumns(int)} limit.
+     * <p>
+     * The default value is {@code false}.
+     * <p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @param expandColumns
      *            {@code true} to expand columns, {@code false} otherwise
@@ -748,8 +779,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Returns whether the columns should expand in width to evenly fill any
-     * remaining space. The default value is {@code false}.
+     * Gets whether the columns should expand in width to evenly fill any
+     * remaining space when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if columns should expand, {@code false} otherwise
      * @see #setExpandColumns(boolean)
@@ -759,22 +790,24 @@ public class FormLayout extends Component
     }
 
     /**
-     * When {@link #setAutoResponsive(boolean)} is enabled, specifies whether
-     * fields should stretch to take up all available space within columns. This
-     * setting also applies to fields inside {@link FormItem} elements. The
-     * default value is {@code false}.
+     * Sets whether fields should stretch to take up all available space within
+     * columns, including fields inside {@link FormItem} elements.
+     * <p>
+     * The default value is {@code false}.
+     * <p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @param expandFields
      *            {@code true} to expand fields, {@code false} otherwise
      */
     public void setExpandFields(boolean expandFields) {
-
         getElement().setProperty("expandFields", expandFields);
     }
 
     /**
-     * Returns whether fields should stretch to take up all available space
-     * within columns.
+     * Gets whether fields should stretch to take up all available space within
+     * columns when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if fields should expand, {@code false} otherwise
      * @see #setExpandFields(boolean)
@@ -784,23 +817,22 @@ public class FormLayout extends Component
     }
 
     /**
+     * Sets whether {@link FormItem} should prefer positioning labels beside the
+     * fields. If the layout is too narrow to fit a single column with a side
+     * label, labels will automatically switch to their default position above
+     * the fields until the layout gets wide again.
      * <p>
-     * When enabled with {@link #setAutoResponsive(boolean)}, {@link FormItem}
-     * prefers positioning labels beside the fields. If the layout is too narrow
-     * to fit a single column with side labels, they revert to their default
-     * position above the fields.
-     * </p>
+     * This setting only applies when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      * <p>
      * To customize the label width and the gap between the label and the field,
      * use the following methods:
-     * </p>
      * <ul>
      * <li>{@link #setLabelWidth(String)}</li>
      * <li>{@link #setLabelSpacing(String)}</li>
      * </ul>
      * <p>
      * Alternatively, you can use the following CSS custom properties:
-     * </p>
      * <ul>
      * <li>{@code --vaadin-form-layout-label-width}</li>
      * <li>{@code --vaadin-form-layout-label-spacing}</li>
@@ -814,8 +846,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Returns whether {@link FormItem} prefers positioning labels beside the
-     * fields.
+     * Gets whether {@link FormItem} is set to prefer positioning labels beside
+     * the fields when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if labels are positioned aside, {@code false}
      *         otherwise
@@ -824,5 +856,4 @@ public class FormLayout extends Component
     public boolean isLabelsAside() {
         return getElement().getProperty("labelsAside", false);
     }
-
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -666,8 +666,9 @@ public class FormLayout extends Component
     }
 
     /**
-     * Gets whether the component is set to automatically distribute fields
-     * across columns when {@link #setAutoResponsive(boolean)} is enabled.
+     * Gets whether the component is configured to automatically distribute
+     * fields across columns when {@link #setAutoResponsive(boolean)} is
+     * enabled.
      *
      * @return {@code true} if auto rows mode is enabled, {@code false}
      *         otherwise
@@ -733,7 +734,7 @@ public class FormLayout extends Component
     }
 
     /**
-     * Sets the maximum number of columns that the component can create The
+     * Sets the maximum number of columns that the component can create. The
      * component will create columns up to this limit based on the available
      * container width.
      * <p>
@@ -761,10 +762,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Sets whether the columns should expand in width to evenly fill any
-     * remaining space after the component has created as many fixed-width
-     * ({@link #setColumnWidth(String)}) columns as possible within the
-     * {@link #setMaxColumns(int)} limit.
+     * Sets whether the columns should evenly expand in width to fill any
+     * remaining space after all columns have been created.
      * <p>
      * The default value is {@code false}.
      * <p>
@@ -779,8 +778,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Gets whether the columns should expand in width to evenly fill any
-     * remaining space when {@link #setAutoResponsive(boolean)} is enabled.
+     * Gets whether columns are configured to expand to fill remaining space
+     * when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if columns should expand, {@code false} otherwise
      * @see #setExpandColumns(boolean)
@@ -791,7 +790,7 @@ public class FormLayout extends Component
 
     /**
      * Sets whether fields should stretch to take up all available space within
-     * columns, including fields inside {@link FormItem} elements.
+     * columns. Fields inside {@link FormItem} elements are also included.
      * <p>
      * The default value is {@code false}.
      * <p>
@@ -806,8 +805,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Gets whether fields should stretch to take up all available space within
-     * columns when {@link #setAutoResponsive(boolean)} is enabled.
+     * Gets whether fields are configured to stretch to take up all available
+     * space within columns when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if fields should expand, {@code false} otherwise
      * @see #setExpandFields(boolean)
@@ -846,8 +845,8 @@ public class FormLayout extends Component
     }
 
     /**
-     * Gets whether {@link FormItem} is set to prefer positioning labels beside
-     * the fields when {@link #setAutoResponsive(boolean)} is enabled.
+     * Gets whether {@link FormItem} is configured to prefer positioning labels
+     * beside the fields when {@link #setAutoResponsive(boolean)} is enabled.
      *
      * @return {@code true} if labels are positioned aside, {@code false}
      *         otherwise

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -387,15 +387,8 @@ public class FormLayout extends Component
     /**
      * Configure the responsive steps used in this layout.
      * <p>
-     * NOTE: Responsive steps are ignored when auto-responsive mode is enabled.
-     * This mode may be enabled either explicitly by calling
-     * {@link #setAutoResponsive(boolean)} with {@code true} or implicitly if
-     * the following feature flag is set in
-     * {@code src/main/resources/vaadin-featureflags.properties}:
-     *
-     * <pre>
-     * com.vaadin.experimental.defaultAutoResponsiveFormLayout = true
-     * </pre>
+     * NOTE: Responsive steps are ignored when
+     * {@link #setAutoResponsive(boolean) auto-responsive mode} is enabled.
      *
      * @see ResponsiveStep
      *
@@ -419,6 +412,9 @@ public class FormLayout extends Component
 
     /**
      * Configure the responsive steps used in this layout.
+     * <p>
+     * NOTE: Responsive steps are ignored when
+     * {@link #setAutoResponsive(boolean) auto-responsive mode} is enabled.
      *
      * @see ResponsiveStep
      *
@@ -637,13 +633,6 @@ public class FormLayout extends Component
      * necessary. {@link ElementFactory#createBr()} elements can be used to
      * force a new row.
      * </ol>
-     * NOTE: The auto-responsive mode is disabled by default unless the
-     * following feature flag is enabled in
-     * {@code src/main/resources/vaadin-featureflags.properties}:
-     *
-     * <pre>
-     * com.vaadin.experimental.defaultAutoResponsiveFormLayout = true
-     * </pre>
      *
      * @param autoResponsive
      *            {@code true} to enable auto responsive mode, {@code false} to

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 
 import elemental.json.Json;
@@ -609,13 +610,13 @@ public class FormLayout extends Component
     }
 
     /**
-     * Enables the auto responsive mode in which the component automatically
-     * creates and adjusts columns based on the container's width. Columns have
-     * a fixed width defined by {@link #setColumnWidth(String)} and their number
-     * increases up to the limit set by {@link #setMaxColumns(int)}. The
-     * component dynamically adjusts the number of columns as the container size
-     * changes. When this mode is enabled, the {@link ResponsiveStep} are
-     * ignored.
+     * When set to {@code true}, the component automatically creates and adjusts
+     * columns based on the container's width.
+     * <p>
+     * In this mode, columns have a fixed width defined by
+     * {@link #setColumnWidth(String)} and their number increases up to the
+     * limit set by {@link #setMaxColumns(int)}. The component dynamically
+     * adjusts the number of columns as the container size changes.
      * <p>
      * By default, each field is placed on a new row. To organize fields into
      * rows, there are two options:
@@ -626,24 +627,20 @@ public class FormLayout extends Component
      * necessary. {@link ElementFactory#createBr()} elements can be used to
      * force a new row.
      * </ol>
+     * NOTE: The auto-responsive mode is disabled by default unless the following
+     * feature flag is enabled in
+     * {@code src/main/resources/vaadin-featureflags.properties}:
+     *
+     * <pre>
+     * com.vaadin.experimental.defaultAutoResponsiveFormLayout = true
+     * </pre>
      *
      * @param autoResponsive
      *            {@code true} to enable auto responsive mode, {@code false}
-     *            otherwise
+     *            to disable
      */
     public void setAutoResponsive(boolean autoResponsive) {
         getElement().setProperty("autoResponsive", autoResponsive);
-    }
-
-    /**
-     * Gets whether the auto responsive mode is enabled.
-     *
-     * @return {@code true} if auto responsive mode is enabled, {@code false}
-     *         otherwise
-     * @see #setAutoResponsive(boolean)
-     */
-    public boolean isAutoResponsive() {
-        return getElement().getProperty("autoResponsive", false);
     }
 
     /**

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -386,6 +386,16 @@ public class FormLayout extends Component
 
     /**
      * Configure the responsive steps used in this layout.
+     * <p>
+     * NOTE: Responsive steps are ignored when auto-responsive mode is enabled.
+     * This mode may be enabled either explicitly by calling
+     * {@link #setAutoResponsive(boolean)} with {@code true} or implicitly if
+     * the following feature flag is set in
+     * {@code src/main/resources/vaadin-featureflags.properties}:
+     *
+     * <pre>
+     * com.vaadin.experimental.defaultAutoResponsiveFormLayout = true
+     * </pre>
      *
      * @see ResponsiveStep
      *
@@ -611,12 +621,12 @@ public class FormLayout extends Component
 
     /**
      * When set to {@code true}, the component automatically creates and adjusts
-     * columns based on the container's width.
-     * <p>
-     * In this mode, columns have a fixed width defined by
-     * {@link #setColumnWidth(String)} and their number increases up to the
-     * limit set by {@link #setMaxColumns(int)}. The component dynamically
-     * adjusts the number of columns as the container size changes.
+     * columns based on the container's width. Columns have a fixed width
+     * defined by {@link #setColumnWidth(String)} and their number increases up
+     * to the limit set by {@link #setMaxColumns(int)}. The component
+     * dynamically adjusts the number of columns as the container size changes.
+     * When this mode is enabled, the {@link ResponsiveStep responsive steps}
+     * are ignored.
      * <p>
      * By default, each field is placed on a new row. To organize fields into
      * rows, there are two options:
@@ -627,8 +637,8 @@ public class FormLayout extends Component
      * necessary. {@link ElementFactory#createBr()} elements can be used to
      * force a new row.
      * </ol>
-     * NOTE: The auto-responsive mode is disabled by default unless the following
-     * feature flag is enabled in
+     * NOTE: The auto-responsive mode is disabled by default unless the
+     * following feature flag is enabled in
      * {@code src/main/resources/vaadin-featureflags.properties}:
      *
      * <pre>
@@ -636,8 +646,8 @@ public class FormLayout extends Component
      * </pre>
      *
      * @param autoResponsive
-     *            {@code true} to enable auto responsive mode, {@code false}
-     *            to disable
+     *            {@code true} to enable auto responsive mode, {@code false} to
+     *            disable
      */
     public void setAutoResponsive(boolean autoResponsive) {
         getElement().setProperty("autoResponsive", autoResponsive);

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -723,13 +723,13 @@ public class FormLayout extends Component
      * Gets the width of columns that is used when
      * {@link #setAutoResponsive(boolean)} is enabled.
      *
-     * @return the value and CSS unit as a string, or an empty string if not
+     * @return the value and CSS unit as a string, or {@code null} if not
      *         explicitly set
      * @see #setColumnWidth(String)
      * @see #setColumnWidth(float, Unit)
      */
     public String getColumnWidth() {
-        return getElement().getProperty("columnWidth", "");
+        return getElement().getProperty("columnWidth");
     }
 
     /**

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -30,10 +30,12 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.JsonSerializable;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.ElementFactory;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -460,7 +462,20 @@ public class FormLayout extends Component
      *      position</a>
      */
     public void setLabelWidth(String width) {
-        this.getStyle().set("--vaadin-form-item-label-width", width);
+        this.getStyle().set("--vaadin-form-layout-label-width", width);
+    }
+
+    /**
+     * Set the width of side-positioned label.
+     *
+     * @param width
+     *            the value of the width
+     * @param unit
+     *            the CSS unit of the width
+     * @see #setLabelWidth(String)
+     */
+    public void setLabelWidth(float width, Unit unit) {
+        setLabelWidth(width + unit.toString());
     }
 
     /**
@@ -472,6 +487,213 @@ public class FormLayout extends Component
      *      position</a>
      */
     public String getLabelWidth() {
-        return this.getStyle().get("--vaadin-form-item-label-width");
+        return this.getStyle().get("--vaadin-form-layout-label-width");
+    }
+
+    /**
+     * Enables the auto responsive mode where the component automatically
+     * creates and adjusts columns based on the container's width. Columns have
+     * a fixed width defined by {@link #setColumnWidth(String)} and their number
+     * increases up to the limit set by {@link #setMaxColumns(int)}. The
+     * component dynamically adjusts the number of columns as the container size
+     * changes. When this mode is enabled, the {@link ResponsiveStep} are
+     * ignored.
+     * <p>
+     * By default, each field is placed on a new row. To organize fields into
+     * rows, there are two options:
+     * <ol>
+     * <li>Use {@link FormRow} to explicitly group fields into rows.</li>
+     *
+     * <li>Enable the {@link #setAutoRows(boolean)} property to automatically
+     * arrange fields in available columns, wrapping to a new row when
+     * necessary. {@link ElementFactory#createBr()} elements can be used to
+     * force a new row.</li>
+     * </ol>
+     *
+     * @param autoResponsive
+     *            {@code true} to enable auto responsive mode, {@code false}
+     *            otherwise
+     */
+    public void setAutoResponsive(boolean autoResponsive) {
+        getElement().setProperty("autoResponsive", autoResponsive);
+    }
+
+    /**
+     * Returns whether the auto responsive mode is enabled.
+     *
+     * @return {@code true} if auto responsive mode is enabled, {@code false}
+     *         otherwise
+     * @see #setAutoResponsive(boolean)
+     */
+    public boolean isAutoResponsive() {
+        return getElement().getProperty("autoResponsive", false);
+    }
+
+    /**
+     * When enabled with {@link #setAutoResponsive(boolean)}, distributes fields
+     * across columns by placing each field in the next available column and
+     * wrapping to the next row when the current row is full.
+     * {@link ElementFactory#createBr()} elements can be used to force a new
+     * row. Default is {@code false}.
+     *
+     * @param autoRows
+     *            {@code true} to enable auto rows mode, {@code false} otherwise
+     */
+    public void setAutoRows(boolean autoRows) {
+        getElement().setProperty("autoRows", autoRows);
+    }
+
+    /**
+     * Returns whether the auto rows mode is enabled.
+     *
+     * @return {@code true} if auto rows mode is enabled, {@code false}
+     *         otherwise
+     * @see #setAutoRows(boolean)
+     */
+    public boolean isAutoRows() {
+        return getElement().getProperty("autoRows", false);
+    }
+
+    /**
+     * When {@link #setAutoResponsive(boolean)} is enabled, defines the width of
+     * each column. The value must be defined in CSS length units, e.g.,
+     * {@code 100px} or {@code 13em}. The default value is {@code 13em}.
+     *
+     * @param columnWidth
+     *            the width of each column
+     */
+    public void setColumnWidth(String columnWidth) {
+        getElement().setProperty("columnWidth", columnWidth);
+    }
+
+    /**
+     * When {@link #setAutoResponsive(boolean)} is enabled, defines the width of
+     * each column. The value must be defined with a {@link Unit}, e.g.,
+     * {@code 100} and {@link Unit#PIXELS}.
+     *
+     * @param columnWidth
+     *            the width of each column
+     * @param unit
+     *            the CSS unit of the width
+     */
+    public void setColumnWidth(float columnWidth, Unit unit) {
+        setColumnWidth(columnWidth + unit.toString());
+    }
+
+    /**
+     * Returns the defined width of each column. It always returns the string
+     * value with the CSS length unit.
+     *
+     * @return the width of each column
+     * @see #setColumnWidth(String)
+     * @see #setColumnWidth(float, Unit)
+     */
+    public String getColumnWidth() {
+        return getElement().getProperty("columnWidth", "");
+    }
+
+    /**
+     * When {@code #setAutoResponsive(boolean)} is enabled, defines the maximum
+     * number of columns that the layout can create. The layout will create
+     * columns up to this limit based on the available container width. The
+     * default value is {@code 10}.
+     *
+     * @param maxColumns
+     *            the maximum number of columns
+     */
+    public void setMaxColumns(int maxColumns) {
+        getElement().setProperty("maxColumns", maxColumns);
+    }
+
+    /**
+     * Returns the maximum number of columns that the layout can create.
+     *
+     * @return the maximum number of columns
+     * @see #setMaxColumns(int)
+     */
+    public int getMaxColumns() {
+        return getElement().getProperty("maxColumns", 0);
+    }
+
+    /**
+     * When {@link #setAutoResponsive(boolean)} is enabled, specifies whether
+     * the columns should expand in width to evenly fill any remaining space
+     * after the layout has created as many fixed-width
+     * ({@link #setColumnWidth(String)}) columns as possible within the
+     * {@link #setMaxColumns(int)} limit. The default value is {@code false}.
+     *
+     * @param expandColumns
+     *            {@code true} to expand columns, {@code false} otherwise
+     */
+    public void setExpandColumns(boolean expandColumns) {
+        getElement().setProperty("expandColumns", expandColumns);
+    }
+
+    /**
+     * Returns whether the columns should expand in width to evenly fill any
+     * remaining space. The default value is {@code false}.
+     *
+     * @return {@code true} if columns should expand, {@code false} otherwise
+     * @see #setExpandColumns(boolean)
+     */
+    public boolean isExpandColumns() {
+        return getElement().getProperty("expandColumns", false);
+    }
+
+    /**
+     * When {@link #setAutoResponsive(boolean)} is enabled, specifies whether
+     * fields should stretch to take up all available space within columns. This
+     * setting also applies to fields inside {@link FormItem} elements. The
+     * default value is {@code false}.
+     *
+     * @param expandFields
+     *            {@code true} to expand fields, {@code false} otherwise
+     */
+    public void setExpandFields(boolean expandFields) {
+
+        getElement().setProperty("expandFields", expandFields);
+    }
+
+    /**
+     * Returns whether fields should stretch to take up all available space
+     * within columns.
+     *
+     * @return {@code true} if fields should expand, {@code false} otherwise
+     * @see #setExpandFields(boolean)
+     */
+    public boolean isExpandFields() {
+        return getElement().getProperty("expandFields", false);
+    }
+
+    /**
+     * When enabled with {@link #setAutoResponsive(boolean)}, {@link FormItem}
+     * prefers positioning labels beside the fields. If the layout is too narrow
+     * to fit a single column with side labels, they revert to their default
+     * position above the fields.
+     * <p>
+     * To customize the label width and the gap between the label and the field,
+     * use the following CSS properties:
+     * <ul>
+     * <li>{@code --vaadin-form-layout-label-width}</li>
+     * <li>{@code --vaadin-form-layout-label-spacing}</li>
+     * </ul>
+     *
+     * @param labelsAside
+     *            {@code true} to position labels aside, {@code false} otherwise
+     */
+    public void setLabelsAside(boolean labelsAside) {
+        getElement().setProperty("labelsAside", labelsAside);
+    }
+
+    /**
+     * Returns whether {@link FormItem} prefers positioning labels beside the
+     * fields.
+     *
+     * @return {@code true} if labels are positioned aside, {@code false}
+     *         otherwise
+     * @see #setLabelsAside(boolean)
+     */
+    public boolean isLabelsAside() {
+        return getElement().getProperty("labelsAside", false);
     }
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -495,7 +495,8 @@ public class FormLayout extends Component
      * aside. The value must be defined in CSS length units, e.g., {@code 1em}
      * or {@code 10px}.
      *
-     * @param labelSpacing the gap between the label and the field
+     * @param labelSpacing
+     *            the gap between the label and the field
      * @see #setLabelSpacing(float, Unit)
      */
     public void setLabelSpacing(String labelSpacing) {
@@ -507,8 +508,10 @@ public class FormLayout extends Component
      * aside. The value must be defined with a {@link Unit}, e.g., {@code 1} and
      * {@link Unit#EM}.
      *
-     * @param labelSpacing the gap between the label and the field
-     * @param unit the CSS unit of the gap
+     * @param labelSpacing
+     *            the gap between the label and the field
+     * @param unit
+     *            the CSS unit of the gap
      * @see #setLabelSpacing(String)
      */
     public void setLabelSpacing(float labelSpacing, Unit unit) {
@@ -516,8 +519,9 @@ public class FormLayout extends Component
     }
 
     /**
-     * Returns the gap between the label and the field when labels are positioned
-     * aside. It always returns the string value with the CSS length unit.
+     * Returns the gap between the label and the field when labels are
+     * positioned aside. It always returns the string value with the CSS length
+     * unit.
      *
      * @return the gap between the label and the field
      * @see #setLabelSpacing(String)
@@ -531,19 +535,23 @@ public class FormLayout extends Component
      * Sets the gap between the columns. The value must be defined in CSS length
      * units, e.g., {@code 1em} or {@code 10px}.
      *
-     * @param columnSpacing the gap between the columns
+     * @param columnSpacing
+     *            the gap between the columns
      * @see #setColumnSpacing(float, Unit)
      */
     public void setColumnSpacing(String columnSpacing) {
-        this.getStyle().set("--vaadin-form-layout-column-spacing", columnSpacing);
+        this.getStyle().set("--vaadin-form-layout-column-spacing",
+                columnSpacing);
     }
 
     /**
      * Sets the gap between the columns. The value must be defined with a
      * {@link Unit}, e.g., {@code 1} and {@link Unit#EM}.
      *
-     * @param columnSpacing the gap between the columns
-     * @param unit the CSS unit of the gap
+     * @param columnSpacing
+     *            the gap between the columns
+     * @param unit
+     *            the CSS unit of the gap
      * @see #setColumnSpacing(String)
      */
     public void setColumnSpacing(float columnSpacing, Unit unit) {
@@ -566,7 +574,8 @@ public class FormLayout extends Component
      * Sets the gap between the rows. The value must be defined in CSS length
      * units, e.g., {@code 1em} or {@code 10px}.
      *
-     * @param rowSpacing the gap between the rows
+     * @param rowSpacing
+     *            the gap between the rows
      * @see #setRowSpacing(float, Unit)
      */
     public void setRowSpacing(String rowSpacing) {
@@ -577,8 +586,10 @@ public class FormLayout extends Component
      * Sets the gap between the rows. The value must be defined with a
      * {@link Unit}, e.g., {@code 1} and {@link Unit#EM}.
      *
-     * @param rowSpacing the gap between the rows
-     * @param unit the CSS unit of the gap
+     * @param rowSpacing
+     *            the gap between the rows
+     * @param unit
+     *            the CSS unit of the gap
      * @see #setRowSpacing(String)
      */
     public void setRowSpacing(float rowSpacing, Unit unit) {
@@ -784,11 +795,11 @@ public class FormLayout extends Component
      * use the following methods:
      * </p>
      * <ul>
-     *     <li>{@link #setLabelWidth(String)}</li>
-     *     <li>{@link #setLabelSpacing(String)}</li>
+     * <li>{@link #setLabelWidth(String)}</li>
+     * <li>{@link #setLabelSpacing(String)}</li>
      * </ul>
      * <p>
-     *     Alternatively, you can use the following CSS custom properties:
+     * Alternatively, you can use the following CSS custom properties:
      * </p>
      * <ul>
      * <li>{@code --vaadin-form-layout-label-width}</li>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.formlayout.tests;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 
@@ -107,5 +108,66 @@ public class FormLayoutTest {
 
         String appliedWidth = formLayout.getLabelWidth();
         Assert.assertEquals(appliedWidth, "2em");
+    }
+
+    @Test
+    public void setAutoResponsive_getAutoResponsive() {
+        FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.isAutoResponsive());
+
+        formLayout.setAutoResponsive(true);
+        Assert.assertTrue(formLayout.isAutoResponsive());
+    }
+
+    @Test
+    public void setAutoRows_getAutoRows() {
+        FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.isAutoRows());
+
+        formLayout.setAutoRows(true);
+        Assert.assertTrue(formLayout.isAutoRows());
+    }
+
+    @Test
+    public void setColumnWidth_getColumnWidth() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setColumnWidth("10em");
+        Assert.assertEquals("10em", formLayout.getColumnWidth());
+
+        formLayout.setColumnWidth(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getColumnWidth());
+    }
+
+    @Test
+    public void setMaxColumns_getMaxColumns() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setMaxColumns(4);
+        Assert.assertEquals(4, formLayout.getMaxColumns());
+    }
+
+    @Test
+    public void setExpandColumns_isExpandColumns() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setExpandColumns(true);
+        Assert.assertTrue(formLayout.isExpandColumns());
+    }
+
+    @Test
+    public void setExpandFields_isExpandFields() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setExpandFields(true);
+        Assert.assertTrue(formLayout.isExpandFields());
+    }
+
+    @Test
+    public void setLabelsAside_isLabelsAside() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setLabelsAside(true);
+        Assert.assertTrue(formLayout.isLabelsAside());
     }
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -140,6 +140,39 @@ public class FormLayoutTest {
     }
 
     @Test
+    public void setColumnSpacing_getColumnSpacing() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setColumnSpacing("10em");
+        Assert.assertEquals("10em", formLayout.getColumnSpacing());
+
+        formLayout.setColumnSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getColumnSpacing());
+    }
+
+    @Test
+    public void setRowSpacing_getRowSpacing() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setRowSpacing("10em");
+        Assert.assertEquals("10em", formLayout.getRowSpacing());
+
+        formLayout.setRowSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getRowSpacing());
+    }
+
+    @Test
+    public void setLabelSpacing_getLabelSpacing() {
+        FormLayout formLayout = new FormLayout();
+
+        formLayout.setLabelSpacing("10em");
+        Assert.assertEquals("10em", formLayout.getLabelSpacing());
+
+        formLayout.setLabelSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getLabelSpacing());
+    }
+
+    @Test
     public void setMaxColumns_getMaxColumns() {
         FormLayout formLayout = new FormLayout();
 

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -102,105 +102,193 @@ public class FormLayoutTest {
     }
 
     @Test
-    public void setLabelWidth_getLabelWidth() {
-        FormLayout formLayout = new FormLayout();
-        formLayout.setLabelWidth("2em");
-
-        String appliedWidth = formLayout.getLabelWidth();
-        Assert.assertEquals(appliedWidth, "2em");
-    }
-
-    @Test
     public void setAutoResponsive_getAutoResponsive() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(
+                formLayout.getElement().hasProperty("autoResponsive"));
         Assert.assertFalse(formLayout.isAutoResponsive());
 
         formLayout.setAutoResponsive(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("autoResponsive", false));
         Assert.assertTrue(formLayout.isAutoResponsive());
     }
 
     @Test
     public void setAutoRows_getAutoRows() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getElement().hasProperty("autoRows"));
         Assert.assertFalse(formLayout.isAutoRows());
 
         formLayout.setAutoRows(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("autoRows", false));
         Assert.assertTrue(formLayout.isAutoRows());
     }
 
     @Test
     public void setColumnWidth_getColumnWidth() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getElement().hasProperty("columnWidth"));
+        Assert.assertNull(formLayout.getColumnWidth());
 
         formLayout.setColumnWidth("10em");
+        Assert.assertEquals("10em",
+                formLayout.getElement().getProperty("columnWidth"));
         Assert.assertEquals("10em", formLayout.getColumnWidth());
 
         formLayout.setColumnWidth(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px",
+                formLayout.getElement().getProperty("columnWidth"));
         Assert.assertEquals("160.0px", formLayout.getColumnWidth());
+
+        Assert.assertThrows("Column width cannot be null",
+                NullPointerException.class,
+                () -> formLayout.setColumnWidth(null));
+
+        Assert.assertThrows("Column width cannot be empty",
+                IllegalArgumentException.class,
+                () -> formLayout.setColumnWidth(""));
     }
 
     @Test
     public void setColumnSpacing_getColumnSpacing() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getStyle()
+                .has("--vaadin-form-layout-column-spacing"));
+        Assert.assertNull(formLayout.getColumnSpacing());
 
         formLayout.setColumnSpacing("10em");
+        Assert.assertEquals("10em", formLayout.getStyle()
+                .get("--vaadin-form-layout-column-spacing"));
         Assert.assertEquals("10em", formLayout.getColumnSpacing());
 
         formLayout.setColumnSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getStyle()
+                .get("--vaadin-form-layout-column-spacing"));
         Assert.assertEquals("160.0px", formLayout.getColumnSpacing());
+
+        formLayout.setColumnSpacing(null);
+        Assert.assertFalse(formLayout.getStyle()
+                .has("--vaadin-form-layout-column-spacing"));
+        Assert.assertNull(formLayout.getColumnSpacing());
     }
 
     @Test
     public void setRowSpacing_getRowSpacing() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(
+                formLayout.getStyle().has("--vaadin-form-layout-row-spacing"));
+        Assert.assertNull(formLayout.getRowSpacing());
 
         formLayout.setRowSpacing("10em");
+        Assert.assertEquals("10em",
+                formLayout.getStyle().get("--vaadin-form-layout-row-spacing"));
         Assert.assertEquals("10em", formLayout.getRowSpacing());
 
         formLayout.setRowSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px",
+                formLayout.getStyle().get("--vaadin-form-layout-row-spacing"));
         Assert.assertEquals("160.0px", formLayout.getRowSpacing());
+
+        formLayout.setRowSpacing(null);
+        Assert.assertFalse(
+                formLayout.getStyle().has("--vaadin-form-layout-row-spacing"));
+        Assert.assertNull(formLayout.getRowSpacing());
+    }
+
+    @Test
+    public void setLabelWidth_getLabelWidth() {
+        FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(
+                formLayout.getStyle().has("--vaadin-form-layout-label-width"));
+        Assert.assertNull(formLayout.getLabelWidth());
+
+        formLayout.setLabelWidth("2em");
+        Assert.assertEquals("2em",
+                formLayout.getStyle().get("--vaadin-form-layout-label-width"));
+        Assert.assertEquals("2em", formLayout.getLabelWidth());
+
+        formLayout.setLabelWidth(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px",
+                formLayout.getStyle().get("--vaadin-form-layout-label-width"));
+        Assert.assertEquals("160.0px", formLayout.getLabelWidth());
+
+        formLayout.setLabelWidth(null);
+        Assert.assertFalse(
+                formLayout.getStyle().has("--vaadin-form-layout-label-width"));
+        Assert.assertNull(formLayout.getLabelWidth());
     }
 
     @Test
     public void setLabelSpacing_getLabelSpacing() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getStyle()
+                .has("--vaadin-form-layout-label-spacing"));
+        Assert.assertNull(formLayout.getLabelSpacing());
 
         formLayout.setLabelSpacing("10em");
+        Assert.assertEquals("10em", formLayout.getStyle()
+                .get("--vaadin-form-layout-label-spacing"));
         Assert.assertEquals("10em", formLayout.getLabelSpacing());
 
         formLayout.setLabelSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getStyle()
+                .get("--vaadin-form-layout-label-spacing"));
         Assert.assertEquals("160.0px", formLayout.getLabelSpacing());
+
+        formLayout.setLabelSpacing(null);
+        Assert.assertFalse(formLayout.getStyle()
+                .has("--vaadin-form-layout-label-spacing"));
+        Assert.assertNull(formLayout.getLabelSpacing());
     }
 
     @Test
     public void setMaxColumns_getMaxColumns() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertEquals(0, formLayout.getMaxColumns());
+        Assert.assertFalse(formLayout.getElement().hasProperty("maxColumns"));
 
         formLayout.setMaxColumns(4);
         Assert.assertEquals(4, formLayout.getMaxColumns());
+        Assert.assertEquals(4,
+                formLayout.getElement().getProperty("maxColumns", 0));
     }
 
     @Test
     public void setExpandColumns_isExpandColumns() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(
+                formLayout.getElement().hasProperty("expandColumns"));
+        Assert.assertFalse(formLayout.isExpandColumns());
 
         formLayout.setExpandColumns(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("expandColumns", false));
         Assert.assertTrue(formLayout.isExpandColumns());
     }
 
     @Test
     public void setExpandFields_isExpandFields() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getElement().hasProperty("expandFields"));
+        Assert.assertFalse(formLayout.isExpandFields());
 
         formLayout.setExpandFields(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("expandFields", false));
         Assert.assertTrue(formLayout.isExpandFields());
     }
 
     @Test
     public void setLabelsAside_isLabelsAside() {
         FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getElement().hasProperty("labelsAside"));
+        Assert.assertFalse(formLayout.isLabelsAside());
 
         formLayout.setLabelsAside(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("labelsAside", false));
         Assert.assertTrue(formLayout.isLabelsAside());
     }
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -102,53 +102,49 @@ public class FormLayoutTest {
     }
 
     @Test
-    public void setAutoResponsive_getAutoResponsive() {
+    public void setLabelWidth_getLabelWidth() {
         FormLayout formLayout = new FormLayout();
         Assert.assertFalse(
-                formLayout.getElement().hasProperty("autoResponsive"));
-        Assert.assertFalse(formLayout.isAutoResponsive());
+                formLayout.getStyle().has("--vaadin-form-layout-label-width"));
+        Assert.assertNull(formLayout.getLabelWidth());
 
-        formLayout.setAutoResponsive(true);
-        Assert.assertTrue(
-                formLayout.getElement().getProperty("autoResponsive", false));
-        Assert.assertTrue(formLayout.isAutoResponsive());
-    }
+        formLayout.setLabelWidth("2em");
+        Assert.assertEquals("2em",
+                formLayout.getStyle().get("--vaadin-form-layout-label-width"));
+        Assert.assertEquals("2em", formLayout.getLabelWidth());
 
-    @Test
-    public void setAutoRows_getAutoRows() {
-        FormLayout formLayout = new FormLayout();
-        Assert.assertFalse(formLayout.getElement().hasProperty("autoRows"));
-        Assert.assertFalse(formLayout.isAutoRows());
-
-        formLayout.setAutoRows(true);
-        Assert.assertTrue(
-                formLayout.getElement().getProperty("autoRows", false));
-        Assert.assertTrue(formLayout.isAutoRows());
-    }
-
-    @Test
-    public void setColumnWidth_getColumnWidth() {
-        FormLayout formLayout = new FormLayout();
-        Assert.assertFalse(formLayout.getElement().hasProperty("columnWidth"));
-        Assert.assertNull(formLayout.getColumnWidth());
-
-        formLayout.setColumnWidth("10em");
-        Assert.assertEquals("10em",
-                formLayout.getElement().getProperty("columnWidth"));
-        Assert.assertEquals("10em", formLayout.getColumnWidth());
-
-        formLayout.setColumnWidth(160, Unit.PIXELS);
+        formLayout.setLabelWidth(160, Unit.PIXELS);
         Assert.assertEquals("160.0px",
-                formLayout.getElement().getProperty("columnWidth"));
-        Assert.assertEquals("160.0px", formLayout.getColumnWidth());
+                formLayout.getStyle().get("--vaadin-form-layout-label-width"));
+        Assert.assertEquals("160.0px", formLayout.getLabelWidth());
 
-        Assert.assertThrows("Column width cannot be null",
-                NullPointerException.class,
-                () -> formLayout.setColumnWidth(null));
+        formLayout.setLabelWidth(null);
+        Assert.assertFalse(
+                formLayout.getStyle().has("--vaadin-form-layout-label-width"));
+        Assert.assertNull(formLayout.getLabelWidth());
+    }
 
-        Assert.assertThrows("Column width cannot be empty",
-                IllegalArgumentException.class,
-                () -> formLayout.setColumnWidth(""));
+    @Test
+    public void setLabelSpacing_getLabelSpacing() {
+        FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getStyle()
+                .has("--vaadin-form-layout-label-spacing"));
+        Assert.assertNull(formLayout.getLabelSpacing());
+
+        formLayout.setLabelSpacing("10em");
+        Assert.assertEquals("10em", formLayout.getStyle()
+                .get("--vaadin-form-layout-label-spacing"));
+        Assert.assertEquals("10em", formLayout.getLabelSpacing());
+
+        formLayout.setLabelSpacing(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px", formLayout.getStyle()
+                .get("--vaadin-form-layout-label-spacing"));
+        Assert.assertEquals("160.0px", formLayout.getLabelSpacing());
+
+        formLayout.setLabelSpacing(null);
+        Assert.assertFalse(formLayout.getStyle()
+                .has("--vaadin-form-layout-label-spacing"));
+        Assert.assertNull(formLayout.getLabelSpacing());
     }
 
     @Test
@@ -198,49 +194,53 @@ public class FormLayoutTest {
     }
 
     @Test
-    public void setLabelWidth_getLabelWidth() {
+    public void setAutoResponsive_getAutoResponsive() {
         FormLayout formLayout = new FormLayout();
         Assert.assertFalse(
-                formLayout.getStyle().has("--vaadin-form-layout-label-width"));
-        Assert.assertNull(formLayout.getLabelWidth());
+                formLayout.getElement().hasProperty("autoResponsive"));
+        Assert.assertFalse(formLayout.isAutoResponsive());
 
-        formLayout.setLabelWidth("2em");
-        Assert.assertEquals("2em",
-                formLayout.getStyle().get("--vaadin-form-layout-label-width"));
-        Assert.assertEquals("2em", formLayout.getLabelWidth());
-
-        formLayout.setLabelWidth(160, Unit.PIXELS);
-        Assert.assertEquals("160.0px",
-                formLayout.getStyle().get("--vaadin-form-layout-label-width"));
-        Assert.assertEquals("160.0px", formLayout.getLabelWidth());
-
-        formLayout.setLabelWidth(null);
-        Assert.assertFalse(
-                formLayout.getStyle().has("--vaadin-form-layout-label-width"));
-        Assert.assertNull(formLayout.getLabelWidth());
+        formLayout.setAutoResponsive(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("autoResponsive", false));
+        Assert.assertTrue(formLayout.isAutoResponsive());
     }
 
     @Test
-    public void setLabelSpacing_getLabelSpacing() {
+    public void setAutoRows_getAutoRows() {
         FormLayout formLayout = new FormLayout();
-        Assert.assertFalse(formLayout.getStyle()
-                .has("--vaadin-form-layout-label-spacing"));
-        Assert.assertNull(formLayout.getLabelSpacing());
+        Assert.assertFalse(formLayout.getElement().hasProperty("autoRows"));
+        Assert.assertFalse(formLayout.isAutoRows());
 
-        formLayout.setLabelSpacing("10em");
-        Assert.assertEquals("10em", formLayout.getStyle()
-                .get("--vaadin-form-layout-label-spacing"));
-        Assert.assertEquals("10em", formLayout.getLabelSpacing());
+        formLayout.setAutoRows(true);
+        Assert.assertTrue(
+                formLayout.getElement().getProperty("autoRows", false));
+        Assert.assertTrue(formLayout.isAutoRows());
+    }
 
-        formLayout.setLabelSpacing(160, Unit.PIXELS);
-        Assert.assertEquals("160.0px", formLayout.getStyle()
-                .get("--vaadin-form-layout-label-spacing"));
-        Assert.assertEquals("160.0px", formLayout.getLabelSpacing());
+    @Test
+    public void setColumnWidth_getColumnWidth() {
+        FormLayout formLayout = new FormLayout();
+        Assert.assertFalse(formLayout.getElement().hasProperty("columnWidth"));
+        Assert.assertNull(formLayout.getColumnWidth());
 
-        formLayout.setLabelSpacing(null);
-        Assert.assertFalse(formLayout.getStyle()
-                .has("--vaadin-form-layout-label-spacing"));
-        Assert.assertNull(formLayout.getLabelSpacing());
+        formLayout.setColumnWidth("10em");
+        Assert.assertEquals("10em",
+                formLayout.getElement().getProperty("columnWidth"));
+        Assert.assertEquals("10em", formLayout.getColumnWidth());
+
+        formLayout.setColumnWidth(160, Unit.PIXELS);
+        Assert.assertEquals("160.0px",
+                formLayout.getElement().getProperty("columnWidth"));
+        Assert.assertEquals("160.0px", formLayout.getColumnWidth());
+
+        Assert.assertThrows("Column width cannot be null",
+                NullPointerException.class,
+                () -> formLayout.setColumnWidth(null));
+
+        Assert.assertThrows("Column width cannot be empty",
+                IllegalArgumentException.class,
+                () -> formLayout.setColumnWidth(""));
     }
 
     @Test

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -198,12 +198,10 @@ public class FormLayoutTest {
         FormLayout formLayout = new FormLayout();
         Assert.assertFalse(
                 formLayout.getElement().hasProperty("autoResponsive"));
-        Assert.assertFalse(formLayout.isAutoResponsive());
 
         formLayout.setAutoResponsive(true);
         Assert.assertTrue(
                 formLayout.getElement().getProperty("autoResponsive", false));
-        Assert.assertTrue(formLayout.isAutoResponsive());
     }
 
     @Test


### PR DESCRIPTION
## Description

Add a set of methods to enable configuring `FormLayout` in the `autoResponsive` mode. Also change `setLabelWidth`/`getLabelWidth` to use the new CSS variable introduced with the lastest changes in the `FormLayout` web-component.

Part #7162

## Type of change

- [ ] Bugfix
- [X] Feature
