### PR TITLE
test: cleanup no longer needed Checkbox setAriaLabel IT

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxDemoPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxDemoPage.java
@@ -37,7 +37,6 @@ public class CheckboxDemoPage extends Div {
         addDisabledCheckbox();
         addIndeterminateCheckbox();
         addValueChangeCheckbox();
-        addAccessibleCheckbox();
         addCheckboxImgComponentLabel();
     }
 
@@ -92,13 +91,6 @@ public class CheckboxDemoPage extends Div {
                 message);
         valueChangeCheckbox.setId("value-change-checkbox");
         message.setId("value-change-checkbox-message");
-    }
-
-    private void addAccessibleCheckbox() {
-        Checkbox accessibleCheckbox = new Checkbox("Accessible Checkbox");
-        accessibleCheckbox.setAriaLabel("Click me");
-        addCard("Checkbox with Custom Accessible Label", accessibleCheckbox);
-        accessibleCheckbox.setId("accessible-checkbox");
     }
 
     private void addCheckboxImgComponentLabel() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxIT.java
@@ -134,16 +134,6 @@ public class CheckboxIT extends AbstractComponentIT {
     }
 
     @Test
-    public void accessibleCheckbox() {
-        WebElement checkbox = layout.findElement(By.id("accessible-checkbox"));
-        WebElement inputElement = checkbox
-                .findElement(By.cssSelector("[slot=input]"));
-        Assert.assertEquals(
-                "Accessible checkbox should have the aria-label attribute",
-                "Click me", inputElement.getDomAttribute("aria-label"));
-    }
-
-    @Test
     public void imgCheckbox_clickOnLabel_checkboxIsChecked() {
         CheckboxElement checkbox = $(CheckboxElement.class)
                 .id("img-component-label-checkbox");


### PR DESCRIPTION
## Description

The IT for `setAriaLabel()` API only exists in Checkbox and was needed because it used to have custom JS logic. It was changed to `accessibleName` in https://github.com/vaadin/flow-components/pull/6808 to align with other components. As discussed in https://github.com/vaadin/flow-components/pull/4760#discussion_r1137039789, we haven't been adding Integration tests for the `HasAriaLabel` functionality so the IT can be removed.

## Type of change

- Test