### PR TITLE
fix: use optional chaining for cell button in the connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -1103,7 +1103,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     if (
       content.some((node) => {
         // Ignore focus buttons that the component renders into cells in focus button mode on MacOS
-        const focusable = cell._focusButton !== node && isFocusable(node);
+        const focusable = cell?._focusButton !== node && isFocusable(node);
         return focusable || node instanceof HTMLLabelElement;
       })
     ) {


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/flow-components/pull/7232

Use optional chaining to avoid errors when clicking on empty grid, in which case click is on the `<tbody>` element and reference to the `cell` becomes `undefined`. Not sure if this needs a test, ideally it should be handled by TS but that would require enabling [`"noUncheckedIndexedAccess": true`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess) and then also removing `// @ts-nocheck` from the connector.

## Type of change

- Bugfix