### PR TITLE
feat: add support for polygons to Map

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PolygonFeaturePage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PolygonFeaturePage.java
@@ -1,12 +1,15 @@
 /**
  * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
  */
 package com.vaadin.flow.component.map;
+
+import java.util.Arrays;
+import java.util.List;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
@@ -17,8 +20,6 @@ import com.vaadin.flow.component.map.configuration.style.Fill;
 import com.vaadin.flow.component.map.configuration.style.Stroke;
 import com.vaadin.flow.component.map.configuration.style.Style;
 import com.vaadin.flow.router.Route;
-import java.util.Arrays;
-import java.util.List;
 
 @Route("vaadin-map/polygon-feature")
 public class PolygonFeaturePage extends Div {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PolygonFeaturePage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PolygonFeaturePage.java
@@ -8,7 +8,6 @@
  */
 package com.vaadin.flow.component.map;
 
-import java.util.Arrays;
 import java.util.List;
 
 import com.vaadin.flow.component.html.Div;
@@ -26,98 +25,73 @@ public class PolygonFeaturePage extends Div {
 
     public PolygonFeaturePage() {
         Map map = new Map();
-        map.setCenter(new Coordinate(10.4515, 51.1657));
-        map.setZoom(4);
         map.getFeatureLayer().setId("feature-layer");
 
-        //
-        // ----
         NativeButton addSimplePolygonFeature = new NativeButton(
                 "Add simple polygon feature", e -> {
-
-                    final List<Coordinate> coordinates = createOuterBoundaries();
-
-                    final PolygonFeature polygon = new PolygonFeature(
-                            coordinates);
+                    List<Coordinate> coordinates = createOuterBoundaries();
+                    PolygonFeature polygon = new PolygonFeature(coordinates);
 
                     map.getFeatureLayer().addFeature(polygon);
-
-                    map.addFeatureClickListener(event -> {
-                        if (event
-                                .getFeature() instanceof PolygonFeature feature) {
-                            System.out.println(Arrays
-                                    .deepToString(feature.getCoordinates()));
-                        }
-                    });
-
                 });
         addSimplePolygonFeature.setId("add-simple-polygon-feature");
 
-        //
-        // ----
-        NativeButton addPolygonWithHoleFeature = new NativeButton(
+        NativeButton addPolygonFeatureWithHole = new NativeButton(
                 "Add polygon feature with a hole", e -> {
-
-                    final List<Coordinate> outerBoundary = createOuterBoundaries();
-                    final List<Coordinate> hole = List.of(new Coordinate(6, 48), // SW
+                    List<Coordinate> outerBoundary = createOuterBoundaries();
+                    List<Coordinate> hole = List.of(new Coordinate(6, 48), // SW
                             new Coordinate(6, 54), // NW
                             new Coordinate(14, 54), // NE
                             new Coordinate(14, 48), // SE
                             new Coordinate(6, 48) // SW
                     );
 
-                    final Coordinate[][] coordinates = new Coordinate[][] {
+                    Coordinate[][] coordinates = new Coordinate[][] {
                             outerBoundary.toArray(new Coordinate[0]),
                             hole.toArray(new Coordinate[0]) };
-                    final PolygonFeature polygon = new PolygonFeature();
+                    PolygonFeature polygon = new PolygonFeature();
                     polygon.setCoordinates(coordinates);
 
                     map.getFeatureLayer().addFeature(polygon);
 
-                    map.addFeatureClickListener(event -> {
-                        if (event
-                                .getFeature() instanceof PolygonFeature feature) {
-                            System.out.println(Arrays
-                                    .deepToString(feature.getCoordinates()));
-                        }
-                    });
-
                 });
-        addSimplePolygonFeature.setId("add-polygon-with-hole-feature");
+        addPolygonFeatureWithHole.setId("add-polygon-feature-with-hole");
 
-        //
-        // ----
-        NativeButton updatePolygonCoordinates = new NativeButton(
+        NativeButton movePolygonFeature = new NativeButton(
+                "Move polygon feature", e -> {
+                    if (!map.getFeatureLayer().getFeatures().isEmpty()) {
+                        Feature feature = map.getFeatureLayer().getFeatures()
+                                .get(0);
+                        if (feature instanceof PolygonFeature polygonFeature) {
+                            polygonFeature.getGeometry().translate(5.0, -3.0);
+                        }
+                    }
+                });
+        movePolygonFeature.setId("move-polygon-feature");
+
+        NativeButton activateDragAndDrop = new NativeButton(
                 "Activate Drag & Drop", e -> map.getFeatureLayer().getFeatures()
                         .forEach(feature -> feature.setDraggable(true)));
-        updatePolygonCoordinates.setId("activate-drag-drop");
 
-        //
-        // ----
         NativeButton updatePolygonStyle = new NativeButton(
                 "Update polygon style", e -> {
-                    if (map.getFeatureLayer().getFeatures().size() > 0) {
-                        final Feature feature = map.getFeatureLayer()
-                                .getFeatures().get(0);
-                        final Style style = new Style();
+                    if (!map.getFeatureLayer().getFeatures().isEmpty()) {
+                        Feature feature = map.getFeatureLayer().getFeatures()
+                                .get(0);
+                        Style style = new Style();
                         style.setStroke(new Stroke("red", 3));
                         style.setFill(new Fill("rgba(255, 0, 0, 0.1)"));
                         feature.setStyle(style);
                     }
                 });
-        updatePolygonStyle.setId("update-polygon-style");
 
-        //
-        // ----
-        NativeButton deletePolygonsCoordinates = new NativeButton(
-                "Delete polygons",
+        NativeButton removePolygons = new NativeButton("Remove polygons",
                 e -> map.getFeatureLayer().removeAllFeatures());
-        deletePolygonsCoordinates.setId("delete-polygons");
 
         add(map);
-        add(new Div(addSimplePolygonFeature, addPolygonWithHoleFeature,
-                updatePolygonCoordinates, updatePolygonStyle,
-                deletePolygonsCoordinates));
+        add(new Div(addSimplePolygonFeature, addPolygonFeatureWithHole,
+                movePolygonFeature, activateDragAndDrop, updatePolygonStyle,
+                removePolygons));
     }
 
     private static List<Coordinate> createOuterBoundaries() {

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PolygonFeaturePage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/PolygonFeaturePage.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.Feature;
+import com.vaadin.flow.component.map.configuration.feature.PolygonFeature;
+import com.vaadin.flow.component.map.configuration.style.Fill;
+import com.vaadin.flow.component.map.configuration.style.Stroke;
+import com.vaadin.flow.component.map.configuration.style.Style;
+import com.vaadin.flow.router.Route;
+import java.util.Arrays;
+import java.util.List;
+
+@Route("vaadin-map/polygon-feature")
+public class PolygonFeaturePage extends Div {
+
+    public PolygonFeaturePage() {
+        Map map = new Map();
+        map.setCenter(new Coordinate(10.4515, 51.1657));
+        map.setZoom(4);
+        map.getFeatureLayer().setId("feature-layer");
+
+        //
+        // ----
+        NativeButton addSimplePolygonFeature = new NativeButton(
+                "Add simple polygon feature", e -> {
+
+                    final List<Coordinate> coordinates = createOuterBoundaries();
+
+                    final PolygonFeature polygon = new PolygonFeature(
+                            coordinates);
+
+                    map.getFeatureLayer().addFeature(polygon);
+
+                    map.addFeatureClickListener(event -> {
+                        if (event
+                                .getFeature() instanceof PolygonFeature feature) {
+                            System.out.println(Arrays
+                                    .deepToString(feature.getCoordinates()));
+                        }
+                    });
+
+                });
+        addSimplePolygonFeature.setId("add-simple-polygon-feature");
+
+        //
+        // ----
+        NativeButton addPolygonWithHoleFeature = new NativeButton(
+                "Add polygon feature with a hole", e -> {
+
+                    final List<Coordinate> outerBoundary = createOuterBoundaries();
+                    final List<Coordinate> hole = List.of(new Coordinate(6, 48), // SW
+                            new Coordinate(6, 54), // NW
+                            new Coordinate(14, 54), // NE
+                            new Coordinate(14, 48), // SE
+                            new Coordinate(6, 48) // SW
+                    );
+
+                    final Coordinate[][] coordinates = new Coordinate[][] {
+                            outerBoundary.toArray(new Coordinate[0]),
+                            hole.toArray(new Coordinate[0]) };
+                    final PolygonFeature polygon = new PolygonFeature();
+                    polygon.setCoordinates(coordinates);
+
+                    map.getFeatureLayer().addFeature(polygon);
+
+                    map.addFeatureClickListener(event -> {
+                        if (event
+                                .getFeature() instanceof PolygonFeature feature) {
+                            System.out.println(Arrays
+                                    .deepToString(feature.getCoordinates()));
+                        }
+                    });
+
+                });
+        addSimplePolygonFeature.setId("add-polygon-with-hole-feature");
+
+        //
+        // ----
+        NativeButton updatePolygonCoordinates = new NativeButton(
+                "Activate Drag & Drop", e -> map.getFeatureLayer().getFeatures()
+                        .forEach(feature -> feature.setDraggable(true)));
+        updatePolygonCoordinates.setId("activate-drag-drop");
+
+        //
+        // ----
+        NativeButton updatePolygonStyle = new NativeButton(
+                "Update polygon style", e -> {
+                    if (map.getFeatureLayer().getFeatures().size() > 0) {
+                        final Feature feature = map.getFeatureLayer()
+                                .getFeatures().get(0);
+                        final Style style = new Style();
+                        style.setStroke(new Stroke("red", 3));
+                        style.setFill(new Fill("rgba(255, 0, 0, 0.1)"));
+                        feature.setStyle(style);
+                    }
+                });
+        updatePolygonStyle.setId("update-polygon-style");
+
+        //
+        // ----
+        NativeButton deletePolygonsCoordinates = new NativeButton(
+                "Delete polygons",
+                e -> map.getFeatureLayer().removeAllFeatures());
+        deletePolygonsCoordinates.setId("delete-polygons");
+
+        add(map);
+        add(new Div(addSimplePolygonFeature, addPolygonWithHoleFeature,
+                updatePolygonCoordinates, updatePolygonStyle,
+                deletePolygonsCoordinates));
+    }
+
+    private static List<Coordinate> createOuterBoundaries() {
+        return List.of(new Coordinate(5, 47), // SW
+                new Coordinate(5, 55), // NW
+                new Coordinate(15, 55), // NE
+                new Coordinate(15, 47), // SE
+                new Coordinate(5, 47) // SW
+        );
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/PolygonFeatureIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/PolygonFeatureIT.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.components.map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-map/polygon-feature")
+public class PolygonFeatureIT extends AbstractComponentIT {
+    private MapElement map;
+    private TestBenchElement addSimplePolygonFeature;
+    private TestBenchElement addPolygonFeatureWithHole;
+    private TestBenchElement movePolygonFeature;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+        addSimplePolygonFeature = $("button").id("add-simple-polygon-feature");
+        addPolygonFeatureWithHole = $("button")
+                .id("add-polygon-feature-with-hole");
+        movePolygonFeature = $("button").id("move-polygon-feature");
+    }
+
+    @Test
+    public void simplePolygonFeature() {
+        addSimplePolygonFeature.click();
+
+        MapElement.FeatureCollectionReference features = getDefaultFeatureLayerFeatures();
+
+        Assert.assertEquals(1, features.getLength());
+
+        MapElement.FeatureReference feature = features.getFeature(0);
+        Assert.assertTrue(feature.exists());
+
+        MapElement.Coordinate[][] coordinates = feature.getGeometry()
+                .getPolygonCoordinates();
+
+        Assert.assertEquals(1, coordinates.length);
+        Assert.assertEquals(5, coordinates[0].length);
+
+        Assert.assertEquals(5.0, coordinates[0][0].getX(), 0.0001);
+        Assert.assertEquals(47.0, coordinates[0][0].getY(), 0.0001);
+
+        Assert.assertEquals(5.0, coordinates[0][1].getX(), 0.0001);
+        Assert.assertEquals(55.0, coordinates[0][1].getY(), 0.0001);
+
+        Assert.assertEquals(15.0, coordinates[0][2].getX(), 0.0001);
+        Assert.assertEquals(55.0, coordinates[0][2].getY(), 0.0001);
+
+        Assert.assertEquals(15.0, coordinates[0][3].getX(), 0.0001);
+        Assert.assertEquals(47.0, coordinates[0][3].getY(), 0.0001);
+
+        Assert.assertEquals(5.0, coordinates[0][4].getX(), 0.0001);
+        Assert.assertEquals(47.0, coordinates[0][4].getY(), 0.0001);
+    }
+
+    @Test
+    public void polygonFeatureWithHole() {
+        addPolygonFeatureWithHole.click();
+
+        MapElement.FeatureCollectionReference features = getDefaultFeatureLayerFeatures();
+
+        Assert.assertEquals(1, features.getLength());
+
+        MapElement.FeatureReference feature = features.getFeature(0);
+        Assert.assertTrue(feature.exists());
+
+        MapElement.Coordinate[][] coordinates = feature.getGeometry()
+                .getPolygonCoordinates();
+
+        Assert.assertEquals(2, coordinates.length);
+        Assert.assertEquals(5, coordinates[0].length);
+
+        Assert.assertEquals(5.0, coordinates[0][0].getX(), 0.0001);
+        Assert.assertEquals(47.0, coordinates[0][0].getY(), 0.0001);
+
+        Assert.assertEquals(5.0, coordinates[0][1].getX(), 0.0001);
+        Assert.assertEquals(55.0, coordinates[0][1].getY(), 0.0001);
+
+        Assert.assertEquals(15.0, coordinates[0][2].getX(), 0.0001);
+        Assert.assertEquals(55.0, coordinates[0][2].getY(), 0.0001);
+
+        Assert.assertEquals(15.0, coordinates[0][3].getX(), 0.0001);
+        Assert.assertEquals(47.0, coordinates[0][3].getY(), 0.0001);
+
+        Assert.assertEquals(5.0, coordinates[0][4].getX(), 0.0001);
+        Assert.assertEquals(47.0, coordinates[0][4].getY(), 0.0001);
+
+        Assert.assertEquals(5, coordinates[1].length);
+
+        Assert.assertEquals(6.0, coordinates[1][0].getX(), 0.0001);
+        Assert.assertEquals(48.0, coordinates[1][0].getY(), 0.0001);
+
+        Assert.assertEquals(6.0, coordinates[1][1].getX(), 0.0001);
+        Assert.assertEquals(54.0, coordinates[1][1].getY(), 0.0001);
+
+        Assert.assertEquals(14.0, coordinates[1][2].getX(), 0.0001);
+        Assert.assertEquals(54.0, coordinates[1][2].getY(), 0.0001);
+
+        Assert.assertEquals(14.0, coordinates[1][3].getX(), 0.0001);
+        Assert.assertEquals(48.0, coordinates[1][3].getY(), 0.0001);
+
+        Assert.assertEquals(6.0, coordinates[1][4].getX(), 0.0001);
+        Assert.assertEquals(48.0, coordinates[1][4].getY(), 0.0001);
+    }
+
+    @Test
+    public void movePolygonFeature() {
+        // Add a polygon first
+        addSimplePolygonFeature.click();
+
+        // Get initial coordinates
+        MapElement.FeatureCollectionReference features = getDefaultFeatureLayerFeatures();
+        MapElement.FeatureReference feature = features.getFeature(0);
+        MapElement.Coordinate[][] originalCoordinates = feature.getGeometry()
+                .getPolygonCoordinates();
+
+        // Move the polygon
+        movePolygonFeature.click();
+
+        // Get the updated coordinates after translation
+        features = getDefaultFeatureLayerFeatures();
+        feature = features.getFeature(0);
+        MapElement.Coordinate[][] translatedCoordinates = feature.getGeometry()
+                .getPolygonCoordinates();
+
+        // Verify all points were moved by the expected amount (5 units right, 3
+        // units down)
+        for (int i = 0; i < originalCoordinates[0].length; i++) {
+            Assert.assertEquals(originalCoordinates[0][i].getX() + 5.0,
+                    translatedCoordinates[0][i].getX(), 0.0001);
+            Assert.assertEquals(originalCoordinates[0][i].getY() - 3.0,
+                    translatedCoordinates[0][i].getY(), 0.0001);
+        }
+    }
+
+    private MapElement.FeatureCollectionReference getDefaultFeatureLayerFeatures() {
+        MapElement.MapReference mapReference = map.getMapReference();
+        MapElement.LayerReference featureLayer = mapReference.getLayers()
+                .getLayer(1);
+        MapElement.VectorSourceReference source = featureLayer.getSource()
+                .asVectorSource();
+        return source.getFeatures();
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Constants.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Constants.java
@@ -26,6 +26,7 @@ public class Constants {
     public static final String OL_SOURCE_IMAGE_WMS = "ol/source/ImageWMS";
     // Geometry
     public static final String OL_GEOMETRY_POINT = "ol/geom/Point";
+    public static final String OL_GEOMETRY_POLYGON = "ol/geom/Polygon";
     // Style
     public static final String OL_STYLE_ICON = "ol/style/Icon";
     public static final String OL_STYLE_FILL = "ol/style/Fill";

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
@@ -34,8 +34,8 @@ public class PolygonFeature extends Feature {
     private static final Style DEFAULT_STYLE;
     static {
         final Style style = new Style();
-        style.setStroke(new Stroke("blue", 3));
-        style.setFill(new Fill("rgba(0, 0, 255, 0.1)"));
+        style.setStroke(new Stroke("hsl(214, 100%, 48%)", 2));
+        style.setFill(new Fill("hsla(214, 100%, 60%, 0.13)"));
         DEFAULT_STYLE = style;
     }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Feature;
 import com.vaadin.flow.component.map.configuration.geometry.Polygon;
@@ -25,7 +24,7 @@ import com.vaadin.flow.component.map.configuration.style.Stroke;
 import com.vaadin.flow.component.map.configuration.style.Style;
 
 /**
- * Class for features that are represented by a single polygon.
+ * A convenience class for displaying a polygon on the map.
  * <p>
  * Technically this is a {@link Feature} that uses a {@link Polygon} geometry
  * for representation.
@@ -48,12 +47,14 @@ public class PolygonFeature extends Feature {
     }
 
     /**
-     * Creates a new polygon-based feature with the default style using the
-     * provided coordinates. The polygon is defined in the map's user
-     * projection, which defaults to {@code EPSG:4326}. The provided coordinate
-     * list defines a linear ring, where the first coordinate and the last
-     * should be equivalent to ensure a closed ring. This ring specifies the
-     * outer boundary or surface of the polygon without any holes.
+     * Creates a new polygon feature with the default style using the provided
+     * coordinates. The provided coordinate list defines a linear ring, where
+     * the first coordinate and the last should be equivalent to ensure a closed
+     * ring. This ring specifies the outer boundary or surface of the polygon
+     * without any holes.
+     * <p>
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the list of coordinates that define the vertices of the
@@ -66,11 +67,12 @@ public class PolygonFeature extends Feature {
     }
 
     /**
-     * The coordinates that define where the feature is located on the map.
-     * Coordinates are returned in the map's user projection, which by default
-     * is {@code EPSG:4326}, also referred to as GPS coordinates. If the user
-     * projection has been changed using {@link Map#setUserProjection(String)},
-     * then coordinates must be specified in that projection instead.
+     * The coordinates where the polygon is located, as a two-dimensional array.
+     * The first array represents the outer boundary of the polygon as a linear
+     * ring of coordinates. Each subsequent array represents a linear ring
+     * defining a hole in the polygon's surface. A linear ring is defined as an
+     * array of coordinates where the first and the last coordinates are
+     * identical.
      *
      * @return the current coordinates
      */
@@ -80,7 +82,16 @@ public class PolygonFeature extends Feature {
     }
 
     /**
-     * @see #setCoordinates(Coordinate[][])
+     * Sets the coordinates that define the polygon. The provided coordinate
+     * list defines a linear ring, where the first coordinate and the last
+     * should be equivalent to ensure a closed ring. This ring specifies the
+     * outer boundary or surface of the polygon without any holes.
+     * <p>
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
+     *
+     * @param coordinates
+     *            the new coordinates
      */
     public void setCoordinates(List<Coordinate> coordinates) {
         Objects.requireNonNull(coordinates);
@@ -88,12 +99,15 @@ public class PolygonFeature extends Feature {
     }
 
     /**
-     * Sets the coordinates that define where the feature is located on the map.
+     * Sets the coordinates that define the polygon as a two-dimensional array.
+     * The first array represents the outer boundary of the polygon as a linear
+     * ring of coordinates. Each subsequent array represents a linear ring
+     * defining a hole in the polygon's surface. A linear ring is defined as an
+     * array of coordinates where the first and the last coordinates are
+     * identical.
+     * <p>
      * Coordinates must be specified in the map's user projection, which by
-     * default is {@code EPSG:4326}, also referred to as GPS coordinates. If the
-     * user projection has been changed using
-     * {@link Map#setUserProjection(String)}, then coordinates must be specified
-     * in that projection instead.
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the new coordinates

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.map.configuration.feature;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.vaadin.flow.component.map.Map;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.Feature;
+import com.vaadin.flow.component.map.configuration.geometry.Polygon;
+import com.vaadin.flow.component.map.configuration.geometry.SimpleGeometry;
+import com.vaadin.flow.component.map.configuration.style.Fill;
+import com.vaadin.flow.component.map.configuration.style.Stroke;
+import com.vaadin.flow.component.map.configuration.style.Style;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class for features that are represented by a single polygon.
+ * <p>
+ * Technically this is a {@link Feature} that uses a {@link Polygon} geometry
+ * for representation.
+ */
+public class PolygonFeature extends Feature {
+
+    private static final Style DEFAULT_STYLE;
+    static {
+        final Style style = new Style();
+        style.setStroke(new Stroke("blue", 3));
+        style.setFill(new Fill("rgba(0, 0, 255, 0.1)"));
+        DEFAULT_STYLE = style;
+    }
+
+    /**
+     * Creates a new polygon feature with the default style.
+     */
+    public PolygonFeature() {
+        this(List.of(new Coordinate(0, 0)));
+    }
+
+    /**
+     * Creates a new polygon-based feature with the default style using the
+     * provided coordinates. The polygon is defined in the map's user
+     * projection, which defaults to {@code EPSG:4326}. The provided coordinate
+     * list defines a linear ring, where the first coordinate and the last
+     * should be equivalent to ensure a closed ring. This ring specifies the
+     * outer boundary or surface of the polygon without any holes.
+     *
+     * @param coordinates
+     *            the list of coordinates that define the vertices of the
+     *            polygon
+     */
+    public PolygonFeature(List<Coordinate> coordinates) {
+        setGeometry(new Polygon(coordinates));
+        // Let the polygon be visible on the map
+        setStyle(DEFAULT_STYLE);
+    }
+
+    /**
+     * The coordinates that define where the feature is located on the map.
+     * Coordinates are returned in the map's user projection, which by default
+     * is {@code EPSG:4326}, also referred to as GPS coordinates. If the user
+     * projection has been changed using {@link Map#setUserProjection(String)},
+     * then coordinates must be specified in that projection instead.
+     *
+     * @return the current coordinates
+     */
+    @JsonIgnore
+    public Coordinate[][] getCoordinates() {
+        return getGeometry().getCoordinates();
+    }
+
+    /**
+     * @see #setCoordinates(Coordinate[][])
+     */
+    public void setCoordinates(List<Coordinate> coordinates) {
+        Objects.requireNonNull(coordinates);
+        getGeometry().setCoordinates(coordinates);
+    }
+
+    /**
+     * Sets the coordinates that define where the feature is located on the map.
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates. If the
+     * user projection has been changed using
+     * {@link Map#setUserProjection(String)}, then coordinates must be specified
+     * in that projection instead.
+     *
+     * @param coordinates
+     *            the new coordinates
+     */
+    public void setCoordinates(Coordinate[][] coordinates) {
+        Objects.requireNonNull(coordinates);
+        getGeometry().setCoordinates(coordinates);
+    }
+
+    /**
+     * The {@link Polygon} geometry representing this feature.
+     *
+     * @return the current polygon geometry
+     */
+    @Override
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public Polygon getGeometry() {
+        return (Polygon) super.getGeometry();
+    }
+
+    /**
+     * Sets the geometry representing this feature. This must be a
+     * {@link Polygon} geometry.
+     *
+     * @param geometry
+     *            the new geometry, not null
+     * @throws IllegalArgumentException
+     *             if the geometry is not an instance of {@link Polygon}
+     */
+    @Override
+    public void setGeometry(SimpleGeometry geometry) {
+        Objects.requireNonNull(geometry);
+        if (!(geometry instanceof Polygon)) {
+            throw new IllegalArgumentException("Geometry must be a polygon");
+        }
+        super.setGeometry(geometry);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
@@ -1,12 +1,15 @@
-/*
+/**
  * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
  */
 package com.vaadin.flow.component.map.configuration.feature;
+
+import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -20,8 +23,6 @@ import com.vaadin.flow.component.map.configuration.geometry.SimpleGeometry;
 import com.vaadin.flow.component.map.configuration.style.Fill;
 import com.vaadin.flow.component.map.configuration.style.Stroke;
 import com.vaadin.flow.component.map.configuration.style.Style;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * Class for features that are represented by a single polygon.

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.map.configuration.Constants;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 
 /**
- * Polygon geometry.
+ * Geometry that represents a polygon.
  *
  * @apiNote <a href=
  *          "https://openlayers.org/en/latest/apidoc/module-ol_geom_Polygon-Polygon.html">ol/geom/Polygon~Polygon
@@ -27,14 +27,16 @@ public class Polygon extends SimpleGeometry {
 
     /**
      * Constructs a new {@code Polygon} geometry based on the provided list of
-     * coordinates. The polygon is defined in the map's user projection, which
-     * defaults to {@code EPSG:4326}. The provided coordinate list defines a
-     * linear ring, where the first coordinate and the last should be equivalent
-     * to ensure a closed ring. This ring specifies the outer boundary or
-     * surface of the polygon without any holes.
+     * coordinates. The provided coordinate list defines a linear ring, where
+     * the first coordinate and the last should be equivalent to ensure a closed
+     * ring. This ring specifies the outer boundary or surface of the polygon
+     * without any holes.
+     * <p>
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
-     *            the coordinates that locate the polygon
+     *            the coordinates that define the polygon
      * @throws IllegalArgumentException
      *             if the provided coordinate list is null or empty
      */
@@ -50,9 +52,10 @@ public class Polygon extends SimpleGeometry {
      * outer boundary of the polygon as a linear ring of coordinates. Each
      * subsequent array represents a linear ring defining a hole in the
      * polygon's surface. A linear ring is defined as an array of coordinates
-     * where the first and the last coordinates are identical. Coordinates must
-     * be specified in the map's user projection, which defaults to
-     * {@code EPSG:4326}.
+     * where the first and the last coordinates are identical.
+     * <p>
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the coordinates that locate the polygon
@@ -71,9 +74,13 @@ public class Polygon extends SimpleGeometry {
     }
 
     /**
-     * Sets the coordinates that define the polygon without a hole in the
-     * surface. Coordinates must be specified in the map's user projection,
-     * which by default is {@code EPSG:4326}.
+     * Sets the coordinates that define the polygon. The provided coordinate
+     * list defines a linear ring, where the first coordinate and the last
+     * should be equivalent to ensure a closed ring. This ring specifies the
+     * outer boundary or surface of the polygon without any holes.
+     * <p>
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the new coordinates
@@ -86,11 +93,15 @@ public class Polygon extends SimpleGeometry {
     }
 
     /**
-     * Array of linear rings that define the polygon. The first linear ring of
-     * the array defines the outer-boundary or surface of the polygon. Each
-     * subsequent linear ring defines a hole in the surface of the polygon. A
-     * linear ring is an array of vertices' coordinates where the first
-     * coordinate and the last are equivalent.
+     * Sets the coordinates that define the polygon as a two-dimensional array.
+     * The first array represents the outer boundary of the polygon as a linear
+     * ring of coordinates. Each subsequent array represents a linear ring
+     * defining a hole in the polygon's surface. A linear ring is defined as an
+     * array of coordinates where the first and the last coordinates are
+     * identical.
+     * <p>
+     * Coordinates must be specified in the map's user projection, which by
+     * default is {@code EPSG:4326}, also referred to as GPS coordinates.
      *
      * @param coordinates
      *            the new coordinates
@@ -102,7 +113,12 @@ public class Polygon extends SimpleGeometry {
     }
 
     /**
-     * The coordinates where the polygon is located
+     * The coordinates where the polygon is located, as a two-dimensional array.
+     * The first array represents the outer boundary of the polygon as a linear
+     * ring of coordinates. Each subsequent array represents a linear ring
+     * defining a hole in the polygon's surface. A linear ring is defined as an
+     * array of coordinates where the first and the last coordinates are
+     * identical.
      *
      * @return the current coordinates
      */
@@ -113,48 +129,22 @@ public class Polygon extends SimpleGeometry {
     @Override
     public void translate(double deltaX, double deltaY) {
         this.coordinates = Arrays.stream(coordinates).map(
-                linearRing -> translateCoordinates(deltaX, deltaY, linearRing))
+                linearRing -> translateLinearRing(deltaX, deltaY, linearRing))
                 .toArray(Coordinate[][]::new);
     }
 
-    private static Coordinate[] translateCoordinates(double deltaX,
+    private static Coordinate[] translateLinearRing(double deltaX,
             double deltaY, Coordinate[] source) {
         return Arrays.stream(source).map(
                 coordinate -> translateCoordinates(deltaX, deltaY, coordinate))
                 .toArray(Coordinate[]::new);
     }
 
-    /**
-     * Translates a given coordinate by the specified delta values along the
-     * x-axis and y-axis.
-     *
-     * @param deltaX
-     *            the amount to move the coordinate along the x-axis
-     * @param deltaY
-     *            the amount to move the coordinate along the y-axis
-     * @param source
-     *            the original coordinate to be translated
-     * @return a new {@code Coordinate} representing the translated position
-     */
     private static Coordinate translateCoordinates(double deltaX, double deltaY,
             Coordinate source) {
         return new Coordinate(source.getX() + deltaX, source.getY() + deltaY);
     }
 
-    /**
-     * Validates the structure and content of the provided two-dimensional array
-     * of {@code Coordinate} objects. Ensures that the array and its nested
-     * arrays are not null or empty. Throws an {@code IllegalArgumentException}
-     * if these conditions are not met.
-     *
-     * @param coordinates
-     *            a two-dimensional array of {@code Coordinate} objects, where
-     *            each nested array represents a linear ring of a polygon; must
-     *            not be null or empty
-     * @throws IllegalArgumentException
-     *             if the input array or any of its nested arrays are null or
-     *             empty
-     */
     private static void validateCoordinates(Coordinate[][] coordinates) {
         if (coordinates == null || coordinates.length == 0) {
             throw new IllegalArgumentException(
@@ -175,5 +165,4 @@ public class Polygon extends SimpleGeometry {
                     "Coordinates must not be null or empty");
         }
     }
-
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
@@ -1,17 +1,18 @@
 /**
  * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
  */
 package com.vaadin.flow.component.map.configuration.geometry;
 
-import com.vaadin.flow.component.map.configuration.Constants;
-import com.vaadin.flow.component.map.configuration.Coordinate;
 import java.util.Arrays;
 import java.util.List;
+
+import com.vaadin.flow.component.map.configuration.Constants;
+import com.vaadin.flow.component.map.configuration.Coordinate;
 
 /**
  * Polygon geometry.

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.map.configuration.geometry;
+
+import com.vaadin.flow.component.map.configuration.Constants;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Polygon geometry.
+ *
+ * @apiNote <a href=
+ *          "https://openlayers.org/en/latest/apidoc/module-ol_geom_Polygon-Polygon.html">ol/geom/Polygon~Polygon
+ *          </a>
+ */
+public class Polygon extends SimpleGeometry {
+
+    private Coordinate[][] coordinates;
+
+    /**
+     * Constructs a new {@code Polygon} geometry based on the provided list of
+     * coordinates. The polygon is defined in the map's user projection, which
+     * defaults to {@code EPSG:4326}. The provided coordinate list defines a
+     * linear ring, where the first coordinate and the last should be equivalent
+     * to ensure a closed ring. This ring specifies the outer boundary or
+     * surface of the polygon without any holes.
+     *
+     * @param coordinates
+     *            the coordinates that locate the polygon
+     * @throws IllegalArgumentException
+     *             if the provided coordinate list is null or empty
+     */
+    public Polygon(List<Coordinate> coordinates) {
+        validateCoordinates(coordinates);
+        this.coordinates = new Coordinate[][] {
+                coordinates.toArray(new Coordinate[0]) };
+    }
+
+    /**
+     * Constructs a new {@code Polygon} geometry based on the provided
+     * two-dimensional array of coordinates. The first array represents the
+     * outer boundary of the polygon as a linear ring of coordinates. Each
+     * subsequent array represents a linear ring defining a hole in the
+     * polygon's surface. A linear ring is defined as an array of coordinates
+     * where the first and the last coordinates are identical. Coordinates must
+     * be specified in the map's user projection, which defaults to
+     * {@code EPSG:4326}.
+     *
+     * @param coordinates
+     *            the coordinates that locate the polygon
+     * @throws IllegalArgumentException
+     *             if any of the arrays in the provided coordinates array are
+     *             null or empty
+     */
+    public Polygon(Coordinate[][] coordinates) {
+        validateCoordinates(coordinates);
+        this.coordinates = coordinates;
+    }
+
+    @Override
+    public String getType() {
+        return Constants.OL_GEOMETRY_POLYGON;
+    }
+
+    /**
+     * Sets the coordinates that define the polygon without a hole in the
+     * surface. Coordinates must be specified in the map's user projection,
+     * which by default is {@code EPSG:4326}.
+     *
+     * @param coordinates
+     *            the new coordinates
+     */
+    public void setCoordinates(List<Coordinate> coordinates) {
+        validateCoordinates(coordinates);
+        this.coordinates = new Coordinate[][] {
+                coordinates.toArray(new Coordinate[0]) };
+        markAsDirty();
+    }
+
+    /**
+     * Array of linear rings that define the polygon. The first linear ring of
+     * the array defines the outer-boundary or surface of the polygon. Each
+     * subsequent linear ring defines a hole in the surface of the polygon. A
+     * linear ring is an array of vertices' coordinates where the first
+     * coordinate and the last are equivalent.
+     *
+     * @param coordinates
+     *            the new coordinates
+     */
+    public void setCoordinates(Coordinate[][] coordinates) {
+        validateCoordinates(coordinates);
+        this.coordinates = coordinates;
+        markAsDirty();
+    }
+
+    /**
+     * The coordinates where the polygon is located
+     *
+     * @return the current coordinates
+     */
+    public Coordinate[][] getCoordinates() {
+        return coordinates;
+    }
+
+    @Override
+    public void translate(double deltaX, double deltaY) {
+        this.coordinates = Arrays.stream(coordinates).map(
+                linearRing -> translateCoordinates(deltaX, deltaY, linearRing))
+                .toArray(Coordinate[][]::new);
+    }
+
+    private static Coordinate[] translateCoordinates(double deltaX,
+            double deltaY, Coordinate[] source) {
+        return Arrays.stream(source).map(
+                coordinate -> translateCoordinates(deltaX, deltaY, coordinate))
+                .toArray(Coordinate[]::new);
+    }
+
+    /**
+     * Translates a given coordinate by the specified delta values along the
+     * x-axis and y-axis.
+     *
+     * @param deltaX
+     *            the amount to move the coordinate along the x-axis
+     * @param deltaY
+     *            the amount to move the coordinate along the y-axis
+     * @param source
+     *            the original coordinate to be translated
+     * @return a new {@code Coordinate} representing the translated position
+     */
+    private static Coordinate translateCoordinates(double deltaX, double deltaY,
+            Coordinate source) {
+        return new Coordinate(source.getX() + deltaX, source.getY() + deltaY);
+    }
+
+    /**
+     * Validates the structure and content of the provided two-dimensional array
+     * of {@code Coordinate} objects. Ensures that the array and its nested
+     * arrays are not null or empty. Throws an {@code IllegalArgumentException}
+     * if these conditions are not met.
+     *
+     * @param coordinates
+     *            a two-dimensional array of {@code Coordinate} objects, where
+     *            each nested array represents a linear ring of a polygon; must
+     *            not be null or empty
+     * @throws IllegalArgumentException
+     *             if the input array or any of its nested arrays are null or
+     *             empty
+     */
+    private static void validateCoordinates(Coordinate[][] coordinates) {
+        if (coordinates == null || coordinates.length == 0) {
+            throw new IllegalArgumentException(
+                    "Coordinates must not be null or empty");
+        }
+
+        for (Coordinate[] linearRing : coordinates) {
+            if (linearRing == null || linearRing.length == 0) {
+                throw new IllegalArgumentException(
+                        "Coordinates of the linearRing must not be null or empty");
+            }
+        }
+    }
+
+    private static void validateCoordinates(List<Coordinate> coordinates) {
+        if (coordinates == null || coordinates.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Coordinates must not be null or empty");
+        }
+    }
+
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/geometry/Polygon.java
@@ -128,9 +128,10 @@ public class Polygon extends SimpleGeometry {
 
     @Override
     public void translate(double deltaX, double deltaY) {
-        this.coordinates = Arrays.stream(coordinates).map(
+        Coordinate[][] nextCoordinates = Arrays.stream(coordinates).map(
                 linearRing -> translateLinearRing(deltaX, deltaY, linearRing))
                 .toArray(Coordinate[][]::new);
+        setCoordinates(nextCoordinates);
     }
 
     private static Coordinate[] translateLinearRing(double deltaX,

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
@@ -23,11 +23,7 @@ import {
   synchronizeXYZSource
 } from './sources.js';
 import { synchronizeIcon, synchronizeFill, synchronizeStroke, synchronizeText, synchronizeStyle } from './styles.js';
-import {
-  convertToCoordinateArray,
-  convertToGeoJSONCoordinateArray,
-  synchronizeCollection
-} from './util.js';
+import { convertToCoordinateArray, convertToGeoJSONCoordinateArray, synchronizeCollection } from './util.js';
 
 /**
  * Fallback text style to use for features that don't have a custom one

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
@@ -9,6 +9,7 @@
  */
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
+import Polygon from 'ol/geom/Polygon';
 import Fill from 'ol/style/Fill';
 import Stroke from 'ol/style/Stroke';
 import Text from 'ol/style/Text';
@@ -22,7 +23,11 @@ import {
   synchronizeXYZSource
 } from './sources.js';
 import { synchronizeIcon, synchronizeFill, synchronizeStroke, synchronizeText, synchronizeStyle } from './styles.js';
-import { convertToCoordinateArray, synchronizeCollection } from './util.js';
+import {
+  convertToCoordinateArray,
+  convertToGeoJSONCoordinateArray,
+  synchronizeCollection
+} from './util.js';
 
 /**
  * Fallback text style to use for features that don't have a custom one
@@ -65,6 +70,16 @@ function synchronizePoint(target, source, _context) {
   }
 
   target.setCoordinates(convertToCoordinateArray(source.coordinates));
+
+  return target;
+}
+
+function synchronizePolygon(target, source, _context) {
+  if (!target) {
+    target = new Polygon(convertToGeoJSONCoordinateArray(source.coordinates));
+  }
+
+  target.setCoordinates(convertToGeoJSONCoordinateArray(source.coordinates));
 
   return target;
 }
@@ -121,6 +136,7 @@ const synchronizerLookup = {
   'ol/source/XYZ': synchronizeXYZSource,
   // Geometry
   'ol/geom/Point': synchronizePoint,
+  'ol/geom/Polygon': synchronizePolygon,
   // Styles
   'ol/style/Icon': synchronizeIcon,
   'ol/style/Fill': synchronizeFill,

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/util.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/util.js
@@ -19,6 +19,21 @@ export function convertToCoordinateArray(coordinate) {
 }
 
 /**
+ * Helper to convert a coordinate object from the server with
+ * the shape [[{ x: number, y: number}]]
+ * to the structure of a GeoJSON coordinate array for polygons.
+ * @param coordinates
+ * @returns {*[[]]}
+ */
+export function convertToGeoJSONCoordinateArray(coordinates) {
+  return coordinates
+    // The first linear ring of the array defines the outer-boundary or surface of the polygon
+    // Each subsequent linear ring defines a hole in the surface of the polygon
+    .map(linearRing => linearRing
+    .map(coordinate => convertToCoordinateArray(coordinate)));
+}
+
+/**
  * Helper to convert a size object with the shape { width: number, height: number}
  * into a size array used by OpenLayers
  * @param size

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/util.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/util.js
@@ -26,11 +26,12 @@ export function convertToCoordinateArray(coordinate) {
  * @returns {*[[]]}
  */
 export function convertToGeoJSONCoordinateArray(coordinates) {
-  return coordinates
-    // The first linear ring of the array defines the outer-boundary or surface of the polygon
-    // Each subsequent linear ring defines a hole in the surface of the polygon
-    .map(linearRing => linearRing
-    .map(coordinate => convertToCoordinateArray(coordinate)));
+  return (
+    coordinates
+      // The first linear ring of the array defines the outer-boundary or surface of the polygon
+      // Each subsequent linear ring defines a hole in the surface of the polygon
+      .map((linearRing) => linearRing.map((coordinate) => convertToCoordinateArray(coordinate)))
+  );
 }
 
 /**

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeatureTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeatureTest.java
@@ -1,0 +1,125 @@
+package com.vaadin.flow.component.map.configuration.feature;
+
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.geometry.Point;
+import com.vaadin.flow.component.map.configuration.geometry.Polygon;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PolygonFeatureTest {
+    private static final Coordinate[] outerCoordinates = {
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+            new Coordinate(10, 10),
+            new Coordinate(0, 10),
+            new Coordinate(0, 0)
+    };
+
+    private static final Coordinate[] innerCoordinates = {
+                    new Coordinate(2, 2),
+                    new Coordinate(8, 2),
+                    new Coordinate(8, 8),
+                    new Coordinate(2, 8),
+                    new Coordinate(2, 2)
+    };
+
+    @Test
+    public void defaults() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+
+        // Test default coordinates
+        Assert.assertNotNull(polygonFeature.getCoordinates());
+        Assert.assertEquals(1, polygonFeature.getGeometry().getCoordinates().length);
+        Assert.assertEquals(1, polygonFeature.getGeometry().getCoordinates()[0].length);
+        Assert.assertEquals(0, polygonFeature.getGeometry().getCoordinates()[0][0].getX(), 0);
+        Assert.assertEquals(0, polygonFeature.getGeometry().getCoordinates()[0][0].getY(), 0);
+
+        // Test default style
+        Assert.assertNotNull(polygonFeature.getStyle());
+        Assert.assertNotNull(polygonFeature.getStyle().getStroke());
+        Assert.assertEquals("hsl(214, 100%, 48%)", polygonFeature.getStyle().getStroke().getColor());
+        Assert.assertEquals(2, polygonFeature.getStyle().getStroke().getWidth(), 0);
+
+        Assert.assertNotNull(polygonFeature.getStyle().getFill());
+        Assert.assertEquals("hsla(214, 100%, 60%, 0.13)", polygonFeature.getStyle().getFill().getColor());
+    }
+
+    @Test
+    public void initializeWithCoordinates() {
+        List<Coordinate> coordinates = List.of(outerCoordinates);
+        PolygonFeature polygonFeature = new PolygonFeature(coordinates);
+
+        assertCoordinates(new Coordinate[][] {outerCoordinates}, polygonFeature);
+    }
+
+    @Test
+    public void setCoordinatesWithList() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        List<Coordinate> coordinates = List.of(outerCoordinates);
+        polygonFeature.setCoordinates(coordinates);
+
+        assertCoordinates(new Coordinate[][] {outerCoordinates}, polygonFeature);
+    }
+
+    @Test
+    public void setCoordinatesWithArray() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        Coordinate[][] coordinatesArray = new Coordinate[][] {
+                outerCoordinates,
+                innerCoordinates
+        };
+        polygonFeature.setCoordinates(coordinatesArray);
+
+        assertCoordinates(coordinatesArray, polygonFeature);
+    }
+
+    @Test
+    public void setGeometry() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        List<Coordinate> coordinates = List.of(outerCoordinates);
+        Polygon polygon = new Polygon(coordinates);
+        polygonFeature.setGeometry(polygon);
+
+        Assert.assertSame(polygon, polygonFeature.getGeometry());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setGeometry_withNull_throwsException() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        polygonFeature.setGeometry(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setGeometry_withNonPolygon_throwsException() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        polygonFeature.setGeometry(new Point(new Coordinate(0, 0)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setCoordinatesList_withNull_throwsException() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        polygonFeature.setCoordinates((List<Coordinate>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setCoordinatesArray_withNull_throwsException() {
+        PolygonFeature polygonFeature = new PolygonFeature();
+        polygonFeature.setCoordinates((Coordinate[][]) null);
+    }
+
+    private void assertCoordinates(Coordinate[][] expected, PolygonFeature feature) {
+        Coordinate[][] actual = feature.getGeometry().getCoordinates();
+
+        Assert.assertEquals(expected.length, actual.length);
+
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(expected[i].length, actual[i].length);
+            for (int j = 0; j < expected[i].length; j++) {
+                Assert.assertEquals(expected[i][j].getX(), actual[i][j].getX(), 0);
+                Assert.assertEquals(expected[i][j].getY(), actual[i][j].getY(), 0);
+            }
+        }
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeatureTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeatureTest.java
@@ -1,29 +1,30 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
 package com.vaadin.flow.component.map.configuration.feature;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.geometry.Point;
 import com.vaadin.flow.component.map.configuration.geometry.Polygon;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.List;
 
 public class PolygonFeatureTest {
-    private static final Coordinate[] outerCoordinates = {
-            new Coordinate(0, 0),
-            new Coordinate(10, 0),
-            new Coordinate(10, 10),
-            new Coordinate(0, 10),
-            new Coordinate(0, 0)
-    };
+    private static final Coordinate[] outerCoordinates = { new Coordinate(0, 0),
+            new Coordinate(10, 0), new Coordinate(10, 10),
+            new Coordinate(0, 10), new Coordinate(0, 0) };
 
-    private static final Coordinate[] innerCoordinates = {
-                    new Coordinate(2, 2),
-                    new Coordinate(8, 2),
-                    new Coordinate(8, 8),
-                    new Coordinate(2, 8),
-                    new Coordinate(2, 2)
-    };
+    private static final Coordinate[] innerCoordinates = { new Coordinate(2, 2),
+            new Coordinate(8, 2), new Coordinate(8, 8), new Coordinate(2, 8),
+            new Coordinate(2, 2) };
 
     @Test
     public void defaults() {
@@ -31,19 +32,26 @@ public class PolygonFeatureTest {
 
         // Test default coordinates
         Assert.assertNotNull(polygonFeature.getCoordinates());
-        Assert.assertEquals(1, polygonFeature.getGeometry().getCoordinates().length);
-        Assert.assertEquals(1, polygonFeature.getGeometry().getCoordinates()[0].length);
-        Assert.assertEquals(0, polygonFeature.getGeometry().getCoordinates()[0][0].getX(), 0);
-        Assert.assertEquals(0, polygonFeature.getGeometry().getCoordinates()[0][0].getY(), 0);
+        Assert.assertEquals(1,
+                polygonFeature.getGeometry().getCoordinates().length);
+        Assert.assertEquals(1,
+                polygonFeature.getGeometry().getCoordinates()[0].length);
+        Assert.assertEquals(0,
+                polygonFeature.getGeometry().getCoordinates()[0][0].getX(), 0);
+        Assert.assertEquals(0,
+                polygonFeature.getGeometry().getCoordinates()[0][0].getY(), 0);
 
         // Test default style
         Assert.assertNotNull(polygonFeature.getStyle());
         Assert.assertNotNull(polygonFeature.getStyle().getStroke());
-        Assert.assertEquals("hsl(214, 100%, 48%)", polygonFeature.getStyle().getStroke().getColor());
-        Assert.assertEquals(2, polygonFeature.getStyle().getStroke().getWidth(), 0);
+        Assert.assertEquals("hsl(214, 100%, 48%)",
+                polygonFeature.getStyle().getStroke().getColor());
+        Assert.assertEquals(2, polygonFeature.getStyle().getStroke().getWidth(),
+                0);
 
         Assert.assertNotNull(polygonFeature.getStyle().getFill());
-        Assert.assertEquals("hsla(214, 100%, 60%, 0.13)", polygonFeature.getStyle().getFill().getColor());
+        Assert.assertEquals("hsla(214, 100%, 60%, 0.13)",
+                polygonFeature.getStyle().getFill().getColor());
     }
 
     @Test
@@ -51,7 +59,8 @@ public class PolygonFeatureTest {
         List<Coordinate> coordinates = List.of(outerCoordinates);
         PolygonFeature polygonFeature = new PolygonFeature(coordinates);
 
-        assertCoordinates(new Coordinate[][] {outerCoordinates}, polygonFeature);
+        assertCoordinates(new Coordinate[][] { outerCoordinates },
+                polygonFeature);
     }
 
     @Test
@@ -60,16 +69,15 @@ public class PolygonFeatureTest {
         List<Coordinate> coordinates = List.of(outerCoordinates);
         polygonFeature.setCoordinates(coordinates);
 
-        assertCoordinates(new Coordinate[][] {outerCoordinates}, polygonFeature);
+        assertCoordinates(new Coordinate[][] { outerCoordinates },
+                polygonFeature);
     }
 
     @Test
     public void setCoordinatesWithArray() {
         PolygonFeature polygonFeature = new PolygonFeature();
-        Coordinate[][] coordinatesArray = new Coordinate[][] {
-                outerCoordinates,
-                innerCoordinates
-        };
+        Coordinate[][] coordinatesArray = new Coordinate[][] { outerCoordinates,
+                innerCoordinates };
         polygonFeature.setCoordinates(coordinatesArray);
 
         assertCoordinates(coordinatesArray, polygonFeature);
@@ -109,7 +117,8 @@ public class PolygonFeatureTest {
         polygonFeature.setCoordinates((Coordinate[][]) null);
     }
 
-    private void assertCoordinates(Coordinate[][] expected, PolygonFeature feature) {
+    private void assertCoordinates(Coordinate[][] expected,
+            PolygonFeature feature) {
         Coordinate[][] actual = feature.getGeometry().getCoordinates();
 
         Assert.assertEquals(expected.length, actual.length);
@@ -117,8 +126,10 @@ public class PolygonFeatureTest {
         for (int i = 0; i < expected.length; i++) {
             Assert.assertEquals(expected[i].length, actual[i].length);
             for (int j = 0; j < expected[i].length; j++) {
-                Assert.assertEquals(expected[i][j].getX(), actual[i][j].getX(), 0);
-                Assert.assertEquals(expected[i][j].getY(), actual[i][j].getY(), 0);
+                Assert.assertEquals(expected[i][j].getX(), actual[i][j].getX(),
+                        0);
+                Assert.assertEquals(expected[i][j].getY(), actual[i][j].getY(),
+                        0);
             }
         }
     }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/geometry/PolygonTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/geometry/PolygonTest.java
@@ -1,20 +1,22 @@
 /**
  * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
  */
 package com.vaadin.flow.component.map.configuration.geometry;
 
-import com.vaadin.flow.component.map.configuration.Coordinate;
 import java.beans.PropertyChangeListener;
 import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import com.vaadin.flow.component.map.configuration.Coordinate;
 
 public class PolygonTest {
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/geometry/PolygonTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/geometry/PolygonTest.java
@@ -32,21 +32,10 @@ public class PolygonTest {
         final Polygon polygon = new Polygon(List.of(new Coordinate(1, 1),
                 new Coordinate(2, 2), new Coordinate(1, 1)));
 
-        final Coordinate[][] coordinates = polygon.getCoordinates();
-        Assert.assertNotNull(coordinates);
-        Assert.assertEquals(1, coordinates.length);
+        Coordinate[][] expected = new Coordinate[][] { { new Coordinate(1, 1),
+                new Coordinate(2, 2), new Coordinate(1, 1) } };
 
-        final Coordinate[] linearRing = coordinates[0];
-        Assert.assertEquals(3, linearRing.length);
-
-        Assert.assertEquals(1, linearRing[0].getX(), 0);
-        Assert.assertEquals(1, linearRing[0].getY(), 0);
-
-        Assert.assertEquals(2, linearRing[1].getX(), 0);
-        Assert.assertEquals(2, linearRing[1].getY(), 0);
-
-        Assert.assertEquals(1, linearRing[2].getX(), 0);
-        Assert.assertEquals(1, linearRing[2].getY(), 0);
+        assertCoordinates(expected, polygon);
     }
 
     @Test
@@ -72,21 +61,32 @@ public class PolygonTest {
         polygon.setCoordinates(List.of(new Coordinate(10, 10),
                 new Coordinate(20, 20), new Coordinate(10, 10)));
 
-        final Coordinate[][] coordinates = polygon.getCoordinates();
-        Assert.assertNotNull(coordinates);
-        Assert.assertEquals(1, coordinates.length);
+        Coordinate[][] expected = new Coordinate[][] { { new Coordinate(10, 10),
+                new Coordinate(20, 20), new Coordinate(10, 10) } };
 
-        final Coordinate[] linearRing = coordinates[0];
-        Assert.assertEquals(3, linearRing.length);
+        assertCoordinates(expected, polygon);
 
-        Assert.assertEquals(10, linearRing[0].getX(), 0);
-        Assert.assertEquals(10, linearRing[0].getY(), 0);
+        Mockito.verify(propertyChangeListenerMock, Mockito.times(1))
+                .propertyChange(Mockito.any());
+    }
 
-        Assert.assertEquals(20, linearRing[1].getX(), 0);
-        Assert.assertEquals(20, linearRing[1].getY(), 0);
+    @Test
+    public void setCoordinatesArray() {
+        final TestPolygon polygon = new TestPolygon(
+                List.of(new Coordinate(1, 1), new Coordinate(2, 2),
+                        new Coordinate(1, 1)));
 
-        Assert.assertEquals(10, linearRing[2].getX(), 0);
-        Assert.assertEquals(10, linearRing[2].getY(), 0);
+        polygon.addPropertyChangeListener(propertyChangeListenerMock);
+
+        Coordinate[][] newCoordinates = new Coordinate[][] {
+                { new Coordinate(10, 10), new Coordinate(20, 20),
+                        new Coordinate(20, 10), new Coordinate(10, 10) },
+                { new Coordinate(12, 12), new Coordinate(15, 15),
+                        new Coordinate(15, 12), new Coordinate(12, 12) } };
+
+        polygon.setCoordinates(newCoordinates);
+
+        assertCoordinates(newCoordinates, polygon);
 
         Mockito.verify(propertyChangeListenerMock, Mockito.times(1))
                 .propertyChange(Mockito.any());
@@ -114,21 +114,27 @@ public class PolygonTest {
 
         polygon.translate(10, 10);
 
-        final Coordinate[][] coordinates = polygon.getCoordinates();
-        Assert.assertNotNull(coordinates);
-        Assert.assertEquals(1, coordinates.length);
+        Coordinate[][] expected = new Coordinate[][] { { new Coordinate(11, 11),
+                new Coordinate(12, 12), new Coordinate(11, 11) } };
 
-        final Coordinate[] linearRing = coordinates[0];
-        Assert.assertEquals(3, linearRing.length);
+        assertCoordinates(expected, polygon);
+    }
 
-        Assert.assertEquals(11, linearRing[0].getX(), 0);
-        Assert.assertEquals(11, linearRing[0].getY(), 0);
+    private void assertCoordinates(Coordinate[][] expected, Polygon polygon) {
+        Coordinate[][] actual = polygon.getCoordinates();
 
-        Assert.assertEquals(12, linearRing[1].getX(), 0);
-        Assert.assertEquals(12, linearRing[1].getY(), 0);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(expected.length, actual.length);
 
-        Assert.assertEquals(11, linearRing[2].getX(), 0);
-        Assert.assertEquals(11, linearRing[2].getY(), 0);
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals(expected[i].length, actual[i].length);
+            for (int j = 0; j < expected[i].length; j++) {
+                Assert.assertEquals(expected[i][j].getX(), actual[i][j].getX(),
+                        0);
+                Assert.assertEquals(expected[i][j].getY(), actual[i][j].getY(),
+                        0);
+            }
+        }
     }
 
     private static class TestPolygon extends Polygon {

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/geometry/PolygonTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/geometry/PolygonTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.map.configuration.geometry;
+
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import java.beans.PropertyChangeListener;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class PolygonTest {
+
+    private PropertyChangeListener propertyChangeListenerMock;
+
+    @Before
+    public void setup() {
+        propertyChangeListenerMock = Mockito.mock(PropertyChangeListener.class);
+    }
+
+    @Test
+    public void defaults() {
+        final Polygon polygon = new Polygon(List.of(new Coordinate(1, 1),
+                new Coordinate(2, 2), new Coordinate(1, 1)));
+
+        final Coordinate[][] coordinates = polygon.getCoordinates();
+        Assert.assertNotNull(coordinates);
+        Assert.assertEquals(1, coordinates.length);
+
+        final Coordinate[] linearRing = coordinates[0];
+        Assert.assertEquals(3, linearRing.length);
+
+        Assert.assertEquals(1, linearRing[0].getX(), 0);
+        Assert.assertEquals(1, linearRing[0].getY(), 0);
+
+        Assert.assertEquals(2, linearRing[1].getX(), 0);
+        Assert.assertEquals(2, linearRing[1].getY(), 0);
+
+        Assert.assertEquals(1, linearRing[2].getX(), 0);
+        Assert.assertEquals(1, linearRing[2].getY(), 0);
+    }
+
+    @Test
+    public void failsWithNullOrEmptyValues() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Polygon((List<Coordinate>) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Polygon(List.of()));
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Polygon((Coordinate[][]) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Polygon(new Coordinate[0][]));
+    }
+
+    @Test
+    public void setCoordinates() {
+        final TestPolygon polygon = new TestPolygon(
+                List.of(new Coordinate(1, 1), new Coordinate(2, 2),
+                        new Coordinate(1, 1)));
+
+        polygon.addPropertyChangeListener(propertyChangeListenerMock);
+        polygon.setCoordinates(List.of(new Coordinate(10, 10),
+                new Coordinate(20, 20), new Coordinate(10, 10)));
+
+        final Coordinate[][] coordinates = polygon.getCoordinates();
+        Assert.assertNotNull(coordinates);
+        Assert.assertEquals(1, coordinates.length);
+
+        final Coordinate[] linearRing = coordinates[0];
+        Assert.assertEquals(3, linearRing.length);
+
+        Assert.assertEquals(10, linearRing[0].getX(), 0);
+        Assert.assertEquals(10, linearRing[0].getY(), 0);
+
+        Assert.assertEquals(20, linearRing[1].getX(), 0);
+        Assert.assertEquals(20, linearRing[1].getY(), 0);
+
+        Assert.assertEquals(10, linearRing[2].getX(), 0);
+        Assert.assertEquals(10, linearRing[2].getY(), 0);
+
+        Mockito.verify(propertyChangeListenerMock, Mockito.times(1))
+                .propertyChange(Mockito.any());
+    }
+
+    @Test
+    public void setCoordinates_failsWithNullOrEmptyValues() {
+        final Polygon polygon = new Polygon(List.of(new Coordinate()));
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> polygon.setCoordinates((List<Coordinate>) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> polygon.setCoordinates(List.of()));
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> polygon.setCoordinates((Coordinate[][]) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> polygon.setCoordinates(new Coordinate[0][]));
+    }
+
+    @Test
+    public void translate() {
+        final Polygon polygon = new Polygon(List.of(new Coordinate(1, 1),
+                new Coordinate(2, 2), new Coordinate(1, 1)));
+
+        polygon.translate(10, 10);
+
+        final Coordinate[][] coordinates = polygon.getCoordinates();
+        Assert.assertNotNull(coordinates);
+        Assert.assertEquals(1, coordinates.length);
+
+        final Coordinate[] linearRing = coordinates[0];
+        Assert.assertEquals(3, linearRing.length);
+
+        Assert.assertEquals(11, linearRing[0].getX(), 0);
+        Assert.assertEquals(11, linearRing[0].getY(), 0);
+
+        Assert.assertEquals(12, linearRing[1].getX(), 0);
+        Assert.assertEquals(12, linearRing[1].getY(), 0);
+
+        Assert.assertEquals(11, linearRing[2].getX(), 0);
+        Assert.assertEquals(11, linearRing[2].getY(), 0);
+    }
+
+    private static class TestPolygon extends Polygon {
+        public TestPolygon(List<Coordinate> coordinates) {
+            super(coordinates);
+        }
+
+        // Expose method for testing
+        @Override
+        public void addPropertyChangeListener(PropertyChangeListener listener) {
+            super.addPropertyChangeListener(listener);
+        }
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -529,6 +529,39 @@ public class MapElement extends TestBenchElement {
             return new Coordinate(getDouble("getCoordinates()[0]"),
                     getDouble("getCoordinates()[1]"));
         }
+
+        public Coordinate[][] getPolygonCoordinates() {
+            // Get the coordinates array from OpenLayers
+            Object coordinatesObj = get("getCoordinates()");
+            if (coordinatesObj == null) {
+                return null;
+            }
+
+            // Cast to List of lists (OpenLayers returns polygon as array of
+            // arrays)
+            @SuppressWarnings("unchecked")
+            List<List<List<Number>>> rings = (List<List<List<Number>>>) coordinatesObj;
+
+            // Create result array with the size matching the number of rings
+            Coordinate[][] result = new Coordinate[rings.size()][];
+
+            // Process each ring
+            for (int ringIndex = 0; ringIndex < rings.size(); ringIndex++) {
+                List<List<Number>> ring = rings.get(ringIndex);
+                result[ringIndex] = new Coordinate[ring.size()];
+
+                // Process each coordinate in the ring
+                for (int coordIndex = 0; coordIndex < ring
+                        .size(); coordIndex++) {
+                    List<Number> coord = ring.get(coordIndex);
+                    double x = coord.get(0).doubleValue();
+                    double y = coord.get(1).doubleValue();
+                    result[ringIndex][coordIndex] = new Coordinate(x, y);
+                }
+            }
+
+            return result;
+        }
     }
 
     public static class IconReference extends ConfigurationObjectReference {


### PR DESCRIPTION
## Description

feat: Add PolygonFeature to the map

If applied, this PR will make it easy to add a styleable (fill, stroke) PolygonFeature to the map.
The ability to set and get the coordinates with a Geometry for Polygons also exists.
Holes within the polygon are supported to display real-life data.

Resolves #2891

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
