### PR TITLE
fix: do not set z-index for sub-cells with text

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
@@ -91,7 +91,12 @@ public class Cell {
             element.setInnerText("");
             element.getStyle().clearZIndex();
         } else {
-            element.getStyle().setZIndex(ZINDEXVALUE);
+            if (sheetWidget.isMergedCell(SheetWidget.toKey(col, row))
+                    && !(this instanceof MergedCell)) {
+                element.getStyle().clearZIndex();
+            } else {
+                element.getStyle().setZIndex(ZINDEXVALUE);
+            }
             if (needsMeasure && getCellWidth() > 0 && sheetWidget
                     .measureValueWidth(cellStyle, value) > getCellWidth()) {
                 element.setInnerText("###");

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -103,7 +103,7 @@ public class SheetWidget extends Panel {
     private static final String EDITING_CELL_STYLE = "{ display: inline !important;"
             + " outline: none !important; width: auto !important; z-index: -10; }";
     private static final String HYPERLINK_CELL_STYLE = "{ cursor: pointer !important; }";
-    private static final String MERGED_REGION_CELL_STYLE = "{ display: none; }";
+    private static final String MERGED_REGION_CELL_STYLE = "{ display: none !important; }";
     private static final String FREEZE_PANEL_OVERFLOW_STYLE = "{ overflow: hidden; }";
 
     final Logger debugConsole = Logger.getLogger("spreadsheet SheetWidget");
@@ -3548,7 +3548,8 @@ public class SheetWidget extends Panel {
         StringBuilder sb = new StringBuilder();
         for (int r = region.row1; r <= region.row2; r++) {
             for (int c = region.col1; c <= region.col2; c++) {
-                sb.append(toCssKey(c, r));
+                sb.append(toCssKey(c, r)).append(":not(.")
+                        .append(MERGED_CELL_CLASSNAME).append(")");
                 if (r != region.row2 || c != region.col2) {
                     sb.append(",");
                 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -103,7 +103,7 @@ public class SheetWidget extends Panel {
     private static final String EDITING_CELL_STYLE = "{ display: inline !important;"
             + " outline: none !important; width: auto !important; z-index: -10; }";
     private static final String HYPERLINK_CELL_STYLE = "{ cursor: pointer !important; }";
-    private static final String MERGED_REGION_CELL_STYLE = "{ display: none !important; }";
+    private static final String MERGED_REGION_CELL_STYLE = "{ display: none; }";
     private static final String FREEZE_PANEL_OVERFLOW_STYLE = "{ overflow: hidden; }";
 
     final Logger debugConsole = Logger.getLogger("spreadsheet SheetWidget");
@@ -3548,8 +3548,7 @@ public class SheetWidget extends Panel {
         StringBuilder sb = new StringBuilder();
         for (int r = region.row1; r <= region.row2; r++) {
             for (int c = region.col1; c <= region.col2; c++) {
-                sb.append(toCssKey(c, r)).append(":not(.")
-                        .append(MERGED_CELL_CLASSNAME).append(")");
+                sb.append(toCssKey(c, r));
                 if (r != region.row2 || c != region.col2) {
                     sb.append(",");
                 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
@@ -87,31 +87,14 @@ public class MergeIT extends AbstractSpreadsheetIT {
     }
 
     @Test
-    public void mergeCells_subcellsShouldHaveDisplayNone() {
-        for (var row = 1; row <= 2; row++) {
-            for (var col = 1; col <= 2; col++) {
-                assertCellHasDisplayNone(row, col, false);
-            }
-        }
-        selectRegion("A1", "B2");
+    public void mergeCellsWithText_firstSubCellShouldNotHaveZIndex() {
+        setCellValue("A1", "A1 text");
+        selectRegion("A1", "B1");
         loadTestFixture(TestFixtures.MergeCells);
-        for (var row = 1; row <= 2; row++) {
-            for (var col = 1; col <= 2; col++) {
-                assertCellHasDisplayNone(row, col, true);
-            }
-        }
-    }
-
-    private void assertCellHasDisplayNone(int row, int col,
-            boolean hasDisplayNone) {
-        var cellSelector = String.format(".cell.row%d.col%d:not(merged-cell)",
-                row, col);
+        var cellSelector = ".cell.row1.col1:not(merged-cell)";
         var element = findElementInShadowRoot(By.cssSelector(cellSelector));
-        var display = element.getCssValue("display");
-        if (hasDisplayNone) {
-            Assert.assertEquals("none", display);
-        } else {
-            Assert.assertNotEquals("none", display);
-        }
+        var style = element.getDomAttribute("style");
+        var hasZIndex = style != null && style.contains("z-index");
+        Assert.assertFalse(hasZIndex);
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.spreadsheet.test;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
 import com.vaadin.flow.testutil.TestPath;
@@ -83,5 +84,34 @@ public class MergeIT extends AbstractSpreadsheetIT {
         loadTestFixture(TestFixtures.MergeCells);
 
         Assert.assertEquals("A1 text", getMergedCellContent("A1"));
+    }
+
+    @Test
+    public void mergeCells_subcellsShouldHaveDisplayNone() {
+        for (var row = 1; row <= 2; row++) {
+            for (var col = 1; col <= 2; col++) {
+                assertCellHasDisplayNone(row, col, false);
+            }
+        }
+        selectRegion("A1", "B2");
+        loadTestFixture(TestFixtures.MergeCells);
+        for (var row = 1; row <= 2; row++) {
+            for (var col = 1; col <= 2; col++) {
+                assertCellHasDisplayNone(row, col, true);
+            }
+        }
+    }
+
+    private void assertCellHasDisplayNone(int row, int col,
+            boolean hasDisplayNone) {
+        var cellSelector = String.format(".cell.row%d.col%d:not(merged-cell)",
+                row, col);
+        var element = findElementInShadowRoot(By.cssSelector(cellSelector));
+        var display = element.getCssValue("display");
+        if (hasDisplayNone) {
+            Assert.assertEquals("none", display);
+        } else {
+            Assert.assertNotEquals("none", display);
+        }
     }
 }


### PR DESCRIPTION
## Description

In the `Cell` class, `z-index` of 1 is automatically applied to cells with text content. However, this should not be the case for sub-cells. The first sub-cell in a merged region still contains the text. Usually, this problem is hidden because initially the sub-cells are added to the DOM before the merged cell. When there are two cells with the same `z-index`, the last added cell is shown on top. However, when the sheet is scrolled, sometimes the sub-cell is removed and the merged cell still stays in the DOM. Scrolling back to the row, the sub-cell is added back to the DOM with the same `z-index` of 1. Since the sub-cell is the last added one in this case, it is shown on top. 

This PR adds a check in the `Cell` class to avoid setting `z-index` for sub-cells with text.

Fixes #7177 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.