### PR TITLE
refactor!: allow setColumnWidth to accept null values

### DIFF
--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -923,7 +923,7 @@ public class FormLayout extends Component
      * {@link #setAutoResponsive(boolean)} is enabled.
      * <p>
      * When the column width is {@code null}, the web component defaults to
-     * {@code 12em} or uses the value of {@code --vaadin-field-default-width`}
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width}
      * if that CSS custom property is defined.
      *
      * @return the value and CSS unit as a string, or {@code null} if not set,

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -902,7 +902,7 @@ public class FormLayout extends Component
      * provided with a {@link Unit}, e.g. {@code 100} and {@link Unit#PIXELS}.
      * <p>
      * When the column width is {@code null}, the web component defaults to
-     * {@code 12em} or uses the value of {@code --vaadin-field-default-width`}
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width}
      * if that CSS custom property is defined.
      * <p>
      * This setting only applies when {@link #setAutoResponsive(boolean)} is

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -883,8 +883,8 @@ public class FormLayout extends Component
      * provided in CSS length units, e.g. {@code 100px}.
      * <p>
      * When the column width is {@code null}, the web component defaults to
-     * {@code 12em} or uses the value of {@code --vaadin-field-default-width`}
-     * if that CSS custom property is defined.
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width} if
+     * that CSS custom property is defined.
      * <p>
      * This setting only applies when {@link #setAutoResponsive(boolean)} is
      * enabled.
@@ -902,8 +902,8 @@ public class FormLayout extends Component
      * provided with a {@link Unit}, e.g. {@code 100} and {@link Unit#PIXELS}.
      * <p>
      * When the column width is {@code null}, the web component defaults to
-     * {@code 12em} or uses the value of {@code --vaadin-field-default-width}
-     * if that CSS custom property is defined.
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width} if
+     * that CSS custom property is defined.
      * <p>
      * This setting only applies when {@link #setAutoResponsive(boolean)} is
      * enabled.
@@ -923,8 +923,8 @@ public class FormLayout extends Component
      * {@link #setAutoResponsive(boolean)} is enabled.
      * <p>
      * When the column width is {@code null}, the web component defaults to
-     * {@code 12em} or uses the value of {@code --vaadin-field-default-width}
-     * if that CSS custom property is defined.
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width} if
+     * that CSS custom property is defined.
      *
      * @return the value and CSS unit as a string, or {@code null} if not set,
      *         in which case the web component uses its default value

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/FormLayout.java
@@ -882,20 +882,17 @@ public class FormLayout extends Component
      * {@link #setAutoResponsive(boolean)} is enabled. The value must be
      * provided in CSS length units, e.g. {@code 100px}.
      * <p>
-     * By default, the web component uses a width of {@code 13em}.
+     * When the column width is {@code null}, the web component defaults to
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width`}
+     * if that CSS custom property is defined.
      * <p>
      * This setting only applies when {@link #setAutoResponsive(boolean)} is
      * enabled.
      *
      * @param columnWidth
-     *            the width of columns
+     *            the width of columns or {@code null} to use the default
      */
     public void setColumnWidth(String columnWidth) {
-        Objects.requireNonNull(columnWidth, "Column width cannot be null");
-        if (columnWidth.isBlank()) {
-            throw new IllegalArgumentException("Column width cannot be empty");
-        }
-
         getElement().setProperty("columnWidth", columnWidth);
     }
 
@@ -904,7 +901,9 @@ public class FormLayout extends Component
      * {@link #setAutoResponsive(boolean)} is enabled. The value must be
      * provided with a {@link Unit}, e.g. {@code 100} and {@link Unit#PIXELS}.
      * <p>
-     * By default, the web component uses a width of {@code 13em}.
+     * When the column width is {@code null}, the web component defaults to
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width`}
+     * if that CSS custom property is defined.
      * <p>
      * This setting only applies when {@link #setAutoResponsive(boolean)} is
      * enabled.
@@ -922,9 +921,13 @@ public class FormLayout extends Component
     /**
      * Gets the width of columns that is used when
      * {@link #setAutoResponsive(boolean)} is enabled.
+     * <p>
+     * When the column width is {@code null}, the web component defaults to
+     * {@code 12em} or uses the value of {@code --vaadin-field-default-width`}
+     * if that CSS custom property is defined.
      *
-     * @return the value and CSS unit as a string, or {@code null} if not
-     *         explicitly set
+     * @return the value and CSS unit as a string, or {@code null} if not set,
+     *         in which case the web component uses its default value
      * @see #setColumnWidth(String)
      * @see #setColumnWidth(float, Unit)
      */

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/test/java/com/vaadin/flow/component/formlayout/tests/FormLayoutTest.java
@@ -237,13 +237,9 @@ public class FormLayoutTest {
                 formLayout.getElement().getProperty("columnWidth"));
         Assert.assertEquals("160.0px", formLayout.getColumnWidth());
 
-        Assert.assertThrows("Column width cannot be null",
-                NullPointerException.class,
-                () -> formLayout.setColumnWidth(null));
-
-        Assert.assertThrows("Column width cannot be empty",
-                IllegalArgumentException.class,
-                () -> formLayout.setColumnWidth(""));
+        formLayout.setColumnWidth(null);
+        Assert.assertNull(formLayout.getElement().getProperty("columnWidth"));
+        Assert.assertNull(formLayout.getColumnWidth());
     }
 
     @Test


### PR DESCRIPTION
## Description

The web component was recently [refactored](https://github.com/vaadin/web-components/pull/8861) to support `null` values as a column width, in which case it defaults to `12em`, or to the value of the `--vaadin-default-field-width` CSS custom property if it is defined.

This PR updates the Flow counterpart to align with that behavior, allowing `setColumnWidth` to accept `null` values as well.

Related to https://github.com/vaadin/platform/issues/7172

## Type of change

- [x] Refactor
