### PR TITLE
test: remove DateTimePicker theme variant IT covered by unit test

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerPage.java
@@ -89,13 +89,6 @@ public class DateTimePickerPage extends Div {
         picker5.setId("date-time-picker-high-precision-initial-value");
 
         add(new Hr(), new H1("Set initial value with high precision"), picker5);
-
-        // Set variant
-        DateTimePicker picker6 = new DateTimePicker();
-        picker6.addThemeVariants(DateTimePickerVariant.LUMO_SMALL);
-        picker6.setId("date-time-picker-variant");
-
-        add(new Hr(), new H1("Small variant"), picker6);
     }
 
     private void updateMessage(Div message, DateTimePicker dateTimePicker) {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
@@ -177,12 +177,4 @@ public class DateTimePickerIT extends AbstractComponentIT {
 
         checkLogsForErrors();
     }
-
-    @Test
-    public void testSmallVariantHasTheme() {
-        DateTimePickerElement picker = $(DateTimePickerElement.class)
-                .id("date-time-picker-variant");
-
-        Assert.assertEquals("small", picker.getDomAttribute("theme"));
-    }
 }


### PR DESCRIPTION
## Description

This IT was added in https://github.com/vaadin/flow-components/pull/2887 alongside with unit tests. Later on the component was updated to use `HasThemeVariant` in https://github.com/vaadin/flow-components/pull/4409 and IMO this IT is now redundant. Let's remove it for consistency with other components, unit tests are enough.

## Type of change

- Test