### PR TITLE
test: extract more MenuBar ITs into separate files

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarDetachReattachPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarDetachReattachPage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-menu-bar/detach-reattach")
+public class MenuBarDetachReattachPage extends Div {
+
+    public MenuBarDetachReattachPage() {
+        MenuBar menuBar = new MenuBar();
+
+        MenuItem item1 = menuBar.addItem("item 1");
+        MenuItem item2 = menuBar.addItem(new Span("item 2"));
+
+        NativeButton setWidthButton = new NativeButton("set width 140px", e -> {
+            setWidth("140px");
+        });
+        setWidthButton.setId("set-width");
+
+        NativeButton resetWidthButton = new NativeButton("reset width", e -> {
+            setWidth("auto");
+        });
+        resetWidthButton.setId("reset-width");
+
+        NativeButton toggleAttachedButton = new NativeButton("toggle attached",
+                e -> {
+                    if (menuBar.getParent().isPresent()) {
+                        remove(menuBar);
+                    } else {
+                        add(menuBar);
+                    }
+                });
+        toggleAttachedButton.setId("toggle-attached");
+
+        NativeButton toggleItem2VisibilityButton = new NativeButton(
+                "toggle item 2 visibility",
+                e -> item2.setVisible(!item2.isVisible()));
+        toggleItem2VisibilityButton.setId("toggle-item-2-visibility");
+
+        NativeButton setI18nButton = new NativeButton("set i18n",
+                e -> menuBar.setI18n(new MenuBar.MenuBarI18n()
+                        .setMoreOptions("more-options")));
+        setI18nButton.setId("set-i18n");
+
+        add(setWidthButton, resetWidthButton, toggleAttachedButton,
+                toggleItem2VisibilityButton, setI18nButton);
+
+        add(new Hr(), menuBar);
+    }
+
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarPreserveOnRefreshPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarPreserveOnRefreshPage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-menu-bar/preserve-on-refresh")
+@PreserveOnRefresh
+public class MenuBarPreserveOnRefreshPage extends Div {
+
+    public MenuBarPreserveOnRefreshPage() {
+        MenuBar menuBar = new MenuBar();
+
+        MenuItem item1 = menuBar.addItem("item 1");
+        MenuItem item2 = menuBar.addItem(new Span("item 2"));
+
+        NativeButton toggleItem2VisibilityButton = new NativeButton(
+                "toggle item 2 visibility",
+                e -> item2.setVisible(!item2.isVisible()));
+        toggleItem2VisibilityButton.setId("toggle-item-2-visibility");
+
+        add(toggleItem2VisibilityButton);
+
+        add(new Hr(), menuBar);
+    }
+
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -21,11 +21,9 @@ import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.menubar.MenuBar;
-import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-menu-bar/menu-bar-test")
-@PreserveOnRefresh
 public class MenuBarTestPage extends Div {
 
     public MenuBarTestPage() {
@@ -100,26 +98,10 @@ public class MenuBarTestPage extends Div {
                 e -> checkable.setChecked(!checkable.isChecked()));
         checkedButton.setId("toggle-checked");
 
-        NativeButton toggleAttachedButton = new NativeButton("toggle attached",
-                e -> {
-                    if (menuBar.getParent().isPresent()) {
-                        remove(menuBar);
-                    } else {
-                        add(menuBar);
-                    }
-                });
-        toggleAttachedButton.setId("toggle-attached");
-
-        NativeButton setI18nButton = new NativeButton("set i18n",
-                e -> menuBar.setI18n(new MenuBar.MenuBarI18n()
-                        .setMoreOptions("more-options")));
-        setI18nButton.setId("set-i18n");
-
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
                 disableItemButton, toggleItem1VisibilityButton,
-                toggleItem2VisibilityButton, checkedButton,
-                toggleAttachedButton, setI18nButton, toggleAttachedButton);
+                toggleItem2VisibilityButton, checkedButton);
     }
 
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarDetachReattachIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarDetachReattachIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-menu-bar/detach-reattach")
+public class MenuBarDetachReattachIT extends AbstractComponentIT {
+
+    private MenuBarElement menuBar;
+
+    @Before
+    public void init() {
+        open();
+        menuBar = $(MenuBarElement.class).waitForFirst();
+    }
+
+    @Test
+    public void detach_reattach_noClientErrors_clientCodeFunctional() {
+        click("toggle-attached");
+        click("toggle-attached");
+        waitForElementPresent(By.tagName("vaadin-menu-bar"));
+        checkLogsForErrors();
+
+        // Verify client-code with setVisible functionality:
+        menuBar = $(MenuBarElement.class).first();
+        click("toggle-item-2-visibility");
+        assertButtonContents("item 1");
+    }
+
+    @Test
+    public void setI18n_i18nIsUpdated() {
+        click("set-width");
+
+        waitForResizeObserver();
+
+        TestBenchElement overflowButton = menuBar.getOverflowButton();
+
+        Assert.assertEquals("More options",
+                overflowButton.getDomAttribute("aria-label"));
+
+        click("set-i18n");
+
+        Assert.assertEquals("more-options",
+                overflowButton.getDomAttribute("aria-label"));
+    }
+
+    @Test
+    public void setI18n_detach_attach_i18nIsPersisted() {
+        click("set-width");
+
+        waitForResizeObserver();
+
+        click("set-i18n");
+
+        TestBenchElement overflowButton = menuBar.getOverflowButton();
+
+        Assert.assertEquals("more-options",
+                overflowButton.getDomAttribute("aria-label"));
+
+        click("toggle-attached");
+        click("toggle-attached");
+
+        menuBar = $(MenuBarElement.class).first();
+        overflowButton = menuBar.getOverflowButton();
+
+        Assert.assertEquals("more-options",
+                overflowButton.getDomAttribute("aria-label"));
+    }
+
+    private void assertButtonContents(String... expectedInnerHTML) {
+        String[] contents = menuBar.getButtons().stream().map(button -> button
+                .$("vaadin-menu-bar-item").first().getDomProperty("innerHTML"))
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(expectedInnerHTML, contents);
+    }
+
+    private void click(String id) {
+        findElement(By.id(id)).click();
+    }
+
+    private void waitForResizeObserver() {
+        getCommandExecutor().getDriver()
+                .executeAsyncScript("requestAnimationFrame(arguments[0])");
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -351,68 +351,6 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void detach_reattach_noClientErrors_clientCodeFunctional() {
-        click("toggle-attached");
-        click("toggle-attached");
-        waitForElementPresent(By.tagName("vaadin-menu-bar"));
-        checkLogsForErrors();
-
-        // Verify client-code with setVisible functionality:
-        menuBar = $(MenuBarElement.class).first();
-        click("toggle-item-2-visibility");
-        assertButtonContents("item 1");
-    }
-
-    @Test
-    public void preserveOnRefresh_refresh_noClientErrors_clientCodeFunctional() {
-        getDriver().navigate().refresh();
-        waitForElementPresent(By.tagName("vaadin-menu-bar"));
-        checkLogsForErrors();
-
-        // Verify client-code with setVisible functionality:
-        menuBar = $(MenuBarElement.class).first();
-        click("toggle-item-2-visibility");
-        assertButtonContents("item 1");
-    }
-
-    @Test
-    public void setI18n_i18nIsUpdated() {
-        click("set-width");
-        waitForResizeObserver();
-        click("add-root-item");
-        TestBenchElement overflowButton = menuBar.getOverflowButton();
-
-        Assert.assertEquals("More options",
-                overflowButton.getDomAttribute("aria-label"));
-
-        click("set-i18n");
-
-        Assert.assertEquals("more-options",
-                overflowButton.getDomAttribute("aria-label"));
-    }
-
-    @Test
-    public void setI18n_detach_attach_i18nIsPersisted() {
-        click("set-width");
-        waitForResizeObserver();
-        click("add-root-item");
-        click("set-i18n");
-        TestBenchElement overflowButton = menuBar.getOverflowButton();
-
-        Assert.assertEquals("more-options",
-                overflowButton.getDomAttribute("aria-label"));
-
-        click("toggle-attached");
-        click("toggle-attached");
-
-        menuBar = $(MenuBarElement.class).first();
-        overflowButton = menuBar.getOverflowButton();
-
-        Assert.assertEquals("more-options",
-                overflowButton.getDomAttribute("aria-label"));
-    }
-
-    @Test
     public void addSubItem_clickMenuItem_clickButton_subMenuOpenedAndClosed() {
         click("add-sub-item");
         menuBar.getButtons().get(1).$("vaadin-menu-bar-item").first().click();

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPreserveOnRefreshIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPreserveOnRefreshIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-menu-bar/preserve-on-refresh")
+public class MenuBarPreserveOnRefreshIT extends AbstractComponentIT {
+
+    private MenuBarElement menuBar;
+
+    @Before
+    public void init() {
+        open();
+        menuBar = $(MenuBarElement.class).waitForFirst();
+    }
+
+    @Test
+    public void preserveOnRefresh_refresh_noClientErrors_clientCodeFunctional() {
+        getDriver().navigate().refresh();
+        waitForElementPresent(By.tagName("vaadin-menu-bar"));
+        checkLogsForErrors();
+
+        // Verify client-code with setVisible functionality:
+        menuBar = $(MenuBarElement.class).first();
+        click("toggle-item-2-visibility");
+        assertButtonContents("item 1");
+    }
+
+    private void assertButtonContents(String... expectedInnerHTML) {
+        String[] contents = menuBar.getButtons().stream().map(button -> button
+                .$("vaadin-menu-bar-item").first().getDomProperty("innerHTML"))
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(expectedInnerHTML, contents);
+    }
+
+    private void click(String id) {
+        findElement(By.id(id)).click();
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #7355

Extracted some ITs that are usually placed in separate files in other components:

- `MenuBarDetachReattachIT`
- `MenuBarPreserveOnRefreshIT`

This also makes it easier to debug tests when serving `MenuBarTestPage` manually as `@PreserveOnRefresh` is now removed (with that annotation, all the changes were preserved on browser tab reload which sometimes can be undesired).

## Type of change

- Test