### PR TITLE
fix: do not set z-index for sub-cells with text (CP 23.5)

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
@@ -91,7 +91,12 @@ public class Cell {
             element.setInnerText("");
             element.getStyle().clearZIndex();
         } else {
-            element.getStyle().setZIndex(ZINDEXVALUE);
+            if (sheetWidget.isMergedCell(SheetWidget.toKey(col, row))
+                    && !(this instanceof MergedCell)) {
+                element.getStyle().clearZIndex();
+            } else {
+                element.getStyle().setZIndex(ZINDEXVALUE);
+            }
             if (needsMeasure && getCellWidth() > 0 && sheetWidget
                     .measureValueWidth(cellStyle, value) > getCellWidth()) {
                 element.setInnerText("###");

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
@@ -93,7 +93,7 @@ public class MergeIT extends AbstractSpreadsheetIT {
         loadTestFixture(TestFixtures.MergeCells);
         var cellSelector = ".cell.row1.col1:not(merged-cell)";
         var element = findElementInShadowRoot(By.cssSelector(cellSelector));
-        var style = element.getDomAttribute("style");
+        var style = element.getAttribute("style");
         var hasZIndex = style != null && style.contains("z-index");
         Assert.assertFalse(hasZIndex);
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.spreadsheet.test;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
 import com.vaadin.flow.testutil.TestPath;
@@ -83,5 +84,17 @@ public class MergeIT extends AbstractSpreadsheetIT {
         loadTestFixture(TestFixtures.MergeCells);
 
         Assert.assertEquals("A1 text", getMergedCellContent("A1"));
+    }
+
+    @Test
+    public void mergeCellsWithText_firstSubCellShouldNotHaveZIndex() {
+        setCellValue("A1", "A1 text");
+        selectRegion("A1", "B1");
+        loadTestFixture(TestFixtures.MergeCells);
+        var cellSelector = ".cell.row1.col1:not(merged-cell)";
+        var element = findElementInShadowRoot(By.cssSelector(cellSelector));
+        var style = element.getDomAttribute("style");
+        var hasZIndex = style != null && style.contains("z-index");
+        Assert.assertFalse(hasZIndex);
     }
 }


### PR DESCRIPTION
## Description

Cherry pick of https://github.com/vaadin/flow-components/pull/7239 to 23.5.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.