### PR TITLE
chore: class com.vaadin.flow.component.sidenav.SideNavItemContainer has been made public.

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItemContainer.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItemContainer.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.dom.Element;
  *
  * @author Vaadin Ltd
  */
-abstract class SideNavItemContainer extends Component {
+public abstract class SideNavItemContainer extends Component {
 
     /**
      * Implement this method to set up/modify the SideNavItem right before it's


### PR DESCRIPTION
## Description

The public modifier for the com.vaadin.flow.component.sidenav.SideNavItemContainer class makes it possible to use its methods, in particular "public void addItem(SideNavItem... items)", for both SideNav and SideNavItem, which simplifies the code for creating a hierarchical menu.

## Type of change

- [ ] Bugfix
- [x] Feature

## Issue

[#5089 Please make The SideNavItemContainer class public](https://github.com/vaadin/flow-components/issues/5089)

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended - no need.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
