### PR TITLE
feat: add setColspan API to FormRow

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -385,12 +385,14 @@ public class FormLayout extends Component
      * <pre>
      * FormLayout formLayout = new FormLayout();
      * formLayout.setAutoResponsive(true);
-     * formLayout.addFormRow(new TextField("First name"),
-     *         new TextField("Last name"));
      *
-     * TextArea addressField = new TextArea("Address");
-     * formLayout.setColspan(addressField, 2);
-     * formLayout.addFormRow(addressField);
+     * FormRow row0 = new FormRow();
+     * row0.add(new TextField("First name"), new TextField("Last name"));
+     *
+     * FormRow row1 = new FormRow();
+     * row1.add(new TextArea("Address"), 2); // shorthand for {@link #add} + {@link #setColspan}
+     *
+     * formLayout.add(row0, row1);
      * </pre>
      *
      * @author Vaadin Ltd

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -112,14 +112,17 @@ import elemental.json.JsonValue;
  * Here is an example of using {@link FormRow}:
  *
  * <pre>
- * FormLayout formLayout = new FormLayout();
- * formLayout.setAutoResponsive(true);
- * formLayout.addFormRow(new TextField("First name"),
- *         new TextField("Last name"));
- * TextArea addressField = new TextArea("Address");
- * formLayout.setColspan(addressField, 2);
- * formLayout.addFormRow(addressField);
- * </pre>
+* FormLayout formLayout = new FormLayout();
+* formLayout.setAutoResponsive(true);
+*
+* FormRow row0 = new FormRow();
+* row0.add(new TextField("First name"), new TextField("Last name"));
+*
+* FormRow row1 = new FormRow();
+* row1.add(new TextArea("Address"), 2); // shorthand for {@code add} and {@code setColspan}
+*
+* formLayout.add(row0, row1);
+* </pre>
  *
  * <h3>Expanding Columns and Fields</h3>
  * <p>
@@ -390,7 +393,7 @@ public class FormLayout extends Component
      * row0.add(new TextField("First name"), new TextField("Last name"));
      *
      * FormRow row1 = new FormRow();
-     * row1.add(new TextArea("Address"), 2); // shorthand for {@link #add} + {@link #setColspan}
+     * row1.add(new TextArea("Address"), 2); // shorthand for {@code add} and {@code setColspan}
      *
      * formLayout.add(row0, row1);
      * </pre>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -414,6 +414,57 @@ public class FormLayout extends Component
         }
 
         /**
+         * Adds a component with the desired colspan. This method is a shorthand
+         * for calling {@link #add(Component...)} and
+         * {@link #setColspan(Component, int)}
+         *
+         * @param component
+         *            the component to add
+         *
+         * @param colspan
+         *            the desired colspan for the component
+         *
+         */
+        public void add(Component component, int colspan) {
+            add(component);
+            setColspan(component, colspan);
+        }
+
+        /**
+         * Sets the colspan of the given component's element. Will default to 1
+         * if an integer lower than 1 is supplied. You can directly add
+         * components with the wanted colspan with {@link #add(Component, int)}.
+         *
+         * @param component
+         *            the component to set the colspan for, not {@code null}
+         *
+         * @param colspan
+         *            the desired colspan for the component
+         *
+         */
+        public void setColspan(Component component, int colspan) {
+            Objects.requireNonNull(component, "component cannot be null");
+            component.getElement().setAttribute("colspan",
+                    String.valueOf(Math.max(1, colspan)));
+        }
+
+        /**
+         * Gets the colspan of the given component. If none is set, returns 1.
+         *
+         * @param component
+         *            the component whose colspan is retrieved
+         * @return the colspan of the given component or 1 if none is set
+         */
+        public int getColspan(Component component) {
+            String colspan = component.getElement().getAttribute("colspan");
+            if (colspan != null && colspan.matches("\\d+")) {
+                return Integer.parseInt(colspan);
+            } else {
+                return 1;
+            }
+        }
+
+        /**
          * Creates a new {@link FormItem} with the given component and the label
          * string, and adds it to the form row. The label is inserted into the
          * form item as a {@link NativeLabel}.
@@ -482,13 +533,8 @@ public class FormLayout extends Component
      */
     public void setColspan(Component component, int colspan) {
         Objects.requireNonNull(component, "component cannot be null");
-        String strColspan = "";
-        if (colspan < 1) {
-            strColspan = "1";
-        } else {
-            strColspan = String.valueOf(colspan);
-        }
-        component.getElement().setAttribute("colspan", strColspan);
+        component.getElement().setAttribute("colspan",
+                String.valueOf(Math.max(1, colspan)));
     }
 
     /**
@@ -517,13 +563,9 @@ public class FormLayout extends Component
      * @return the colspan of the given component or 1 if none is set
      */
     public int getColspan(Component component) {
-        String strColspan = component.getElement().getAttribute("colspan");
-        if (strColspan == null) {
-            return 1;
-            // need this in case the colspan is modified outside the API to an
-            // incorrect format somehow.
-        } else if (strColspan.matches("\\d+")) {
-            return Integer.parseInt(strColspan);
+        String colspan = component.getElement().getAttribute("colspan");
+        if (colspan != null && colspan.matches("\\d+")) {
+            return Integer.parseInt(colspan);
         } else {
             return 1;
         }

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -422,10 +422,8 @@ public class FormLayout extends Component
          *
          * @param component
          *            the component to add
-         *
          * @param colspan
          *            the desired colspan for the component
-         *
          */
         public void add(Component component, int colspan) {
             add(component);
@@ -439,10 +437,8 @@ public class FormLayout extends Component
          *
          * @param component
          *            the component to set the colspan for, not {@code null}
-         *
          * @param colspan
          *            the desired colspan for the component
-         *
          */
         public void setColspan(Component component, int colspan) {
             Objects.requireNonNull(component, "component cannot be null");

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -86,7 +86,7 @@ import elemental.json.JsonValue;
  * FormLayout formLayout = new FormLayout();
  * formLayout.setAutoResponsive(true);
  * formLayout.add(new TextField("First name"), new TextField("Last name"));
- * formLayout.add(new TextArea("Address"), 2);
+ * formLayout.add(new TextArea("Address"), 2); // colspan 2
  * </pre>
  *
  * <p>
@@ -112,17 +112,17 @@ import elemental.json.JsonValue;
  * Here is an example of using {@link FormRow}:
  *
  * <pre>
-* FormLayout formLayout = new FormLayout();
-* formLayout.setAutoResponsive(true);
-*
-* FormRow row0 = new FormRow();
-* row0.add(new TextField("First name"), new TextField("Last name"));
-*
-* FormRow row1 = new FormRow();
-* row1.add(new TextArea("Address"), 2); // shorthand for {@code add} and {@code setColspan}
-*
-* formLayout.add(row0, row1);
-* </pre>
+ * FormLayout formLayout = new FormLayout();
+ * formLayout.setAutoResponsive(true);
+ *
+ * FormRow firstRow = new FormRow();
+ * firstRow.add(new TextField("First name"), new TextField("Last name"));
+ *
+ * FormRow secondRow = new FormRow();
+ * secondRow.add(new TextArea("Address"), 2); // colspan 2
+ *
+ * formLayout.add(firstRow, secondRow);
+ * </pre>
  *
  * <h3>Expanding Columns and Fields</h3>
  * <p>
@@ -147,13 +147,15 @@ import elemental.json.JsonValue;
  * formLayout.setAutoResponsive(true);
  * formLayout.setLabelsAside(true);
  *
- * FormRow firstRow = formLayout.addFormRow();
+ * FormRow firstRow = new FormRow();
  * firstRow.addFormItem(new TextField(), "First Name");
  * firstRow.addFormItem(new TextField(), "Last Name");
  *
- * FormRow secondRow = formLayout.addFormRow();
+ * FormRow secondRow = new FormRow();
  * FormItem addressField = secondRow.addFormItem(new TextArea(), "Address");
- * formLayout.setColspan(addressField, 2);
+ * secondRow.setColspan(addressField, 2);
+ *
+ * formLayout.add(firstRow, secondRow);
  * </pre>
  * <p>
  * With this, FormLayout will display labels beside fields, falling back to the
@@ -389,13 +391,13 @@ public class FormLayout extends Component
      * FormLayout formLayout = new FormLayout();
      * formLayout.setAutoResponsive(true);
      *
-     * FormRow row0 = new FormRow();
-     * row0.add(new TextField("First name"), new TextField("Last name"));
+     * FormRow firstRow = new FormRow();
+     * firstRow.add(new TextField("First name"), new TextField("Last name"));
      *
-     * FormRow row1 = new FormRow();
-     * row1.add(new TextArea("Address"), 2); // shorthand for {@code add} and {@code setColspan}
+     * FormRow secondRow = new FormRow();
+     * secondRow.add(new TextArea("Address"), 2); // colspan 2
      *
-     * formLayout.add(row0, row1);
+     * formLayout.add(firstRow, secondRow);
      * </pre>
      *
      * @author Vaadin Ltd

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -346,6 +346,9 @@ public class FormLayoutTest {
 
         row.setColspan(input, 2);
         Assert.assertEquals(2, row.getColspan(input));
+
+        row.setColspan(input, -1);
+        Assert.assertEquals(1, row.getColspan(input));
     }
 
     @Test

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -335,4 +335,24 @@ public class FormLayoutTest {
         Assert.assertEquals("span", label.getTag());
         Assert.assertEquals("custom label", label.getText());
     }
+
+    @Test
+    public void formRow_setColspan_getColspan() {
+        Input input = new Input();
+        FormRow row = new FormRow();
+        row.add(input);
+
+        Assert.assertEquals(1, row.getColspan(input));
+
+        row.setColspan(input, 2);
+        Assert.assertEquals(2, row.getColspan(input));
+    }
+
+    @Test
+    public void formRow_addComponentWithColspan() {
+        Input input = new Input();
+        FormRow row = new FormRow();
+        row.add(input, 2);
+        Assert.assertEquals(2, row.getColspan(input));
+    }
 }


### PR DESCRIPTION
## Description

The PR adds APIs for managing components' colspan inside rows:

- `FormRow#setColspan(Component component, int colspan)`
- `FormRow#getColspan(Component component)`
- `FormRow#add(Component component, int colspan)`

Follow-up to https://github.com/vaadin/flow-components/issues/7162

Related to https://github.com/vaadin/platform/issues/7172

## Type of change

- [x] Feature
