### PR TITLE
test: use global CSS for menu-bar not animated styles

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/frontend/menu-bar-not-animated-styles.css
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/frontend/menu-bar-not-animated-styles.css
@@ -1,0 +1,6 @@
+vaadin-menu-bar-overlay[opening],
+vaadin-menu-bar-overlay[closing],
+vaadin-menu-bar-overlay[opening]::part(overlay),
+vaadin-menu-bar-overlay[closing]::part(overlay) {
+  animation: none !important;
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/frontend/not-animated-styles.css
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/frontend/not-animated-styles.css
@@ -1,6 +1,0 @@
-:host([opening]),
-:host([closing]),
-:host([opening]) [part='overlay'],
-:host([closing]) [part='overlay'] {
-  animation: none !important;
-}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarClassNamesPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarClassNamesPage.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.router.Route;
 
-@CssImport(value = "./not-animated-styles.css", themeFor = "vaadin-menu-bar-overlay")
+@CssImport("./menu-bar-not-animated-styles.css")
 @Route("vaadin-menu-bar/menu-bar-class-names")
 public class MenuBarClassNamesPage extends Div {
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarThemePage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarThemePage.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.router.Route;
 
-@CssImport(value = "./not-animated-styles.css", themeFor = "vaadin-menu-bar-overlay")
+@CssImport("./menu-bar-not-animated-styles.css")
 @Route("vaadin-menu-bar/menu-bar-theme")
 public class MenuBarThemePage extends Div {
 


### PR DESCRIPTION
## Description

Updated not animated styles to use global CSS instead of `themeFor`. This is needed because on `lit-components-test` branch with `useLitWebComponents()` there are 2 versions of Lit loaded and styles added with `registerStyles()` do not apply. Using global CSS prevents this, and also makes more sense as `themeFor` is going to be deprecated in V25.

Also renamed the file to add `menu-bar-` prefix to avoid potential problems with merging ITs if we add more such files.

## Type of change

- Test