### PR TITLE
refactor: align bad input clearing with other similar fields

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldClearValueIT.java
@@ -51,6 +51,15 @@ public class BigDecimalFieldClearValueIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setInputValue_clearAndSetSameValue_inputValueIsPresent() {
+        bigDecimalField.sendKeys("12.34", Keys.ENTER);
+        Assert.assertEquals("12.34", input.getPropertyString("value"));
+
+        $("button").id(CLEAR_AND_SET_VALUE_BUTTON).click();
+        Assert.assertEquals("12.34", input.getPropertyString("value"));
+    }
+
+    @Test
     public void badInput_setInputValue_clearValue_inputValueIsEmpty() {
         bigDecimalField.sendKeys("--2", Keys.ENTER);
         Assert.assertEquals("--2", input.getPropertyString("value"));

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -307,7 +307,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
     @Override
     public void setValue(BigDecimal value) {
         BigDecimal oldValue = getValue();
-        if (oldValue == null && value == null && !getInputElementValue().isEmpty()) {
+        if (oldValue == null && value == null
+                && !getInputElementValue().isEmpty()) {
             // When the value is programmatically cleared while the field
             // contains an unparsable input, ValueChangeEvent isn't fired,
             // so we need to call setModelValue manually to clear the bad
@@ -336,7 +337,8 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
         }
 
         // Case: setValue(null) is called on a field with unparsable input
-        if (!fromClient && isModelValueRemainedEmpty && !getInputElementValue().isEmpty()) {
+        if (!fromClient && isModelValueRemainedEmpty
+                && !getInputElementValue().isEmpty()) {
             setInputElementValue("");
             validate();
             fireValidationStatusChangeEvent();


### PR DESCRIPTION
## Description

BigDecimalField wasn't among the components affected by the regression fixed in #7277 because it reads the input element's value directly from the `value` property instead of using `_inputElementValue`. However, that fix also moved the logic of clearing bad input in a different place, which makes sense to do for BigDecimalField as well to make it consistent.

## Type of change

- [x] Refactor
