### PR TITLE
feat: add string based title api to card

### DIFF
--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/main/java/com/vaadin/flow/component/card/tests/CardPage.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/main/java/com/vaadin/flow/component/card/tests/CardPage.java
@@ -33,7 +33,6 @@ public class CardPage extends Div {
         card.setSubtitle(new Span("Subtitle"));
         card.setMedia(
                 new Image("https://vaadin.com/images/vaadin-logo.svg", ""));
-        card.setHeader(new Span("Header"));
         card.setHeaderPrefix(new Span("Header prefix"));
         card.setHeaderSuffix(new Span("Header suffix"));
         card.add(new Text(
@@ -49,5 +48,15 @@ public class CardPage extends Div {
         card.setMaxWidth("300px");
         card.setMaxHeight("500px");
         add(card);
+
+        var setStringTitle = new NativeButton("Set string title",
+                event -> card.setTitle("String title"));
+        setStringTitle.setId("set-string-title");
+        add(setStringTitle);
+
+        var setTitleComponent = new NativeButton("Set title component",
+                event -> card.setTitle(new Div("Title component")));
+        setTitleComponent.setId("set-title-component");
+        add(setTitleComponent);
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
@@ -52,22 +52,4 @@ public class CardIT extends AbstractComponentIT {
         Assert.assertFalse(card.getFooterContents().isEmpty());
         Assert.assertFalse(card.getContents().isEmpty());
     }
-
-    @Test
-    public void setTitleComponent_setTitleString_titleComponentIsRemoved() {
-        clickElementWithJs("set-title-component");
-        var titleComponent = card.getTitle();
-        clickElementWithJs("set-string-title");
-        Assert.assertNotEquals(titleComponent, card.getTitle());
-        Assert.assertEquals("String title", card.getStringTitle());
-    }
-
-    @Test
-    public void setStringTitle_setTitleComponent_stringTitleIsRemoved() {
-        clickElementWithJs("set-string-title");
-        var stringTitleComponent = card.getTitle();
-        clickElementWithJs("set-title-component");
-        Assert.assertNotEquals(stringTitleComponent, card.getTitle());
-        Assert.assertNull(card.getStringTitle());
-    }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
@@ -68,6 +68,6 @@ public class CardIT extends AbstractComponentIT {
         var stringTitleComponent = card.getTitle();
         clickElementWithJs("set-title-component");
         Assert.assertNotEquals(stringTitleComponent, card.getTitle());
-        Assert.assertEquals("", card.getStringTitle());
+        Assert.assertNull(card.getStringTitle());
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
@@ -25,15 +25,17 @@ import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-card")
 public class CardIT extends AbstractComponentIT {
+
+    private CardElement card;
+
     @Before
     public void init() {
         open();
+        card = $(CardElement.class).waitForFirst();
     }
 
     @Test
     public void rendersCardComponent() {
-        CardElement card = $(CardElement.class).waitForFirst();
-
         boolean hasShadowRoot = (Boolean) executeScript(
                 "return arguments[0].shadowRoot !== null", card);
         String componentName = (String) executeScript(
@@ -42,5 +44,30 @@ public class CardIT extends AbstractComponentIT {
 
         Assert.assertTrue(hasShadowRoot);
         Assert.assertEquals("vaadin-card", componentName);
+        Assert.assertNotNull(card.getTitle());
+        Assert.assertNotNull(card.getSubtitle());
+        Assert.assertNotNull(card.getMedia());
+        Assert.assertNotNull(card.getHeaderPrefix());
+        Assert.assertNotNull(card.getHeaderSuffix());
+        Assert.assertFalse(card.getFooterElements().isEmpty());
+        Assert.assertFalse(card.getContentElements().isEmpty());
+    }
+
+    @Test
+    public void setTitleComponent_setTitleString_titleComponentIsRemoved() {
+        clickElementWithJs("set-title-component");
+        var titleComponent = card.getTitle();
+        clickElementWithJs("set-string-title");
+        Assert.assertNotEquals(titleComponent, card.getTitle());
+        Assert.assertEquals("String title", card.getStringTitle());
+    }
+
+    @Test
+    public void setStringTitle_setTitleComponent_stringTitleIsRemoved() {
+        clickElementWithJs("set-string-title");
+        var stringTitleComponent = card.getTitle();
+        clickElementWithJs("set-title-component");
+        Assert.assertNotEquals(stringTitleComponent, card.getTitle());
+        Assert.assertEquals("", card.getStringTitle());
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/src/test/java/com/vaadin/flow/component/card/tests/CardIT.java
@@ -49,8 +49,8 @@ public class CardIT extends AbstractComponentIT {
         Assert.assertNotNull(card.getMedia());
         Assert.assertNotNull(card.getHeaderPrefix());
         Assert.assertNotNull(card.getHeaderSuffix());
-        Assert.assertFalse(card.getFooterElements().isEmpty());
-        Assert.assertFalse(card.getContentElements().isEmpty());
+        Assert.assertFalse(card.getFooterContents().isEmpty());
+        Assert.assertFalse(card.getContents().isEmpty());
     }
 
     @Test

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -99,7 +99,8 @@ public class Card extends Component implements HasSize,
      * @see #getTitleAsText()
      */
     public void setTitle(String title) {
-        getElement().setProperty("cardTitle", title);
+        doSetTitle((Component) null);
+        doSetTitle(title);
     }
 
     /**
@@ -158,7 +159,8 @@ public class Card extends Component implements HasSize,
      *            the title component, or {@code null} to remove
      */
     public void setTitle(Component title) {
-        SlotUtils.setSlot(this, TITLE_SLOT_NAME, title);
+        doSetTitle((String) null);
+        doSetTitle(title);
     }
 
     /**
@@ -444,5 +446,17 @@ public class Card extends Component implements HasSize,
         contentRoot = new Element("div");
         contentRoot.getStyle().set("display", "contents");
         getElement().appendChild(contentRoot);
+    }
+
+    private void doSetTitle(String title) {
+        if (title == null) {
+            getElement().removeProperty(CARD_TITLE_PROPERTY);
+        } else {
+            getElement().setProperty(CARD_TITLE_PROPERTY, title);
+        }
+    }
+
+    private void doSetTitle(Component title) {
+        SlotUtils.setSlot(this, TITLE_SLOT_NAME, title);
     }
 }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -110,7 +110,7 @@ public class Card extends Component implements HasSize,
      * Sets the title and the heading level for the title. If a
      * {@link #setHeader(Component) header component} is set, the title will not
      * be displayed. Setting a title this way removes any title component set
-     * using {@link #setTitle(String)}. Setting {@code null} or empty title
+     * using {@link #setTitle(Component)}. Setting {@code null} or empty title
      * removes any previously set {@code String} titles.
      *
      * @param title

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -175,9 +175,6 @@ public class Card extends Component implements HasSize,
      * @return the title component, or {@code null} if none is set
      */
     public Component getTitle() {
-        if (!getTitleAsText().isEmpty()) {
-            return null;
-        }
         return SlotUtils.getChildInSlot(this, TITLE_SLOT_NAME);
     }
 

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
-import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -168,7 +167,6 @@ public class Card extends Component implements HasSize,
      *
      * @return the value of the title property
      */
-    @Synchronize(property = "cardTitle", value = "card-title-changed")
     public String getTitleAsText() {
         return getElement().getProperty("cardTitle", "");
     }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -59,6 +59,9 @@ public class Card extends Component implements HasSize,
     private static final String HEADER_SUFFIX_SLOT_NAME = "header-suffix";
     private static final String FOOTER_SLOT_NAME = "footer";
 
+    private static final String CARD_TITLE_PROPERTY = "cardTitle";
+    private static final String TITLE_HEADING_LEVEL_PROPERTY = "titleHeadingLevel";
+
     private Element contentRoot;
 
     private boolean featureFlagEnabled;
@@ -125,27 +128,20 @@ public class Card extends Component implements HasSize,
 
     /**
      * Sets the title heading level property for the titles set using
-     * {@link #setTitle(String)}. The acceptable range is [1, 6] and the default
-     * is 2. Setting {@code null} resets it to default. Does not affect the
-     * title components set using {@link #setTitle(Component)}.
+     * {@link #setTitle(String)}. The default is 2. Setting {@code null} resets
+     * it to default. Does not affect the title components set using
+     * {@link #setTitle(Component)}.
      *
      * @param titleHeadingLevel
-     *            the title heading level property, {@code null} or in the range
-     *            [1, 6]
-     * @throws IllegalArgumentException
-     *             if the title heading level property is an integer out of the
-     *             range [1, 6]
+     *            the title heading level property, {@code null} to remove
      */
     public void setTitleHeadingLevel(Integer titleHeadingLevel) {
         if (titleHeadingLevel == null) {
-            getElement().removeProperty("titleHeadingLevel");
-            return;
+            getElement().removeProperty(TITLE_HEADING_LEVEL_PROPERTY);
+        } else {
+            getElement().setProperty(TITLE_HEADING_LEVEL_PROPERTY,
+                    titleHeadingLevel);
         }
-        if (titleHeadingLevel < 1 || titleHeadingLevel > 6) {
-            throw new IllegalArgumentException(
-                    "Title heading level must be between 1 and 6.");
-        }
-        getElement().setProperty("titleHeadingLevel", titleHeadingLevel);
     }
 
     /**
@@ -170,7 +166,7 @@ public class Card extends Component implements HasSize,
      * @return the value of the title property
      */
     public String getTitleAsText() {
-        return getElement().getProperty("cardTitle", "");
+        return getElement().getProperty(CARD_TITLE_PROPERTY, "");
     }
 
     /**

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -86,9 +87,71 @@ public class Card extends Component implements HasSize,
     }
 
     /**
+     * Sets the title property. If a {@link #setHeader(Component) header
+     * component} is set, the title will not be displayed. Setting a title this
+     * way removes any title component set using {@link #setTitle(Component)}.
+     * Setting {@code null} or empty string removes any previously set
+     * {@code String} titles.
+     *
+     * @param title
+     *            the title property
+     * @see #setTitle(String, Integer)
+     * @see #setTitleHeadingLevel(Integer)
+     * @see #getTitleAsText()
+     */
+    public void setTitle(String title) {
+        getElement().setProperty("title", title);
+    }
+
+    /**
+     * Sets the title and the heading level for the title. If a
+     * {@link #setHeader(Component) header component} is set, the title will not
+     * be displayed. Setting a title this way removes any title component set
+     * using {@link #setTitle(String)}. Setting {@code null} or empty title
+     * removes any previously set {@code String} titles.
+     *
+     * @param title
+     *            the title property
+     * @param titleHeadingLevel
+     *            the title heading level property,
+     * @see #setTitle(String)
+     * @see #setTitleHeadingLevel(Integer)
+     * @see #getTitleAsText()
+     */
+    public void setTitle(String title, Integer titleHeadingLevel) {
+        setTitleHeadingLevel(titleHeadingLevel);
+        setTitle(title);
+    }
+
+    /**
+     * Sets the title heading level property for the titles set using
+     * {@link #setTitle(String)}. The acceptable range is [1, 6] and the default
+     * is 2. Setting {@code null} resets it to default. Does not affect the
+     * title components set using {@link #setTitle(Component)}.
+     *
+     * @param titleHeadingLevel
+     *            the title heading level property, {@code null} or in the range
+     *            [1, 6]
+     * @throws IllegalArgumentException
+     *             if the title heading level property is an integer out of the
+     *             range [1, 6]
+     */
+    public void setTitleHeadingLevel(Integer titleHeadingLevel) {
+        if (titleHeadingLevel == null) {
+            getElement().removeProperty("titleHeadingLevel");
+            return;
+        }
+        if (titleHeadingLevel < 1 || titleHeadingLevel > 6) {
+            throw new IllegalArgumentException(
+                    "Title heading level must be between 1 and 6.");
+        }
+        getElement().setProperty("titleHeadingLevel", titleHeadingLevel);
+    }
+
+    /**
      * Sets the component used as the card's title. If a
      * {@link #setHeader(Component) header component} is set, the title will not
-     * be displayed.
+     * be displayed. This also removes any previously set {@code String} titles.
      * <p>
      * Passing {@code null} removes the current title from the card.
      *
@@ -100,11 +163,24 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Gets the current title component.
+     * Gets the value of the title property. Returns empty if no title is set.
+     *
+     * @return the value of the title property
+     */
+    @Synchronize(property = "title", value = "title-changed")
+    public String getTitleAsText() {
+        return getElement().getProperty("title", "");
+    }
+
+    /**
+     * Gets the current title component set using {@link #setTitle(Component)}.
      *
      * @return the title component, or {@code null} if none is set
      */
     public Component getTitle() {
+        if (!getTitleAsText().isEmpty()) {
+            return null;
+        }
         return SlotUtils.getChildInSlot(this, TITLE_SLOT_NAME);
     }
 

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -87,11 +87,11 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Sets the title property. If a {@link #setHeader(Component) header
-     * component} is set, the title will not be displayed. Setting a title this
-     * way removes any title component set using {@link #setTitle(Component)}.
-     * Setting {@code null} or empty string removes any previously set
-     * {@code String} titles.
+     * Sets the {@code cardTitle} property. If a {@link #setHeader(Component)
+     * header component} is set, the title will not be displayed. Setting a
+     * title this way removes any title component set using
+     * {@link #setTitle(Component)}. Setting {@code null} or empty string
+     * removes any previously set {@code String} titles.
      *
      * @param title
      *            the title property
@@ -100,7 +100,7 @@ public class Card extends Component implements HasSize,
      * @see #getTitleAsText()
      */
     public void setTitle(String title) {
-        getElement().setProperty("title", title);
+        getElement().setProperty("cardTitle", title);
     }
 
     /**
@@ -163,13 +163,14 @@ public class Card extends Component implements HasSize,
     }
 
     /**
-     * Gets the value of the title property. Returns empty if no title is set.
+     * Gets the value of the {@code cardTitle} property. Returns empty if no
+     * title is set.
      *
      * @return the value of the title property
      */
-    @Synchronize(property = "title", value = "title-changed")
+    @Synchronize(property = "cardTitle", value = "card-title-changed")
     public String getTitleAsText() {
-        return getElement().getProperty("title", "");
+        return getElement().getProperty("cardTitle", "");
     }
 
     /**

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -99,6 +99,19 @@ public class CardTest {
                 () -> card.setTitleHeadingLevel(7));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> card.setTitleHeadingLevel(0));
+
+    @Test
+    public void setStringTitle_setComponentTitle_stringTitleIsRemoved() {
+        card.setTitle("Some Title");
+        card.setTitle(new Div("Other Title"));
+        Assert.assertEquals("", card.getTitleAsText());
+    }
+
+    @Test
+    public void setComponentTitle_setStringTitle_componentTitleIsRemoved() {
+        card.setTitle(new Div("Other Title"));
+        card.setTitle("Some Title");
+        Assert.assertNull(card.getTitle());
     }
 
     @Test

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -69,6 +69,39 @@ public class CardTest {
     }
 
     @Test
+    public void stringTitleIsEmptyByDefault() {
+        Assert.assertEquals("", card.getTitleAsText());
+    }
+
+    @Test
+    public void setStringTitle_titleIsSet() {
+        var title = "Some Title";
+        card.setTitle(title);
+        Assert.assertEquals(title, card.getTitleAsText());
+        title = "Other Title";
+        card.setTitle(title, 2);
+        Assert.assertEquals(title, card.getTitleAsText());
+    }
+
+    @Test
+    public void setStringTitle_setNullStringTitle_titleCleared() {
+        card.setTitle("Some Title");
+        card.setTitle((String) null);
+        Assert.assertEquals("", card.getTitleAsText());
+    }
+
+    @Test
+    public void setTitleHeadingLevel_throwsIllegalArgumentExceptionOnlyForOutOfRange() {
+        card.setTitleHeadingLevel(null);
+        card.setTitleHeadingLevel(1);
+        card.setTitleHeadingLevel(6);
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> card.setTitleHeadingLevel(7));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> card.setTitleHeadingLevel(0));
+    }
+
+    @Test
     public void subtitleNullByDefault() {
         Assert.assertNull(card.getSubtitle());
     }

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -78,9 +78,11 @@ public class CardTest {
         var title = "Some Title";
         card.setTitle(title);
         Assert.assertEquals(title, card.getTitleAsText());
+        Assert.assertEquals(title, card.getElement().getProperty("cardTitle"));
         title = "Other Title";
         card.setTitle(title, 2);
         Assert.assertEquals(title, card.getTitleAsText());
+        Assert.assertEquals(title, card.getElement().getProperty("cardTitle"));
     }
 
     @Test

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardTest.java
@@ -93,14 +93,23 @@ public class CardTest {
     }
 
     @Test
-    public void setTitleHeadingLevel_throwsIllegalArgumentExceptionOnlyForOutOfRange() {
-        card.setTitleHeadingLevel(null);
+    public void setTitleHeadingLevel_elementPropertyIsUpdated() {
+        var titleHeadingLevel = 1;
+        card.setTitleHeadingLevel(titleHeadingLevel);
+        Assert.assertEquals(titleHeadingLevel,
+                card.getElement().getProperty("titleHeadingLevel", -1));
+        titleHeadingLevel = 7;
+        card.setTitleHeadingLevel(titleHeadingLevel);
+        Assert.assertEquals(titleHeadingLevel,
+                card.getElement().getProperty("titleHeadingLevel", -1));
+    }
+
+    @Test
+    public void setTitleHeadingLevelNull_elementPropertyIsRemoved() {
         card.setTitleHeadingLevel(1);
-        card.setTitleHeadingLevel(6);
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> card.setTitleHeadingLevel(7));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> card.setTitleHeadingLevel(0));
+        card.setTitleHeadingLevel(null);
+        Assert.assertFalse(card.getElement().hasProperty("titleHeadingLevel"));
+    }
 
     @Test
     public void setStringTitle_setComponentTitle_stringTitleIsRemoved() {

--- a/vaadin-card-flow-parent/vaadin-card-testbench/src/main/java/com/vaadin/flow/component/card/testbench/CardElement.java
+++ b/vaadin-card-flow-parent/vaadin-card-testbench/src/main/java/com/vaadin/flow/component/card/testbench/CardElement.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;

--- a/vaadin-card-flow-parent/vaadin-card-testbench/src/main/java/com/vaadin/flow/component/card/testbench/CardElement.java
+++ b/vaadin-card-flow-parent/vaadin-card-testbench/src/main/java/com/vaadin/flow/component/card/testbench/CardElement.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;


### PR DESCRIPTION
## Description

Adds the following String based title API to the Card component:

- String getTitleAsText()
- void setTitle(String title)
- void setTitle(String title, Integer titleHeadingLevel)
- void setTitleHeadingLevel(Integer titleHeadingLevel)

Depends on the related [web component PR](https://github.com/vaadin/web-components/pull/8822) and [TestBench API PR](https://github.com/vaadin/flow-components/pull/7224).

Fixes #7212 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.