### PR TITLE
refactor: convert side nav item container base class into an interface

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/HasSideNavItems.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/HasSideNavItems.java
@@ -19,25 +19,21 @@ import java.util.List;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.dom.Element;
 
 /**
- * Base class for components used in the side navigation item hierarchy.
+ * {@code HasSideNavItems} is an interface for components used in the side
+ * navigation item hierarchy. The implementing components can contain and manage
+ * multiple {@code SideNavItem} instances. The interface defines methods for
+ * adding, removing, and accessing the items within a container.
+ *
+ * @see SideNav
+ * @see SideNavItem
  *
  * @author Vaadin Ltd
  */
-abstract class SideNavItemContainer extends Component {
-
-    /**
-     * Implement this method to set up/modify the SideNavItem right before it's
-     * added to the list of the navigation items.
-     *
-     * @param item
-     *            Item to be set up
-     */
-    protected void setupSideNavItem(SideNavItem item) {
-        // no setup by default
-    }
+public interface HasSideNavItems extends HasElement {
 
     /**
      * Adds navigation menu item(s) to the menu.
@@ -45,7 +41,7 @@ abstract class SideNavItemContainer extends Component {
      * @param items
      *            the navigation menu item(s) to add
      */
-    public void addItem(SideNavItem... items) {
+    default void addItem(SideNavItem... items) {
         assert items != null;
 
         for (SideNavItem item : items) {
@@ -61,7 +57,7 @@ abstract class SideNavItemContainer extends Component {
      * @param item
      *            the item to add, value must not be null
      */
-    public void addItemAsFirst(SideNavItem item) {
+    default void addItemAsFirst(SideNavItem item) {
         addItemAtIndex(0, item);
     }
 
@@ -75,7 +71,7 @@ abstract class SideNavItemContainer extends Component {
      * @param item
      *            the item to add, value must not be null
      */
-    public void addItemAtIndex(int index, SideNavItem item) {
+    default void addItemAtIndex(int index, SideNavItem item) {
         assert item != null;
 
         if (index < 0) {
@@ -109,7 +105,7 @@ abstract class SideNavItemContainer extends Component {
      * @return the child {@link SideNavItem} instances in this navigation menu
      * @see #addItem(SideNavItem...)
      */
-    public List<SideNavItem> getItems() {
+    default List<SideNavItem> getItems() {
         return getElement().getChildren().map(Element::getComponent)
                 .flatMap(Optional::stream)
                 .filter(component -> component instanceof SideNavItem)
@@ -124,7 +120,7 @@ abstract class SideNavItemContainer extends Component {
      * @param items
      *            the menu item(s) to remove
      */
-    public void remove(SideNavItem... items) {
+    default void remove(SideNavItem... items) {
         for (SideNavItem item : items) {
             Optional<Component> parent = item.getParent();
             if (parent.isPresent() && parent.get() == this) {
@@ -136,10 +132,13 @@ abstract class SideNavItemContainer extends Component {
     /**
      * Removes all navigation menu items from this item.
      */
-    public void removeAll() {
+    default void removeAll() {
         final List<Element> items = getItems().stream()
                 .map(Component::getElement).toList();
         getElement().removeChild(items);
     }
 
+    private void setupSideNavItem(SideNavItem item) {
+        item.getElement().setAttribute("slot", "children");
+    }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/HasSideNavItems.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/HasSideNavItems.java
@@ -139,6 +139,8 @@ public interface HasSideNavItems extends HasElement {
     }
 
     private void setupSideNavItem(SideNavItem item) {
-        item.getElement().setAttribute("slot", "children");
+        if (this instanceof SideNavItem) {
+            item.getElement().setAttribute("slot", "children");
+        }
     }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.sidenav;
 import java.io.Serializable;
 import java.util.Objects;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
@@ -39,7 +40,8 @@ import com.vaadin.flow.internal.JsonSerializer;
 @Tag("vaadin-side-nav")
 @NpmPackage(value = "@vaadin/side-nav", version = "24.8.0-alpha8")
 @JsModule("@vaadin/side-nav/src/vaadin-side-nav.js")
-public class SideNav extends SideNavItemContainer implements HasSize, HasStyle {
+public class SideNav extends Component
+        implements HasSideNavItems, HasSize, HasStyle {
 
     private Element labelElement;
 

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -59,8 +59,8 @@ import elemental.json.JsonArray;
 @Tag("vaadin-side-nav-item")
 @NpmPackage(value = "@vaadin/side-nav", version = "24.8.0-alpha8")
 @JsModule("@vaadin/side-nav/src/vaadin-side-nav-item.js")
-public class SideNavItem extends SideNavItemContainer
-        implements HasEnabled, HasPrefix, HasSuffix {
+public class SideNavItem extends Component
+        implements HasSideNavItems, HasEnabled, HasPrefix, HasSuffix {
 
     private Element labelElement;
 
@@ -195,11 +195,6 @@ public class SideNavItem extends SideNavItemContainer
         setPath(view, routeParameters);
         setLabel(label);
         setPrefixComponent(prefixComponent);
-    }
-
-    @Override
-    protected void setupSideNavItem(SideNavItem item) {
-        item.getElement().setAttribute("slot", "children");
     }
 
     /**


### PR DESCRIPTION
## Description

This PR converts the base class for components that can contain `SideNavItem`s (`SideNavItemContainer`) into an interface (`HasSideNavItems`). This makes it possible to use the API in a more generic way.

NOTE 1: The protected method `setupSideNavItem` in `SideNavItemContainer` was made private. It seems that this method was intended to be used only internally. However, it can possibly be a breaking change if it was overridden for some reason.

NOTE 2: The 2 failing tests also fail on the main branch without any changes. Related PR: https://github.com/vaadin/flow-components/pull/7270

NOTE 3: An alternative PR https://github.com/vaadin/flow-components/pull/7237 exists and should be closed if this PR is merged.

Related issue: #5089 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.