### PR TITLE
fix: cancel connector init if target is detached in beforeClientResponse

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -71,6 +71,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     private String openOnEventName = "vaadin-contextmenu";
     private Registration targetBeforeOpenRegistration;
     private Registration targetAttachRegistration;
+    private Registration targetDetachRegistration;
     private PendingJavaScriptResult targetJsRegistration;
 
     private boolean autoAddedToTheUi;
@@ -120,12 +121,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         if (getTarget() != null) {
             targetBeforeOpenRegistration.remove();
             targetAttachRegistration.remove();
+            targetDetachRegistration.remove();
             getTarget().getElement().executeJs(
                     "if (this.$contextMenuTargetConnector) { this.$contextMenuTargetConnector.removeConnector() }");
-            if (isTargetJsPending()) {
-                targetJsRegistration.cancelExecution();
-                targetJsRegistration = null;
-            }
+            cancelTargetJavascriptExecution();
         }
 
         this.target = target;
@@ -142,6 +141,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         target.getUI().ifPresent(this::onTargetAttach);
         targetAttachRegistration = target
                 .addAttachListener(e -> onTargetAttach(e.getUI()));
+        targetDetachRegistration = target
+                .addDetachListener(e -> cancelTargetJavascriptExecution());
 
         // Server round-trip before opening the overlay
         targetBeforeOpenRegistration = target.getElement()
@@ -424,9 +425,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      */
     private void requestTargetJsExecutions() {
         if (target != null) {
-            if (isTargetJsPending()) {
-                targetJsRegistration.cancelExecution();
-            }
+            cancelTargetJavascriptExecution();
             targetJsRegistration = target.getElement().executeJs(
                     "window.Vaadin.Flow.contextMenuTargetConnector.init(this);"
                             + "this.$contextMenuTargetConnector.updateOpenOn($0);",
@@ -434,9 +433,12 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         }
     }
 
-    private boolean isTargetJsPending() {
-        return targetJsRegistration != null
-                && !targetJsRegistration.isSentToBrowser();
+    private void cancelTargetJavascriptExecution() {
+        if (targetJsRegistration != null
+                && !targetJsRegistration.isSentToBrowser()) {
+            targetJsRegistration.cancelExecution();
+        }
+        targetJsRegistration = null;
     }
 
     private void beforeOpenHandler(DomEvent event) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTargetTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTargetTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+public class ContextMenuTargetTest {
+    private final UI ui = new UI();
+    private final ContextMenu menu = new ContextMenu();
+
+    @Before
+    public void setup() {
+        var mockSession = Mockito.mock(VaadinSession.class);
+        var mockService = Mockito.mock(VaadinService.class);
+        var mockContext = Mockito.mock(VaadinContext.class);
+        var mockConfiguration = Mockito.mock(DeploymentConfiguration.class);
+
+        Mockito.when(mockSession.getService()).thenReturn(mockService);
+        Mockito.when(mockSession.getConfiguration())
+                .thenReturn(mockConfiguration);
+        Mockito.when(mockService.getContext()).thenReturn(mockContext);
+
+        ui.getInternals().setSession(mockSession);
+    }
+
+    @Test
+    public void setTarget_attachTarget_initTargetConnector() {
+        var target = new Div();
+        menu.setTarget(target);
+
+        ui.add(target);
+
+        assertTargetConnectorInit(getPendingInvocations(), target);
+    }
+
+    @Test
+    public void attachTarget_setTarget_initTargetConnector() {
+        var target = new Div();
+        ui.add(target);
+
+        menu.setTarget(target);
+
+        assertTargetConnectorInit(getPendingInvocations(), target);
+    }
+
+    @Test
+    public void attachTarget_detachTargetInBeforeClientResponse_cancelTargetConnectorInit() {
+        var target = new Div();
+        menu.setTarget(target);
+
+        ui.add(target);
+        ui.beforeClientResponse(target, context -> ui.remove(target));
+
+        assertNoTargetConnectorInit(getPendingInvocations());
+    }
+
+    @Test
+    public void clearTarget_removeTargetConnector() {
+        var target = new Div();
+        ui.add(target);
+
+        menu.setTarget(target);
+
+        assertTargetConnectorInit(getPendingInvocations(), target);
+
+        menu.setTarget(null);
+
+        assertTargetConnectorRemove(getPendingInvocations(), target);
+    }
+
+    @Test
+    public void replaceTarget_updateTargetConnector() {
+        var target = new Div();
+        ui.add(target);
+
+        menu.setTarget(target);
+
+        assertTargetConnectorInit(getPendingInvocations(), target);
+
+        var newTarget = new Div();
+        ui.add(newTarget);
+
+        menu.setTarget(newTarget);
+
+        var invocations = getPendingInvocations();
+        assertTargetConnectorInit(invocations, newTarget);
+        assertTargetConnectorRemove(invocations, target);
+    }
+
+    private void assertTargetConnectorInit(
+            List<PendingJavaScriptInvocation> invocations, Component target) {
+        var initInvocations = filterTargetConnectorInitInvocations(invocations);
+
+        Assert.assertEquals(1, initInvocations.size());
+
+        var invocation = initInvocations.get(0);
+        Assert.assertEquals(target.getElement().getNode(),
+                invocation.getOwner());
+        Assert.assertEquals(
+                "return (async function() { window.Vaadin.Flow.contextMenuTargetConnector.init(this);this.$contextMenuTargetConnector.updateOpenOn($0);}).apply($1)",
+                invocation.getInvocation().getExpression());
+    }
+
+    private void assertNoTargetConnectorInit(
+            List<PendingJavaScriptInvocation> invocations) {
+        var initInvocations = filterTargetConnectorInitInvocations(invocations);
+
+        Assert.assertEquals(0, initInvocations.size());
+    }
+
+    private void assertTargetConnectorRemove(
+            List<PendingJavaScriptInvocation> invocations, Component target) {
+        var removeInvocations = filterTargetConnectorRemoveInvocations(
+                invocations);
+
+        Assert.assertEquals(1, removeInvocations.size());
+
+        var invocation = removeInvocations.get(0);
+        Assert.assertEquals(target.getElement().getNode(),
+                invocation.getOwner());
+        Assert.assertEquals(
+                "return (async function() { if (this.$contextMenuTargetConnector) { this.$contextMenuTargetConnector.removeConnector() }}).apply($0)",
+                invocation.getInvocation().getExpression());
+    }
+
+    private List<PendingJavaScriptInvocation> filterTargetConnectorInitInvocations(
+            List<PendingJavaScriptInvocation> invocations) {
+        return invocations.stream()
+                .filter(invocation -> invocation.getInvocation().getExpression()
+                        .contains("contextMenuTargetConnector.init"))
+                .toList();
+    }
+
+    private List<PendingJavaScriptInvocation> filterTargetConnectorRemoveInvocations(
+            List<PendingJavaScriptInvocation> invocations) {
+        return invocations.stream()
+                .filter(invocation -> invocation.getInvocation().getExpression()
+                        .contains("contextMenuTargetConnector.removeConnector"))
+                .toList();
+    }
+
+    protected List<PendingJavaScriptInvocation> getPendingInvocations() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+        return ui.getInternals().dumpPendingJavaScriptInvocations();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
-import java.util.Optional;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -28,11 +26,7 @@ import com.vaadin.flow.component.contextmenu.MenuManager;
 import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.dom.DomListenerRegistration;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableRunnable;
-import com.vaadin.flow.internal.StateNode;
-import com.vaadin.flow.shared.Registration;
 
 public class GridContextMenuTest {
 
@@ -88,38 +82,5 @@ public class GridContextMenuTest {
         gridContextMenu.setTarget(grid);
 
         Assert.assertEquals(grid, gridContextMenu.getTarget());
-    }
-
-    @Test
-    public void setTarget_nullTarget_connectorIsRemovedFromPreviousTarget() {
-        Grid grid = Mockito.mock(Grid.class);
-        Element element = Mockito.mock(Element.class);
-        StateNode node = Mockito.mock(StateNode.class);
-        Mockito.when(grid.getElement()).thenReturn(element);
-        Mockito.when(element.getNode()).thenReturn(node);
-
-        DomListenerRegistration registration = Mockito
-                .mock(DomListenerRegistration.class);
-        Mockito.when(
-                element.addEventListener(Mockito.anyString(), Mockito.any()))
-                .thenReturn(registration);
-
-        Mockito.when(registration.addEventData(Mockito.anyString()))
-                .thenReturn(registration);
-
-        Mockito.when(grid.getUI()).thenReturn(Optional.empty());
-
-        Registration attachRegistration = Mockito.mock(Registration.class);
-        Mockito.when(grid.addAttachListener(Mockito.any()))
-                .thenReturn(attachRegistration);
-
-        GridContextMenu gridContextMenu = new GridContextMenu<>();
-        gridContextMenu.setTarget(grid);
-
-        gridContextMenu.setTarget(null);
-
-        Mockito.verify(registration).remove();
-        Mockito.verify(element).executeJs(
-                "if (this.$contextMenuTargetConnector) { this.$contextMenuTargetConnector.removeConnector() }");
     }
 }


### PR DESCRIPTION
## Description

When detaching an element in `beforeClientResponse`, Flow doesn't seem to cancel pending Javascript invocations. This adds a detach listener to context menu targets to cancel invocations explicitly when the target is removed.

Fixes https://github.com/vaadin/flow-components/issues/7280

## Type of change

- Bugfix
