### PR TITLE
fix: do not keep column id map in gridpro

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3530,13 +3530,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     /**
      * Gets a {@link Column} of this grid by its internal id ({@code _flowId}).
+     * Intended only for internal use and can be removed in the future.
      *
      * @param internalId
      *            the internal identifier of the column to get
      * @return the column corresponding to the given column identifier, or
      *         {@code null} if no column has such an identifier
      */
-    Column<T> getColumnByInternalId(String internalId) {
+    protected final Column<T> getColumnByInternalId(String internalId) {
         return idToColumnMap.get(internalId);
     }
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -394,7 +394,7 @@ public class BasicIT extends AbstractComponentIT {
                 .first();
 
         textField.setProperty("value", "Updated Person 1");
-        executeScript("arguments[0].blur();", textField);
+        textField.sendKeys(Keys.ENTER);
 
         Assert.assertEquals("Updated Person 1",
                 grid.getCell(0, 1).getInnerHTML());

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -8,9 +8,7 @@
  */
 package com.vaadin.flow.component.gridpro;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -66,8 +64,6 @@ import elemental.json.JsonObject;
  */
 public class GridPro<E> extends Grid<E> {
 
-    private Map<String, Column<E>> idToColumnMap = new HashMap<>();
-
     /**
      * Instantiates a new CrudGrid for the supplied bean type.
      *
@@ -117,8 +113,8 @@ public class GridPro<E> extends Grid<E> {
             if (e.getItem() == null) {
                 return;
             }
-            EditColumn<E> column = (EditColumn<E>) this.idToColumnMap
-                    .get(e.getPath());
+            EditColumn<E> column = (EditColumn<E>) getColumnByInternalId(
+                    e.getPath());
 
             Object idBeforeUpdate = getItemId(e.getItem());
             if (column.getEditorType().equals("custom")) {
@@ -146,8 +142,8 @@ public class GridPro<E> extends Grid<E> {
         });
 
         addCellEditStartedListener(e -> {
-            EditColumn<E> column = (EditColumn<E>) this.idToColumnMap
-                    .get(e.getPath());
+            EditColumn<E> column = (EditColumn<E>) getColumnByInternalId(
+                    e.getPath());
 
             if (column.getEditorType().equals("custom")) {
                 column.getEditorField()
@@ -389,7 +385,6 @@ public class GridPro<E> extends Grid<E> {
                         return "";
                     }
                 }, renderer)), this::createEditColumn);
-        idToColumnMap.put(columnId, column);
 
         return new EditColumnConfigurator<>(column, valueProvider);
     }
@@ -538,7 +533,6 @@ public class GridPro<E> extends Grid<E> {
     protected EditColumn<E> createEditColumn(Renderer<E> renderer,
             String columnId) {
         EditColumn<E> column = new EditColumn<>(this, columnId, renderer);
-        idToColumnMap.put(columnId, column);
         return column;
     }
 
@@ -713,8 +707,8 @@ public class GridPro<E> extends Grid<E> {
         // Wrap the listener to filter out events for cells that are not
         // editable
         ComponentEventListener<ItemPropertyChangedEvent<E>> wrapper = event -> {
-            EditColumn<E> column = (EditColumn<E>) this.idToColumnMap
-                    .get(event.getPath());
+            EditColumn<E> column = (EditColumn<E>) getColumnByInternalId(
+                    event.getPath());
 
             if (column.cellEditableProvider == null
                     || column.cellEditableProvider.test(event.getItem())) {


### PR DESCRIPTION
## Description

The entries in `idToColumnMap` in `GridPro` are not cleared whenever the columns are removed unlike its `Grid` counterpart. It can be fixed by overriding `Grid.removeColumn` and removing the column from the map. However, keeping this map on top of the already existing map in `Grid` seems redundant and prone to errors.

This PR removes this map from `GridPro` entirely, making the `Grid` class the only class responsible for handling this map.

Fixes #7322 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.