### PR TITLE
feat: add possibilty to use the new DownloadHandler

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/main/java/com/vaadin/flow/component/avatar/tests/AvatarGroupPage.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/main/java/com/vaadin/flow/component/avatar/tests/AvatarGroupPage.java
@@ -61,8 +61,8 @@ public class AvatarGroupPage extends Div {
                 });
         setItemsWithResource.setId("set-items-with-resource");
 
-        NativeButton setItemsDownloadHandler = new NativeButton(
-                "Set new item with StreamResource image", e -> {
+        NativeButton setItemsWithDownloadHandler = new NativeButton(
+                "Set new item with download resource image", e -> {
                     DownloadHandler download = DownloadHandler.forClassResource(
                             getClass(),
                             "/META-INF/resources/frontend/images/user.png",
@@ -72,7 +72,7 @@ public class AvatarGroupPage extends Div {
 
                     avatarGroup.setItems(newItem);
                 });
-        setItemsDownloadHandler.setId("set-items-with-download-resource");
+        setItemsWithDownloadHandler.setId("set-items-with-download-resource");
 
         NativeButton addClassNames = new NativeButton("Add class name", e -> {
             items.get(0).addClassNames("red");
@@ -86,6 +86,6 @@ public class AvatarGroupPage extends Div {
         removeClassNames.setId("remove-class-names");
 
         add(avatarGroup, updateItems, setItemsWithResource, addClassNames,
-                removeClassNames, setItemsDownloadHandler);
+                removeClassNames, setItemsWithDownloadHandler);
     }
 }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/main/java/com/vaadin/flow/component/avatar/tests/AvatarGroupPage.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/main/java/com/vaadin/flow/component/avatar/tests/AvatarGroupPage.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.avatar.AvatarGroup.AvatarGroupItem;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 
 @Route("vaadin-avatar/avatar-group-test")
@@ -60,6 +61,19 @@ public class AvatarGroupPage extends Div {
                 });
         setItemsWithResource.setId("set-items-with-resource");
 
+        NativeButton setItemsDownloadHandler = new NativeButton(
+                "Set new item with StreamResource image", e -> {
+                    DownloadHandler download = DownloadHandler.forClassResource(
+                            getClass(),
+                            "/META-INF/resources/frontend/images/user.png",
+                            "avatar-group-img");
+                    AvatarGroupItem newItem = new AvatarGroupItem();
+                    newItem.setImageHandler(download);
+
+                    avatarGroup.setItems(newItem);
+                });
+        setItemsDownloadHandler.setId("set-items-with-download-resource");
+
         NativeButton addClassNames = new NativeButton("Add class name", e -> {
             items.get(0).addClassNames("red");
         });
@@ -72,6 +86,6 @@ public class AvatarGroupPage extends Div {
         removeClassNames.setId("remove-class-names");
 
         add(avatarGroup, updateItems, setItemsWithResource, addClassNames,
-                removeClassNames);
+                removeClassNames, setItemsDownloadHandler);
     }
 }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/main/java/com/vaadin/flow/component/avatar/tests/AvatarPage.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/main/java/com/vaadin/flow/component/avatar/tests/AvatarPage.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 
 @Route("vaadin-avatar/avatar-test")
@@ -69,6 +70,20 @@ public class AvatarPage extends Div {
                 });
         toggleImgResource.setId("toggle-res");
 
+        NativeButton toggleImgHandler = new NativeButton("Toggle image handler",
+                e -> {
+                    if (avatar.getImageResource() == null) {
+                        DownloadHandler download = DownloadHandler
+                                .forClassResource(getClass(),
+                                        "/META-INF/resources/frontend/images/user.png",
+                                        "user+.png");
+                        avatar.setImageHandler(download);
+                    } else {
+                        avatar.setImageHandler(null);
+                    }
+                });
+        toggleImgHandler.setId("toggle-res-handler");
+
         Div dataImg = new Div();
         dataImg.setId("data-block-img");
 
@@ -92,6 +107,7 @@ public class AvatarPage extends Div {
         getPropertyValues.setId("get-props");
 
         add(avatar, toggleImage, toggleAbbr, toggleName, toggleImgResource,
-                dataImg, dataAbbr, dataName, dataResource, getPropertyValues);
+                toggleImgHandler, dataImg, dataAbbr, dataName, dataResource,
+                getPropertyValues);
     }
 }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
@@ -63,6 +63,15 @@ public class AvatarGroupIT extends AbstractComponentIT {
     }
 
     @Test
+    public void avatarGroupAttached_setItemsWithDownloadHandler_imageLoaded() {
+        clickElementWithJs("set-items-with-download-resource");
+        String imageUrl = $(AvatarGroupElement.class).first()
+                .getAvatarElement(0).getPropertyString("img");
+        Assert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
+        checkLogsForErrors(); // would fail if the image wasn't hosted
+    }
+
+    @Test
     public void addClassNames_removeClassNames_avatarsUpdated() {
         findElement(By.id("add-class-names")).click();
         Assert.assertEquals("red", getAvatarClassName(0));

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
@@ -67,7 +67,7 @@ public class AvatarGroupIT extends AbstractComponentIT {
         clickElementWithJs("set-items-with-download-resource");
         String imageUrl = $(AvatarGroupElement.class).first()
                 .getAvatarElement(0).getPropertyString("img");
-        Assert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
+        Assert.assertTrue(imageUrl.startsWith("VAADIN/dynamic"));
         checkLogsForErrors(); // would fail if the image wasn't hosted
     }
 

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarIT.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarIT.java
@@ -46,6 +46,8 @@ public class AvatarIT extends AbstractComponentIT {
         WebElement toggleAbbr = findElement(By.id("toggle-abbr"));
         WebElement toggleName = findElement(By.id("toggle-name"));
         WebElement toggleResource = findElement(By.id("toggle-res"));
+        WebElement toggleResourceHandler = findElement(
+                By.id("toggle-res-handler"));
 
         WebElement imgBlock = findElement(By.id("data-block-img"));
         WebElement abbrBlock = findElement(By.id("data-block-abbr"));
@@ -55,6 +57,12 @@ public class AvatarIT extends AbstractComponentIT {
         toggleImg.click();
         getPropsBtn.click();
         Assert.assertEquals("https://vaadin.com/", imgBlock.getText());
+
+        toggleResourceHandler.click();
+        getPropsBtn.click();
+        Assert.assertTrue("img url contains file name",
+                resourceBlock.getText().contains("user%2B.png"));
+        toggleResourceHandler.click();
 
         toggleAbbr.click();
         getPropsBtn.click();
@@ -78,6 +86,8 @@ public class AvatarIT extends AbstractComponentIT {
         WebElement toggleAbbr = findElement(By.id("toggle-abbr"));
         WebElement toggleName = findElement(By.id("toggle-name"));
         WebElement toggleResource = findElement(By.id("toggle-res"));
+        WebElement toggleResourceHandler = findElement(
+                By.id("toggle-res-handler"));
 
         WebElement imgBlock = findElement(By.id("data-block-img"));
         WebElement abbrBlock = findElement(By.id("data-block-abbr"));
@@ -103,6 +113,11 @@ public class AvatarIT extends AbstractComponentIT {
 
         toggleResource.click();
         toggleResource.click();
+        getPropsBtn.click();
+        Assert.assertEquals("", resourceBlock.getText());
+
+        toggleResourceHandler.click();
+        toggleResourceHandler.click();
         getPropsBtn.click();
         Assert.assertEquals("", resourceBlock.getText());
     }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -282,7 +282,7 @@ public class Avatar extends Component
             return;
         }
         imageResource = new StreamResourceRegistry.ElementStreamResource(
-                downloadHandler, this.getElement());
+                downloadHandler, getElement());
 
         getElement().setAttribute("img", imageResource);
     }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.DownloadHandler;
+import com.vaadin.flow.server.StreamResourceRegistry;
 
 import elemental.json.JsonObject;
 
@@ -261,6 +263,28 @@ public class Avatar extends Component
         }
 
         getElement().setAttribute("img", resource);
+    }
+
+    /**
+     * Sets the image for the avatar.
+     * <p>
+     * Setting the image as a resource with this method resets the image URL
+     * that was set with {@link Avatar#setImage(String)}
+     *
+     * @see Avatar#setImage(String)
+     * @param downloadHandler
+     *            the download resource or {@code null} to remove the resource
+     */
+    public void setImageHandler(DownloadHandler downloadHandler) {
+        if (downloadHandler == null) {
+            imageResource = null;
+            getElement().removeAttribute("img");
+            return;
+        }
+        imageResource = new StreamResourceRegistry.ElementStreamResource(
+                downloadHandler, this.getElement());
+
+        getElement().setAttribute("img", imageResource);
     }
 
     /**

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
@@ -43,6 +44,7 @@ import com.vaadin.flow.internal.NodeOwner;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinSession;
@@ -217,6 +219,28 @@ public class AvatarGroup extends Component implements HasOverlayClassName,
             if (getHost() != null) {
                 getHost().setClientItems();
             }
+        }
+
+        /**
+         * Sets the image for the avatar.
+         * <p>
+         * Setting the image as a resource with this method resets the image URL
+         * that was set with {@link AvatarGroupItem#setImage(String)}
+         *
+         * @see AvatarGroupItem#setImage(String)
+         * @param downloadHandler
+         *            the download resource or {@code null} to remove the
+         *            resource
+         */
+        public void setImageHandler(DownloadHandler downloadHandler) {
+            if (downloadHandler == null) {
+                unsetResource();
+                return;
+            }
+
+            setImageResource(new StreamResourceRegistry.ElementStreamResource(
+                    downloadHandler, getHost() != null ? getHost().getElement()
+                            : UI.getCurrent().getElement()));
         }
 
         /**

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
@@ -16,7 +16,9 @@
 package com.vaadin.flow.component.icon;
 
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.StreamResourceRegistry;
 
 /**
  * Component for displaying an icon from a SVG file.
@@ -80,6 +82,33 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
      * @see #setSymbol(String)
      */
     public SvgIcon(AbstractStreamResource src, String symbol) {
+        this(src);
+        setSymbol(symbol);
+    }
+
+    /**
+     * Creates an SVG icon with the given download handler resource
+     *
+     * @param src
+     *            the download handler resource
+     * @see #setSrc(AbstractStreamResource)
+     */
+    public SvgIcon(DownloadHandler src) {
+        setSrc(new StreamResourceRegistry.ElementStreamResource(src,
+                this.getElement()));
+    }
+
+    /**
+     * Creates an SVG icon with the given download handler resource
+     *
+     * @param src
+     *            the download handler resource
+     * @param symbol
+     *            the symbol reference of the icon
+     * @see #setSrc(AbstractStreamResource)
+     * @see #setSymbol(String)
+     */
+    public SvgIcon(DownloadHandler src, String symbol) {
         this(src);
         setSymbol(symbol);
     }

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
@@ -95,7 +95,7 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
      */
     public SvgIcon(DownloadHandler src) {
         setSrc(new StreamResourceRegistry.ElementStreamResource(src,
-                this.getElement()));
+                getElement()));
     }
 
     /**

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.icon.tests;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.After;
@@ -24,6 +25,8 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.icon.SvgIcon;
+import com.vaadin.flow.server.DownloadEvent;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 
 public class SvgIconTest {
@@ -76,6 +79,63 @@ public class SvgIconTest {
         var resource = new StreamResource("image.svg",
                 () -> new ByteArrayInputStream(
                         "<svg></svg>".getBytes(StandardCharsets.UTF_8)));
+        var symbol = "symbol";
+        var icon = new SvgIcon(resource, symbol);
+        Assert.assertTrue(icon.getSrc().contains("image.svg"));
+        Assert.assertTrue(
+                icon.getElement().getAttribute("src").contains("image.svg"));
+        Assert.assertEquals(symbol, icon.getSymbol());
+        Assert.assertEquals(symbol, icon.getElement().getProperty("symbol"));
+    }
+
+    @Test
+    public void downloadHandlerConstructor_hasSrc() {
+        UI.setCurrent(new UI());
+        var resource = new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event) {
+                event.getOutputStream().ifPresent(output -> {
+                    try {
+                        output.write(
+                                "<svg></svg>".getBytes(StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return "image.svg";
+            }
+        };
+        var icon = new SvgIcon(resource);
+        Assert.assertTrue(icon.getSrc().contains("image.svg"));
+        Assert.assertTrue(
+                icon.getElement().getAttribute("src").contains("image.svg"));
+    }
+
+    @Test
+    public void downloadHandlerConstructorWithSymbol_hasSrcAndSymbol() {
+        UI.setCurrent(new UI());
+        var resource = new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event) {
+                event.getOutputStream().ifPresent(output -> {
+                    try {
+                        output.write(
+                                "<svg></svg>".getBytes(StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return "image.svg";
+            }
+        };
         var symbol = "symbol";
         var icon = new SvgIcon(resource, symbol);
         Assert.assertTrue(icon.getSrc().contains("image.svg"));

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.icon.SvgIcon;
-import com.vaadin.flow.server.DownloadEvent;
 import com.vaadin.flow.server.DownloadHandler;
+import com.vaadin.flow.server.DownloadRequest;
 import com.vaadin.flow.server.StreamResource;
 
 public class SvgIconTest {
@@ -64,9 +64,7 @@ public class SvgIconTest {
     @Test
     public void streamResourceConstructor_hasSrc() {
         UI.setCurrent(new UI());
-        var resource = new StreamResource("image.svg",
-                () -> new ByteArrayInputStream(
-                        "<svg></svg>".getBytes(StandardCharsets.UTF_8)));
+        var resource = getStreamResource();
         var icon = new SvgIcon(resource);
         Assert.assertTrue(icon.getSrc().contains("image.svg"));
         Assert.assertTrue(
@@ -76,9 +74,7 @@ public class SvgIconTest {
     @Test
     public void streamResourceConstructorWithSymbol_hasSrcAndSymbol() {
         UI.setCurrent(new UI());
-        var resource = new StreamResource("image.svg",
-                () -> new ByteArrayInputStream(
-                        "<svg></svg>".getBytes(StandardCharsets.UTF_8)));
+        var resource = getStreamResource();
         var symbol = "symbol";
         var icon = new SvgIcon(resource, symbol);
         Assert.assertTrue(icon.getSrc().contains("image.svg"));
@@ -91,24 +87,7 @@ public class SvgIconTest {
     @Test
     public void downloadHandlerConstructor_hasSrc() {
         UI.setCurrent(new UI());
-        var resource = new DownloadHandler() {
-            @Override
-            public void handleDownloadRequest(DownloadEvent event) {
-                event.getOutputStream().ifPresent(output -> {
-                    try {
-                        output.write(
-                                "<svg></svg>".getBytes(StandardCharsets.UTF_8));
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-            }
-
-            @Override
-            public String getUrlPostfix() {
-                return "image.svg";
-            }
-        };
+        var resource = getDownloadHandler();
         var icon = new SvgIcon(resource);
         Assert.assertTrue(icon.getSrc().contains("image.svg"));
         Assert.assertTrue(
@@ -118,24 +97,7 @@ public class SvgIconTest {
     @Test
     public void downloadHandlerConstructorWithSymbol_hasSrcAndSymbol() {
         UI.setCurrent(new UI());
-        var resource = new DownloadHandler() {
-            @Override
-            public void handleDownloadRequest(DownloadEvent event) {
-                event.getOutputStream().ifPresent(output -> {
-                    try {
-                        output.write(
-                                "<svg></svg>".getBytes(StandardCharsets.UTF_8));
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-            }
-
-            @Override
-            public String getUrlPostfix() {
-                return "image.svg";
-            }
-        };
+        var resource = getDownloadHandler();
         var symbol = "symbol";
         var icon = new SvgIcon(resource, symbol);
         Assert.assertTrue(icon.getSrc().contains("image.svg"));
@@ -170,9 +132,7 @@ public class SvgIconTest {
     @Test
     public void hasStreamResource_setSrcWithSymbol_hasSrcAndSymbol() {
         UI.setCurrent(new UI());
-        var resource = new StreamResource("image.svg",
-                () -> new ByteArrayInputStream(
-                        "<svg></svg>".getBytes(StandardCharsets.UTF_8)));
+        var resource = getStreamResource();
         var symbol = "symbol";
         var icon = new SvgIcon();
         icon.setSrc(resource, symbol);
@@ -207,9 +167,7 @@ public class SvgIconTest {
     public void withStreamResource_setSrc_hasSrc() {
         UI.setCurrent(new UI());
         var icon = new SvgIcon();
-        var resource = new StreamResource("image.svg",
-                () -> new ByteArrayInputStream(
-                        "<svg></svg>".getBytes(StandardCharsets.UTF_8)));
+        var resource = getStreamResource();
         icon.setSrc(resource);
         Assert.assertTrue(icon.getSrc().contains("image.svg"));
     }
@@ -229,5 +187,29 @@ public class SvgIconTest {
         icon.setColor(null);
         Assert.assertNull(icon.getColor());
         Assert.assertNull(icon.getStyle().get("fill"));
+    }
+
+    private static StreamResource getStreamResource() {
+        return new StreamResource("image.svg", () -> new ByteArrayInputStream(
+                "<svg></svg>".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static DownloadHandler getDownloadHandler() {
+        return new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadRequest downloadRequest) {
+                try {
+                    downloadRequest.getOutputStream().write(
+                            "<svg></svg>".getBytes(StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return "image.svg";
+            }
+        };
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/main/java/com/vaadin/flow/component/messages/tests/MessageListPage.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/main/java/com/vaadin/flow/component/messages/tests/MessageListPage.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.messages.MessageListItem;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 
 @Route("vaadin-messages/message-list-test")
@@ -70,6 +71,14 @@ public class MessageListPage extends Div {
                     () -> getClass().getResourceAsStream(
                             "/META-INF/resources/frontend/images/avatar.png"));
             foo.setUserImageResource(resource);
+        });
+
+        addButton("setImageAsDownloadHandler", () -> {
+            DownloadHandler resource = DownloadHandler.forClassResource(
+                    getClass(),
+                    "/META-INF/resources/frontend/images/avatar.png",
+                    "message-list-img");
+            foo.setUserImageHandler(resource);
         });
 
     }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -165,11 +166,21 @@ public class MessageListIT extends AbstractComponentIT {
 
     @Test
     public void setImageAsStreamResource_imageLoaded() {
+        getLogEntries(Level.WARNING); // message logs before setting resource
         clickElementWithJs("setImageAsStreamResource");
         String imageUrl = messageList.getMessageElements().get(0).getUserImg();
         MatcherAssert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
         // would fail if the avatar.png image wasn't hosted
         checkLogsForErrors(message -> message.contains("test.jpg"));
+    }
+
+    @Test
+    public void setImageAsDownloadResource_imageLoaded() {
+        getLogEntries(Level.WARNING); // message logs before setting resource
+        clickElementWithJs("setImageAsDownloadHandler");
+        String imageUrl = messageList.getMessageElements().get(0).getUserImg();
+        MatcherAssert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
+        checkLogsForErrors(); // would fail if the image wasn't hosted
     }
 
     private MessageElement getFirstMessage(MessageListElement list) {

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -419,15 +419,13 @@ public class MessageListItem implements Serializable {
      */
     public void setUserImageHandler(DownloadHandler downloadHandler) {
         if (downloadHandler == null) {
-            imageResource = null;
             unsetResource();
-        } else {
-            setUserImageResource(
-                    new StreamResourceRegistry.ElementStreamResource(
-                            downloadHandler,
-                            getHost() != null ? getHost().getElement()
-                                    : UI.getCurrent().getElement()));
+            return;
         }
+
+        setUserImageResource(new StreamResourceRegistry.ElementStreamResource(
+                downloadHandler, getHost() != null ? getHost().getElement()
+                        : UI.getCurrent().getElement()));
     }
 
     /**

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -30,10 +30,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.NodeOwner;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinSession;
@@ -402,6 +404,30 @@ public class MessageListItem implements Serializable {
     @JsonIgnore
     public AbstractStreamResource getUserImageResource() {
         return imageResource;
+    }
+
+    /**
+     * Sets the image for the message sender's avatar.
+     * <p>
+     * Setting the image as a resource with this method overrides the image URL
+     * set with {@link MessageListItem#setUserImage(String)}.
+     *
+     * @param downloadHandler
+     *            download handler for the image resource, or {@code null} to
+     *            remove the resource
+     * @see MessageListItem#setUserImage(String)
+     */
+    public void setUserImageHandler(DownloadHandler downloadHandler) {
+        if (downloadHandler == null) {
+            imageResource = null;
+            unsetResource();
+        } else {
+            setUserImageResource(
+                    new StreamResourceRegistry.ElementStreamResource(
+                            downloadHandler,
+                            getHost() != null ? getHost().getElement()
+                                    : UI.getCurrent().getElement()));
+        }
     }
 
     /**

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -30,7 +30,9 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.messages.MessageListItem;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.server.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.streams.DownloadResponse;
 
 import elemental.json.JsonType;
 import elemental.json.JsonValue;
@@ -107,6 +109,29 @@ public class MessageListTest {
         UI.setCurrent(new UI());
         item1.setUserImageResource(new StreamResource("message-list-img",
                 () -> getClass().getResourceAsStream("baz/qux")));
+        item1.setUserImage("foo/bar");
+        Assert.assertNull(item1.getUserImageResource());
+    }
+
+    @Test
+    public void setImageHandler_overridesImageUrl() {
+        UI.setCurrent(new UI());
+        item1.setUserImage("foo/bar");
+        item1.setUserImageHandler(
+                DownloadHandler.fromInputStream(data -> new DownloadResponse(
+                        getClass().getResourceAsStream("baz/qux"),
+                        "message-list-img", null, -1)));
+        MatcherAssert.assertThat(item1.getUserImage(),
+                startsWith("VAADIN/dynamic"));
+    }
+
+    @Test
+    public void setImageHandler_streamResourceBecomesNull() {
+        UI.setCurrent(new UI());
+        item1.setUserImageHandler(
+                DownloadHandler.fromInputStream(data -> new DownloadResponse(
+                        getClass().getResourceAsStream("baz/qux"),
+                        "message-list-img", null, -1)));
         item1.setUserImage("foo/bar");
         Assert.assertNull(item1.getUserImageResource());
     }


### PR DESCRIPTION
## Description

Add methods/constructors for using the
new DownloadHandler instead of
AbstractStreamResource.

Part of vaadin/flow#21255

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
