### PR TITLE
chore: remove usage of internal field removed in Jackson 2.19

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/BeanSerializerDelegator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/BeanSerializerDelegator.java
@@ -87,8 +87,7 @@ public class BeanSerializerDelegator<T> extends BeanSerializerBase {
     @Override
     protected BeanSerializerBase asArraySerializer() {
         // copied from BeanSerializer
-        if ((_objectIdWriter == null) && (_anyGetterWriter == null)
-                && (_propertyFilterId == null)) {
+        if ((_objectIdWriter == null) && (_propertyFilterId == null)) {
             return new BeanAsArraySerializer(this);
         }
         return this;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/ThemeGradientColorBeanSerializer.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/ThemeGradientColorBeanSerializer.java
@@ -84,8 +84,7 @@ public class ThemeGradientColorBeanSerializer extends BeanSerializerBase {
     @Override
     protected BeanSerializerBase asArraySerializer() {
         // copied from BeanSerializer
-        if ((_objectIdWriter == null) && (_anyGetterWriter == null)
-                && (_propertyFilterId == null)) {
+        if ((_objectIdWriter == null) && (_propertyFilterId == null)) {
             return new BeanAsArraySerializer(this);
         }
         return this;


### PR DESCRIPTION
## Description

Aligned the code with `BeanSerializer` in the latest `jackson-databind` where `_anyGetterWriter` was removed.
See https://github.com/FasterXML/jackson-databind/pull/4775 (dependency version bumped in Flow by https://github.com/vaadin/flow/pull/21355).

## Type of change

- Internal change