### PR TITLE
fix: additionally set invalid state via executeJs

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/BasicValidationIT.java
@@ -88,6 +88,26 @@ public class BasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationIT.java
@@ -87,6 +87,26 @@ public class CheckboxBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/ComboBoxBasicValidationIT.java
@@ -111,6 +111,26 @@ public class ComboBoxBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/validation/MultiSelectComboBoxBasicValidationIT.java
@@ -117,6 +117,26 @@ public class MultiSelectComboBoxBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
@@ -216,6 +216,26 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -288,6 +288,26 @@ public class BasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java
@@ -32,18 +32,17 @@ public final class ClientValidationUtil {
 
     public static <C extends Component & HasValidation> void preventWebComponentFromModifyingInvalidState(
             C component) {
-        component.getElement().executeJs(
-                "this._shouldSetInvalid = function (invalid) { return false }");
+        StringBuilder expression = new StringBuilder(
+                "this._shouldSetInvalid = function (invalid) { return false };");
 
-        component.getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(component, context -> {
-                    /*
-                     * Workaround the case where the client side validation
-                     * overrides the invalid state before the
-                     * `_shouldSetInvalid` method is overridden above.
-                     */
-                    component.getElement().executeJs("this.invalid = $0",
-                            component.isInvalid());
-                }));
+        /*
+         * Workaround the case where the client side validation overrides the
+         * invalid state before the `_shouldSetInvalid` method is overridden
+         * above.
+         */
+        expression.append("this.invalid = ").append(component.isInvalid())
+                .append(";");
+
+        component.getElement().executeJs(expression.toString());
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasValidationProperties.java
@@ -67,6 +67,7 @@ public interface HasValidationProperties extends HasElement, HasValidation {
     @Override
     default void setInvalid(boolean invalid) {
         getElement().setProperty("invalid", invalid);
+        getElement().executeJs("this.invalid = $0", invalid);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationIT.java
@@ -15,12 +15,15 @@
  */
 package com.vaadin.tests.validation;
 
+import static com.vaadin.tests.validation.AbstractValidationPage.ATTACH_AND_INVALIDATE_FIELD_BUTTON;
 import static com.vaadin.tests.validation.AbstractValidationPage.ATTACH_FIELD_BUTTON;
 import static com.vaadin.tests.validation.AbstractValidationPage.DETACH_FIELD_BUTTON;
+import static com.vaadin.tests.validation.AbstractValidationPage.HIDE_FIELD_BUTTON;
 import static com.vaadin.tests.validation.AbstractValidationPage.SERVER_VALIDATION_COUNTER;
 import static com.vaadin.tests.validation.AbstractValidationPage.SERVER_VALIDATION_COUNTER_RESET_BUTTON;
 import static com.vaadin.tests.validation.AbstractValidationPage.SERVER_VALIDITY_STATE;
 import static com.vaadin.tests.validation.AbstractValidationPage.SERVER_VALIDITY_STATE_BUTTON;
+import static com.vaadin.tests.validation.AbstractValidationPage.SHOW_AND_INVALIDATE_FIELD_BUTTON;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -107,12 +110,33 @@ public abstract class AbstractValidationIT<T extends TestBenchElement>
     }
 
     protected void detachAndReattachField() {
+        detachField();
+        attachField();
+    }
+
+    protected void detachField() {
         $("button").id(DETACH_FIELD_BUTTON).click();
         // Verify element has been removed
         waitUntil(ExpectedConditions.stalenessOf(testField));
+    }
 
+    protected void attachField() {
         $("button").id(ATTACH_FIELD_BUTTON).click();
         // Retrieve new element instance
         testField = getTestField();
+    }
+
+    protected void attachAndInvalidateField() {
+        $("button").id(ATTACH_AND_INVALIDATE_FIELD_BUTTON).click();
+        // Retrieve new element instance
+        testField = getTestField();
+    }
+
+    protected void hideField() {
+        $("button").id(HIDE_FIELD_BUTTON).click();
+    }
+
+    protected void showAndInvalidateField() {
+        $("button").id(SHOW_AND_INVALIDATE_FIELD_BUTTON).click();
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationPage.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/validation/AbstractValidationPage.java
@@ -34,7 +34,11 @@ public abstract class AbstractValidationPage<T extends Component & HasValidation
     public static final String SERVER_VALIDATION_COUNTER_RESET_BUTTON = "server-validation-counter-reset-button";
 
     public static final String ATTACH_FIELD_BUTTON = "attach-field-button";
+    public static final String ATTACH_AND_INVALIDATE_FIELD_BUTTON = "attach-and-invalidate-field-button";
     public static final String DETACH_FIELD_BUTTON = "detach-field-button";
+
+    public static final String HIDE_FIELD_BUTTON = "hide-field-button";
+    public static final String SHOW_AND_INVALIDATE_FIELD_BUTTON = "show-and-invalidate-field-button";
 
     private Div serverValidationCounter;
 
@@ -47,6 +51,7 @@ public abstract class AbstractValidationPage<T extends Component & HasValidation
         addServerValidityStateControls();
         addServerValidationCounter();
         addAttachDetachControls();
+        addVisibilityControls();
     }
 
     private void addServerValidityStateControls() {
@@ -85,10 +90,32 @@ public abstract class AbstractValidationPage<T extends Component & HasValidation
     private void addAttachDetachControls() {
         NativeButton attachButton = createButton(ATTACH_FIELD_BUTTON,
                 "Attach field", event -> add(testField));
+
+        NativeButton attachAndInvalidateButton = createButton(
+                ATTACH_AND_INVALIDATE_FIELD_BUTTON,
+                "Attach field and invalidate", event -> {
+                    add(testField);
+                    testField.setInvalid(true);
+                });
+
         NativeButton detachButton = createButton(DETACH_FIELD_BUTTON,
                 "Detach field", event -> remove(testField));
 
-        add(new Div(attachButton, detachButton));
+        add(new Div(attachButton, attachAndInvalidateButton, detachButton));
+    }
+
+    private void addVisibilityControls() {
+        NativeButton hideButton = createButton(HIDE_FIELD_BUTTON, "Hide field",
+                event -> testField.setVisible(false));
+
+        NativeButton showAndInvalidateButton = createButton(
+                SHOW_AND_INVALIDATE_FIELD_BUTTON, "Show and invalidate field",
+                event -> {
+                    testField.setVisible(true);
+                    testField.setInvalid(true);
+                });
+
+        add(new Div(hideButton, showAndInvalidateButton));
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/validation/BasicValidationIT.java
@@ -76,6 +76,26 @@ public class BasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/validation/BasicValidationIT.java
@@ -86,6 +86,26 @@ public class BasicValidationIT extends AbstractValidationIT<SelectElement> {
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldBasicValidationIT.java
@@ -155,6 +155,26 @@ public class BigDecimalFieldBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/EmailFieldBasicValidationIT.java
@@ -171,6 +171,26 @@ public class EmailFieldBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldBasicValidationIT.java
@@ -278,6 +278,26 @@ public class IntegerFieldBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldBasicValidationIT.java
@@ -248,6 +248,26 @@ public class NumberFieldBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/PasswordFieldBasicValidationIT.java
@@ -161,6 +161,26 @@ public class PasswordFieldBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextAreaBasicValidationIT.java
@@ -155,6 +155,26 @@ public class TextAreaBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/TextFieldBasicValidationIT.java
@@ -155,6 +155,26 @@ public class TextFieldBasicValidationIT
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationIT.java
@@ -216,6 +216,26 @@ public class BasicValidationIT extends AbstractValidationIT<TimePickerElement> {
     }
 
     @Test
+    public void detach_attachAndInvalidate_preservesInvalidState() {
+        detachField();
+        attachAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
+    public void detach_hide_attach_showAndInvalidate_preservesInvalidState() {
+        detachField();
+        hideField();
+        attachField();
+        showAndInvalidateField();
+
+        assertServerInvalid();
+        assertClientInvalid();
+    }
+
+    @Test
     public void webComponentCanNotModifyInvalidState() {
         assertWebComponentCanNotModifyInvalidState();
 


### PR DESCRIPTION
## Description

When a component is made invisible, Flow defers all JS executions from being sent to the client until the component becomes visible again. This includes JS executions added during attach, such as [invalid state synchronization after overriding _shouldSetInvalid](https://github.com/vaadin/flow-components/blob/e6fd1706797ccc8498df7a3f143e18446dde4b47/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ClientValidationUtil.java#L43-L44). Once the component is visible, all deferred JS executions are sent to the client, but they always execute after property updates. As a result, if `setInvalid(...)` was called earlier, it gets overridden by the deferred JS executions. 

To fix this issue, I currently added `executeJs` to `setInvalid()` to ensure the invalid state is ultimately updated to the latest value. Though, it's worth noting that if our components used [manual-validation mode](https://github.com/vaadin/flow-components/pull/6792), this issue wouldn't exist in the first place. I'll again look into whether we could do that refactoring sooner than Vaadin 25.

Fixes #7194 

## Type of change

- [x] Bugfix
