### PR TITLE
feat: add dashboard root heading level api

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -519,6 +519,30 @@ public class Dashboard extends Component implements HasWidgets, HasSize {
         return true;
     }
 
+    /**
+     * Sets the root heading level used by sections and widgets, which controls
+     * their <code>aria-level</code> attributes on title elements. The nested
+     * widgets will have their {@code aria-level} one higher than the root
+     * heading level.
+     * <p>
+     * For example, if root heading level is set to {@code 1}:
+     * <ul>
+     * <li>Sections and non-nested widgets will have {@code aria-level="1"}</li>
+     * <li>Nested widgets will have {@code aria-level="2"}</li>
+     * </ul>
+     * Setting it {@code null} resets it to the default value of {@code 2}.
+     *
+     * @param rootHeadingLevel
+     *            the root heading level property, {@code null} to remove
+     */
+    public void setRootHeadingLevel(Integer rootHeadingLevel) {
+        if (rootHeadingLevel == null) {
+            getElement().removeProperty("rootHeadingLevel");
+        } else {
+            getElement().setProperty("rootHeadingLevel", rootHeadingLevel);
+        }
+    }
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
@@ -1074,6 +1074,26 @@ public class DashboardTest extends DashboardTestBase {
         assertItemSelectedChangedEventCorrectlyFired(widget, false);
     }
 
+    @Test
+    public void setRootHeadingLevel_elementPropertyIsUpdated() {
+        var rootHeadingLevel = 1;
+        dashboard.setRootHeadingLevel(rootHeadingLevel);
+        Assert.assertEquals(rootHeadingLevel,
+                dashboard.getElement().getProperty("rootHeadingLevel", -1));
+        rootHeadingLevel = 7;
+        dashboard.setRootHeadingLevel(rootHeadingLevel);
+        Assert.assertEquals(rootHeadingLevel,
+                dashboard.getElement().getProperty("rootHeadingLevel", -1));
+    }
+
+    @Test
+    public void setTitleHeadingLevelNull_elementPropertyIsRemoved() {
+        dashboard.setRootHeadingLevel(1);
+        dashboard.setRootHeadingLevel(null);
+        Assert.assertFalse(
+                dashboard.getElement().hasProperty("rootHeadingLevel"));
+    }
+
     private void assertItemSelectedChangedEventCorrectlyFired(Component item,
             boolean selected) {
         AtomicInteger listenerInvokedCount = new AtomicInteger(0);


### PR DESCRIPTION
## Description

This PR adds the Flow counterpart for the new API that controls the root heading level of the dashboard.

Fixes #[8779](https://github.com/vaadin/web-components/issues/8779)

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.