### PR TITLE
fix: do not clear displayed value if component value was reverted

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/ClearValueIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/ClearValueIT.java
@@ -47,6 +47,15 @@ public class ClearValueIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInputValue_clearAndSetSameValue_inputValueIsPresent() {
+        datePicker.sendKeys("1/1/2022", Keys.ENTER);
+        Assert.assertEquals("1/1/2022", datePicker.getInputValue());
+
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1/1/2022", datePicker.getInputValue());
+    }
+
+    @Test
     public void setBadInputValue_clearValue_inputValueIsEmpty() {
         datePicker.sendKeys("INVALID", Keys.ENTER);
         Assert.assertEquals("INVALID", datePicker.getInputValue());

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -760,17 +760,18 @@ public class DatePicker
     }
 
     @Override
-    public void setValue(LocalDate newValue) {
-        if (getValue() == null && newValue == null && unparsableValue != null) {
+    public void setValue(LocalDate value) {
+        LocalDate oldValue = getValue();
+        if (oldValue == null && value == null && unparsableValue != null) {
             // When the value is programmatically cleared while the field
             // contains an unparsable input, ValueChangeEvent isn't fired,
             // so we need to call setModelValue manually to clear the bad
             // input and trigger validation.
-            setModelValue(newValue, false);
+            setModelValue(value, false);
             return;
         }
 
-        super.setValue(newValue);
+        super.setValue(value);
     }
 
     @Override

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -158,7 +158,7 @@ public class DatePicker
 
     private StateTree.ExecutionRegistration pendingI18nUpdate;
 
-    private String unparsableValue = null;
+    private String unparsableValue;
 
     private SerializableFunction<String, Result<LocalDate>> fallbackParser;
     private String fallbackParserErrorMessage = null;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -266,13 +266,13 @@ public class DatePicker
 
         getElement().addEventListener("unparsable-change", event -> {
             // The unparsable-change event is fired in the following situations:
-            // 1. The user modifies the input but it still remains unparsable
-            // 2. The user enters an unparsable input into empty field
-            // 3. The user clears an unparsable input
+            // 1. User modifies input but it remains unparsable
+            // 2. User enters unparsable input in empty field
+            // 3. User clears unparsable input
             //
             // In all these cases, ValueChangeEvent isn't fired, so
-            // we call setModelValue manually to trigger validation
-            // and the fallback parser.
+            // we call setModelValue manually to run fallback parser
+            // and trigger validation.
             setModelValue(getEmptyValue(), true);
         });
 
@@ -814,33 +814,28 @@ public class DatePicker
             isFallbackParserRunning = false;
         }
 
-        super.setModelValue(newModelValue, fromClient);
+        boolean isModelValueRemainedEmpty = newModelValue == null
+                && oldModelValue == null;
 
-        if (newModelValue == null && oldModelValue == null) {
-            // This branch handles cases where `setModelValue` is called
-            // despite no model value change. This can happen in the following
-            // situations:
-            //
-            // 1. The user modifies the input but it still remains unparsable
-            // 2. The user enters an unparsable input into empty field
-            // 3. The user clears an unparsable input
-            // 4. The value is programmatically cleared while the field contains
-            // an unparsable input
-
-            if (oldUnparsableValue != null) {
-                // Ensure bad input is cleared when the value is cleared
-                // programmatically (see case 4)
-                setInputElementValue("");
-            }
-
-            if (oldUnparsableValue != null || unparsableValue != null) {
-                // Trigger validation when there was a change that didn't fire a
-                // ValueChangeEvent, but the field still needs to be revalidated
-                // (see cases 1, 2, 3, 4).
-                validate();
-                fireValidationStatusChangeEvent();
-            }
+        // Case: setValue(null) is called on a field with unparsable input
+        if (isModelValueRemainedEmpty && oldUnparsableValue != null) {
+            setInputElementValue("");
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
         }
+
+        // Cases:
+        // - User modifies input but it remains unparsable
+        // - User enters unparsable input in empty field
+        // - User clears unparsable input
+        if (isModelValueRemainedEmpty && unparsableValue != null) {
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
+        }
+
+        super.setModelValue(newModelValue, fromClient);
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -268,10 +268,14 @@ public class DatePicker
         addValueChangeListener(e -> validate());
 
         getElement().addEventListener("unparsable-change", event -> {
-            // Handles the following cases:
-            // 1. The user enters an unparsable input into a field that already contained unparsable input
-            // 2. The user enters an unparsable input into a previously empty field
+            // The unparsable-change event is fired in the following situations:
+            // 1. The user modifies the input but it still remains unparsable
+            // 2. The user enters an unparsable input into empty field
             // 3. The user clears an unparsable input
+            //
+            // In all these cases, ValueChangeEvent isn't fired, so
+            // we call setModelValue manually to trigger validation
+            // and the fallback parser.
             setModelValue(getEmptyValue(), true);
         });
 
@@ -753,7 +757,9 @@ public class DatePicker
     @Override
     public void setValue(LocalDate newValue) {
         if (getValue() == null && newValue == null && unparsableInputValue != null) {
-            // Handles the case when the bad input is cleared programmatically.
+            // When the value is programmatically cleared while the field contains
+            // an unparsable input, ValueChangeEvent isn't fired, so we need to call
+            // setModelValue manually to clear the bad input and trigger validation.
             setModelValue(newValue, false);
             return;
         }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -827,7 +827,7 @@ public class DatePicker
             // 4. The value is programmatically cleared while the field contains
             // an unparsable input
 
-            if (oldUnparsableValue != null && unparsableValue == null) {
+            if (oldUnparsableValue != null) {
                 // Ensure bad input is cleared when the value is cleared
                 // programmatically (see case 4)
                 setInputElementValue("");

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -169,12 +169,9 @@ public class DatePicker
     private Validator<LocalDate> defaultValidator = (value, context) -> {
         boolean fromComponent = context == null;
 
-        if (unparsableInput != null) {
-            if (fallbackParserErrorMessage != null) {
-                return ValidationResult.error(getI18nErrorMessage(
-                        DatePickerI18n::getBadInputErrorMessage));
-            }
-
+        if (unparsableInput != null && fallbackParserErrorMessage != null) {
+            return ValidationResult.error(fallbackParserErrorMessage);
+        } else if (unparsableInput != null) {
             return ValidationResult.error(getI18nErrorMessage(
                     DatePickerI18n::getBadInputErrorMessage));
         }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -673,7 +673,7 @@ public class DatePicker
      *         <code>false</code> otherwise
      */
     protected boolean isInputValuePresent() {
-        return !isEmpty() || unparsableInput != null;
+        return !getInputElementValue().isEmpty();
     }
 
     /**
@@ -783,16 +783,16 @@ public class DatePicker
             return;
         }
 
+        LocalDate oldModelValue = getValue();
+
         // Synchronize unparsable input value
         String oldUnparsableInput = this.unparsableInput;
-
         if (fromClient && newModelValue == null
                 && !getInputElementValue().isEmpty()) {
             this.unparsableInput = getInputElementValue();
         } else {
             this.unparsableInput = null;
         }
-
         String newUnparsableInput = this.unparsableInput;
 
         // Try to parse unparsable input using the fallback parser
@@ -815,8 +815,6 @@ public class DatePicker
         } finally {
             isFallbackParserRunning = false;
         }
-
-        LocalDate oldModelValue = getValue();
 
         super.setModelValue(newModelValue, fromClient);
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -767,7 +767,7 @@ public class DatePicker
             // contains an unparsable input, ValueChangeEvent isn't fired,
             // so we need to call setModelValue manually to clear the bad
             // input and trigger validation.
-            setModelValue(value, false);
+            setModelValue(getEmptyValue(), false);
             return;
         }
 
@@ -817,19 +817,20 @@ public class DatePicker
         boolean isModelValueRemainedEmpty = newModelValue == null
                 && oldModelValue == null;
 
-        // Case: setValue(null) is called on a field with unparsable input
-        if (isModelValueRemainedEmpty && oldUnparsableValue != null) {
-            setInputElementValue("");
+        // Cases:
+        // - User modifies input but it remains unparsable
+        // - User enters unparsable input in empty field
+        // - User clears unparsable input
+        if (fromClient && isModelValueRemainedEmpty) {
             validate();
             fireValidationStatusChangeEvent();
             return;
         }
 
-        // Cases:
-        // - User modifies input but it remains unparsable
-        // - User enters unparsable input in empty field
-        // - User clears unparsable input
-        if (isModelValueRemainedEmpty && unparsableValue != null) {
+        // Case: setValue(null) is called on a field with unparsable input
+        if (!fromClient && isModelValueRemainedEmpty
+                && oldUnparsableValue != null) {
+            setInputElementValue("");
             validate();
             fireValidationStatusChangeEvent();
             return;

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/ClearValuePage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/ClearValuePage.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.datetimepicker;
 
+import java.time.LocalDateTime;
+
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
@@ -22,6 +24,7 @@ import com.vaadin.flow.router.Route;
 @Route("vaadin-date-time-picker/clear-value")
 public class ClearValuePage extends Div {
     public static final String CLEAR_BUTTON = "clear-button";
+    public static final String CLEAR_AND_SET_VALUE_BUTTON = "clear-and-set-value-button";
 
     public ClearValuePage() {
         DateTimePicker datePicker = new DateTimePicker();
@@ -30,6 +33,13 @@ public class ClearValuePage extends Div {
         clearButton.setId(CLEAR_BUTTON);
         clearButton.addClickListener(event -> datePicker.clear());
 
-        add(datePicker, clearButton);
+        NativeButton clearAndSetValueButton = new NativeButton(
+                "Clear and set value", event -> {
+                    datePicker.clear();
+                    datePicker.setValue(LocalDateTime.of(2022, 1, 1, 12, 0));
+                });
+        clearAndSetValueButton.setId(CLEAR_AND_SET_VALUE_BUTTON);
+
+        add(datePicker, clearButton, clearAndSetValueButton);
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/ClearValueIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/ClearValueIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.datetimepicker;
 
+import static com.vaadin.flow.component.datetimepicker.ClearValuePage.CLEAR_AND_SET_VALUE_BUTTON;
 import static com.vaadin.flow.component.datetimepicker.ClearValuePage.CLEAR_BUTTON;
 
 import org.junit.Assert;
@@ -69,6 +70,18 @@ public class ClearValueIT extends AbstractComponentIT {
         $("button").id(CLEAR_BUTTON).click();
         Assert.assertEquals("", dateInput.getPropertyString("value"));
         Assert.assertEquals("", timeInput.getPropertyString("value"));
+    }
+
+    @Test
+    public void setDateAndTimeInputValue_clearAndSetSameValue_inputValueIsPresent() {
+        dateInput.sendKeys("1/1/2022", Keys.ENTER);
+        timeInput.sendKeys("12:00 PM", Keys.ENTER);
+        Assert.assertEquals("1/1/2022", dateInput.getPropertyString("value"));
+        Assert.assertEquals("12:00 PM", timeInput.getPropertyString("value"));
+
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1/1/2022", dateInput.getPropertyString("value"));
+        Assert.assertEquals("12:00 PM", timeInput.getPropertyString("value"));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldClearValueIT.java
@@ -51,6 +51,15 @@ public class IntegerFieldClearValueIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInputValue_clearAndSetSameValue_inputValueIsPresent() {
+        integerField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+    }
+
+    @Test
     public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
         // Native [type=number] inputs don't update their value
         // when you are entering input that the browser is unable to parse,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldClearValueIT.java
@@ -51,6 +51,15 @@ public class NumberFieldClearValueIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInputValue_clearAndSetSameValue_inputValueIsPresent() {
+        numberField.sendKeys("1234", Keys.ENTER);
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("1234", input.getPropertyString("value"));
+    }
+
+    @Test
     public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
         // Native [type=number] inputs don't update their value
         // when you are entering input that the browser is unable to parse,

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -57,14 +57,14 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
     private DomListenerRegistration inputListenerRegistration;
 
+    private String unparsableValue;
+
     private final CopyOnWriteArrayList<ValidationStatusChangeListener<T>> validationStatusChangeListeners = new CopyOnWriteArrayList<>();
 
     private Validator<T> defaultValidator = (value, context) -> {
         boolean fromComponent = context == null;
 
-        boolean hasBadInput = valueEquals(value, getEmptyValue())
-                && !getInputElementValue().isEmpty();
-        if (hasBadInput) {
+        if (unparsableValue != null) {
             return ValidationResult.error(getI18nErrorMessage(
                     AbstractNumberFieldI18n::getBadInputErrorMessage));
         }
@@ -149,8 +149,14 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         addValueChangeListener(e -> validate());
 
         getElement().addEventListener("unparsable-change", e -> {
-            validate();
-            fireValidationStatusChangeEvent();
+            // The unparsable-change event is fired in the following situations:
+            // 1. User modifies input but it remains unparsable
+            // 2. User enters unparsable input in empty field
+            // 3. User clears unparsable input
+            //
+            // In all these cases, ValueChangeEvent isn't fired, so
+            // we call setModelValue manually to trigger validation.
+            setModelValue(getEmptyValue(), true);
         }).synchronizeProperty("_inputElementValue");
     }
 
@@ -229,44 +235,54 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
     @Override
     public void setValue(T value) {
         T oldValue = getValue();
-        boolean isOldValueEmpty = valueEquals(oldValue, getEmptyValue());
-        boolean isNewValueEmpty = valueEquals(value, getEmptyValue());
-        boolean isValueRemainedEmpty = isOldValueEmpty && isNewValueEmpty;
-        String oldInputElementValue = getInputElementValue();
-
-        // When the value is cleared programmatically, there is no change event
-        // that would synchronize _inputElementValue, so we reset it ourselves
-        // to prevent the following validation from treating this as bad input.
-        if (isNewValueEmpty) {
-            setInputElementValue("");
+        if (oldValue == null && value == null && unparsableValue != null) {
+            // When the value is programmatically cleared while the field
+            // contains an unparsable input, ValueChangeEvent isn't fired,
+            // so we need to call setModelValue manually to clear the bad
+            // input and trigger validation.
+            setModelValue(value, false);
+            return;
         }
 
         super.setValue(value);
-
-        // Revalidate if setValue(null) didn't result in a value change but
-        // cleared bad input
-        if (isValueRemainedEmpty && !oldInputElementValue.isEmpty()) {
-            validate();
-            fireValidationStatusChangeEvent();
-        }
     }
 
     @Override
     protected void setModelValue(T newModelValue, boolean fromClient) {
         T oldModelValue = getValue();
+        String oldUnparsableValue = unparsableValue;
 
-        super.setModelValue(newModelValue, fromClient);
+        if (fromClient && newModelValue == null
+                && !getInputElementValue().isEmpty()) {
+            unparsableValue = getInputElementValue();
+        } else {
+            unparsableValue = null;
+        }
 
-        // Triggers validation when an unparsable or empty value changes to a
-        // value that is parsable on the client but still unparsable on the
-        // server, which can happen for example due to the difference in Integer
-        // limit in Java and JavaScript. In this case, there is no
-        // ValueChangeEvent and no unparsable-change event.
-        if (fromClient && valueEquals(oldModelValue, getEmptyValue())
-                && valueEquals(newModelValue, getEmptyValue())) {
+        boolean isModelValueRemainedEmpty = newModelValue == null
+                && oldModelValue == null;
+
+        // Case: setValue(null) is called on a field with unparsable input
+        if (isModelValueRemainedEmpty && oldUnparsableValue != null) {
+            setInputElementValue("");
             validate();
             fireValidationStatusChangeEvent();
+            return;
         }
+
+        // Cases:
+        // - User modifies input but it remains unparsable
+        // - User enters unparsable input in empty field
+        // - User clears unparsable input
+        // - User enters input that is parsable in JavaScript but unparsable in
+        // Java (e.g., integer overflow)
+        if (isModelValueRemainedEmpty && unparsableValue != null) {
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
+        }
+
+        super.setModelValue(newModelValue, fromClient);
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -46,15 +46,6 @@ public class ClearValueIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setInputValue_clearAndSetSameValue_inputValueIsPresent() {
-        timePicker.selectByText("12:00 PM");
-        Assert.assertEquals("12:00 PM", timePicker.getTimePickerInputValue());
-
-        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
-        Assert.assertEquals("12:00 PM", timePicker.getTimePickerInputValue());
-    }
-
-    @Test
     public void setBadInputValue_clearValue_inputValueIsEmpty() {
         timePicker.selectByText("INVALID");
         Assert.assertEquals("INVALID", timePicker.getTimePickerInputValue());

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/ClearValueIT.java
@@ -46,6 +46,15 @@ public class ClearValueIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInputValue_clearAndSetSameValue_inputValueIsPresent() {
+        timePicker.selectByText("12:00 PM");
+        Assert.assertEquals("12:00 PM", timePicker.getTimePickerInputValue());
+
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("12:00 PM", timePicker.getTimePickerInputValue());
+    }
+
+    @Test
     public void setBadInputValue_clearValue_inputValueIsEmpty() {
         timePicker.selectByText("INVALID");
         Assert.assertEquals("INVALID", timePicker.getTimePickerInputValue());

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -369,7 +369,7 @@ public class TimePicker
             // contains an unparsable input, ValueChangeEvent isn't fired,
             // so we need to call setModelValue manually to clear the bad
             // input and trigger validation.
-            setModelValue(value, false);
+            setModelValue(getEmptyValue(), false);
             return;
         }
 
@@ -397,19 +397,20 @@ public class TimePicker
         boolean isModelValueRemainedEmpty = newModelValue == null
                 && oldModelValue == null;
 
-        // Case: setValue(null) is called on a field with unparsable input
-        if (isModelValueRemainedEmpty && oldUnparsableValue != null) {
-            setInputElementValue("");
+        // Cases:
+        // - User modifies input but it remains unparsable
+        // - User enters unparsable input in empty field
+        // - User clears unparsable input
+        if (fromClient && isModelValueRemainedEmpty) {
             validate();
             fireValidationStatusChangeEvent();
             return;
         }
 
-        // Cases:
-        // - User modifies input but it remains unparsable
-        // - User enters unparsable input in empty field
-        // - User clears unparsable input
-        if (isModelValueRemainedEmpty && unparsableValue != null) {
+        // Case: setValue(null) is called on a field with unparsable input
+        if (!fromClient && isModelValueRemainedEmpty
+                && oldUnparsableValue != null) {
+            setInputElementValue("");
             validate();
             fireValidationStatusChangeEvent();
             return;

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -235,13 +235,12 @@ public class TimePicker
 
         getElement().addEventListener("unparsable-change", event -> {
             // The unparsable-change event is fired in the following situations:
-            // 1. The user modifies the input but it still remains unparsable
-            // 2. The user enters an unparsable input into empty field
-            // 3. The user clears an unparsable input
+            // 1. User modifies input but it remains unparsable
+            // 2. User enters unparsable input in empty field
+            // 3. User clears unparsable input
             //
             // In all these cases, ValueChangeEvent isn't fired, so
-            // we call setModelValue manually to trigger validation
-            // and the fallback parser.
+            // we call setModelValue manually to trigger validation.
             setModelValue(getEmptyValue(), true);
         });
 
@@ -395,33 +394,28 @@ public class TimePicker
             unparsableValue = null;
         }
 
-        super.setModelValue(newModelValue, fromClient);
+        boolean isModelValueRemainedEmpty = newModelValue == null
+                && oldModelValue == null;
 
-        if (newModelValue == null && oldModelValue == null) {
-            // This branch handles cases where `setModelValue` is called
-            // despite no model value change. This can happen in the following
-            // situations:
-            //
-            // 1. The user modifies the input but it still remains unparsable
-            // 2. The user enters an unparsable input into empty field
-            // 3. The user clears an unparsable input
-            // 4. The value is programmatically cleared while the field contains
-            // an unparsable input
-
-            if (oldUnparsableValue != null) {
-                // Ensure bad input is cleared when the value is cleared
-                // programmatically (see case 4)
-                setInputElementValue("");
-            }
-
-            if (oldUnparsableValue != null || unparsableValue != null) {
-                // Trigger validation when there was a change that didn't fire a
-                // ValueChangeEvent, but the field still needs to be revalidated
-                // (see cases 1, 2, 3, 4).
-                validate();
-                fireValidationStatusChangeEvent();
-            }
+        // Case: setValue(null) is called on a field with unparsable input
+        if (isModelValueRemainedEmpty && oldUnparsableValue != null) {
+            setInputElementValue("");
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
         }
+
+        // Cases:
+        // - User modifies input but it remains unparsable
+        // - User enters unparsable input in empty field
+        // - User clears unparsable input
+        if (isModelValueRemainedEmpty && unparsableValue != null) {
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
+        }
+
+        super.setModelValue(newModelValue, fromClient);
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes an issue where calling `setValue(null)` followed by `setValue(previousValue)` in the same round-trip cleared the input element's value, even though the second call should have restored it to a non-empty value. 

To fix this, the logic was refactored to store and read unparsable input from a separate field, rather than relying directly on `getInputElementValue()`.  

Relying directly on `getInputElementValue()` was the cause of the issue, as it required calling `setInputElementValue("")` on every `setValue(null)` call to prevent the validation logic from treating an empty value as bad input. However, `setInputElementValue("")` also triggered a client-side update of the `inputElementValue` property. When followed by `setValue(previousValue)`, this led to a situation where the `value` property remained unchanged (since it was reverted to its previous value) but the `inputElementValue` was changed, which caused the input to be cleared.

Fixes https://github.com/vaadin/flow-components/issues/7250, https://github.com/vaadin/flow-components/issues/7227

## Affected components

- DatePicker
- TimePicker
- NumberField
- IntegerField

## Type of change

- [x] Bugfix
