### PR TITLE
feat(FormLayout): add `FormRow` class to `FormLayout`

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -280,17 +280,13 @@ public class FormLayout extends Component
     }
 
     /**
-     * <p>
      * Server-side component for the {@code <vaadin-form-row>} element. Used to
      * arrange fields into rows inside a {@link FormLayout} when
      * {@code #setAutoResponsive(boolean)} is enabled.
-     * </p>
      * <p>
-     * Each {@code <vaadin-form-row>} always starts on a new row. Fields that
+     * Each {@link FormRow} always starts on a new row. Fields that
      * exceed the available columns wrap to a new row, which then remains
-     * reserved exclusively for the fields of that {@code <vaadin-form-row>}
-     * element. wrap components for display in a {@link FormLayout}.
-     * </p>
+     * reserved exclusively for the fields of that {@link FormRow}.
      *
      * @author Vaadin Ltd
      */

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -282,11 +282,26 @@ public class FormLayout extends Component
     /**
      * Server-side component for the {@code <vaadin-form-row>} element. Used to
      * arrange fields into rows inside a {@link FormLayout} when
-     * {@code #setAutoResponsive(boolean)} is enabled.
+     * {@link FormLayout#setAutoResponsive(boolean) auto-responsive mode} is
+     * enabled.
      * <p>
-     * Each {@link FormRow} always starts on a new row. Fields that exceed the
-     * available columns wrap to a new row, which then remains reserved
-     * exclusively for the fields of that {@link FormRow}.
+     * Each FormRow always starts on a new row. Fields that exceed the available
+     * columns wrap to a new row, which then remains reserved exclusively for
+     * the fields of that FormRow.
+     * <p>
+     * Example of creating a FormRow with two fields and a single field that
+     * spans two columns:
+     *
+     * <pre>
+     * FormLayout formLayout = new FormLayout();
+     * formLayout.setAutoResponsive(true);
+     * formLayout.addFormRow(new TextField("First name"),
+     *         new TextField("Last name"));
+     *
+     * TextArea addressField = new TextArea("Address");
+     * formLayout.setColspan(addressField, 2);
+     * formLayout.addFormRow(addressField);
+     * </pre>
      *
      * @author Vaadin Ltd
      */
@@ -325,6 +340,17 @@ public class FormLayout extends Component
             return addFormItem(field, new NativeLabel(label));
         }
 
+        /**
+         * Creates a new {@link FormItem} with the given field and label
+         * components and adds it to the form row.
+         *
+         * @param field
+         *            the field component to be wrapped in a form item
+         * @param label
+         *            the label component to be displayed
+         *
+         * @return the created form item
+         */
         public FormItem addFormItem(Component field, Component label) {
             FormItem formItem = new FormItem(field);
             formItem.addToLabel(label);

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -284,9 +284,9 @@ public class FormLayout extends Component
      * arrange fields into rows inside a {@link FormLayout} when
      * {@code #setAutoResponsive(boolean)} is enabled.
      * <p>
-     * Each {@link FormRow} always starts on a new row. Fields that
-     * exceed the available columns wrap to a new row, which then remains
-     * reserved exclusively for the fields of that {@link FormRow}.
+     * Each {@link FormRow} always starts on a new row. Fields that exceed the
+     * available columns wrap to a new row, which then remains reserved
+     * exclusively for the fields of that {@link FormRow}.
      *
      * @author Vaadin Ltd
      */

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -306,12 +306,11 @@ public class FormLayout extends Component
      * @author Vaadin Ltd
      */
     @Tag("vaadin-form-row")
-    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.7.0-beta1")
+    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.8.0-alpha2")
     @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
-    @NpmPackage(value = "@vaadin/form-layout", version = "24.7.0-beta1")
+    @NpmPackage(value = "@vaadin/form-layout", version = "24.8.0-alpha2")
     @JsModule("@vaadin/form-layout/src/vaadin-form-row.js")
-    public static class FormRow extends Component
-            implements HasComponents, HasStyle {
+    public static class FormRow extends Component implements HasComponents {
 
         /**
          * Constructs an empty FormRow. Components to wrap can be added after

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -280,6 +280,64 @@ public class FormLayout extends Component
     }
 
     /**
+     * <p>
+     * Server-side component for the {@code <vaadin-form-row>} element. Used to
+     * arrange fields into rows inside a {@link FormLayout} when
+     * {@code #setAutoResponsive(boolean)} is enabled.
+     * </p>
+     * <p>
+     * Each {@code <vaadin-form-row>} always starts on a new row. Fields that
+     * exceed the available columns wrap to a new row, which then remains
+     * reserved exclusively for the fields of that {@code <vaadin-form-row>}
+     * element. wrap components for display in a {@link FormLayout}.
+     * </p>
+     *
+     * @author Vaadin Ltd
+     */
+    @Tag("vaadin-form-row")
+    @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.7.0-beta1")
+    @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
+    @NpmPackage(value = "@vaadin/form-layout", version = "24.7.0-beta1")
+    @JsModule("@vaadin/form-layout/src/vaadin-form-row.js")
+    public static class FormRow extends Component
+            implements HasComponents, HasStyle {
+
+        /**
+         * Constructs an empty FormRow. Components to wrap can be added after
+         * construction with {@link #add(Component...)}, or by using the
+         * {@link #addFormItem(Component, String)} and
+         * {@link #addFormItem(Component, Component)} methods.
+         *
+         * @see HasComponents#add(Component...)
+         */
+        public FormRow() {
+        }
+
+        /**
+         * Creates a new {@link FormItem} with the given component and the label
+         * string, and adds it to the form row. The label is inserted into the
+         * form item as a {@link NativeLabel}.
+         *
+         * @param field
+         *            the field component to be wrapped in a form item
+         * @param label
+         *            the label text to be displayed
+         *
+         * @return the created form item
+         */
+        public FormItem addFormItem(Component field, String label) {
+            return addFormItem(field, new NativeLabel(label));
+        }
+
+        public FormItem addFormItem(Component field, Component label) {
+            FormItem formItem = new FormItem(field);
+            formItem.addToLabel(label);
+            add(formItem);
+            return formItem;
+        }
+    }
+
+    /**
      * Constructs an empty layout. Components can be added with
      * {@link #add(Component...)}.
      */
@@ -448,6 +506,22 @@ public class FormLayout extends Component
         formItem.addToLabel(label);
         add(formItem);
         return formItem;
+    }
+
+    /**
+     * Convenience method dor creating and adding a new {@link FormRow} to this
+     * layout. The method accepts a list of components that will be added to the
+     * row.
+     *
+     * @param components
+     *            the components to add to the row
+     * @return the created form row
+     */
+    public FormRow addFormRow(Component... components) {
+        FormRow formRow = new FormRow();
+        formRow.add(components);
+        add(formRow);
+        return formRow;
     }
 
     /**

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -119,7 +119,7 @@ public class FormLayoutTest {
     public void addFormRow() {
         FormLayout formLayout = new FormLayout();
         FormRow row = formLayout.addFormRow(new Input(), new Input());
-        Assert.assertEquals(1, row.getElement().getChildCount());
+        Assert.assertEquals(2, row.getElement().getChildCount());
         Assert.assertEquals(formLayout.getElement(),
                 row.getElement().getParent());
     }
@@ -128,15 +128,15 @@ public class FormLayoutTest {
     public void formRow_addFormItem() {
         FormRow row = new FormRow();
         FormItem item = row.addFormItem(new Input(), "custom label");
-        Assert.assertEquals(1, item.getElement().getChildCount());
+        Assert.assertEquals(2, item.getElement().getChildCount());
 
         Element input = item.getElement().getChild(0);
         Assert.assertNotNull(input);
-        Assert.assertEquals(Input.class, input.getClass());
+        Assert.assertEquals("input", input.getTag());
 
         Element label = item.getElement().getChild(1);
         Assert.assertNotNull(label);
-        Assert.assertEquals(NativeLabel.class, label.getClass());
+        Assert.assertEquals("label", label.getTag());
         Assert.assertEquals("custom label", label.getText());
     }
 
@@ -144,14 +144,15 @@ public class FormLayoutTest {
     public void formRow_addFormItemWithComponent() {
         FormRow row = new FormRow();
         FormItem item = row.addFormItem(new Input(), new Span("custom label"));
+        Assert.assertEquals(2, item.getElement().getChildCount());
 
         Element input = item.getElement().getChild(0);
         Assert.assertNotNull(input);
-        Assert.assertEquals(Input.class, input.getClass());
+        Assert.assertEquals("input", input.getTag());
 
         Element label = item.getElement().getChild(1);
         Assert.assertNotNull(label);
-        Assert.assertEquals(Span.class, label.getClass());
+        Assert.assertEquals("span", label.getTag());
         Assert.assertEquals("custom label", label.getText());
     }
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -120,7 +120,8 @@ public class FormLayoutTest {
         FormLayout formLayout = new FormLayout();
         FormRow row = formLayout.addFormRow(new Input(), new Input());
         Assert.assertEquals(1, row.getElement().getChildCount());
-        Assert.assertEquals(formLayout.getElement(), row.getElement().getParent());
+        Assert.assertEquals(formLayout.getElement(),
+                row.getElement().getParent());
     }
 
     @Test

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.formlayout.FormLayout.FormItem;
 import com.vaadin.flow.component.formlayout.FormLayout.FormRow;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 import com.vaadin.flow.component.html.Input;
-import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.dom.Element;
 

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -19,7 +19,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.formlayout.FormLayout.FormItem;
+import com.vaadin.flow.component.formlayout.FormLayout.FormRow;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.component.html.Span;
 
 public class FormLayoutTest {
 
@@ -107,5 +112,57 @@ public class FormLayoutTest {
 
         String appliedWidth = formLayout.getLabelWidth();
         Assert.assertEquals(appliedWidth, "2em");
+    }
+
+    @Test
+    public void addFormRow() {
+        FormLayout formLayout = new FormLayout();
+        FormRow row = formLayout.addFormRow(new Input(), new Input());
+        // Assert row has 2 children
+        Assert.assertEquals(2, row.getChildren().count());
+        // Assert parent is the formLayout
+        Assert.assertTrue(row.getParent().isPresent());
+        Assert.assertEquals(formLayout, row.getParent().get());
+    }
+
+    @Test
+    public void formRow_addFormItem() {
+        FormRow row = new FormRow();
+        FormItem item = row.addFormItem(new Input(), "custom label");
+        // Assert item has a label
+
+        var label = item.getChildren()
+                .filter(child -> "label"
+                        .equals(child.getElement().getAttribute("slot")))
+                .findFirst().map(NativeLabel.class::cast);
+        Assert.assertTrue(label.isPresent());
+        Assert.assertEquals("custom label", label.get().getText());
+
+        // Assert item has a component
+        var component = item.getChildren().filter(
+                child -> child.getElement().getAttribute("slot") == null)
+                .findFirst().map(Input.class::cast);
+        Assert.assertTrue(component.isPresent());
+        Assert.assertEquals(Input.class, component.get().getClass());
+    }
+
+    @Test
+    public void formRow_addFormItemWithComponent() {
+        FormRow row = new FormRow();
+        FormItem item = row.addFormItem(new Input(), new Span("custom label"));
+        // Assert item has a label
+        var label = item.getChildren()
+                .filter(child -> "label"
+                        .equals(child.getElement().getAttribute("slot")))
+                .findFirst().map(Span.class::cast);
+        Assert.assertTrue(label.isPresent());
+        Assert.assertEquals("custom label", label.get().getText());
+
+        // Assert item has a component
+        var component = item.getChildren().filter(
+                child -> child.getElement().getAttribute("slot") == null)
+                .findFirst().map(Input.class::cast);
+        Assert.assertTrue(component.isPresent());
+        Assert.assertEquals(Input.class, component.get().getClass());
     }
 }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.dom.Element;
 
 public class FormLayoutTest {
 
@@ -118,51 +119,38 @@ public class FormLayoutTest {
     public void addFormRow() {
         FormLayout formLayout = new FormLayout();
         FormRow row = formLayout.addFormRow(new Input(), new Input());
-        // Assert row has 2 children
-        Assert.assertEquals(2, row.getChildren().count());
-        // Assert parent is the formLayout
-        Assert.assertTrue(row.getParent().isPresent());
-        Assert.assertEquals(formLayout, row.getParent().get());
+        Assert.assertEquals(1, row.getElement().getChildCount());
+        Assert.assertEquals(formLayout.getElement(), row.getElement().getParent());
     }
 
     @Test
     public void formRow_addFormItem() {
         FormRow row = new FormRow();
         FormItem item = row.addFormItem(new Input(), "custom label");
-        // Assert item has a label
+        Assert.assertEquals(1, item.getElement().getChildCount());
 
-        var label = item.getChildren()
-                .filter(child -> "label"
-                        .equals(child.getElement().getAttribute("slot")))
-                .findFirst().map(NativeLabel.class::cast);
-        Assert.assertTrue(label.isPresent());
-        Assert.assertEquals("custom label", label.get().getText());
+        Element input = item.getElement().getChild(0);
+        Assert.assertNotNull(input);
+        Assert.assertEquals(Input.class, input.getClass());
 
-        // Assert item has a component
-        var component = item.getChildren().filter(
-                child -> child.getElement().getAttribute("slot") == null)
-                .findFirst().map(Input.class::cast);
-        Assert.assertTrue(component.isPresent());
-        Assert.assertEquals(Input.class, component.get().getClass());
+        Element label = item.getElement().getChild(1);
+        Assert.assertNotNull(label);
+        Assert.assertEquals(NativeLabel.class, label.getClass());
+        Assert.assertEquals("custom label", label.getText());
     }
 
     @Test
     public void formRow_addFormItemWithComponent() {
         FormRow row = new FormRow();
         FormItem item = row.addFormItem(new Input(), new Span("custom label"));
-        // Assert item has a label
-        var label = item.getChildren()
-                .filter(child -> "label"
-                        .equals(child.getElement().getAttribute("slot")))
-                .findFirst().map(Span.class::cast);
-        Assert.assertTrue(label.isPresent());
-        Assert.assertEquals("custom label", label.get().getText());
 
-        // Assert item has a component
-        var component = item.getChildren().filter(
-                child -> child.getElement().getAttribute("slot") == null)
-                .findFirst().map(Input.class::cast);
-        Assert.assertTrue(component.isPresent());
-        Assert.assertEquals(Input.class, component.get().getClass());
+        Element input = item.getElement().getChild(0);
+        Assert.assertNotNull(input);
+        Assert.assertEquals(Input.class, input.getClass());
+
+        Element label = item.getElement().getChild(1);
+        Assert.assertNotNull(label);
+        Assert.assertEquals(Span.class, label.getClass());
+        Assert.assertEquals("custom label", label.getText());
     }
 }


### PR DESCRIPTION
## Description

Add a new `FormRow` class that maps to the `<vaadin-form-row>` web component introduced as part of the new `autoResponsive` mode. The class contains a few helper methods to add `FormItem` elements as child of the row.

Part of #7162

## Type of change

- [ ] Bugfix
- [X] Feature
