### PR TITLE
feat: implement card component flow counterpart

### DIFF
--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/main/java/com/vaadin/flow/component/card/tests/CardPage.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/main/java/com/vaadin/flow/component/card/tests/CardPage.java
@@ -40,8 +40,10 @@ public class CardPage extends Div {
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
                         + "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim "
                         + "veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex "
-                        + "ea commodo consequat."));
-        card.add(new NativeButton("Interactive Content"));
+                        + "ea commodo consequat."),
+                new NativeButton("Interactive Content"));
+        card.addToFooter(new Div("Footer text"),
+                new NativeButton("Interactive Footer Content"));
 
         card.getStyle().set("background-color", "lightblue");
         card.setMaxWidth("300px");

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/main/java/com/vaadin/flow/component/card/tests/CardPage.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/main/java/com/vaadin/flow/component/card/tests/CardPage.java
@@ -15,8 +15,12 @@
  */
 package com.vaadin.flow.component.card.tests;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-card")
@@ -25,6 +29,23 @@ public class CardPage extends Div {
     public CardPage() {
         Card card = new Card();
 
+        card.setTitle(new Span("Title"));
+        card.setSubtitle(new Span("Subtitle"));
+        card.setMedia(
+                new Image("https://vaadin.com/images/vaadin-logo.svg", ""));
+        card.setHeader(new Span("Header"));
+        card.setHeaderPrefix(new Span("Header prefix"));
+        card.setHeaderSuffix(new Span("Header suffix"));
+        card.add(new Text(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
+                        + "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim "
+                        + "veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex "
+                        + "ea commodo consequat."));
+        card.add(new NativeButton("Interactive Content"));
+
+        card.getStyle().set("background-color", "lightblue");
+        card.setMaxWidth("300px");
+        card.setMaxHeight("500px");
         add(card);
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -15,12 +15,26 @@
  */
 package com.vaadin.flow.component.card;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.Element;
 
 /**
  * Card is a visual content container for creating a card-based layout.
@@ -32,6 +46,315 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @NpmPackage(value = "@vaadin/card", version = "24.8.0-alpha3")
 @JsModule("@vaadin/card/src/vaadin-card.js")
-public class Card extends Component
-        implements HasSize, HasThemeVariant<CardVariant> {
+public class Card extends Component implements HasSize,
+        HasThemeVariant<CardVariant>, HasComponents, HasAriaLabel {
+
+    static final String MEDIA_SLOT_NAME = "media";
+    static final String TITLE_SLOT_NAME = "title";
+    static final String SUBTITLE_SLOT_NAME = "subtitle";
+    static final String HEADER_SLOT_NAME = "header";
+    static final String HEADER_PREFIX_SLOT_NAME = "header-prefix";
+    static final String HEADER_SUFFIX_SLOT_NAME = "header-suffix";
+    static final String FOOTER_SLOT_NAME = "footer";
+
+    private Element contentRoot;
+
+    /**
+     * Sets the component used as the card's media. The media slot is typically
+     * used to display an image, icon, or other visual element.
+     * <p>
+     * Passing {@code null} removes the current media component from the card.
+     *
+     * @param media
+     *            the media component, or {@code null} to remove
+     */
+    public void setMedia(Component media) {
+        setSlotContent(media, MEDIA_SLOT_NAME);
+    }
+
+    /**
+     * Gets the current media component.
+     *
+     * @return the media component, or {@code null} if none is set
+     */
+    public Component getMedia() {
+        return getSlotContent(MEDIA_SLOT_NAME);
+    }
+
+    /**
+     * Sets the component used as the card's title. If a header component is
+     * set, the title will not be displayed.
+     * <p>
+     * Passing {@code null} removes the current title from the card.
+     *
+     * @param title
+     *            the title component, or {@code null} to remove
+     */
+    public void setTitle(Component title) {
+        setSlotContent(title, TITLE_SLOT_NAME);
+    }
+
+    /**
+     * Gets the current title component.
+     *
+     * @return the title component, or {@code null} if none is set
+     */
+    public Component getTitle() {
+        return getSlotContent(TITLE_SLOT_NAME);
+    }
+
+    /**
+     * Sets the component used as the card's subtitle. If a header component is
+     * set, the subtitle will not be displayed.
+     * <p>
+     * Passing {@code null} removes the current subtitle from the card.
+     *
+     * @param subtitle
+     *            the subtitle component, or {@code null} to remove
+     */
+    public void setSubtitle(Component subtitle) {
+        setSlotContent(subtitle, SUBTITLE_SLOT_NAME);
+    }
+
+    /**
+     * Gets the current subtitle component.
+     *
+     * @return the subtitle component, or {@code null} if none is set
+     */
+    public Component getSubtitle() {
+        return getSlotContent(SUBTITLE_SLOT_NAME);
+    }
+
+    /**
+     * Sets the component used as the card's header. The header is prioritized
+     * over the title and subtitle components, and will be displayed instead.
+     * <p>
+     * Passing {@code null} removes the current header component from the card.
+     *
+     * @param header
+     *            the header component, or {@code null} to remove
+     */
+    public void setHeader(Component header) {
+        setSlotContent(header, HEADER_SLOT_NAME);
+    }
+
+    /**
+     * Gets the current header component.
+     *
+     * @return the header component, or {@code null} if none is set
+     */
+    public Component getHeader() {
+        return getSlotContent(HEADER_SLOT_NAME);
+    }
+
+    /**
+     * Sets a component to the header prefix slot, displayed before the header
+     * content.
+     * <p>
+     * Passing {@code null} removes any existing prefix from the header.
+     *
+     * @param headerPrefix
+     *            the header prefix component, or {@code null} to remove
+     */
+    public void setHeaderPrefix(Component headerPrefix) {
+        setSlotContent(headerPrefix, HEADER_PREFIX_SLOT_NAME);
+    }
+
+    /**
+     * Gets the current header prefix component.
+     *
+     * @return the header prefix component, or {@code null} if none is set
+     */
+    public Component getHeaderPrefix() {
+        return getSlotContent(HEADER_PREFIX_SLOT_NAME);
+    }
+
+    /**
+     * Sets a component to the header suffix slot, displayed after the header
+     * content. Commonly used for decorative icons or custom suffixes.
+     * <p>
+     * Passing {@code null} removes any existing suffix from the header.
+     *
+     * @param headerSuffix
+     *            the header suffix component, or {@code null} to remove
+     */
+    public void setHeaderSuffix(Component headerSuffix) {
+        setSlotContent(headerSuffix, HEADER_SUFFIX_SLOT_NAME);
+    }
+
+    /**
+     * Gets the current header suffix component.
+     *
+     * @return the header suffix component, or {@code null} if none is set
+     */
+    public Component getHeaderSuffix() {
+        return getSlotContent(HEADER_SUFFIX_SLOT_NAME);
+    }
+
+    /**
+     * Adds components to the card's footer slot.
+     *
+     * @param footerComponent
+     *            the components to add into the footer
+     */
+    public void addToFooter(Component... footerComponent) {
+        Objects.requireNonNull(footerComponent,
+                "Components should not be null");
+        var elementsToAdd = Arrays.stream(footerComponent)
+                .map(component -> Objects.requireNonNull(component,
+                        "Component to add cannot be null"))
+                .map(Component::getElement).toList();
+        if (!elementsToAdd.isEmpty()) {
+            var footerRoot = new AtomicReference<Element>();
+            SlotUtils.getElementsInSlot(this, FOOTER_SLOT_NAME).findFirst()
+                    .ifPresentOrElse(footerRoot::set,
+                            () -> footerRoot.set(initSlot(FOOTER_SLOT_NAME)));
+            elementsToAdd.forEach(footerRoot.get()::appendChild);
+        }
+    }
+
+    /**
+     * Gets all components added to the card's footer.
+     *
+     * @return an array of footer components
+     */
+    public Component[] getFooterComponents() {
+        return SlotUtils.getElementsInSlot(this, FOOTER_SLOT_NAME).findFirst()
+                .map(element -> element.getChildren().map(Element::getComponent)
+                        .map(Optional::orElseThrow).toArray(Component[]::new))
+                .orElseGet(() -> new Component[0]);
+    }
+
+    @Override
+    public Stream<Component> getChildren() {
+        if (contentRoot == null) {
+            return Stream.empty();
+        }
+        return contentRoot.getChildren()
+                .map(element -> element.getComponent().orElseThrow());
+    }
+
+    @Override
+    public void add(Collection<Component> components) {
+        Objects.requireNonNull(components, "Components should not be null");
+        var componentsToAdd = components.stream()
+                .map(component -> Objects.requireNonNull(component,
+                        "Component to add cannot be null"))
+                .map(Component::getElement).toList();
+        if (!componentsToAdd.isEmpty()) {
+            if (contentRoot == null) {
+                initContentRoot();
+            }
+            componentsToAdd.forEach(contentRoot::appendChild);
+        }
+    }
+
+    @Override
+    public void remove(Collection<Component> components) {
+        Objects.requireNonNull(components, "Components should not be null.");
+        var toRemove = new ArrayList<Component>(components.size());
+        for (var component : components) {
+            Objects.requireNonNull(component,
+                    "Component to remove cannot be null");
+            var parent = component.getElement().getParent();
+            if (parent == null) {
+                LoggerFactory.getLogger(getClass()).debug(
+                        "Remove of a component with no parent does nothing.");
+                continue;
+            }
+            if (contentRoot != null && contentRoot.equals(parent)) {
+                toRemove.add(component);
+            } else {
+                throw new IllegalArgumentException("The given component ("
+                        + component + ") is not a child of this component");
+            }
+        }
+        toRemove.stream().map(Component::getElement)
+                .forEach(contentRoot::removeChild);
+        if (contentRoot != null && contentRoot.getChildCount() == 0) {
+            getElement().removeChild(contentRoot);
+            contentRoot = null;
+        }
+    }
+
+    @Override
+    public void removeAll() {
+        if (contentRoot != null) {
+            contentRoot.removeAllChildren();
+            getElement().removeChild(contentRoot);
+            contentRoot = null;
+        }
+    }
+
+    @Override
+    public void addComponentAtIndex(int index, Component component) {
+        Objects.requireNonNull(component, "Component should not be null");
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Cannot add a component with a negative index");
+        }
+        if (contentRoot == null) {
+            initContentRoot();
+        }
+        contentRoot.insertChild(index, component.getElement());
+    }
+
+    /**
+     * Sets the ARIA role attribute on the card.
+     *
+     * @param role
+     *            the ARIA role, or {@code null} to clear
+     */
+    public void setAriaRole(String role) {
+        if (role == null) {
+            getElement().removeAttribute("role");
+        } else {
+            getElement().setAttribute("role", role);
+        }
+    }
+
+    /**
+     * Gets the ARIA role attribute of the card.
+     *
+     * @return an optional ARIA role of the card if no ARIA role has been set
+     */
+    public Optional<String> getAriaRole() {
+        return Optional.ofNullable(getElement().getAttribute("role"));
+    }
+
+    private void setSlotContent(Component slotContent, String slotName) {
+        if (slotContent == null) {
+            SlotUtils.getElementsInSlot(this, slotName).findFirst()
+                    .ifPresent(Element::removeAllChildren);
+            SlotUtils.clearSlot(this, slotName);
+            return;
+        }
+        var slotElement = new AtomicReference<Element>();
+        SlotUtils.getElementsInSlot(this, slotName).findFirst().ifPresentOrElse(
+                slotElement::set, () -> slotElement.set(initSlot(slotName)));
+        slotElement.get().removeAllChildren();
+        slotElement.get().appendChild(slotContent.getElement());
+    }
+
+    private Element initSlot(String slotName) {
+        var div = new Element("div");
+        SlotUtils.setSlot(this, slotName, div);
+        return div;
+    }
+
+    private Component getSlotContent(String slotName) {
+        var slotElement = SlotUtils.getElementsInSlot(this, slotName)
+                .findFirst();
+        if (slotElement.isEmpty()) {
+            return null;
+        }
+        var childElement = slotElement.get().getChildren().findFirst()
+                .orElseThrow();
+        return childElement.getComponent().orElseThrow();
+    }
+
+    private void initContentRoot() {
+        contentRoot = new Element("div");
+        getElement().appendChild(contentRoot);
+    }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -367,6 +367,7 @@ public class Card extends Component implements HasSize,
 
     private void initContentRoot() {
         contentRoot = new Element("div");
+        contentRoot.getStyle().set("display", "contents");
         getElement().appendChild(contentRoot);
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -25,11 +25,14 @@ import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -58,6 +61,8 @@ public class Card extends Component implements HasSize,
     static final String FOOTER_SLOT_NAME = "footer";
 
     private Element contentRoot;
+
+    private boolean featureFlagEnabled;
 
     /**
      * Sets the component used as the card's media. The media slot is typically
@@ -320,6 +325,47 @@ public class Card extends Component implements HasSize,
      */
     public Optional<String> getAriaRole() {
         return Optional.ofNullable(getElement().getAttribute("role"));
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        checkFeatureFlag();
+    }
+
+    /**
+     * Gets the feature flags for the current UI.
+     * <p>
+     * Not private in order to support mocking
+     *
+     * @return the current set of feature flags
+     */
+    FeatureFlags getFeatureFlags() {
+        return FeatureFlags
+                .get(UI.getCurrent().getSession().getService().getContext());
+    }
+
+    /**
+     * Only for test use.
+     */
+    void setFeatureFlagEnabled() {
+        featureFlagEnabled = true;
+    }
+
+    /**
+     * Checks whether the Card component feature flag is active. Succeeds if the
+     * flag is enabled, and throws otherwise.
+     *
+     * @throws ExperimentalFeatureException
+     *             when the {@link FeatureFlags#CARD_COMPONENT} feature is not
+     *             enabled
+     */
+    private void checkFeatureFlag() {
+        boolean enabled = featureFlagEnabled
+                || getFeatureFlags().isEnabled(FeatureFlags.CARD_COMPONENT);
+        if (!enabled) {
+            throw new ExperimentalFeatureException();
+        }
     }
 
     private void setSlotContent(Component slotContent, String slotName) {

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -52,13 +52,13 @@ import com.vaadin.flow.dom.Element;
 public class Card extends Component implements HasSize,
         HasThemeVariant<CardVariant>, HasComponents, HasAriaLabel {
 
-    static final String MEDIA_SLOT_NAME = "media";
-    static final String TITLE_SLOT_NAME = "title";
-    static final String SUBTITLE_SLOT_NAME = "subtitle";
-    static final String HEADER_SLOT_NAME = "header";
-    static final String HEADER_PREFIX_SLOT_NAME = "header-prefix";
-    static final String HEADER_SUFFIX_SLOT_NAME = "header-suffix";
-    static final String FOOTER_SLOT_NAME = "footer";
+    private static final String MEDIA_SLOT_NAME = "media";
+    private static final String TITLE_SLOT_NAME = "title";
+    private static final String SUBTITLE_SLOT_NAME = "subtitle";
+    private static final String HEADER_SLOT_NAME = "header";
+    private static final String HEADER_PREFIX_SLOT_NAME = "header-prefix";
+    private static final String HEADER_SUFFIX_SLOT_NAME = "header-suffix";
+    private static final String FOOTER_SLOT_NAME = "footer";
 
     private Element contentRoot;
 

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -132,7 +132,7 @@ public class Card extends Component implements HasSize,
 
     /**
      * Sets the component used as the card's header. The header is prioritized
-     * over the title and subtitle components, and will be displayed instead.
+     * over the {@link setTitle(Component) title} and {@link setSubtitle(Component) subtitle} components, and will be displayed instead.
      * <p>
      * Passing {@code null} removes the current header component from the card.
      *

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -73,7 +73,7 @@ public class Card extends Component implements HasSize,
      *            the media component, or {@code null} to remove
      */
     public void setMedia(Component media) {
-        setSlotContent(MEDIA_SLOT_NAME, media);
+        SlotUtils.setSlot(this, MEDIA_SLOT_NAME, media);
     }
 
     /**
@@ -82,7 +82,7 @@ public class Card extends Component implements HasSize,
      * @return the media component, or {@code null} if none is set
      */
     public Component getMedia() {
-        return getSlotContent(MEDIA_SLOT_NAME);
+        return SlotUtils.getChildInSlot(this, MEDIA_SLOT_NAME);
     }
 
     /**
@@ -96,7 +96,7 @@ public class Card extends Component implements HasSize,
      *            the title component, or {@code null} to remove
      */
     public void setTitle(Component title) {
-        setSlotContent(TITLE_SLOT_NAME, title);
+        SlotUtils.setSlot(this, TITLE_SLOT_NAME, title);
     }
 
     /**
@@ -105,7 +105,7 @@ public class Card extends Component implements HasSize,
      * @return the title component, or {@code null} if none is set
      */
     public Component getTitle() {
-        return getSlotContent(TITLE_SLOT_NAME);
+        return SlotUtils.getChildInSlot(this, TITLE_SLOT_NAME);
     }
 
     /**
@@ -119,7 +119,7 @@ public class Card extends Component implements HasSize,
      *            the subtitle component, or {@code null} to remove
      */
     public void setSubtitle(Component subtitle) {
-        setSlotContent(SUBTITLE_SLOT_NAME, subtitle);
+        SlotUtils.setSlot(this, SUBTITLE_SLOT_NAME, subtitle);
     }
 
     /**
@@ -128,7 +128,7 @@ public class Card extends Component implements HasSize,
      * @return the subtitle component, or {@code null} if none is set
      */
     public Component getSubtitle() {
-        return getSlotContent(SUBTITLE_SLOT_NAME);
+        return SlotUtils.getChildInSlot(this, SUBTITLE_SLOT_NAME);
     }
 
     /**
@@ -143,7 +143,7 @@ public class Card extends Component implements HasSize,
      *            the header component, or {@code null} to remove
      */
     public void setHeader(Component header) {
-        setSlotContent(HEADER_SLOT_NAME, header);
+        SlotUtils.setSlot(this, HEADER_SLOT_NAME, header);
     }
 
     /**
@@ -152,7 +152,7 @@ public class Card extends Component implements HasSize,
      * @return the header component, or {@code null} if none is set
      */
     public Component getHeader() {
-        return getSlotContent(HEADER_SLOT_NAME);
+        return SlotUtils.getChildInSlot(this, HEADER_SLOT_NAME);
     }
 
     /**
@@ -165,7 +165,7 @@ public class Card extends Component implements HasSize,
      *            the header prefix component, or {@code null} to remove
      */
     public void setHeaderPrefix(Component headerPrefix) {
-        setSlotContent(HEADER_PREFIX_SLOT_NAME, headerPrefix);
+        SlotUtils.setSlot(this, HEADER_PREFIX_SLOT_NAME, headerPrefix);
     }
 
     /**
@@ -174,7 +174,7 @@ public class Card extends Component implements HasSize,
      * @return the header prefix component, or {@code null} if none is set
      */
     public Component getHeaderPrefix() {
-        return getSlotContent(HEADER_PREFIX_SLOT_NAME);
+        return SlotUtils.getChildInSlot(this, HEADER_PREFIX_SLOT_NAME);
     }
 
     /**
@@ -187,7 +187,7 @@ public class Card extends Component implements HasSize,
      *            the header suffix component, or {@code null} to remove
      */
     public void setHeaderSuffix(Component headerSuffix) {
-        setSlotContent(HEADER_SUFFIX_SLOT_NAME, headerSuffix);
+        SlotUtils.setSlot(this, HEADER_SUFFIX_SLOT_NAME, headerSuffix);
     }
 
     /**
@@ -196,7 +196,7 @@ public class Card extends Component implements HasSize,
      * @return the header suffix component, or {@code null} if none is set
      */
     public Component getHeaderSuffix() {
-        return getSlotContent(HEADER_SUFFIX_SLOT_NAME);
+        return SlotUtils.getChildInSlot(this, HEADER_SUFFIX_SLOT_NAME);
     }
 
     /**
@@ -363,18 +363,6 @@ public class Card extends Component implements HasSize,
         if (!enabled) {
             throw new ExperimentalFeatureException();
         }
-    }
-
-    private void setSlotContent(String slotName, Component slotContent) {
-        if (slotContent == null) {
-            SlotUtils.clearSlot(this, slotName);
-        } else {
-            SlotUtils.setSlot(this, slotName, slotContent);
-        }
-    }
-
-    private Component getSlotContent(String slotName) {
-        return SlotUtils.getChildInSlot(this, slotName);
     }
 
     private void initContentRoot() {

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -87,8 +87,9 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the component used as the card's title. If a {@link #setHeader(Component) header component} is
-     * set, the title will not be displayed.
+     * Sets the component used as the card's title. If a
+     * {@link #setHeader(Component) header component} is set, the title will not
+     * be displayed.
      * <p>
      * Passing {@code null} removes the current title from the card.
      *
@@ -109,8 +110,9 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the component used as the card's subtitle. If a {@link #setHeader(Component) header component} is
-     * set, the subtitle will not be displayed.
+     * Sets the component used as the card's subtitle. If a
+     * {@link #setHeader(Component) header component} is set, the subtitle will
+     * not be displayed.
      * <p>
      * Passing {@code null} removes the current subtitle from the card.
      *
@@ -132,7 +134,9 @@ public class Card extends Component implements HasSize,
 
     /**
      * Sets the component used as the card's header. The header is prioritized
-     * over the {@link #setTitle(Component) title} and {@link #setSubtitle(Component) subtitle} components, and will be displayed instead.
+     * over the {@link #setTitle(Component) title} and
+     * {@link #setSubtitle(Component) subtitle} components, and will be
+     * displayed instead.
      * <p>
      * Passing {@code null} removes the current header component from the card.
      *

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -87,7 +87,7 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the component used as the card's title. If a {@link setHeader(Component) header component} is
+     * Sets the component used as the card's title. If a {@link #setHeader(Component) header component} is
      * set, the title will not be displayed.
      * <p>
      * Passing {@code null} removes the current title from the card.
@@ -109,7 +109,7 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the component used as the card's subtitle. If a {@link setHeader(Component) header component} is
+     * Sets the component used as the card's subtitle. If a {@link #setHeader(Component) header component} is
      * set, the subtitle will not be displayed.
      * <p>
      * Passing {@code null} removes the current subtitle from the card.
@@ -132,7 +132,7 @@ public class Card extends Component implements HasSize,
 
     /**
      * Sets the component used as the card's header. The header is prioritized
-     * over the {@link setTitle(Component) title} and {@link setSubtitle(Component) subtitle} components, and will be displayed instead.
+     * over the {@link #setTitle(Component) title} and {@link #setSubtitle(Component) subtitle} components, and will be displayed instead.
      * <p>
      * Passing {@code null} removes the current header component from the card.
      *

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -87,7 +87,7 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the component used as the card's title. If a header component is
+     * Sets the component used as the card's title. If a {@link setHeader(Component) header component} is
      * set, the title will not be displayed.
      * <p>
      * Passing {@code null} removes the current title from the card.

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -74,7 +74,7 @@ public class Card extends Component implements HasSize,
      *            the media component, or {@code null} to remove
      */
     public void setMedia(Component media) {
-        setSlotContent(media, MEDIA_SLOT_NAME);
+        setSlotContent(MEDIA_SLOT_NAME, media);
     }
 
     /**
@@ -96,7 +96,7 @@ public class Card extends Component implements HasSize,
      *            the title component, or {@code null} to remove
      */
     public void setTitle(Component title) {
-        setSlotContent(title, TITLE_SLOT_NAME);
+        setSlotContent(TITLE_SLOT_NAME, title);
     }
 
     /**
@@ -118,7 +118,7 @@ public class Card extends Component implements HasSize,
      *            the subtitle component, or {@code null} to remove
      */
     public void setSubtitle(Component subtitle) {
-        setSlotContent(subtitle, SUBTITLE_SLOT_NAME);
+        setSlotContent(SUBTITLE_SLOT_NAME, subtitle);
     }
 
     /**
@@ -140,7 +140,7 @@ public class Card extends Component implements HasSize,
      *            the header component, or {@code null} to remove
      */
     public void setHeader(Component header) {
-        setSlotContent(header, HEADER_SLOT_NAME);
+        setSlotContent(HEADER_SLOT_NAME, header);
     }
 
     /**
@@ -162,7 +162,7 @@ public class Card extends Component implements HasSize,
      *            the header prefix component, or {@code null} to remove
      */
     public void setHeaderPrefix(Component headerPrefix) {
-        setSlotContent(headerPrefix, HEADER_PREFIX_SLOT_NAME);
+        setSlotContent(HEADER_PREFIX_SLOT_NAME, headerPrefix);
     }
 
     /**
@@ -184,7 +184,7 @@ public class Card extends Component implements HasSize,
      *            the header suffix component, or {@code null} to remove
      */
     public void setHeaderSuffix(Component headerSuffix) {
-        setSlotContent(headerSuffix, HEADER_SUFFIX_SLOT_NAME);
+        setSlotContent(HEADER_SUFFIX_SLOT_NAME, headerSuffix);
     }
 
     /**
@@ -368,7 +368,7 @@ public class Card extends Component implements HasSize,
         }
     }
 
-    private void setSlotContent(Component slotContent, String slotName) {
+    private void setSlotContent(String slotName, Component slotContent) {
         if (slotContent == null) {
             SlotUtils.getElementsInSlot(this, slotName).findFirst()
                     .ifPresent(Element::removeAllChildren);

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -109,7 +109,7 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the component used as the card's subtitle. If a header component is
+     * Sets the component used as the card's subtitle. If a {@link setHeader(Component) header component} is
      * set, the subtitle will not be displayed.
      * <p>
      * Passing {@code null} removes the current subtitle from the card.

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/CardVariant.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/CardVariant.java
@@ -23,6 +23,9 @@ import com.vaadin.flow.component.shared.ThemeVariant;
 public enum CardVariant implements ThemeVariant {
     LUMO_ELEVATED("elevated"),
     LUMO_OUTLINED("outlined"),
+    LUMO_HORIZONTAL("horizontal"),
+    LUMO_STRETCH_MEDIA("stretch-media"),
+    LUMO_COVER_MEDIA("cover-media"),
     /**
      * @deprecated Since 24.7, the Material theme is deprecated and will be
      *             removed in Vaadin 25.
@@ -34,7 +37,25 @@ public enum CardVariant implements ThemeVariant {
      *             removed in Vaadin 25.
      */
     @Deprecated
-    MATERIAL_OUTLINED("outlined");
+    MATERIAL_OUTLINED("outlined"),
+    /**
+     * @deprecated Since 24.7, the Material theme is deprecated and will be
+     *             removed in Vaadin 25.
+     */
+    @Deprecated
+    MATERIAL_HORIZONTAL("horizontal"),
+    /**
+     * @deprecated Since 24.7, the Material theme is deprecated and will be
+     *             removed in Vaadin 25.
+     */
+    @Deprecated
+    MATERIAL_STRETCH_MEDIA("stretch-media"),
+    /**
+     * @deprecated Since 24.7, the Material theme is deprecated and will be
+     *             removed in Vaadin 25.
+     */
+    @Deprecated
+    MATERIAL_COVER_MEDIA("cover-media");
 
     private final String variant;
 

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/ExperimentalFeatureException.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/ExperimentalFeatureException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.card;
+
+/**
+ * An exception which is thrown when somebody attempts to use the {@link Card}
+ * component without activating the associated feature flag first.
+ *
+ * @author Vaadin Ltd
+ */
+public class ExperimentalFeatureException extends RuntimeException {
+    public ExperimentalFeatureException() {
+        super("The Card component is currently an experimental feature and needs to be "
+                + "explicitly enabled. The component can be enabled using Copilot, in the "
+                + "experimental features tab, or by adding a "
+                + "`src/main/resources/vaadin-featureflags.properties` file with the following content: "
+                + "`com.vaadin.experimental.cardComponent=true`");
+    }
+}

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -167,11 +167,9 @@ public class CardTest {
     public void addToFooter_slotAttributeSet() {
         var footerComponents = List.of(new Div(), new Span());
         footerComponents.forEach(card::addToFooter);
-        footerComponents.forEach(footerComponent -> {
-            var slotElement = footerComponent.getElement().getParent();
-            Assert.assertNotNull(slotElement);
-            Assert.assertEquals("footer", slotElement.getAttribute("slot"));
-        });
+        footerComponents
+                .forEach(footerComponent -> Assert.assertEquals("footer",
+                        footerComponent.getElement().getAttribute("slot")));
     }
 
     @Test
@@ -313,9 +311,8 @@ public class CardTest {
             BiConsumer<Card, Component> setter, String slotName) {
         var slotContent = new Div();
         setter.accept(card, slotContent);
-        var slotElement = slotContent.getElement().getParent();
-        Assert.assertNotNull(slotElement);
-        Assert.assertEquals(slotName, slotElement.getAttribute("slot"));
+        Assert.assertEquals(slotName,
+                slotContent.getElement().getAttribute("slot"));
     }
 
     private void slotBasedFieldUpdatedCorrectly(

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -240,6 +240,23 @@ public class CardTest {
     }
 
     @Test
+    public void removeAll_onlyRemovesContent() {
+        card.setTitle(new Div());
+        card.setSubtitle(new Div());
+        card.setHeader(new Div());
+        card.setHeaderPrefix(new Div());
+        card.setHeaderSuffix(new Div());
+        card.setMedia(new Div());
+        card.removeAll();
+        Assert.assertNotNull(card.getTitle());
+        Assert.assertNotNull(card.getSubtitle());
+        Assert.assertNotNull(card.getHeader());
+        Assert.assertNotNull(card.getHeaderPrefix());
+        Assert.assertNotNull(card.getHeaderSuffix());
+        Assert.assertNotNull(card.getMedia());
+    }
+
+    @Test
     public void removeAll_allChildrenRemoved() {
         card.add(new Div(), new Div());
         card.removeAll();

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.card;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+
+/**
+ * Unit tests for the {@link Card} component.
+ */
+public class CardTest {
+
+    @Test
+    public void titleNullByDefault() {
+        var card = new Card();
+        Assert.assertNull(card.getTitle());
+    }
+
+    @Test
+    public void titleUpdatedCorrectly() {
+        slotBasedFieldUpdatedCorrectly(Card::getTitle, Card::setTitle);
+    }
+
+    @Test
+    public void setTitle_slotAttributeSet() {
+        setSlotContent_slotContentIsSet(Card::setTitle, Card.TITLE_SLOT_NAME);
+    }
+
+    @Test
+    public void subtitleNullByDefault() {
+        var card = new Card();
+        Assert.assertNull(card.getSubtitle());
+    }
+
+    @Test
+    public void subtitleUpdatedCorrectly() {
+        slotBasedFieldUpdatedCorrectly(Card::getSubtitle, Card::setSubtitle);
+    }
+
+    @Test
+    public void setSubtitle_slotAttributeSet() {
+        setSlotContent_slotContentIsSet(Card::setSubtitle,
+                Card.SUBTITLE_SLOT_NAME);
+    }
+
+    @Test
+    public void mediaNullByDefault() {
+        var card = new Card();
+        Assert.assertNull(card.getMedia());
+    }
+
+    @Test
+    public void mediaUpdatedCorrectly() {
+        slotBasedFieldUpdatedCorrectly(Card::getMedia, Card::setMedia);
+    }
+
+    @Test
+    public void setMedia_slotAttributeSet() {
+        setSlotContent_slotContentIsSet(Card::setMedia, Card.MEDIA_SLOT_NAME);
+    }
+
+    @Test
+    public void headerNullByDefault() {
+        var card = new Card();
+        Assert.assertNull(card.getHeader());
+    }
+
+    @Test
+    public void headerUpdatedCorrectly() {
+        slotBasedFieldUpdatedCorrectly(Card::getHeader, Card::setHeader);
+    }
+
+    @Test
+    public void setHeader_slotAttributeSet() {
+        setSlotContent_slotContentIsSet(Card::setHeader, Card.HEADER_SLOT_NAME);
+    }
+
+    @Test
+    public void headerPrefixNullByDefault() {
+        var card = new Card();
+        Assert.assertNull(card.getHeaderPrefix());
+    }
+
+    @Test
+    public void headerPrefixUpdatedCorrectly() {
+        slotBasedFieldUpdatedCorrectly(Card::getHeaderPrefix,
+                Card::setHeaderPrefix);
+    }
+
+    @Test
+    public void setHeaderPrefix_slotAttributeSet() {
+        setSlotContent_slotContentIsSet(Card::setHeaderPrefix,
+                Card.HEADER_PREFIX_SLOT_NAME);
+    }
+
+    @Test
+    public void headerSuffixNullByDefault() {
+        var card = new Card();
+        Assert.assertNull(card.getHeaderSuffix());
+    }
+
+    @Test
+    public void headerSuffixUpdatedCorrectly() {
+        slotBasedFieldUpdatedCorrectly(Card::getHeaderSuffix,
+                Card::setHeaderSuffix);
+    }
+
+    @Test
+    public void setHeaderSuffix_slotAttributeSet() {
+        setSlotContent_slotContentIsSet(Card::setHeaderSuffix,
+                Card.HEADER_SUFFIX_SLOT_NAME);
+    }
+
+    @Test
+    public void hasNoFooterComponentsByDefault() {
+        var card = new Card();
+        Assert.assertEquals(0, card.getFooterComponents().length);
+    }
+
+    @Test
+    public void addToFooterInArray_footerUpdated() {
+        var card = new Card();
+        var firstFooterContent = new Div();
+        var secondFooterContent = new Div();
+        card.addToFooter(firstFooterContent, secondFooterContent);
+        var footerComponents = card.getFooterComponents();
+        Assert.assertEquals(2, footerComponents.length);
+        Assert.assertEquals(firstFooterContent, footerComponents[0]);
+        Assert.assertEquals(secondFooterContent, footerComponents[1]);
+    }
+
+    @Test
+    public void addToFooterSeparately_footerUpdated() {
+        var card = new Card();
+        var firstFooterContent = new Div();
+        var secondFooterContent = new Div();
+        card.addToFooter(firstFooterContent);
+        card.addToFooter(secondFooterContent);
+        var footerComponents = card.getFooterComponents();
+        Assert.assertEquals(2, footerComponents.length);
+        Assert.assertEquals(firstFooterContent, footerComponents[0]);
+        Assert.assertEquals(secondFooterContent, footerComponents[1]);
+    }
+
+    @Test
+    public void addToFooter_slotAttributeSet() {
+        var card = new Card();
+        var footerComponents = List.of(new Div(), new Span());
+        footerComponents.forEach(card::addToFooter);
+        footerComponents.forEach(footerComponent -> {
+            var slotElement = footerComponent.getElement().getParent();
+            Assert.assertNotNull(slotElement);
+            Assert.assertEquals(Card.FOOTER_SLOT_NAME,
+                    slotElement.getAttribute("slot"));
+        });
+    }
+
+    @Test
+    public void cardHasNoChildrenByDefault() {
+        var card = new Card();
+        Assert.assertTrue(card.getChildren().findAny().isEmpty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addNullCollection_throwsNullPointerException() {
+        var card = new Card();
+        card.add((Collection<Component>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addNullArray_throwsNullPointerException() {
+        var card = new Card();
+        card.add((Component[]) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addNullComponentInArray_throwsNullPointerException() {
+        var card = new Card();
+        card.add(new Div(), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addNullComponentInCollection_throwsNullPointerException() {
+        var card = new Card();
+        card.add(Arrays.asList(new Div(), null));
+    }
+
+    @Test
+    public void addNullComponentInCollection_childrenNotUpdated() {
+        var card = new Card();
+        try {
+            card.add(new Div(), null);
+        } catch (NullPointerException e) {
+            // Do nothing
+        }
+        Assert.assertTrue(card.getChildren().findAny().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void removeContentWithAnotherParent_throwsIllegalArgumentException() {
+        var contentWithAnotherParent = new Span();
+        var otherParent = new Div();
+        otherParent.add(contentWithAnotherParent);
+        var card = new Card();
+        var content = new Div();
+        card.add(content);
+        card.remove(List.of(contentWithAnotherParent));
+    }
+
+    @Test
+    public void removeContentWithNoParent_childrenNotUpdated() {
+        var contentWithNoParent = new Span();
+        var card = new Card();
+        var content = new Div();
+        card.add(content);
+        card.remove(List.of(contentWithNoParent));
+        Assert.assertEquals(List.of(content), card.getChildren().toList());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cardWithContent_removeNull_throwsNullPointerException() {
+        var card = new Card();
+        card.add(new Span());
+        card.remove(Collections.singletonList(null));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cardWithoutContent_removeNull_throwsNullPointerException() {
+        var card = new Card();
+        card.remove(Collections.singletonList(null));
+    }
+
+    @Test
+    public void removeAll_allChildrenRemoved() {
+        var card = new Card();
+        card.add(new Div(), new Div());
+        card.removeAll();
+        Assert.assertTrue(card.getChildren().findAny().isEmpty());
+    }
+
+    @Test
+    public void emptyCard_addComponentAtIndex_componentAddedAtCorrectIndex() {
+        var card = new Card();
+        var component = new Div();
+        card.addComponentAtIndex(0, component);
+        var firstComponent = card.getChildren().findFirst();
+        Assert.assertTrue(firstComponent.isPresent());
+        Assert.assertEquals(component, firstComponent.get());
+    }
+
+    @Test
+    public void addComponentAtNextIndex_componentAddedAtCorrectIndex() {
+        var card = new Card();
+        card.add(new Span());
+        var component = new Div();
+        var initialCount = (int) card.getChildren().count();
+        card.addComponentAtIndex(initialCount, component);
+        var firstComponent = card.getChildren().skip(initialCount).findFirst();
+        Assert.assertTrue(firstComponent.isPresent());
+        Assert.assertEquals(component, firstComponent.get());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addComponentAtOutOfBoundsIndex_throwsIllegalArgumentException() {
+        var card = new Card();
+        card.add(new Span());
+        var component = new Div();
+        card.addComponentAtIndex((int) card.getChildren().count() + 1,
+                component);
+    }
+
+    @Test
+    public void addComponentAtIndex_componentsAddedAtCorrectIndexes() {
+        var card = new Card();
+        card.add(new Span());
+        var component = new Div();
+        card.addComponentAtIndex(0, component);
+        var firstComponent = card.getChildren().findFirst();
+        Assert.assertTrue(firstComponent.isPresent());
+        Assert.assertEquals(component, firstComponent.get());
+    }
+
+    @Test
+    public void cardThemeVariantsEmptyByDefault() {
+        var card = new Card();
+        Assert.assertTrue(card.getThemeNames().isEmpty());
+    }
+
+    @Test
+    public void ariaRoleEmptyByDefault() {
+        var card = new Card();
+        Assert.assertTrue(card.getAriaRole().isEmpty());
+    }
+
+    @Test
+    public void setAriaRole_ariaRoleUpdated() {
+        var ariaRole = "custom-role";
+        var card = new Card();
+        card.setAriaRole(ariaRole);
+        Assert.assertTrue(card.getAriaRole().isPresent());
+        Assert.assertEquals(ariaRole, card.getAriaRole().get());
+    }
+
+    @Test
+    public void setAriaRoleNull_ariaRoleUpdated() {
+        var card = new Card();
+        card.setAriaRole("custom-role");
+        card.setAriaRole(null);
+        Assert.assertTrue(card.getAriaRole().isEmpty());
+    }
+
+    private static void setSlotContent_slotContentIsSet(
+            BiConsumer<Card, Component> setter, String slotName) {
+        var card = new Card();
+        var slotContent = new Div();
+        setter.accept(card, slotContent);
+        var slotElement = slotContent.getElement().getParent();
+        Assert.assertNotNull(slotElement);
+        Assert.assertEquals(slotName, slotElement.getAttribute("slot"));
+    }
+
+    private static void slotBasedFieldUpdatedCorrectly(
+            Function<Card, Component> getter,
+            BiConsumer<Card, Component> setter) {
+        var card = new Card();
+        var component = new Span("Text");
+        setter.accept(card, component);
+        Assert.assertEquals(component, getter.apply(card));
+        var anotherComponent = new Div("New Text");
+        setter.accept(card, anotherComponent);
+        Assert.assertEquals(anotherComponent, getter.apply(card));
+        setter.accept(card, null);
+        Assert.assertNull(getter.apply(card));
+    }
+}

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -55,7 +55,7 @@ public class CardTest {
 
     @Test
     public void setTitle_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setTitle, Card.TITLE_SLOT_NAME);
+        setSlotContent_slotContentIsSet(Card::setTitle, "title");
     }
 
     @Test
@@ -70,8 +70,7 @@ public class CardTest {
 
     @Test
     public void setSubtitle_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setSubtitle,
-                Card.SUBTITLE_SLOT_NAME);
+        setSlotContent_slotContentIsSet(Card::setSubtitle, "subtitle");
     }
 
     @Test
@@ -86,7 +85,7 @@ public class CardTest {
 
     @Test
     public void setMedia_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setMedia, Card.MEDIA_SLOT_NAME);
+        setSlotContent_slotContentIsSet(Card::setMedia, "media");
     }
 
     @Test
@@ -101,7 +100,7 @@ public class CardTest {
 
     @Test
     public void setHeader_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setHeader, Card.HEADER_SLOT_NAME);
+        setSlotContent_slotContentIsSet(Card::setHeader, "header");
     }
 
     @Test
@@ -117,8 +116,7 @@ public class CardTest {
 
     @Test
     public void setHeaderPrefix_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setHeaderPrefix,
-                Card.HEADER_PREFIX_SLOT_NAME);
+        setSlotContent_slotContentIsSet(Card::setHeaderPrefix, "header-prefix");
     }
 
     @Test
@@ -134,8 +132,7 @@ public class CardTest {
 
     @Test
     public void setHeaderSuffix_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setHeaderSuffix,
-                Card.HEADER_SUFFIX_SLOT_NAME);
+        setSlotContent_slotContentIsSet(Card::setHeaderSuffix, "header-suffix");
     }
 
     @Test
@@ -173,8 +170,7 @@ public class CardTest {
         footerComponents.forEach(footerComponent -> {
             var slotElement = footerComponent.getElement().getParent();
             Assert.assertNotNull(slotElement);
-            Assert.assertEquals(Card.FOOTER_SLOT_NAME,
-                    slotElement.getAttribute("slot"));
+            Assert.assertEquals("footer", slotElement.getAttribute("slot"));
         });
     }
 

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
@@ -34,9 +35,16 @@ import com.vaadin.flow.component.html.Span;
  */
 public class CardTest {
 
+    private Card card;
+
+    @Before
+    public void setup() {
+        card = new Card();
+        card.setFeatureFlagEnabled();
+    }
+
     @Test
     public void titleNullByDefault() {
-        var card = new Card();
         Assert.assertNull(card.getTitle());
     }
 
@@ -52,7 +60,6 @@ public class CardTest {
 
     @Test
     public void subtitleNullByDefault() {
-        var card = new Card();
         Assert.assertNull(card.getSubtitle());
     }
 
@@ -69,7 +76,6 @@ public class CardTest {
 
     @Test
     public void mediaNullByDefault() {
-        var card = new Card();
         Assert.assertNull(card.getMedia());
     }
 
@@ -85,7 +91,6 @@ public class CardTest {
 
     @Test
     public void headerNullByDefault() {
-        var card = new Card();
         Assert.assertNull(card.getHeader());
     }
 
@@ -101,7 +106,6 @@ public class CardTest {
 
     @Test
     public void headerPrefixNullByDefault() {
-        var card = new Card();
         Assert.assertNull(card.getHeaderPrefix());
     }
 
@@ -119,7 +123,6 @@ public class CardTest {
 
     @Test
     public void headerSuffixNullByDefault() {
-        var card = new Card();
         Assert.assertNull(card.getHeaderSuffix());
     }
 
@@ -137,13 +140,11 @@ public class CardTest {
 
     @Test
     public void hasNoFooterComponentsByDefault() {
-        var card = new Card();
         Assert.assertEquals(0, card.getFooterComponents().length);
     }
 
     @Test
     public void addToFooterInArray_footerUpdated() {
-        var card = new Card();
         var firstFooterContent = new Div();
         var secondFooterContent = new Div();
         card.addToFooter(firstFooterContent, secondFooterContent);
@@ -155,7 +156,6 @@ public class CardTest {
 
     @Test
     public void addToFooterSeparately_footerUpdated() {
-        var card = new Card();
         var firstFooterContent = new Div();
         var secondFooterContent = new Div();
         card.addToFooter(firstFooterContent);
@@ -168,7 +168,6 @@ public class CardTest {
 
     @Test
     public void addToFooter_slotAttributeSet() {
-        var card = new Card();
         var footerComponents = List.of(new Div(), new Span());
         footerComponents.forEach(card::addToFooter);
         footerComponents.forEach(footerComponent -> {
@@ -181,37 +180,31 @@ public class CardTest {
 
     @Test
     public void cardHasNoChildrenByDefault() {
-        var card = new Card();
         Assert.assertTrue(card.getChildren().findAny().isEmpty());
     }
 
     @Test(expected = NullPointerException.class)
     public void addNullCollection_throwsNullPointerException() {
-        var card = new Card();
         card.add((Collection<Component>) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void addNullArray_throwsNullPointerException() {
-        var card = new Card();
         card.add((Component[]) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void addNullComponentInArray_throwsNullPointerException() {
-        var card = new Card();
         card.add(new Div(), null);
     }
 
     @Test(expected = NullPointerException.class)
     public void addNullComponentInCollection_throwsNullPointerException() {
-        var card = new Card();
         card.add(Arrays.asList(new Div(), null));
     }
 
     @Test
     public void addNullComponentInCollection_childrenNotUpdated() {
-        var card = new Card();
         try {
             card.add(new Div(), null);
         } catch (NullPointerException e) {
@@ -225,7 +218,6 @@ public class CardTest {
         var contentWithAnotherParent = new Span();
         var otherParent = new Div();
         otherParent.add(contentWithAnotherParent);
-        var card = new Card();
         var content = new Div();
         card.add(content);
         card.remove(List.of(contentWithAnotherParent));
@@ -234,7 +226,6 @@ public class CardTest {
     @Test
     public void removeContentWithNoParent_childrenNotUpdated() {
         var contentWithNoParent = new Span();
-        var card = new Card();
         var content = new Div();
         card.add(content);
         card.remove(List.of(contentWithNoParent));
@@ -243,20 +234,17 @@ public class CardTest {
 
     @Test(expected = NullPointerException.class)
     public void cardWithContent_removeNull_throwsNullPointerException() {
-        var card = new Card();
         card.add(new Span());
         card.remove(Collections.singletonList(null));
     }
 
     @Test(expected = NullPointerException.class)
     public void cardWithoutContent_removeNull_throwsNullPointerException() {
-        var card = new Card();
         card.remove(Collections.singletonList(null));
     }
 
     @Test
     public void removeAll_allChildrenRemoved() {
-        var card = new Card();
         card.add(new Div(), new Div());
         card.removeAll();
         Assert.assertTrue(card.getChildren().findAny().isEmpty());
@@ -264,7 +252,6 @@ public class CardTest {
 
     @Test
     public void emptyCard_addComponentAtIndex_componentAddedAtCorrectIndex() {
-        var card = new Card();
         var component = new Div();
         card.addComponentAtIndex(0, component);
         var firstComponent = card.getChildren().findFirst();
@@ -274,7 +261,6 @@ public class CardTest {
 
     @Test
     public void addComponentAtNextIndex_componentAddedAtCorrectIndex() {
-        var card = new Card();
         card.add(new Span());
         var component = new Div();
         var initialCount = (int) card.getChildren().count();
@@ -286,7 +272,6 @@ public class CardTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void addComponentAtOutOfBoundsIndex_throwsIllegalArgumentException() {
-        var card = new Card();
         card.add(new Span());
         var component = new Div();
         card.addComponentAtIndex((int) card.getChildren().count() + 1,
@@ -295,7 +280,6 @@ public class CardTest {
 
     @Test
     public void addComponentAtIndex_componentsAddedAtCorrectIndexes() {
-        var card = new Card();
         card.add(new Span());
         var component = new Div();
         card.addComponentAtIndex(0, component);
@@ -306,20 +290,17 @@ public class CardTest {
 
     @Test
     public void cardThemeVariantsEmptyByDefault() {
-        var card = new Card();
         Assert.assertTrue(card.getThemeNames().isEmpty());
     }
 
     @Test
     public void ariaRoleEmptyByDefault() {
-        var card = new Card();
         Assert.assertTrue(card.getAriaRole().isEmpty());
     }
 
     @Test
     public void setAriaRole_ariaRoleUpdated() {
         var ariaRole = "custom-role";
-        var card = new Card();
         card.setAriaRole(ariaRole);
         Assert.assertTrue(card.getAriaRole().isPresent());
         Assert.assertEquals(ariaRole, card.getAriaRole().get());
@@ -327,15 +308,13 @@ public class CardTest {
 
     @Test
     public void setAriaRoleNull_ariaRoleUpdated() {
-        var card = new Card();
         card.setAriaRole("custom-role");
         card.setAriaRole(null);
         Assert.assertTrue(card.getAriaRole().isEmpty());
     }
 
-    private static void setSlotContent_slotContentIsSet(
+    private void setSlotContent_slotContentIsSet(
             BiConsumer<Card, Component> setter, String slotName) {
-        var card = new Card();
         var slotContent = new Div();
         setter.accept(card, slotContent);
         var slotElement = slotContent.getElement().getParent();
@@ -343,10 +322,9 @@ public class CardTest {
         Assert.assertEquals(slotName, slotElement.getAttribute("slot"));
     }
 
-    private static void slotBasedFieldUpdatedCorrectly(
+    private void slotBasedFieldUpdatedCorrectly(
             Function<Card, Component> getter,
             BiConsumer<Card, Component> setter) {
-        var card = new Card();
         var component = new Span("Text");
         setter.accept(card, component);
         Assert.assertEquals(component, getter.apply(card));

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -55,7 +55,7 @@ public class CardTest {
 
     @Test
     public void setTitle_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setTitle, "title");
+        setSlotContent_slotAttributeIsSet(Card::setTitle, "title");
     }
 
     @Test
@@ -70,7 +70,7 @@ public class CardTest {
 
     @Test
     public void setSubtitle_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setSubtitle, "subtitle");
+        setSlotContent_slotAttributeIsSet(Card::setSubtitle, "subtitle");
     }
 
     @Test
@@ -85,7 +85,7 @@ public class CardTest {
 
     @Test
     public void setMedia_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setMedia, "media");
+        setSlotContent_slotAttributeIsSet(Card::setMedia, "media");
     }
 
     @Test
@@ -100,7 +100,7 @@ public class CardTest {
 
     @Test
     public void setHeader_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setHeader, "header");
+        setSlotContent_slotAttributeIsSet(Card::setHeader, "header");
     }
 
     @Test
@@ -116,7 +116,8 @@ public class CardTest {
 
     @Test
     public void setHeaderPrefix_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setHeaderPrefix, "header-prefix");
+        setSlotContent_slotAttributeIsSet(Card::setHeaderPrefix,
+                "header-prefix");
     }
 
     @Test
@@ -132,7 +133,8 @@ public class CardTest {
 
     @Test
     public void setHeaderSuffix_slotAttributeSet() {
-        setSlotContent_slotContentIsSet(Card::setHeaderSuffix, "header-suffix");
+        setSlotContent_slotAttributeIsSet(Card::setHeaderSuffix,
+                "header-suffix");
     }
 
     @Test
@@ -307,7 +309,7 @@ public class CardTest {
         Assert.assertTrue(card.getAriaRole().isEmpty());
     }
 
-    private void setSlotContent_slotContentIsSet(
+    private void setSlotContent_slotAttributeIsSet(
             BiConsumer<Card, Component> setter, String slotName) {
         var slotContent = new Div();
         setter.accept(card, slotContent);

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -376,13 +376,6 @@ public class CardTest {
     }
 
     private boolean isAncestor(Component component, Card probableAncestor) {
-        var parent = component.getParent();
-        while (parent.isPresent()) {
-            if (parent.get().equals(probableAncestor)) {
-                return true;
-            }
-            parent = parent.get().getParent();
-        }
-        return false;
+        return probableAncestor.getElement().getNode().isAncestorOf(component.getElement().getNode());
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -376,6 +376,13 @@ public class CardTest {
     }
 
     private boolean isAncestor(Component component, Card probableAncestor) {
-        return probableAncestor.getElement().getNode().isAncestorOf(component.getElement().getNode());
+        var parent = component.getParent();
+        while (parent.isPresent()) {
+            if (parent.get().equals(probableAncestor)) {
+                return true;
+            }
+            parent = parent.get().getParent();
+        }
+        return false;
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/FeatureFlagTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/FeatureFlagTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.card;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Tag;
+
+public class FeatureFlagTest {
+    FeatureFlags mockFeatureFlags;
+
+    @Before
+    public void setup() {
+        mockFeatureFlags = Mockito.mock(FeatureFlags.class);
+    }
+
+    @Test
+    public void featureEnabled_attachCard_doesNotThrow() {
+        Mockito.when(mockFeatureFlags.isEnabled(FeatureFlags.CARD_COMPONENT))
+                .thenReturn(true);
+        var testCard = new TestCard();
+        testCard.onAttach(new AttachEvent(testCard, true));
+    }
+
+    @Test(expected = ExperimentalFeatureException.class)
+    public void featureDisabled_attachCard_throwsExperimentalFeatureException() {
+        Mockito.when(mockFeatureFlags.isEnabled(FeatureFlags.CARD_COMPONENT))
+                .thenReturn(false);
+        var testCard = new TestCard();
+        testCard.onAttach(new AttachEvent(testCard, true));
+    }
+
+    @Tag("test-card")
+    private class TestCard extends Card {
+        // Override to expose to test class
+        @Override
+        protected void onAttach(AttachEvent attachEvent) {
+            super.onAttach(attachEvent);
+        }
+
+        // Override to return mock feature flags
+        @Override
+        protected FeatureFlags getFeatureFlags() {
+            return mockFeatureFlags;
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR implements the Flow counterpart for the Card component.

Note 1: One difference from the API described in the issue is the getter for ARIA role. In the issue, the getter for the ARIA attributes are written as `public String getAria...()`. However, the already implemented API for ARIA labels in `HasAriaLabel` return `Optional<String>`. Therefore, the getter for the new ARIA role attribute also returns `Optional<String>` in this PR.

Note 2: Convenience APIs that take String parameters are not a part of this initial implementation.

Fixes #7008 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.