### PR TITLE
feat: add initial APIs to MasterDetailLayout

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/masterdetaillayout/tests/MasterDetailLayoutPage.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/masterdetaillayout/tests/MasterDetailLayoutPage.java
@@ -19,17 +19,16 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.masterdetaillayout.MasterDetailLayout;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-master-detail-layout/master-detail-layout-test")
+@Route("vaadin-master-detail-layout")
 public class MasterDetailLayoutPage extends Div {
     public MasterDetailLayoutPage() {
         MasterDetailLayout layout = new MasterDetailLayout();
 
         Div master = new Div("Master content");
-        layout.getElement().appendChild(master.getElement());
+        layout.setMaster(master);
 
         Div detail = new Div("Detail content");
-        detail.getElement().setAttribute("slot", "detail");
-        layout.getElement().appendChild(detail.getElement());
+        layout.setDetail(detail);
 
         add(layout);
     }

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/masterdetaillayout/tests/MasterDetailLayoutIT.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/masterdetaillayout/tests/MasterDetailLayoutIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.masterdetaillayout.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-master-detail-layout")
+public class MasterDetailLayoutIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void basics() {
+        TestBenchElement layout = $("vaadin-master-detail-layout")
+                .waitForFirst();
+
+        boolean hasShadowRoot = (Boolean) executeScript(
+                "return arguments[0].shadowRoot !== null", layout);
+        String componentName = (String) executeScript(
+                "return Object.getPrototypeOf(arguments[0]).constructor.is",
+                layout);
+
+        Assert.assertTrue(hasShadowRoot);
+        Assert.assertEquals("vaadin-master-detail-layout", componentName);
+
+        Assert.assertTrue(layout.$("div").withAttribute("slot", "").exists());
+        Assert.assertTrue(
+                layout.$("div").withAttribute("slot", "detail").exists());
+    }
+}

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -43,6 +43,9 @@ import com.vaadin.flow.router.RouterLayout;
 public class MasterDetailLayout extends Component
         implements HasSize, RouterLayout {
 
+    public static final String MASTER_SLOT = "";
+    public static final String DETAIL_SLOT = "detail";
+
     /**
      * Gets the component currently in the master area.
      *
@@ -62,8 +65,8 @@ public class MasterDetailLayout extends Component
      */
     public void setMaster(Component component) {
         Objects.requireNonNull(component, "Master component cannot be null");
-        SlotUtils.clearSlot(this, "");
-        SlotUtils.addToSlot(this, "", component);
+        SlotUtils.clearSlot(this, MASTER_SLOT);
+        SlotUtils.addToSlot(this, MASTER_SLOT, component);
     }
 
     /**
@@ -73,7 +76,7 @@ public class MasterDetailLayout extends Component
      *         component in the detail area
      */
     public Component getDetail() {
-        return SlotUtils.getElementsInSlot(this, "detail").findFirst()
+        return SlotUtils.getElementsInSlot(this, DETAIL_SLOT).findFirst()
                 .flatMap(Element::getComponent).orElse(null);
     }
 
@@ -89,15 +92,15 @@ public class MasterDetailLayout extends Component
     }
 
     private void doSetDetail(HasElement hasElement) {
-        if (hasElement instanceof Text) {
+        if (hasElement != null && hasElement instanceof Text) {
             throw new IllegalArgumentException(
                     "Text as a slot content is not supported. "
                             + "Consider wrapping the Text inside a Div.");
         }
 
-        SlotUtils.clearSlot(this, "detail");
+        SlotUtils.clearSlot(this, DETAIL_SLOT);
         if (hasElement != null) {
-            SlotUtils.addToSlot(this, "detail", hasElement.getElement());
+            SlotUtils.addToSlot(this, DETAIL_SLOT, hasElement.getElement());
         }
     }
 

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.SlotUtils;
@@ -88,6 +89,12 @@ public class MasterDetailLayout extends Component
     }
 
     private void doSetDetail(HasElement hasElement) {
+        if (hasElement instanceof Text) {
+            throw new IllegalArgumentException(
+                    "Text as a slot content is not supported. "
+                            + "Consider wrapping the Text inside a Div.");
+        }
+
         SlotUtils.clearSlot(this, "detail");
         if (hasElement != null) {
             SlotUtils.addToSlot(this, "detail", hasElement.getElement());

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.SlotUtils;
@@ -128,6 +129,22 @@ public class MasterDetailLayout extends Component
     }
 
     /**
+     * Sets the size of the master area in CSS length units. When specified, it
+     * prevents the master area from growing or shrinking. If there is not
+     * enough space to show master and detail areas next to each other, the
+     * layout switches to the overlay mode.
+     *
+     * @param size
+     *            the size of the master area
+     * @param unit
+     *            the unit
+     */
+    public void setMasterSize(float size, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
+        getElement().setProperty("masterSize", HasSize.getCssSize(size, unit));
+    }
+
+    /**
      * Gets the minimum size of the master area.
      *
      * @return the minimum size of the master area in CSS length units, or
@@ -148,6 +165,23 @@ public class MasterDetailLayout extends Component
      */
     public void setMasterMinSize(String minSize) {
         getElement().setProperty("masterMinSize", minSize);
+    }
+
+    /**
+     * Sets the minimum size of the master area in CSS length units. When
+     * specified, it prevents the master area from shrinking below this size. If
+     * there is not enough space to show master and detail areas next to each
+     * other, the layout switches to the overlay mode.
+     *
+     * @param minSize
+     *            the minimum size of the master area
+     * @param unit
+     *            the unit
+     */
+    public void setMasterMinSize(float minSize, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
+        getElement().setProperty("masterMinSize",
+                HasSize.getCssSize(minSize, unit));
     }
 
     /**
@@ -174,6 +208,22 @@ public class MasterDetailLayout extends Component
     }
 
     /**
+     * Sets the size of the detail area in CSS length units. When specified, it
+     * prevents the detail area from growing or shrinking. If there is not
+     * enough space to show master and detail areas next to each other, the
+     * layout switches to the overlay mode.
+     *
+     * @param size
+     *            the size of the detail area
+     * @param unit
+     *            the unit
+     */
+    public void setDetailSize(float size, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
+        getElement().setProperty("detailSize", HasSize.getCssSize(size, unit));
+    }
+
+    /**
      * Gets the minimum size of the detail area.
      *
      * @return the minimum size of the detail area in CSS length units, or
@@ -194,6 +244,23 @@ public class MasterDetailLayout extends Component
      */
     public void setDetailMinSize(String minSize) {
         getElement().setProperty("detailMinSize", minSize);
+    }
+
+    /**
+     * Sets the minimum size of the detail area in CSS length units. When
+     * specified, it prevents the detail area from shrinking below this size. If
+     * there is not enough space to show master and detail areas next to each
+     * other, the layout switches to the overlay mode.
+     *
+     * @param minSize
+     *            the minimum size of the detail area
+     * @param unit
+     *            the unit
+     */
+    public void setDetailMinSize(float minSize, Unit unit) {
+        Objects.requireNonNull(unit, "Unit cannot be null");
+        getElement().setProperty("detailMinSize",
+                HasSize.getCssSize(minSize, unit));
     }
 
     @Override

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -15,10 +15,17 @@
  */
 package com.vaadin.flow.component.masterdetaillayout;
 
+import java.util.Objects;
+
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.RouterLayout;
 
 /**
  * MasterDetailLayout is a component for building UIs with a master (or primary)
@@ -32,5 +39,160 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/master-detail-layout", version = "24.8.0-alpha3")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/master-detail-layout/src/vaadin-master-detail-layout.js")
-public class MasterDetailLayout extends Component {
+public class MasterDetailLayout extends Component
+        implements HasSize, RouterLayout {
+
+    /**
+     * Gets the component currently in the master area.
+     *
+     * @return the component in the master area, or {@code null} if there is no
+     *         component in the master area
+     */
+    public Component getMaster() {
+        return SlotUtils.getElementsInSlot(this, "").findFirst()
+                .flatMap(Element::getComponent).orElse(null);
+    }
+
+    /**
+     * Sets the component to be displayed in the master area.
+     *
+     * @param component
+     *            the component to display in the master area, not {@code null}
+     */
+    public void setMaster(Component component) {
+        Objects.requireNonNull(component, "Master component cannot be null");
+        SlotUtils.clearSlot(this, "");
+        SlotUtils.addToSlot(this, "", component);
+    }
+
+    /**
+     * Gets the component currently in the detail area.
+     *
+     * @return the component in the detail area, or {@code null} if there is no
+     *         component in the detail area
+     */
+    public Component getDetail() {
+        return SlotUtils.getElementsInSlot(this, "detail").findFirst()
+                .flatMap(Element::getComponent).orElse(null);
+    }
+
+    /**
+     * Sets the component to be displayed in the detail area.
+     *
+     * @param component
+     *            the component to display in the detail area, or {@code null}
+     *            to clear the detail area
+     */
+    public void setDetail(Component component) {
+        doSetDetail(component);
+    }
+
+    private void doSetDetail(HasElement hasElement) {
+        SlotUtils.clearSlot(this, "detail");
+        if (hasElement != null) {
+            SlotUtils.addToSlot(this, "detail", hasElement.getElement());
+        }
+    }
+
+    /**
+     * Gets the size of the master area.
+     *
+     * @return the size of the master area in CSS length units, or {@code null}
+     *         if the size is not set
+     */
+    public String getMasterSize() {
+        return getElement().getProperty("masterSize");
+    }
+
+    /**
+     * Sets the size of the master area in CSS length units. When specified, it
+     * prevents the master area from growing or shrinking. If there is not
+     * enough space to show master and detail areas next to each other, the
+     * layout switches to the overlay mode.
+     *
+     * @param size
+     *            the size of the master area in CSS length units
+     */
+    public void setMasterSize(String size) {
+        getElement().setProperty("masterSize", size);
+    }
+
+    /**
+     * Gets the minimum size of the master area.
+     *
+     * @return the minimum size of the master area in CSS length units, or
+     *         {@code null} if the minimum size is not set
+     */
+    public String getMasterMinSize() {
+        return getElement().getProperty("masterMinSize");
+    }
+
+    /**
+     * Sets the minimum size of the master area in CSS length units. When
+     * specified, it prevents the master area from shrinking below this size. If
+     * there is not enough space to show master and detail areas next to each
+     * other, the layout switches to the overlay mode.
+     *
+     * @param minSize
+     *            the minimum size of the master area in CSS length units
+     */
+    public void setMasterMinSize(String minSize) {
+        getElement().setProperty("masterMinSize", minSize);
+    }
+
+    /**
+     * Gets the size of the detail area.
+     *
+     * @return the size of the detail area in CSS length units, or {@code null}
+     *         if the size is not set
+     */
+    public String getDetailSize() {
+        return getElement().getProperty("detailSize");
+    }
+
+    /**
+     * Sets the size of the detail area in CSS length units. When specified, it
+     * prevents the detail area from growing or shrinking. If there is not
+     * enough space to show master and detail areas next to each other, the
+     * layout switches to the overlay mode.
+     *
+     * @param size
+     *            the size of the detail area in CSS length units
+     */
+    public void setDetailSize(String size) {
+        getElement().setProperty("detailSize", size);
+    }
+
+    /**
+     * Gets the minimum size of the detail area.
+     *
+     * @return the minimum size of the detail area in CSS length units, or
+     *         {@code null} if the minimum size is not set
+     */
+    public String getDetailMinSize() {
+        return getElement().getProperty("detailMinSize");
+    }
+
+    /**
+     * Sets the minimum size of the detail area in CSS length units. When
+     * specified, it prevents the detail area from shrinking below this size. If
+     * there is not enough space to show master and detail areas next to each
+     * other, the layout switches to the overlay mode.
+     *
+     * @param minSize
+     *            the minimum size of the detail area in CSS length units
+     */
+    public void setDetailMinSize(String minSize) {
+        getElement().setProperty("detailMinSize", minSize);
+    }
+
+    @Override
+    public void showRouterLayoutContent(HasElement content) {
+        doSetDetail(content);
+    }
+
+    @Override
+    public void removeRouterLayoutContent(HasElement oldContent) {
+        doSetDetail(null);
+    }
 }

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.html.Div;
 
 public class MasterDetailLayoutTest {
@@ -173,11 +174,27 @@ public class MasterDetailLayoutTest {
     }
 
     @Test
+    public void setMasterSizeWithUnit_getMasterSize() {
+        layout.setMasterSize(30, Unit.EM);
+        Assert.assertEquals("30.0em", layout.getMasterSize());
+        Assert.assertEquals("30.0em",
+                layout.getElement().getProperty("masterSize"));
+    }
+
+    @Test
     public void setMasterMinSize_getMasterMinSize() {
         String minSize = "200px";
         layout.setMasterMinSize(minSize);
         Assert.assertEquals(minSize, layout.getMasterMinSize());
         Assert.assertEquals(minSize,
+                layout.getElement().getProperty("masterMinSize"));
+    }
+
+    @Test
+    public void setMasterMinSizeWithUnit_getMasterMinSize() {
+        layout.setMasterMinSize(30, Unit.EM);
+        Assert.assertEquals("30.0em", layout.getMasterMinSize());
+        Assert.assertEquals("30.0em",
                 layout.getElement().getProperty("masterMinSize"));
     }
 
@@ -191,11 +208,27 @@ public class MasterDetailLayoutTest {
     }
 
     @Test
+    public void setDetailSizeWithUnit_getDetailSize() {
+        layout.setDetailSize(30, Unit.EM);
+        Assert.assertEquals("30.0em", layout.getDetailSize());
+        Assert.assertEquals("30.0em",
+                layout.getElement().getProperty("detailSize"));
+    }
+
+    @Test
     public void setDetailMinSize_getDetailMinSize() {
         String minSize = "250px";
         layout.setDetailMinSize(minSize);
         Assert.assertEquals(minSize, layout.getDetailMinSize());
         Assert.assertEquals(minSize,
+                layout.getElement().getProperty("detailMinSize"));
+    }
+
+    @Test
+    public void setDetailMinSizeWithUnit_getDetailMinSize() {
+        layout.setDetailMinSize(30, Unit.EM);
+        Assert.assertEquals("30.0em", layout.getDetailMinSize());
+        Assert.assertEquals("30.0em",
                 layout.getElement().getProperty("detailMinSize"));
     }
 

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.masterdetaillayout;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+
+public class MasterDetailLayoutTest {
+    private MasterDetailLayout layout;
+
+    @Before
+    public void init() {
+        layout = new MasterDetailLayout();
+    }
+
+    @Test
+    public void setMaster() {
+        var master = new Div();
+        layout.setMaster(master);
+
+        assertMasterContent(master);
+    }
+
+    @Test
+    public void getMaster() {
+        var master = new Div();
+        layout.setMaster(master);
+
+        Assert.assertEquals(master, layout.getMaster());
+    }
+
+    @Test
+    public void setMaster_replaceMaster() {
+        var master = new Div();
+        layout.setMaster(master);
+
+        var newMaster = new Div();
+        layout.setMaster(newMaster);
+
+        assertMasterContent(newMaster);
+        Assert.assertNull(master.getElement().getParent());
+        Assert.assertNull(master.getElement().getAttribute("slot"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setMasterNull_throws() {
+        layout.setMaster(null);
+    }
+
+    @Test
+    public void setMaster_preservesDetail() {
+        var detail = new Div();
+        layout.setDetail(detail);
+        var master = new Div();
+        layout.setMaster(master);
+
+        Assert.assertEquals(2, layout.getElement().getChildCount());
+        assertMasterContent(master);
+        assertDetailContent(detail);
+    }
+
+    @Test
+    public void setDetail() {
+        var detail = new Div();
+        layout.setDetail(detail);
+
+        assertDetailContent(detail);
+    }
+
+    @Test
+    public void getDetail() {
+        var detail = new Div();
+        layout.setDetail(detail);
+
+        Assert.assertEquals(detail, layout.getDetail());
+    }
+
+    @Test
+    public void setDetail_replaceDetail() {
+        var detail = new Div();
+        layout.setDetail(detail);
+
+        var newDetail = new Div();
+        layout.setDetail(newDetail);
+
+        assertDetailContent(newDetail);
+        Assert.assertNull(detail.getElement().getParent());
+        Assert.assertNull(detail.getElement().getAttribute("slot"));
+    }
+
+    @Test
+    public void setDetail_preservesMaster() {
+        var master = new Div();
+        layout.setMaster(master);
+        var detail = new Div();
+        layout.setDetail(detail);
+
+        assertMasterContent(master);
+        assertDetailContent(detail);
+    }
+
+    @Test
+    public void setDetail_removeDetail() {
+        var detail = new Div();
+        layout.setDetail(detail);
+
+        layout.setDetail(null);
+
+        Assert.assertEquals(0, layout.getElement().getChildCount());
+        Assert.assertNull(detail.getElement().getParent());
+        Assert.assertNull(detail.getElement().getAttribute("slot"));
+    }
+
+    @Test
+    public void showRouterLayoutContent() {
+        var detail = new Div();
+        layout.showRouterLayoutContent(detail);
+
+        assertDetailContent(detail);
+        Assert.assertEquals(detail, layout.getDetail());
+    }
+
+    @Test
+    public void updateRouterLayoutContent() {
+        var detail = new Div();
+        layout.showRouterLayoutContent(detail);
+
+        var newDetail = new Div();
+        layout.removeRouterLayoutContent(detail);
+        layout.showRouterLayoutContent(newDetail);
+
+        assertDetailContent(newDetail);
+        Assert.assertNull(detail.getElement().getParent());
+        Assert.assertNull(detail.getElement().getAttribute("slot"));
+    }
+
+    @Test
+    public void setMasterSize_getMasterSize() {
+        String size = "300px";
+        layout.setMasterSize(size);
+        Assert.assertEquals(size, layout.getMasterSize());
+        Assert.assertEquals(size,
+                layout.getElement().getProperty("masterSize"));
+    }
+
+    @Test
+    public void setMasterMinSize_getMasterMinSize() {
+        String minSize = "200px";
+        layout.setMasterMinSize(minSize);
+        Assert.assertEquals(minSize, layout.getMasterMinSize());
+        Assert.assertEquals(minSize,
+                layout.getElement().getProperty("masterMinSize"));
+    }
+
+    @Test
+    public void setDetailSize_getDetailSize() {
+        String size = "400px";
+        layout.setDetailSize(size);
+        Assert.assertEquals(size, layout.getDetailSize());
+        Assert.assertEquals(size,
+                layout.getElement().getProperty("detailSize"));
+    }
+
+    @Test
+    public void setDetailMinSize_getDetailMinSize() {
+        String minSize = "250px";
+        layout.setDetailMinSize(minSize);
+        Assert.assertEquals(minSize, layout.getDetailMinSize());
+        Assert.assertEquals(minSize,
+                layout.getElement().getProperty("detailMinSize"));
+    }
+
+    private void assertMasterContent(Component component) {
+        Assert.assertEquals("", component.getElement().getAttribute("slot"));
+        Assert.assertEquals(layout.getElement(),
+                component.getElement().getParent());
+    }
+
+    private void assertDetailContent(Component component) {
+        Assert.assertEquals("detail",
+                component.getElement().getAttribute("slot"));
+        Assert.assertEquals(layout.getElement(),
+                component.getElement().getParent());
+    }
+}

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
 
 public class MasterDetailLayoutTest {
@@ -64,6 +65,11 @@ public class MasterDetailLayoutTest {
         layout.setMaster(null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void setMasterText_throws() {
+        layout.setMaster(new Text("master"));
+    }
+
     @Test
     public void setMaster_preservesDetail() {
         var detail = new Div();
@@ -105,6 +111,11 @@ public class MasterDetailLayoutTest {
         Assert.assertNull(detail.getElement().getAttribute("slot"));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void setDetailText_throws() {
+        layout.setDetail(new Text("detail"));
+    }
+
     @Test
     public void setDetail_preservesMaster() {
         var master = new Div();
@@ -112,6 +123,7 @@ public class MasterDetailLayoutTest {
         var detail = new Div();
         layout.setDetail(detail);
 
+        Assert.assertEquals(2, layout.getElement().getChildCount());
         assertMasterContent(master);
         assertDetailContent(detail);
     }


### PR DESCRIPTION
## Description

Adds some basic APIs to `MasterDetailLayout`:
- Implement `HasSize`
- Implement `RouterLayout` which automatically sets route content as detail
- Getters and setters for master and detail component
- Getters and setters for size / min size

Other properties are not covered yet as they are not part of the alpha used by the Flow component.

Part of https://github.com/vaadin/platform/issues/7173

## Type of change

- Feature
