### PR TITLE
refactor: do not keep column id map in gridpro (#7356) (CP: 23.6) 

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3021,13 +3021,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     /**
      * Gets a {@link Column} of this grid by its internal id ({@code _flowId}).
+     * Intended only for internal use and can be removed in the future.
      *
      * @param internalId
      *            the internal identifier of the column to get
      * @return the column corresponding to the given column identifier, or
      *         {@code null} if no column has such an identifier
      */
-    Column<T> getColumnByInternalId(String internalId) {
+    protected final Column<T> getColumnByInternalId(String internalId) {
         return idToColumnMap.get(internalId);
     }
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -296,6 +296,23 @@ public class BasicIT extends AbstractParallelTest {
                 getPanelText("events-panel").contains("ItemPropertyChanged"));
     }
 
+    @Test
+    public void columnWithManualRefresh_updateProperty_propertyUpdatedCorrectly() {
+        Assert.assertEquals("Person 1", grid.getCell(0, 1).getInnerHTML());
+
+        assertCellEnterEditModeOnDoubleClick(0, 1,
+                "vaadin-grid-pro-edit-text-field");
+
+        var textField = grid.getCell(0, 1).$("vaadin-grid-pro-edit-text-field")
+                .first();
+
+        textField.setProperty("value", "Updated Person 1");
+        textField.sendKeys(Keys.ENTER);
+
+        Assert.assertEquals("Updated Person 1",
+                grid.getCell(0, 1).getInnerHTML());
+    }
+
     private void assertCellEnterEditModeOnDoubleClick(Integer rowIndex,
             Integer colIndex, String editorTag) {
         assertCellEnterEditModeOnDoubleClick(rowIndex, colIndex, editorTag,

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -8,9 +8,7 @@
  */
 package com.vaadin.flow.component.gridpro;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -65,8 +63,6 @@ import elemental.json.JsonObject;
  */
 public class GridPro<E> extends Grid<E> {
 
-    private Map<String, Column<E>> idToColumnMap = new HashMap<>();
-
     /**
      * Instantiates a new CrudGrid for the supplied bean type.
      *
@@ -114,8 +110,8 @@ public class GridPro<E> extends Grid<E> {
             if (e.getItem() == null) {
                 return;
             }
-            EditColumn<E> column = (EditColumn<E>) this.idToColumnMap
-                    .get(e.getPath());
+            EditColumn<E> column = (EditColumn<E>) getColumnByInternalId(
+                    e.getPath());
 
             Object idBeforeUpdate = getItemId(e.getItem());
             if (column.getEditorType().equals("custom")) {
@@ -138,8 +134,8 @@ public class GridPro<E> extends Grid<E> {
         });
 
         addCellEditStartedListener(e -> {
-            EditColumn<E> column = (EditColumn<E>) this.idToColumnMap
-                    .get(e.getPath());
+            EditColumn<E> column = (EditColumn<E>) getColumnByInternalId(
+                    e.getPath());
 
             if (column.getEditorType().equals("custom")) {
                 column.getEditorField()
@@ -350,7 +346,6 @@ public class GridPro<E> extends Grid<E> {
                         return "";
                     }
                 }, renderer)), this::createEditColumn);
-        idToColumnMap.put(columnId, column);
 
         return new EditColumnConfigurator<>(column, valueProvider);
     }
@@ -499,7 +494,6 @@ public class GridPro<E> extends Grid<E> {
     protected EditColumn<E> createEditColumn(Renderer<E> renderer,
             String columnId) {
         EditColumn<E> column = new EditColumn<>(this, columnId, renderer);
-        idToColumnMap.put(columnId, column);
         return column;
     }
 


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/flow-components/pull/7356 to v23.6.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.