### PR TITLE
chore: add JavaDoc to explain unreliable TreeGridElement.getRowCount behavior

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -292,4 +292,30 @@ public class TreeGridElement extends GridElement {
     protected boolean isLoading() {
         return super.isLoading() || isLoadingExpandedRows();
     }
+
+    /**
+     * Gets the total number of rows.
+     * <p>
+     * Note that for TreeGrid this does not return reliable results if rows are
+     * expanded. Due to the lazy-loading nature of the grid, children of
+     * expanded rows are only loaded into the grid when they are scrolled into
+     * view. Likewise, they are removed again from the grid at some point when
+     * they are scrolled out of view. These child rows then only count against
+     * the total row count while they are loaded into the grid. Effectively,
+     * that means that the total row count will depend on the scroll position of
+     * the grid.
+     * <p>
+     * We are looking into making this more reliable by adding additional APIs
+     * to TreeGrid that would allow the component to keep track of the total
+     * number of rows just based on the expanded rows, and regardless of the
+     * scroll position. Please see
+     * <a href="https://github.com/vaadin/flow-components/issues/7269">this
+     * issue</a> for more details.
+     *
+     * @return the number of rows
+     */
+    @Override
+    public int getRowCount() {
+        return super.getRowCount();
+    }
 }


### PR DESCRIPTION
## Description

Adds JavaDoc to explain why `TreeGridElement.getRowCount` does not produce reliable results when nodes are expanded.

Related to https://github.com/vaadin/flow-components/issues/7293

## Type of change

- Chore