### PR TITLE
test: cleanup Button theme variants IT covered by unit test

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Image;
@@ -52,7 +51,6 @@ public class ButtonView extends Div {
         createButtonWithDisableOnClickThatEnablesInSameRoundTrip();
         createButtonWithDisableOnClickThatIsHidden();
         createButtonWithDisableOnClickAndPointerEventsAuto();
-        addVariantsFeature();
         createButtonsWithShortcuts();
 
         message = new Div();
@@ -137,19 +135,6 @@ public class ButtonView extends Div {
                 + evt.getSource().getText()
                 + " was clicked, but the button is disabled and this shouldn't happen!"));
         button.setId("disabled-button");
-    }
-
-    private void addVariantsFeature() {
-        Button button = new Button("Button");
-        button.setId("button-theme-variants");
-        button.addThemeVariants(ButtonVariant.LUMO_SMALL,
-                ButtonVariant.LUMO_PRIMARY);
-
-        Button removeVariantButton = new Button("Remove theme variant", e -> {
-            button.removeThemeVariants(ButtonVariant.LUMO_SMALL);
-        });
-        removeVariantButton.setId("remove-theme-variant-button");
-        addCard("Button theme variants", button, removeVariantButton);
     }
 
     private void createButtonsWithShortcuts() {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -87,7 +87,7 @@ public class ButtonIT extends AbstractComponentIT {
 
         buttonElements = $(ButtonElement.class)
                 .withText("button", ButtonIT::containsIgnoreCase).all();
-        Assert.assertEquals(4, buttonElements.size());
+        Assert.assertEquals(3, buttonElements.size());
     }
 
     @Test

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -410,15 +410,6 @@ public class ButtonIT extends AbstractComponentIT {
         });
     }
 
-    @Test
-    public void assertVariants() {
-        WebElement button = findElement(By.id("button-theme-variants"));
-        Assert.assertEquals("small primary", button.getDomAttribute("theme"));
-
-        findElement(By.id("remove-theme-variant-button")).click();
-        Assert.assertEquals("primary", button.getDomAttribute("theme"));
-    }
-
     private int getCenterX(WebElement element) {
         return element.getLocation().getX() + element.getSize().getWidth() / 2;
     }


### PR DESCRIPTION
## Description

The logic for adding / removing theme variants on `Button` was covered by unit tests when adding `HasThemeVariant`, see https://github.com/vaadin/flow-components/pull/3284 and https://github.com/vaadin/flow-components/pull/3431. Removed the IT which is redundant so that we don't use Lumo related variant.

## Type of change

- Test