### PR TITLE
refactor: add package private convenience bulk size updaters in spreadsheet for performance

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -4004,7 +4004,7 @@ public class Spreadsheet extends Component
     public void setRowHeight(int index, float height) {
         doSetRowHeight(index, height);
         var isRowHidden = height == 0.0F;
-        reloadSheetStyles(isRowHidden, isRowHidden);
+        reloadSheetStyles(true, isRowHidden);
     }
 
     /**
@@ -4024,7 +4024,7 @@ public class Spreadsheet extends Component
                 isAnyRowHidden.set(true);
             }
         });
-        reloadSheetStyles(isAnyRowHidden.get(), isAnyRowHidden.get());
+        reloadSheetStyles(true, isAnyRowHidden.get());
     }
 
     private void doSetRowHeight(int index, float height) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -3274,6 +3274,16 @@ public class Spreadsheet extends Component
         reloadSheetStyles(false, true);
     }
 
+    /**
+     * Hides or shows the given columns. Used internally in order to defer the
+     * style calculations until visibility of all columns are updated.
+     *
+     * @see #setColumnHidden(int, boolean)
+     *
+     * @param columnIndexToHidden
+     *            Map of 0-based column indexes to the indicator whether the
+     *            column should be hidden
+     */
     void setColumnsHidden(Map<Integer, Boolean> columnIndexToHidden) {
         columnIndexToHidden.forEach(this::doSetColumnHidden);
         reloadSheetStyles(false, true);
@@ -3325,6 +3335,16 @@ public class Spreadsheet extends Component
         reloadSheetStyles(true, true);
     }
 
+    /**
+     * Hides or shows the given rows. Used internally in order to defer the
+     * style calculations until visibility of all rows are updated.
+     *
+     * @see #setRowHidden(int, boolean)
+     *
+     * @param rowIndexToHidden
+     *            Map of 0-based row indexes to the indicator whether the row
+     *            should be hidden
+     */
     void setRowsHidden(Map<Integer, Boolean> rowIndexToHidden) {
         rowIndexToHidden.forEach(this::doSetRowHidden);
         reloadSheetStyles(true, true);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -3274,9 +3274,8 @@ public class Spreadsheet extends Component
         reloadSheetStyles(false, true);
     }
 
-    void setColumnsHidden(Collection<Integer> columnIndexes, boolean hidden) {
-        columnIndexes
-                .forEach(columnIndex -> doSetColumnHidden(columnIndex, hidden));
+    void setColumnsHidden(Map<Integer, Boolean> columnIndexToHidden) {
+        columnIndexToHidden.forEach(this::doSetColumnHidden);
         reloadSheetStyles(false, true);
     }
 
@@ -3326,8 +3325,8 @@ public class Spreadsheet extends Component
         reloadSheetStyles(true, true);
     }
 
-    void setRowsHidden(Collection<Integer> rowIndexes, boolean hidden) {
-        rowIndexes.forEach(rowIndex -> doSetRowHidden(rowIndex, hidden));
+    void setRowsHidden(Map<Integer, Boolean> rowIndexToHidden) {
+        rowIndexToHidden.forEach(this::doSetRowHidden);
         reloadSheetStyles(true, true);
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.poi.hssf.usermodel.HSSFClientAnchor;
@@ -1071,9 +1073,11 @@ public class SpreadsheetFactory implements Serializable {
              * mimic this behavior here.
              */
             spreadsheet.setColumnsHidden(
-                    IntStream.range(0, leftCol).boxed().toList(), true);
+                    IntStream.range(0, leftCol).boxed().collect(Collectors
+                            .toMap(Function.identity(), index -> true)));
             spreadsheet.setRowsHidden(
-                    IntStream.range(0, topRow).boxed().toList(), true);
+                    IntStream.range(0, topRow).boxed().collect(Collectors
+                            .toMap(Function.identity(), index -> true)));
         } else {
             spreadsheet.setVerticalSplitPosition(0);
             spreadsheet.setHorizontalSplitPosition(0);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.stream.IntStream;
 
 import org.apache.poi.hssf.usermodel.HSSFClientAnchor;
 import org.apache.poi.hssf.usermodel.HSSFPatriarch;
@@ -1069,12 +1070,10 @@ public class SpreadsheetFactory implements Serializable {
              * invisible frozen rows/columns are effectively hidden in Excel. We
              * mimic this behavior here.
              */
-            for (int col = 0; col < leftCol; col++) {
-                spreadsheet.setColumnHidden(col, true);
-            }
-            for (int row = 0; row < topRow; row++) {
-                spreadsheet.setRowHidden(row, true);
-            }
+            spreadsheet.setColumnsHidden(
+                    IntStream.range(0, leftCol).boxed().toList(), true);
+            spreadsheet.setRowsHidden(
+                    IntStream.range(0, topRow).boxed().toList(), true);
         } else {
             spreadsheet.setVerticalSplitPosition(0);
             spreadsheet.setHorizontalSplitPosition(0);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFilterTable.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFilterTable.java
@@ -13,6 +13,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
@@ -148,11 +151,11 @@ public class SpreadsheetFilterTable extends SpreadsheetTable {
             popupButtonToClearButtonMap.get(popupButton).setEnabled(false);
             popupButton.markActive(false);
         }
-        Spreadsheet spreadsheet = getSpreadsheet();
-        for (int r = filteringRegion.getFirstRow(); r <= filteringRegion
-                .getLastRow(); r++) {
-            spreadsheet.setRowHidden(r, false);
-        }
+        getSpreadsheet().setRowsHidden(IntStream
+                .range(filteringRegion.getFirstRow(),
+                        filteringRegion.getLastRow() + 1)
+                .boxed().collect(
+                        Collectors.toMap(Function.identity(), index -> false)));
     }
 
     /**
@@ -252,11 +255,11 @@ public class SpreadsheetFilterTable extends SpreadsheetTable {
             popupButton.markActive(!temp.isEmpty());
             filteredRows.addAll(temp);
         }
-        Spreadsheet spreadsheet = getSpreadsheet();
-        for (int r = filteringRegion.getFirstRow(); r <= filteringRegion
-                .getLastRow(); r++) {
-            spreadsheet.setRowHidden(r, filteredRows.contains(r));
-        }
+        getSpreadsheet().setRowsHidden(IntStream
+                .range(filteringRegion.getFirstRow(),
+                        filteringRegion.getLastRow() + 1)
+                .boxed().collect(Collectors.toMap(Function.identity(),
+                        filteredRows::contains)));
     }
 
     /**


### PR DESCRIPTION
## Description

This PR adds 4 package private internal methods that provide bulk updates:
- `void setColumnsHidden(Map<Integer, Boolean>)`
- `void setRowsHidden(Map<Integer, Boolean>)`
- `void setRowHeights(Map<Integer, Float>)`
- `void setColumnWidths(Map<Integer, Integer>)`

The logic that updates the row is separated from the block that does the style reload. This allows the style reload to be executed once per a set of rows instead of executing for each of them. This greatly increases the filtering performance for large sheets.

Inspired by [another PR](https://github.com/vaadin/flow-components/pull/7252), and retains the main idea. The difference is avoiding the management of the state using a field and less changes to the code.

Fixes #7211 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.