### PR TITLE
test: fix side nav tests by waiting for navigation

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.sidenav.tests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
@@ -25,7 +26,6 @@ import com.vaadin.flow.component.sidenav.testbench.SideNavElement;
 import com.vaadin.flow.component.sidenav.testbench.SideNavItemElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
-import org.openqa.selenium.By;
 
 /**
  * Integration tests for the {@link SideNavPage}.
@@ -71,7 +71,8 @@ public class SideNavIT extends AbstractComponentIT {
     public void clickNavigableParent_urlChanged() {
         navigableParent.click();
 
-        waitUntil(driver -> findElement(By.id("navigate-to-main-page")) != null);
+        waitUntil(
+                driver -> findElement(By.id("navigate-to-main-page")) != null);
 
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));
@@ -82,7 +83,8 @@ public class SideNavIT extends AbstractComponentIT {
         navigableParent.toggle();
         navigableParent.getItems().get(0).click();
 
-        waitUntil(driver -> findElement(By.id("navigate-to-main-page")) != null);
+        waitUntil(
+                driver -> findElement(By.id("navigate-to-main-page")) != null);
 
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.sidenav.testbench.SideNavElement;
 import com.vaadin.flow.component.sidenav.testbench.SideNavItemElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
+import org.openqa.selenium.By;
 
 /**
  * Integration tests for the {@link SideNavPage}.
@@ -70,6 +71,8 @@ public class SideNavIT extends AbstractComponentIT {
     public void clickNavigableParent_urlChanged() {
         navigableParent.click();
 
+        waitUntil(driver -> findElement(By.id("navigate-to-main-page")) != null);
+
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));
     }
@@ -78,6 +81,8 @@ public class SideNavIT extends AbstractComponentIT {
     public void clickChildOfNavigableParent_urlChanged() {
         navigableParent.toggle();
         navigableParent.getItems().get(0).click();
+
+        waitUntil(driver -> findElement(By.id("navigate-to-main-page")) != null);
 
         Assert.assertTrue(getDriver().getCurrentUrl()
                 .contains("side-nav-test-target-view"));


### PR DESCRIPTION
## Description

Two `SideNav` tests have been failing on CI and locally: `clickNavigableParent_urlChanged` and `clickChildOfNavigableParent_urlChanged`. The reason is that the URL assertion can happen before the navigation happens. This PR makes sure that the navigation occurs before the assertions.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Test

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.