### PR TITLE
test: cleanup TextField ITs for features covered by unit tests

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPage.java
@@ -45,11 +45,6 @@ public class BigDecimalFieldPage extends Div {
                 e -> field.setReadOnly(!field.isReadOnly()));
         toggleReadOnly.setId("toggle-read-only");
 
-        NativeButton toggleRequired = new NativeButton("toggle required",
-                e -> field.setRequiredIndicatorVisible(
-                        !field.isRequiredIndicatorVisible()));
-        toggleRequired.setId("toggle-required");
-
         NativeButton toggleEnabled = new NativeButton("toggle enabled",
                 e -> field.setEnabled(!field.isEnabled()));
         toggleEnabled.setId("toggle-enabled");
@@ -63,8 +58,8 @@ public class BigDecimalFieldPage extends Div {
         fieldWithClearButton.setId("clear-big-decimal-field");
         fieldWithClearButton.addValueChangeListener(this::logValueChangeEvent);
 
-        Div buttons = new Div(setValueWithScale, toggleReadOnly, toggleRequired,
-                toggleEnabled, setFrenchLocale);
+        Div buttons = new Div(setValueWithScale, toggleReadOnly, toggleEnabled,
+                setFrenchLocale);
         add(field, buttons, fieldWithClearButton, messageContainer);
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/EmailFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/EmailFieldPage.java
@@ -45,14 +45,6 @@ public class EmailFieldPage extends Div {
                 event -> emailField.setReadOnly(!emailField.isReadOnly()));
         add(button);
 
-        NativeButton required = new NativeButton(
-                "Set/unset field required property");
-        required.setId("required");
-        required.addClickListener(
-                event -> emailField.setRequiredIndicatorVisible(
-                        !emailField.isRequiredIndicatorVisible()));
-        add(required);
-
         NativeButton enabled = new NativeButton(
                 "Set/unset field enabled property");
         enabled.setId("disabled");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPage.java
@@ -44,13 +44,6 @@ public class IntegerFieldPage extends Div {
                 event -> integerField.setReadOnly(!integerField.isReadOnly()));
         add(toggleReadOnly);
 
-        NativeButton required = new NativeButton("Toggle required");
-        required.setId("toggle-required");
-        required.addClickListener(
-                event -> integerField.setRequiredIndicatorVisible(
-                        !integerField.isRequiredIndicatorVisible()));
-        add(required);
-
         NativeButton toggleEnabled = new NativeButton("Toggle enabled");
         toggleEnabled.setId("toggle-enabled");
         toggleEnabled.addClickListener(

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldPage.java
@@ -19,7 +19,6 @@ import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.HasValue.ValueChangeListener;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.router.Route;
 
@@ -75,7 +74,6 @@ public class NumberFieldPage extends Div {
                 logValueChangeListener(stepValueMessage));
 
         add(numberFieldStep, stepValueMessage);
-        addNumberFields();
     }
 
     private ValueChangeListener<? super ComponentValueChangeEvent<NumberField, Double>> logValueChangeListener(
@@ -83,27 +81,5 @@ public class NumberFieldPage extends Div {
         return event -> stepValueMessage
                 .setText(String.format("Old value: '%s'. New value: '%s'.",
                         event.getOldValue(), event.getValue()));
-    }
-
-    private void addNumberFields() {
-        NumberField dollarField = new NumberField("Dollars");
-        dollarField.setPrefixComponent(new Span("$"));
-
-        NumberField euroField = new NumberField("Euros");
-        euroField.setSuffixComponent(new Span("€"));
-
-        NumberField stepperField = new NumberField("Stepper");
-        stepperField.setValue(1d);
-        stepperField.setMin(0);
-        stepperField.setMax(10);
-        stepperField.setStepButtonsVisible(true);
-
-        euroField.setSuffixComponent(new Span("€"));
-
-        dollarField.setId("dollar-field");
-        euroField.setId("euro-field");
-        stepperField.setId("step-number-field-2");
-
-        add(dollarField, euroField, stepperField);
     }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/NumberFieldPage.java
@@ -46,14 +46,6 @@ public class NumberFieldPage extends Div {
                 event -> numberField.setReadOnly(!numberField.isReadOnly()));
         add(button);
 
-        NativeButton required = new NativeButton(
-                "Set/unset field required property");
-        required.setId("required");
-        required.addClickListener(
-                event -> numberField.setRequiredIndicatorVisible(
-                        !numberField.isRequiredIndicatorVisible()));
-        add(required);
-
         NativeButton enabled = new NativeButton(
                 "Set/unset field enabled property");
         enabled.setId("disabled");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPage.java
@@ -82,7 +82,6 @@ public class PasswordFieldPage extends Div {
 
         PasswordField passwordField = new PasswordField();
         passwordField.setLabel("Password field label");
-        passwordField.setPlaceholder("placeholder text");
         passwordField.addValueChangeListener(event -> message.setText(
                 String.format("Password field value changed from '%s' to '%s'",
                         event.getOldValue(), event.getValue())));

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPage.java
@@ -46,14 +46,6 @@ public class PasswordFieldPage extends Div {
                 .setReadOnly(!passwordField.isReadOnly()));
         add(button);
 
-        NativeButton required = new NativeButton(
-                "Set/unset field required property");
-        required.setId("required");
-        required.addClickListener(
-                event -> passwordField.setRequiredIndicatorVisible(
-                        !passwordField.isRequiredIndicatorVisible()));
-        add(required);
-
         PasswordField passwordFieldClear = new PasswordField();
         passwordFieldClear.setId("clear-password-field");
         passwordFieldClear.getStyle().set("display", "block");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextAreaPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextAreaPage.java
@@ -77,7 +77,6 @@ public class TextAreaPage extends Div {
         Div message = new Div();
         TextArea textArea = new TextArea();
         textArea.setLabel("Text area label");
-        textArea.setPlaceholder("placeholder text");
         textArea.addValueChangeListener(event -> message.setText(
                 String.format("Text area value changed from '%s' to '%s'",
                         event.getOldValue(), event.getValue())));

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextFieldPage.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextFieldPage.java
@@ -52,14 +52,6 @@ public class TextFieldPage extends Div {
                 event -> textField.setReadOnly(!textField.isReadOnly()));
         add(button);
 
-        NativeButton required = new NativeButton(
-                "Set/unset field required property");
-        required.setId("required");
-        required.addClickListener(
-                event -> textField.setRequiredIndicatorVisible(
-                        !textField.isRequiredIndicatorVisible()));
-        add(required);
-
         TextField valueChangeSource = new TextField();
         valueChangeSource.getStyle().set("display", "block");
         valueChangeSource.setId("value-change");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertFalse;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 
 import java.util.List;
 
@@ -145,18 +144,6 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
         toggleEnabled.click();
         field.setValue("987");
         assertValueChange(2, 123, 987);
-    }
-
-    @Test
-    public void assertRequired() {
-        assertFalse(field.hasAttribute("required"));
-
-        WebElement toggleRequired = findElement(By.id("toggle-required"));
-        toggleRequired.click();
-        waitUntil(attributeToBe(field, "required", "true"));
-
-        toggleRequired.click();
-        waitUntil(attributeToBe(field, "required", ""));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldPageIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertFalse;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -93,20 +92,6 @@ public class EmailFieldPageIT extends AbstractComponentIT {
         Assert.assertEquals(
                 "Old value: 'mail@domain.com'. New value: 'yetanother@domain.com'.",
                 messageDiv.getText());
-    }
-
-    @Test
-    public void assertRequired() {
-        EmailFieldElement emailField = $(EmailFieldElement.class).first();
-
-        assertFalse(emailField.hasAttribute("required"));
-
-        WebElement button = findElement(By.id("required"));
-        button.click();
-        waitUntil(attributeToBe(emailField, "required", "true"));
-
-        button.click();
-        waitUntil(attributeToBe(emailField, "required", ""));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPageIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertFalse;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 
 import java.util.List;
 
@@ -102,18 +101,6 @@ public class IntegerFieldPageIT extends AbstractComponentIT {
         toggleEnabled.click();
         field.setValue("987");
         assertValueChange(2, 123, 987);
-    }
-
-    @Test
-    public void assertRequired() {
-        assertFalse(field.hasAttribute("required"));
-
-        WebElement toggleRequired = findElement(By.id("toggle-required"));
-        toggleRequired.click();
-        waitUntil(attributeToBe(field, "required", "true"));
-
-        toggleRequired.click();
-        waitUntil(attributeToBe(field, "required", ""));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import static org.junit.Assert.assertFalse;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -100,20 +99,6 @@ public class NumberFieldPageIT extends AbstractComponentIT {
         numberField.setValue("987");
         Assert.assertEquals("Old value: '123.0'. New value: '987.0'.",
                 messageDiv.getText());
-    }
-
-    @Test
-    public void assertRequired() {
-        NumberFieldElement numberField = $(NumberFieldElement.class).first();
-
-        assertFalse(numberField.hasAttribute("required"));
-
-        WebElement button = findElement(By.id("required"));
-        button.click();
-        waitUntil(attributeToBe(numberField, "required", "true"));
-
-        button.click();
-        waitUntil(attributeToBe(numberField, "required", ""));
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
@@ -138,36 +138,4 @@ public class NumberFieldPageIT extends AbstractComponentIT {
         String message = $("div").id("clear-message").getText();
         Assert.assertEquals("Old value: 'null'. New value: '123.0'.", message);
     }
-
-    @Test
-    public void dollarFieldHasDollarPrefix() {
-        WebElement dollarField = findElement(By.id("dollar-field"));
-        WebElement span = dollarField.findElement(By.tagName("span"));
-
-        Assert.assertEquals("$", span.getText());
-
-        int spanX = span.getLocation().getX();
-        int middleX = dollarField.getLocation().getX()
-                + dollarField.getSize().getWidth() / 2;
-
-        Assert.assertTrue(
-                "The dollar sign should be located on the left side of the text field",
-                spanX < middleX);
-    }
-
-    @Test
-    public void euroFieldHasEuroSuffix() {
-        WebElement euroField = findElement(By.id("euro-field"));
-        WebElement span = euroField.findElement(By.tagName("span"));
-
-        Assert.assertEquals("€", span.getText());
-
-        int spanX = span.getLocation().getX();
-        int middleX = euroField.getLocation().getX()
-                + euroField.getSize().getWidth() / 2;
-
-        Assert.assertTrue(
-                "The euro sign should be located on the right side of the text field",
-                spanX > middleX);
-    }
 }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
@@ -57,23 +57,6 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void assertRequired() {
-        WebElement webComponent = findElement(
-                By.tagName("vaadin-password-field"));
-
-        Assert.assertNull(webComponent.getDomAttribute("required"));
-
-        WebElement button = findElement(By.id("required"));
-        button.click();
-        waitUntil(
-                driver -> "true".equals(getProperty(webComponent, "required")));
-
-        button.click();
-        waitUntil(driver -> "false"
-                .equals(getProperty(webComponent, "required")));
-    }
-
-    @Test
     public void assertClearValue() {
         PasswordFieldElement field = $(PasswordFieldElement.class)
                 .id("clear-password-field");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
@@ -119,14 +119,6 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void passwordFieldHasPlaceholder() {
-        WebElement passwordField = findElement(
-                By.id("password-field-with-value-change-listener"));
-        Assert.assertEquals(passwordField.getDomAttribute("placeholder"),
-                "placeholder text");
-    }
-
-    @Test
     public void valueChangeListenerReportsCorrectValues() {
         WebElement passwordFieldValueDiv = findElement(
                 By.id("password-field-value"));

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -121,14 +121,6 @@ public class TextAreaPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void textAreaHasPlaceholder() {
-        WebElement textField = findElement(
-                By.id("text-area-with-value-change-listener"));
-        Assert.assertEquals(textField.getDomAttribute("placeholder"),
-                "placeholder text");
-    }
-
-    @Test
     public void maxHeight() {
         WebElement textArea = findElement(By.id("text-area-with-max-height"));
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
@@ -64,20 +64,6 @@ public class TextFieldPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void assertRequired() {
-        WebElement webComponent = findElement(By.tagName("vaadin-text-field"));
-        Assert.assertNull(webComponent.getDomAttribute("required"));
-        WebElement button = findElement(By.id("required"));
-        button.click();
-        waitUntil(
-                driver -> "true".equals(getProperty(webComponent, "required")));
-
-        button.click();
-        waitUntil(driver -> "false"
-                .equals(getProperty(webComponent, "required")));
-    }
-
-    @Test
     public void labelMatches() {
         List<TextFieldElement> textFieldElements = $(TextFieldElement.class)
                 .withLabel("Text field label").all();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
@@ -267,14 +267,6 @@ public class TextFieldPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void textFieldHasPlaceholder() {
-        WebElement textField = findElement(
-                By.id("text-field-with-value-change-listener"));
-        Assert.assertEquals("placeholder text",
-                textField.getDomAttribute("placeholder"));
-    }
-
-    @Test
     public void assertFocusShortcut() {
         TextFieldElement shortcutField = $(TextFieldElement.class)
                 .id("shortcut-field");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PrefixSuffixTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PrefixSuffixTest.java
@@ -18,81 +18,64 @@ package com.vaadin.flow.component.textfield.tests;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.html.H1;
-import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.shared.HasPrefix;
+import com.vaadin.flow.component.shared.HasSuffix;
+import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.component.textfield.EmailField;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.PasswordField;
+import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 
-/**
- * Tests for setting prefix and suffix components for {@link TextField}.
- */
 public class PrefixSuffixTest {
 
     @Test
-    public void setPrefix_replacesPrefix() {
-        TextField field = new TextField();
-        Assert.assertNull("There should be no prefix component by default",
-                field.getPrefixComponent());
-
-        setAndAssertPrefix(field, new Span());
-        setAndAssertPrefix(field, new H1());
+    public void bigDecimalField() {
+        BigDecimalField c = new BigDecimalField();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 
     @Test
-    public void setPrefix_setPrefixNull_prefixRemoved() {
-        TextField field = new TextField();
-        field.setPrefixComponent(new Span());
-        field.setPrefixComponent(null);
-
-        Assert.assertNull(field.getPrefixComponent());
-        Assert.assertEquals(
-                "Setting prefix component to null should remove all children in the prefix-slot",
-                0, getNumOfChildrenInSlot(field, "prefix"));
+    public void emailField() {
+        EmailField c = new EmailField();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 
     @Test
-    public void setSuffix_replacesSuffix() {
-        TextField field = new TextField();
-        Assert.assertNull("There should be no suffix component by default",
-                field.getSuffixComponent());
-
-        setAndAssertSuffix(field, new Span());
-        setAndAssertSuffix(field, new H1());
+    public void integerField() {
+        IntegerField c = new IntegerField();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 
     @Test
-    public void setSuffix_setSuffixNull_suffixRemoved() {
-        TextField field = new TextField();
-        field.setSuffixComponent(new Span());
-        field.setSuffixComponent(null);
-
-        Assert.assertNull(field.getSuffixComponent());
-        Assert.assertEquals(
-                "Setting suffix component to null should remove all children in the suffix-slot",
-                0, getNumOfChildrenInSlot(field, "suffix"));
+    public void numberField() {
+        NumberField c = new NumberField();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 
-    private void setAndAssertPrefix(TextField field, Component prefix) {
-        field.setPrefixComponent(prefix);
-        Assert.assertEquals(
-                "Setting a prefix component should remove existing prefix components",
-                1, getNumOfChildrenInSlot(field, "prefix"));
-        Assert.assertEquals("getPrefixComponent did not return set value",
-                prefix, field.getPrefixComponent());
+    @Test
+    public void passwordField() {
+        PasswordField c = new PasswordField();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 
-    private void setAndAssertSuffix(TextField field, Component suffix) {
-        field.setSuffixComponent(suffix);
-        Assert.assertEquals(
-                "Setting a suffix component should remove existing suffix components",
-                1, getNumOfChildrenInSlot(field, "suffix"));
-        Assert.assertEquals("getSuffixComponent did not return set value",
-                suffix, field.getSuffixComponent());
+    @Test
+    public void textArea() {
+        TextArea c = new TextArea();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 
-    private int getNumOfChildrenInSlot(Component component, String slot) {
-        return (int) component.getElement().getChildren()
-                .filter(child -> slot.equals(child.getAttribute("slot")))
-                .count();
+    @Test
+    public void textField() {
+        TextField c = new TextField();
+        Assert.assertTrue(c instanceof HasPrefix);
+        Assert.assertTrue(c instanceof HasSuffix);
     }
 }


### PR DESCRIPTION
## Description

Removed ITs for `placeholder` attribute as all the components implement `HasPlaceholder` interface since https://github.com/vaadin/flow-components/pull/5756 and have corresponding unit tests. There are also ITs added by #6276 - IMO they are questionable but I didn't change them.

Removed ITs for `required` attribute as they are leftovers from the very early version, see https://github.com/vaadin/vaadin-text-field-flow/pull/34.
Nowadays we have both unit tests and validation ITs using `setRequiredIndicatorVisible(true)` that cover actual logic.

Removed ITs for `prefix` and `suffix` only present in NumberField page. Also updated `PrefixSuffixTest` to check if components implement corresponding interfaces added in https://github.com/vaadin/flow-components/pull/4458 (that have proper unit tests for methods).

## Type of change

- Test