### PR TITLE
fix: allow setting flex-grow to 0 through FlexComponent

### DIFF
--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/FlexComponent.java
@@ -249,17 +249,11 @@ public interface FlexComponent extends HasOrderedComponents, HasStyle, HasSize {
             throw new IllegalArgumentException(
                     "Flex grow property cannot be negative");
         }
-        if (flexGrow == 0) {
-            for (HasElement component : components) {
-                component.getElement().getStyle()
-                        .remove(FlexConstants.FLEX_GROW_CSS_PROPERTY);
-            }
-        } else {
-            for (HasElement component : components) {
-                component.getElement().getStyle().set(
-                        FlexConstants.FLEX_GROW_CSS_PROPERTY,
-                        String.valueOf(flexGrow));
-            }
+
+        for (HasElement component : components) {
+            component.getElement().getStyle().set(
+                    FlexConstants.FLEX_GROW_CSS_PROPERTY,
+                    String.valueOf(flexGrow));
         }
     }
 

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexComponentTest.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/FlexComponentTest.java
@@ -54,6 +54,21 @@ public class FlexComponentTest {
         component.setFlexShrink(-1, div);
     }
 
+    @Test
+    public void setFlexGrow() {
+        TestComponent component = new TestComponent();
+        Div div = new Div();
+        component.add(div);
+
+        component.setFlexGrow(2, div);
+        Assert.assertEquals(2, component.getFlexGrow(div), 0);
+        Assert.assertEquals("2.0", div.getStyle().get("flex-grow"));
+
+        component.setFlexGrow(0, div);
+        Assert.assertEquals(0, component.getFlexGrow(div), 0);
+        Assert.assertEquals("0.0", div.getStyle().get("flex-grow"));
+    }
+
     @Tag("test")
     private static class TestComponent extends Component
             implements FlexComponent {


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description

As mentioned in the issue below the setFlexGrow method in FlexComponent removes the flex-grow attribute if 0 is passed in. The expected behavior is that it is set to 0.

Fixes #1244  (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
