### PR TITLE
refactor: deprecate hascomponents api and provide alternatives

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.contextmenu;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.function.SerializableRunnable;
 
@@ -81,13 +80,6 @@ public class ContextMenu extends ContextMenuBase<ContextMenu, MenuItem, SubMenu>
     public MenuItem addItem(Component component,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         return getMenuManager().addItem(component, clickListener);
-    }
-
-    /**
-     * Adds a separator between items.
-     */
-    public void addSeparator() {
-        getMenuManager().add(new Hr());
     }
 
     @Override

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -235,23 +235,58 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      * @see HasMenuItems#addItem(String, ComponentEventListener)
      * @see HasMenuItems#addItem(Component, ComponentEventListener)
      *
-     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
+     * @deprecated Since 24.8, use {@link #addComponent(Component...)} instead
      */
     @Deprecated(since = "24.8")
     @Override
     public void add(Component... components) {
-        getMenuManager().add(components);
+        addComponent(components);
+    }
+
+    /**
+     * Adds the given components into the context menu overlay.
+     * <p>
+     * The added elements in the DOM will not be children of the
+     * {@code <vaadin-context-menu>} element, but will be inserted into an
+     * overlay that is attached into the {@code <body>}.
+     *
+     * @param components
+     *            the components to add
+     * @see HasMenuItems#addItem(String, ComponentEventListener)
+     * @see HasMenuItems#addItem(Component, ComponentEventListener)
+     */
+    public void addComponent(Component... components) {
+        getMenuManager().addComponent(components);
     }
 
     /**
      * @inheritDoc
      *
-     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
+     * @deprecated Since 24.8, use {@link #addComponent(Collection)} instead
      */
     @Deprecated(since = "24.8")
     @Override
     public void add(Collection<Component> components) {
-        HasComponents.super.add(components);
+        addComponent(components);
+    }
+
+    /**
+     * Adds the given components into the context menu overlay.
+     * <p>
+     * The added elements in the DOM will not be children of the
+     * {@code <vaadin-context-menu>} element, but will be inserted into an
+     * overlay that is attached into the {@code <body>}.
+     *
+     * @param components
+     *            the components to add
+     * @see HasMenuItems#addItem(String, ComponentEventListener)
+     * @see HasMenuItems#addItem(Component, ComponentEventListener)
+     */
+    public void addComponent(Collection<Component> components) {
+        if (components == null) {
+            return;
+        }
+        getMenuManager().addComponent(components.toArray(Component[]::new));
     }
 
     /**
@@ -263,25 +298,6 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     @Override
     public void add(String text) {
         HasComponents.super.add(text);
-    }
-
-    /**
-     * @inheritDoc
-     *
-     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
-     */
-    @Deprecated(since = "24.8")
-    @Override
-    public void addComponentAsFirst(Component component) {
-        HasComponents.super.addComponentAsFirst(component);
-    }
-
-    /**
-     * @inheritDoc
-     *
-     */
-    @Deprecated(since = "24.8")
-    @Override
     }
 
     @Override
@@ -309,11 +325,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      *            the index, where the component will be added
      * @param component
      *            the component to add
-     *
-     * @deprecated Since 24.8, use {@link #addItemAtIndex(int, Component)}
-     *             instead
      */
-    @Deprecated(since = "24.8")
     @Override
     public void addComponentAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -201,17 +202,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     /**
      * Adds a new item component with the given text content to the context menu
      * overlay.
-     * <p>
-     * This is a convenience method for the use case where you have a list of
-     * highlightable {@link MenuItem}s inside the overlay. If you want to
-     * configure the contents of the overlay without wrapping them inside
-     * {@link MenuItem}s, or if you just want to add some non-highlightable
-     * components between the items, use the {@link #add(Component...)} method.
      *
      * @param text
      *            the text content for the created menu item
      * @return the created menu item
-     * @see #add(Component...)
      */
     public I addItem(String text) {
         return getMenuManager().addItem(text);
@@ -220,17 +214,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     /**
      * Adds a new item component with the given component to the context menu
      * overlay.
-     * <p>
-     * This is a convenience method for the use case where you have a list of
-     * highlightable {@link MenuItem}s inside the overlay. If you want to
-     * configure the contents of the overlay without wrapping them inside
-     * {@link MenuItem}s, or if you just want to add some non-highlightable
-     * components between the items, use the {@link #add(Component...)} method.
      *
      * @param component
      *            the component to add to the created menu item
      * @return the created menu item
-     * @see #add(Component...)
      */
     public I addItem(Component component) {
         return getMenuManager().addItem(component);
@@ -238,10 +225,6 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Adds the given components into the context menu overlay.
-     * <p>
-     * For the common use case of having a list of high-lightable items inside
-     * the overlay, you can use the {@link #addItem(String)} convenience methods
-     * instead.
      * <p>
      * The added elements in the DOM will not be children of the
      * {@code <vaadin-context-menu>} element, but will be inserted into an
@@ -251,23 +234,98 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      *            the components to add
      * @see HasMenuItems#addItem(String, ComponentEventListener)
      * @see HasMenuItems#addItem(Component, ComponentEventListener)
+     *
+     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
      */
+    @Deprecated(since = "24.8")
     @Override
     public void add(Component... components) {
         getMenuManager().add(components);
     }
 
+    /**
+     * @inheritDoc
+     *
+     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
+     */
+    @Deprecated(since = "24.8")
+    @Override
+    public void add(Collection<Component> components) {
+        HasComponents.super.add(components);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @deprecated Since 24.8, use {@link #addItem(String)} instead
+     */
+    @Deprecated(since = "24.8")
+    @Override
+    public void add(String text) {
+        HasComponents.super.add(text);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
+     */
+    @Deprecated(since = "24.8")
+    @Override
+    public void addComponentAsFirst(Component component) {
+        HasComponents.super.addComponentAsFirst(component);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @deprecated Since 24.8, use {@link #removeItem(Component...)} instead
+     */
+    @Deprecated(since = "24.8")
     @Override
     public void remove(Component... components) {
+        removeItem(components);
+    }
+
+    /**
+     * Removes the provided components from the context menu overlay.
+     *
+     * @param components
+     *            the components to remove
+     */
+    public void removeItem(Component... components) {
         getMenuManager().remove(components);
     }
 
     /**
-     * Removes all of the child components. This also removes all the items
-     * added with {@link #addItem(String)} and its overload methods.
+     * @inheritDoc
+     *
+     * @deprecated Since 24.8, use {@link #removeItem(Component...)} instead
      */
+    @Deprecated(since = "24.8")
+    @Override
+    public void remove(Collection<Component> components) {
+        removeItem(components == null ? null
+                : components.toArray(new Component[0]));
+    }
+
+    /**
+     * Removes all the child components. This also removes all the items added
+     * with {@link #addItem(String)} and its overload methods.
+     *
+     * @deprecated Since 24.8, use {@link #removeAllItems()} instead
+     */
+    @Deprecated(since = "24.8")
     @Override
     public void removeAll() {
+        removeAllItems();
+    }
+
+    /**
+     * Removes all the child components. This also removes all the items added
+     * with {@link #addItem(String)} and its overload methods.
+     */
+    public void removeAllItems() {
         getMenuManager().removeAll();
     }
 
@@ -282,10 +340,29 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      *            the index, where the component will be added
      * @param component
      *            the component to add
-     * @see #add(Component...)
+     *
+     * @deprecated Since 24.8, use {@link #addItemAtIndex(int, Component)}
+     *             instead
      */
+    @Deprecated(since = "24.8")
     @Override
     public void addComponentAtIndex(int index, Component component) {
+        addItemAtIndex(index, component);
+    }
+
+    /**
+     * Adds the given component into this context menu at the given index.
+     * <p>
+     * The added elements in the DOM will not be children of the
+     * {@code <vaadin-context-menu>} element, but will be inserted into an
+     * overlay that is attached into the {@code <body>}.
+     *
+     * @param index
+     *            the index, where the component will be added
+     * @param component
+     *            the component to add
+     */
+    public void addItemAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);
     }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -374,6 +374,16 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
+     * Adds a separator between items using the {@code index}.
+     *
+     * @param index
+     *            index to insert, not negative
+     */
+    public void addSeparatorAtIndex(int index) {
+        getMenuManager().addSeparatorAtIndex(index);
+    }
+
+    /**
      * Gets the child components of this component. This includes components
      * added with {@link #add(Component...)} and the {@link MenuItem} components
      * created with {@link #addItem(String)} and its overload methods. This

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -367,6 +367,13 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
+     * Adds a separator between items.
+     */
+    public void addSeparator() {
+        getMenuManager().addSeparator();
+    }
+
+    /**
      * Gets the child components of this component. This includes components
      * added with {@link #add(Component...)} and the {@link MenuItem} components
      * created with {@link #addItem(String)} and its overload methods. This

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -327,7 +327,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given component into this context menu at the given index.
+     * Adds the given component into this context menu overlay at the given
+     * index.
      * <p>
      * For the common use case of having a list of high-lightable items inside
      * the overlay, use {@link #addItem(String)} and its overload methods
@@ -345,6 +346,26 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     @Override
     public void addComponentAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);
+    }
+
+    /**
+     * Adds the given component as the first child into this context menu
+     * overlay.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, use {@link #addItem(String)} and its overload methods
+     * instead.
+     * <p>
+     * The added elements in the DOM will not be children of the
+     * {@code <vaadin-context-menu>} element, but will be inserted into an
+     * overlay that is attached into the {@code <body>}.
+     *
+     * @param component
+     *            the component to add
+     */
+    @Override
+    public void addComponentAsFirst(Component component) {
+        HasComponents.super.addComponentAsFirst(component);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -320,37 +320,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given component into this context menu at the given index as an
-     * item.
-     * <p>
-     * The added elements in the DOM will not be children of the
-     * {@code <vaadin-context-menu>} element, but will be inserted into an
-     * overlay that is attached into the {@code <body>}.
-     *
-     * @param index
-     *            the index, where the item will be added
-     * @param component
-     *            the component to add
-     */
-    public void addItemAtIndex(int index, Component component) {
-        getMenuManager().addItemAtIndex(index, component);
-    }
-
-    /**
      * Adds a separator between items.
      */
     public void addSeparator() {
         getMenuManager().addSeparator();
-    }
-
-    /**
-     * Adds a separator between items using the {@code index}.
-     *
-     * @param index
-     *            index to insert, not negative
-     */
-    public void addSeparatorAtIndex(int index) {
-        getMenuManager().addSeparatorAtIndex(index);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -327,7 +327,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given component into this context menu overlay at the given
+     * Adds the given component into the context menu overlay at the given
      * index.
      * <p>
      * For the common use case of having a list of high-lightable items inside
@@ -349,7 +349,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given component as the first child into this context menu
+     * Adds the given component as the first child into the context menu
      * overlay.
      * <p>
      * For the common use case of having a list of high-lightable items inside

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -279,53 +279,22 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     /**
      * @inheritDoc
      *
-     * @deprecated Since 24.8, use {@link #removeItem(Component...)} instead
      */
     @Deprecated(since = "24.8")
     @Override
-    public void remove(Component... components) {
-        removeItem(components);
     }
 
-    /**
-     * Removes the provided components from the context menu overlay.
-     *
-     * @param components
-     *            the components to remove
-     */
-    public void removeItem(Component... components) {
+    @Override
+    public void remove(Component... components) {
         getMenuManager().remove(components);
     }
 
     /**
-     * @inheritDoc
-     *
-     * @deprecated Since 24.8, use {@link #removeItem(Component...)} instead
-     */
-    @Deprecated(since = "24.8")
-    @Override
-    public void remove(Collection<Component> components) {
-        removeItem(components == null ? null
-                : components.toArray(new Component[0]));
-    }
-
-    /**
      * Removes all the child components. This also removes all the items added
      * with {@link #addItem(String)} and its overload methods.
-     *
-     * @deprecated Since 24.8, use {@link #removeAllItems()} instead
      */
-    @Deprecated(since = "24.8")
     @Override
     public void removeAll() {
-        removeAllItems();
-    }
-
-    /**
-     * Removes all the child components. This also removes all the items added
-     * with {@link #addItem(String)} and its overload methods.
-     */
-    public void removeAllItems() {
         getMenuManager().removeAll();
     }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -200,8 +200,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds a new item component with the given text content to the context menu
-     * overlay.
+     * Creates a new menu item with the given text content and adds it to the
+     * context menu overlay.
      *
      * @param text
      *            the text content for the created menu item
@@ -212,8 +212,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds a new item component with the given component to the context menu
-     * overlay.
+     * Creates a new menu item with the given component content and to the
+     * context menu overlay.
      *
      * @param component
      *            the component to add to the created menu item
@@ -225,6 +225,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Adds the given components into the context menu overlay.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, use {@link #addItem(String)} and its overload methods
+     * instead.
      * <p>
      * The added elements in the DOM will not be children of the
      * {@code <vaadin-context-menu>} element, but will be inserted into an
@@ -245,6 +249,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Adds the given components into the context menu overlay.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, use {@link #addItem(String)} and its overload methods
+     * instead.
      * <p>
      * The added elements in the DOM will not be children of the
      * {@code <vaadin-context-menu>} element, but will be inserted into an
@@ -272,6 +280,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Adds the given components into the context menu overlay.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, use {@link #addItem(String)} and its overload methods
+     * instead.
      * <p>
      * The added elements in the DOM will not be children of the
      * {@code <vaadin-context-menu>} element, but will be inserted into an
@@ -316,6 +328,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Adds the given component into this context menu at the given index.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, use {@link #addItem(String)} and its overload methods
+     * instead.
      * <p>
      * The added elements in the DOM will not be children of the
      * {@code <vaadin-context-menu>} element, but will be inserted into an

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -347,23 +347,24 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     @Deprecated(since = "24.8")
     @Override
     public void addComponentAtIndex(int index, Component component) {
-        addItemAtIndex(index, component);
+        getMenuManager().addComponentAtIndex(index, component);
     }
 
     /**
-     * Adds the given component into this context menu at the given index.
+     * Adds the given component into this context menu at the given index as an
+     * item.
      * <p>
      * The added elements in the DOM will not be children of the
      * {@code <vaadin-context-menu>} element, but will be inserted into an
      * overlay that is attached into the {@code <body>}.
      *
      * @param index
-     *            the index, where the component will be added
+     *            the index, where the item will be added
      * @param component
      *            the component to add
      */
     public void addItemAtIndex(int index, Component component) {
-        getMenuManager().addComponentAtIndex(index, component);
+        getMenuManager().addItemAtIndex(index, component);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/HasMenuItems.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/HasMenuItems.java
@@ -33,15 +33,8 @@ import com.vaadin.flow.component.ComponentEventListener;
 public interface HasMenuItems extends Serializable {
 
     /**
-     * Adds a new item component with the given text content and click listener
-     * to the context menu overlay.
-     * <p>
-     * This is a convenience method for the use case where you have a list of
-     * highlightable {@link MenuItem}s inside the overlay. If you want to
-     * configure the contents of the overlay without wrapping them inside
-     * {@link MenuItem}s, or if you just want to add some non-highlightable
-     * components between the items, use the
-     * {@link ContextMenu#add(Component...)} method.
+     * Creates a new menu item with the given text content and click listener
+     * and adds it to the context menu overlay.
      *
      * @param text
      *            the text content for the new item
@@ -57,15 +50,8 @@ public interface HasMenuItems extends Serializable {
             ComponentEventListener<ClickEvent<MenuItem>> clickListener);
 
     /**
-     * Adds a new item component with the given component and click listener to
-     * the context menu overlay.
-     * <p>
-     * This is a convenience method for the use case where you have a list of
-     * highlightable {@link MenuItem}s inside the overlay. If you want to
-     * configure the contents of the overlay without wrapping them inside
-     * {@link MenuItem}s, or if you just want to add some non-highlightable
-     * components between the items, use the
-     * {@link ContextMenu#add(Component...)} method.
+     * Creates a new menu item with the given component content and click
+     * listener and adds it to the context menu overlay.
      *
      * @param component
      *            the component inside the new item

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -221,7 +221,10 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      *
      * @see #add(Component...)
      * @see #remove(Component...)
+     * @deprecated Since 24.8, use {@link #addItemAtIndex(int, Component)} or
+     *             {@link #addSeparatorAtIndex(int)} instead
      */
+    @Deprecated(since = "24.8")
     public void addComponentAtIndex(int index, Component component) {
         if (parentMenuItem != null && parentMenuItem.isCheckable()) {
             throw new IllegalStateException(
@@ -234,6 +237,37 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
         }
         children.add(index, component);
         updateChildren();
+    }
+
+    /**
+     * Inserts component as a menu item to the (sub)menu using the
+     * {@code index}.
+     *
+     * @param index
+     *            index to insert, not negative
+     * @param component
+     *            the component for the menu item
+     *
+     * @see #addItem(Component)
+     * @see #remove(Component...)
+     *
+     * @return a new menu item
+     */
+    public I addItemAtIndex(int index, Component component) {
+        if (parentMenuItem != null && parentMenuItem.isCheckable()) {
+            throw new IllegalStateException(
+                    "A checkable item cannot have a sub menu");
+        }
+        Objects.requireNonNull(component, "Component should not be null");
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Cannot add a component with a negative index");
+        }
+        var menuItem = itemGenerator.apply(menu, contentReset);
+        children.add(index, menuItem);
+        updateChildren();
+        menuItem.add(component);
+        return menuItem;
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -266,6 +266,23 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Adds a separator between items.
+     */
+    public void addSeparator() {
+        add(new Hr());
+    }
+
+    /**
+     * Adds a separator between items using the {@code index}.
+     *
+     * @param index
+     *            index to insert, not negative
+     */
+    public void addSeparatorAtIndex(int index) {
+        addComponentAtIndex(index, new Hr());
+    }
+
     private void updateChildren() {
         contentReset.run();
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableRunnable;
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -156,7 +156,9 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      *            components to add
      * @see #remove(Component...)
      * @see #addComponentAtIndex(int, Component)
+     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
      */
+    @Deprecated(since = "24.8")
     public void add(Component... components) {
         if (parentMenuItem != null && parentMenuItem.isCheckable()) {
             throw new IllegalStateException(

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -243,37 +243,6 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
     }
 
     /**
-     * Inserts component as a menu item to the (sub)menu using the
-     * {@code index}.
-     *
-     * @param index
-     *            index to insert, not negative
-     * @param component
-     *            the component for the menu item
-     *
-     * @see #addItem(Component)
-     * @see #remove(Component...)
-     *
-     * @return a new menu item
-     */
-    public I addItemAtIndex(int index, Component component) {
-        if (parentMenuItem != null && parentMenuItem.isCheckable()) {
-            throw new IllegalStateException(
-                    "A checkable item cannot have a sub menu");
-        }
-        Objects.requireNonNull(component, "Component should not be null");
-        if (index < 0) {
-            throw new IllegalArgumentException(
-                    "Cannot add a component with a negative index");
-        }
-        var menuItem = itemGenerator.apply(menu, contentReset);
-        children.add(index, menuItem);
-        updateChildren();
-        menuItem.add(component);
-        return menuItem;
-    }
-
-    /**
      * Gets all (sub)menu children.
      * <p>
      * Children consist of components and items.
@@ -308,16 +277,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      */
     public void addSeparator() {
         add(new Hr());
-    }
-
-    /**
-     * Adds a separator between items using the {@code index}.
-     *
-     * @param index
-     *            index to insert, not negative
-     */
-    public void addSeparatorAtIndex(int index) {
-        addComponentAtIndex(index, new Hr());
+        addComponent(new Hr());
     }
 
     private void updateChildren() {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -156,10 +156,25 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      *            components to add
      * @see #remove(Component...)
      * @see #addComponentAtIndex(int, Component)
-     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
+     * @deprecated Since 24.8, use {@link #addComponent(Component...)} instead
      */
     @Deprecated(since = "24.8")
     public void add(Component... components) {
+        addComponent(components);
+    }
+
+    /**
+     * Adds components to the (sub)menu.
+     * <p>
+     * The components are added into the content as is, they are not wrapped as
+     * menu items.
+     *
+     * @param components
+     *            components to add
+     * @see #remove(Component...)
+     * @see #addComponentAtIndex(int, Component)
+     */
+    public void addComponent(Component... components) {
         if (parentMenuItem != null && parentMenuItem.isCheckable()) {
             throw new IllegalStateException(
                     "A checkable item cannot have a sub menu");
@@ -224,10 +239,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      *
      * @see #add(Component...)
      * @see #remove(Component...)
-     * @deprecated Since 24.8, use {@link #addItemAtIndex(int, Component)} or
-     *             {@link #addSeparatorAtIndex(int)} instead
      */
-    @Deprecated(since = "24.8")
     public void addComponentAtIndex(int index, Component component) {
         if (parentMenuItem != null && parentMenuItem.isCheckable()) {
             throw new IllegalStateException(
@@ -276,7 +288,6 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      * Adds a separator between items.
      */
     public void addSeparator() {
-        add(new Hr());
         addComponent(new Hr());
     }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.contextmenu;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.function.SerializableRunnable;
 
 /**
@@ -56,12 +55,5 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
         return new MenuManager<>(getParentMenuItem().getContextMenu(),
                 contentReset, MenuItem::new, MenuItem.class,
                 getParentMenuItem());
-    }
-
-    /**
-     * Adds a separator between items.
-     */
-    public void addSeparator() {
-        add(new Hr());
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -96,7 +96,9 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      *            the components to add
      * @see HasMenuItems#addItem(String, ComponentEventListener)
      * @see HasMenuItems#addItem(Component, ComponentEventListener)
+     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
      */
+    @Deprecated(since = "24.8")
     public void add(Component... components) {
         getMenuManager().add(components);
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -143,23 +143,6 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Adds the given component into the sub menu overlay at the given index as
-     * an item.
-     * <p>
-     * The added elements will be inserted into an overlay that is attached into
-     * the {@code <body>}.
-     *
-     * @param index
-     *            the index, where the item will be added
-     * @param component
-     *            the component to add
-     * @see #addItem(Component)
-     */
-    public void addItemAtIndex(int index, Component component) {
-        getMenuManager().addItemAtIndex(index, component);
-    }
-
-    /**
      * Gets the child components of this sub menu. This includes components
      * added with {@link #add(Component...)} and the {@link MenuItem} components
      * created with {@link #addItem(String)} and its overload methods. This
@@ -198,16 +181,6 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      */
     public void addSeparator() {
         getMenuManager().addSeparator();
-    }
-
-    /**
-     * Adds a separator between items using the {@code index}.
-     *
-     * @param index
-     *            index to insert, not negative
-     */
-    public void addSeparatorAtIndex(int index) {
-        getMenuManager().addSeparatorAtIndex(index);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -45,14 +45,8 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Adds a new item component with the given text content to the sub menu
-     * overlay.
-     * <p>
-     * This is a convenience method for the use case where you have a list of
-     * highlightable {@link MenuItem}s inside the overlay. If you want to
-     * configure the contents of the overlay without wrapping them inside
-     * {@link MenuItem}s, or if you just want to add some non-highlightable
-     * components between the items, use the {@link #add(Component...)} method.
+     * Creates a new menu item with the given text content and adds it to the
+     * sub menu overlay.
      *
      * @param text
      *            the text content for the created menu item
@@ -64,14 +58,8 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Adds a new item component with the given component to the sub menu
-     * overlay.
-     * <p>
-     * This is a convenience method for the use case where you have a list of
-     * highlightable {@link MenuItem}s inside the overlay. If you want to
-     * configure the contents of the overlay without wrapping them inside
-     * {@link MenuItem}s, or if you just want to add some non-highlightable
-     * components between the items, use the {@link #add(Component...)} method.
+     * Creates a new menu item with the given component content and adds it to
+     * the sub menu overlay.
      *
      * @param component
      *            the component to add to the created menu item
@@ -86,7 +74,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      * Adds the given components into the sub menu overlay.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, you can use the {@link #addItem(String)} convenience methods
+     * the overlay, use {@link #addItem(String)} and its overload methods
      * instead.
      * <p>
      * The added elements will be inserted into an overlay that is attached into
@@ -107,7 +95,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      * Adds the given components into the sub menu overlay.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, you can use the {@link #addItem(String)} convenience methods
+     * the overlay, use {@link #addItem(String)} and its overload methods
      * instead.
      * <p>
      * The added elements will be inserted into an overlay that is attached into
@@ -144,6 +132,10 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
 
     /**
      * Adds the given component into the sub menu overlay at the given index.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, use {@link #addItem(String)} and its overload methods
+     * instead.
      * <p>
      * The added elements will be inserted into an overlay that is attached into
      * the {@code <body>}.

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -172,6 +172,13 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
+     * Adds a separator between items.
+     */
+    public void addSeparator() {
+        getMenuManager().addSeparator();
+    }
+
+    /**
      * Gets a (sub) menu manager.
      *
      * @return

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -179,6 +179,16 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
+     * Adds a separator between items using the {@code index}.
+     *
+     * @param index
+     *            index to insert, not negative
+     */
+    public void addSeparatorAtIndex(int index) {
+        getMenuManager().addSeparatorAtIndex(index);
+    }
+
+    /**
      * Gets a (sub) menu manager.
      *
      * @return

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -132,9 +132,29 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      * @param component
      *            the component to add
      * @see #add(Component...)
+     * @deprecated Since 24.8, use {@link #addItemAtIndex(int, Component)}
+     *             instead
      */
+    @Deprecated(since = "24.8")
     public void addComponentAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);
+    }
+
+    /**
+     * Adds the given component into the sub menu overlay at the given index as
+     * an item.
+     * <p>
+     * The added elements will be inserted into an overlay that is attached into
+     * the {@code <body>}.
+     *
+     * @param index
+     *            the index, where the item will be added
+     * @param component
+     *            the component to add
+     * @see #addItem(Component)
+     */
+    public void addItemAtIndex(int index, Component component) {
+        getMenuManager().addItemAtIndex(index, component);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -96,11 +96,30 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      *            the components to add
      * @see HasMenuItems#addItem(String, ComponentEventListener)
      * @see HasMenuItems#addItem(Component, ComponentEventListener)
-     * @deprecated Since 24.8, use {@link #addItem(Component)} instead
+     * @deprecated Since 24.8, use {@link #addComponent(Component...)} instead
      */
     @Deprecated(since = "24.8")
     public void add(Component... components) {
-        getMenuManager().add(components);
+        addComponent(components);
+    }
+
+    /**
+     * Adds the given components into the sub menu overlay.
+     * <p>
+     * For the common use case of having a list of high-lightable items inside
+     * the overlay, you can use the {@link #addItem(String)} convenience methods
+     * instead.
+     * <p>
+     * The added elements will be inserted into an overlay that is attached into
+     * the {@code <body>}.
+     *
+     * @param components
+     *            the components to add
+     * @see HasMenuItems#addItem(String, ComponentEventListener)
+     * @see HasMenuItems#addItem(Component, ComponentEventListener)
+     */
+    public void addComponent(Component... components) {
+        getMenuManager().addComponent(components);
     }
 
     /**
@@ -134,10 +153,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      * @param component
      *            the component to add
      * @see #add(Component...)
-     * @deprecated Since 24.8, use {@link #addItemAtIndex(int, Component)}
-     *             instead
      */
-    @Deprecated(since = "24.8")
     public void addComponentAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);
     }


### PR DESCRIPTION
## Description

This PR

- deprecates all `HasComponents` `add` API and introduces `addComponent` as an alternative
- updates JavaDocs based on the deprecations
- moves `addSeperator` methods to base classes

Part of #5532 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.