### PR TITLE
test: cleanup duplicate and redundant DatePicker ITs

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerPage.java
@@ -16,37 +16,23 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Locale;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
-import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
-/**
- * View for {@link DatePicker} demo.
- *
- * @author Vaadin Ltd
- */
-@Route("vaadin-date-picker-test-demo")
-public class DatePickerViewDemoPage extends Div {
+@Route("vaadin-date-picker/date-picker-test")
+public class DatePickerPage extends Div {
 
-    public DatePickerViewDemoPage() {
+    public DatePickerPage() {
         createSimpleDatePicker();
         createMinAndMaxDatePicker();
         createDisabledDatePicker();
-        createFinnishDatePicker();
-        createWithClearButton();
         createStartAndEndDatePickers();
-        createLocaleChangeDatePicker();
-        createDatePickerInsideDisabledParent();
         createDatePickerWithOpenedChangeListener();
-        addCard("Additional code used in the demo",
-                new Label("These methods are used in the demo."));
     }
 
     private void createSimpleDatePicker() {
@@ -96,56 +82,6 @@ public class DatePickerViewDemoPage extends Div {
 
         datePicker.setId("disabled-picker");
         addCard("Disabled date picker", datePicker, message);
-    }
-
-    private void createWithClearButton() {
-        DatePicker datePicker = new DatePicker();
-        datePicker.setValue(LocalDate.now());
-
-        // Display an icon which can be clicked to clear the value:
-        datePicker.setClearButtonVisible(true);
-
-        addCard("Clear button", datePicker);
-    }
-
-    private void createFinnishDatePicker() {
-        Div message = createMessageDiv("finnish-picker-message");
-
-        DatePicker datePicker = new DatePicker();
-        datePicker.setLabel("Finnish date picker");
-        datePicker.setPlaceholder("Syntymäpäivä");
-        datePicker.setLocale(new Locale("fi"));
-
-        datePicker.setI18n(new DatePicker.DatePickerI18n().setToday("tänään")
-                .setCancel("peruuta").setFirstDayOfWeek(1)
-                .setMonthNames(Arrays.asList("tammiku", "helmikuu", "maaliskuu",
-                        "huhtikuu", "toukokuu", "kesäkuu", "heinäkuu", "elokuu",
-                        "syyskuu", "lokakuu", "marraskuu", "joulukuu"))
-                .setWeekdays(Arrays.asList("sunnuntai", "maanantai", "tiistai",
-                        "keskiviikko", "torstai", "perjantai", "lauantai"))
-                .setWeekdaysShort(Arrays.asList("su", "ma", "ti", "ke", "to",
-                        "pe", "la")));
-
-        datePicker.addValueChangeListener(event -> {
-            LocalDate selectedDate = event.getValue();
-            if (selectedDate != null) {
-                int weekday = selectedDate.getDayOfWeek().getValue() % 7;
-                String weekdayName = datePicker.getI18n().getWeekdays()
-                        .get(weekday);
-
-                int month = selectedDate.getMonthValue() - 1;
-                String monthName = datePicker.getI18n().getMonthNames()
-                        .get(month);
-
-                message.setText("Day of week: " + weekdayName + "\nMonth: "
-                        + monthName);
-            } else {
-                message.setText("No date is selected");
-            }
-        });
-
-        datePicker.setId("finnish-picker");
-        addCard("Internationalized date picker", datePicker, message);
     }
 
     private void createStartAndEndDatePickers() {
@@ -202,56 +138,6 @@ public class DatePickerViewDemoPage extends Div {
         addCard("Two linked date pickers", startDatePicker, endDatePicker,
                 message);
 
-    }
-
-    private void createLocaleChangeDatePicker() {
-        Div message = createMessageDiv("Customize-locale-picker-message");
-        // By default, the datePicker uses the current UI locale
-        DatePicker datePicker = new DatePicker();
-        NativeButton locale1 = new NativeButton("Locale: US");
-        NativeButton locale2 = new NativeButton("Locale: UK");
-        NativeButton locale3 = new NativeButton("Locale: CHINA");
-
-        locale1.addClickListener(e -> {
-            datePicker.setLocale(Locale.US);
-            updateMessage(message, datePicker);
-        });
-        locale2.addClickListener(e -> {
-            datePicker.setLocale(Locale.UK);
-            updateMessage(message, datePicker);
-        });
-        locale3.addClickListener(e -> {
-            datePicker.setLocale(Locale.CHINA);
-            updateMessage(message, datePicker);
-        });
-
-        datePicker.addValueChangeListener(
-                event -> updateMessage(message, datePicker));
-        DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n();
-        i18n.setReferenceDate(LocalDate.of(1980, 2, 2));
-        datePicker.setI18n(i18n);
-        locale1.setId("Locale-US");
-        locale2.setId("Locale-UK");
-        locale3.setId("Locale-CHINA");
-        datePicker.setId("locale-change-picker");
-        addCard("Date picker with customize locales", datePicker, locale1,
-                locale2, locale3, message);
-    }
-
-    private void createDatePickerInsideDisabledParent() {
-        Div parent = new Div();
-        DatePicker datePicker = new DatePicker();
-        datePicker.setId("picker-inside-disabled-parent");
-
-        parent.add(datePicker);
-        parent.setEnabled(false);
-
-        NativeButton enableParent = new NativeButton("Enable parent");
-        enableParent.setId("enable-parent");
-        enableParent.addClickListener(event -> parent.setEnabled(true));
-
-        addCard("DatePicker inside a disabled parent div", parent,
-                enableParent);
     }
 
     private void createDatePickerWithOpenedChangeListener() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -31,8 +31,6 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-date-picker/date-picker-test")
 public class DatePickerIT extends AbstractComponentIT {
 
-    private static final String DATEPICKER_OVERLAY = "vaadin-date-picker-overlay";
-
     @Before
     public void init() {
         open();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
-import java.time.Month;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,10 +28,7 @@ import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
-/**
- * Integration tests for the {@link DatePickerViewDemoPage}.
- */
-@TestPath("vaadin-date-picker-test-demo")
+@TestPath("vaadin-date-picker/date-picker-test")
 public class DatePickerIT extends AbstractComponentIT {
 
     private static final String DATEPICKER_OVERLAY = "vaadin-date-picker-overlay";
@@ -97,30 +93,6 @@ public class DatePickerIT extends AbstractComponentIT {
     }
 
     @Test
-    public void selectDateOnFinnishDatePicker() {
-        DatePickerElement picker = $(DatePickerElement.class)
-                .id("finnish-picker");
-        WebElement message = findElement(By.id("finnish-picker-message"));
-
-        picker.setDate(LocalDate.of(1985, 1, 10));
-
-        waitUntil(driver -> "Day of week: torstai\nMonth: tammiku"
-                .equals(message.getText()));
-
-        picker.clear();
-
-        waitUntil(driver -> "No date is selected".equals(message.getText()));
-
-        picker.open();
-
-        WebElement overlay = $(DATEPICKER_OVERLAY).waitForFirst();
-        WebElement todayButton = overlay
-                .findElement(By.cssSelector("[slot=today-button]"));
-
-        waitUntil(driver -> "tänään".equals(todayButton.getText()));
-    }
-
-    @Test
     public void selectDatesOnLinkedDatePickers() {
         DatePickerElement startPicker = $(DatePickerElement.class)
                 .id("start-picker");
@@ -149,181 +121,6 @@ public class DatePickerIT extends AbstractComponentIT {
         startPicker.clear();
         waitUntil(
                 driver -> "Select the starting date".equals(message.getText()));
-    }
-
-    @Test
-    public void selectDatesOnCustomLocaleDatePickers() {
-        DatePickerElement localePicker = $(DatePickerElement.class)
-                .id("locale-change-picker");
-        WebElement message = findElement(
-                By.id("Customize-locale-picker-message"));
-        localePicker.setDate(LocalDate.of(2018, 3, 27));
-
-        waitUntil(driver -> message.getText()
-                .contains("Day: 27\nMonth: 3\nYear: 2018\nLocale:"));
-
-        Assert.assertEquals(
-                "The format of the displayed date should be MM/DD/YYYY",
-                "3/27/2018", localePicker.getInputValue());
-
-        findElement(By.id("Locale-UK")).click();
-        localePicker.setDate(LocalDate.of(2018, 3, 26));
-        waitUntil(driver -> "Day: 26\nMonth: 3\nYear: 2018\nLocale: en_GB"
-                .equals(message.getText()));
-
-        Assert.assertEquals(
-                "The format of the displayed date should be DD/MM/YYYY",
-                "26/03/2018", localePicker.getInputValue());
-
-        findElement(By.id("Locale-US")).click();
-        localePicker.setDate(LocalDate.of(2018, 3, 25));
-        waitUntil(driver -> "Day: 25\nMonth: 3\nYear: 2018\nLocale: en_US"
-                .equals(message.getText()));
-        Assert.assertEquals(
-                "The format of the displayed date should be MM/DD/YYYY",
-                "3/25/2018", localePicker.getInputValue());
-
-        findElement(By.id("Locale-UK")).click();
-        Assert.assertEquals(
-                "The format of the displayed date should be DD/MM/YYYY",
-                "25/03/2018", localePicker.getInputValue());
-    }
-
-    private void setDateAndAssert(DatePickerElement datePicker, LocalDate date,
-            String expectedInputValue) {
-        datePicker.setDate(date);
-        Assert.assertEquals(expectedInputValue, datePicker.getInputValue());
-    }
-
-    @Test
-    public void selectDatesBeforeYear1000() {
-        DatePickerElement localePicker = $(DatePickerElement.class)
-                .id("locale-change-picker");
-
-        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 7),
-                "3/7/0900");
-        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 7),
-                "3/7/0087");
-
-        $("button").id("Locale-UK").click();
-        Assert.assertEquals("07/03/0087", localePicker.getInputValue());
-
-        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 6),
-                "06/03/0900");
-        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 6),
-                "06/03/0087");
-
-        $("button").id("Locale-US").click();
-        Assert.assertEquals("3/6/0087", localePicker.getInputValue());
-
-        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 5),
-                "3/5/0900");
-        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 5),
-                "3/5/0087");
-
-        $("button").id("Locale-CHINA").click();
-        Assert.assertEquals("0087/3/5", localePicker.getInputValue());
-
-        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 4),
-                "0900/3/4");
-        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 4),
-                "0087/3/4");
-
-        $("button").id("Locale-UK").click();
-        Assert.assertEquals("04/03/0087", localePicker.getInputValue());
-    }
-
-    /**
-     * Expects input value to change to expectedInputValue after setting it.
-     */
-    private void setInputValueAndAssert(DatePickerElement datePicker,
-            String inputValue, String expectedInputValue,
-            LocalDate expectedDate) {
-        datePicker.setInputValue(inputValue);
-        Assert.assertEquals(expectedInputValue, datePicker.getInputValue());
-        Assert.assertEquals(expectedDate, datePicker.getDate());
-    }
-
-    /**
-     * Expects input value to stay the same as it is set to.
-     */
-    private void setInputValueAndAssert(DatePickerElement datePicker,
-            String inputValue, LocalDate expectedDate) {
-        setInputValueAndAssert(datePicker, inputValue, inputValue,
-                expectedDate);
-    }
-
-    @Test
-    public void selectDatesBeforeYear1000SimulateUserInput() {
-        DatePickerElement localePicker = $(DatePickerElement.class)
-                .id("locale-change-picker");
-
-        setInputValueAndAssert(localePicker, "3/7/0900",
-                LocalDate.of(900, Month.MARCH, 7));
-
-        setInputValueAndAssert(localePicker, "3/6/900", "3/6/0900",
-                LocalDate.of(900, Month.MARCH, 6));
-        setInputValueAndAssert(localePicker, "3/5/0087",
-                LocalDate.of(87, Month.MARCH, 5));
-        setInputValueAndAssert(localePicker, "3/6/87", "3/6/1987",
-                LocalDate.of(1987, Month.MARCH, 6));
-        setInputValueAndAssert(localePicker, "3/7/20", "3/7/2020",
-                LocalDate.of(2020, Month.MARCH, 7));
-        setInputValueAndAssert(localePicker, "3/8/0020",
-                LocalDate.of(20, Month.MARCH, 8));
-
-        $("button").id("Locale-UK").click();
-        Assert.assertEquals("08/03/0020", localePicker.getInputValue());
-
-        setInputValueAndAssert(localePicker, "7/3/0900", "07/03/0900",
-                LocalDate.of(900, Month.MARCH, 7));
-
-        setInputValueAndAssert(localePicker, "6/3/900", "06/03/0900",
-                LocalDate.of(900, Month.MARCH, 6));
-        setInputValueAndAssert(localePicker, "5/3/0087", "05/03/0087",
-                LocalDate.of(87, Month.MARCH, 5));
-        setInputValueAndAssert(localePicker, "6/3/87", "06/03/1987",
-                LocalDate.of(1987, Month.MARCH, 6));
-        setInputValueAndAssert(localePicker, "7/3/20", "07/03/2020",
-                LocalDate.of(2020, Month.MARCH, 7));
-        setInputValueAndAssert(localePicker, "8/3/0020", "08/03/0020",
-                LocalDate.of(20, Month.MARCH, 8));
-
-        $("button").id("Locale-CHINA").click();
-        Assert.assertEquals("0020/3/8", localePicker.getInputValue());
-
-        setInputValueAndAssert(localePicker, "0900/3/7",
-                LocalDate.of(900, Month.MARCH, 7));
-        setInputValueAndAssert(localePicker, "900/3/6", "0900/3/6",
-                LocalDate.of(900, Month.MARCH, 6));
-        setInputValueAndAssert(localePicker, "0087/3/5",
-                LocalDate.of(87, Month.MARCH, 5));
-        setInputValueAndAssert(localePicker, "87/3/6", "1987/3/6",
-                LocalDate.of(1987, Month.MARCH, 6));
-        setInputValueAndAssert(localePicker, "20/3/7", "2020/3/7",
-                LocalDate.of(2020, Month.MARCH, 7));
-        setInputValueAndAssert(localePicker, "0020/3/8",
-                LocalDate.of(20, Month.MARCH, 8));
-
-        $("button").id("Locale-US").click();
-        Assert.assertEquals("3/8/0020", localePicker.getInputValue());
-    }
-
-    @Test
-    public void datePickerInsideDisabledParent_pickerIsDisabled() {
-        WebElement picker = findElement(By.id("picker-inside-disabled-parent"));
-        Assert.assertFalse(
-                "The date picker should be disabled, when the parent component is disabled.",
-                picker.isEnabled());
-    }
-
-    @Test
-    public void datePickerInsideDisabledParent_enableParent_pickerIsEnabled() {
-        WebElement picker = findElement(By.id("picker-inside-disabled-parent"));
-        findElement(By.id("enable-parent")).click();
-        Assert.assertTrue(
-                "The date picker should be enabled after parent component is enabled.",
-                picker.isEnabled());
     }
 
     @Test

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -256,6 +256,42 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals(testDate, picker.getDate());
     }
 
+    @Test
+    public void setLocale_setDate_yearBefore1000_assertDisplayedValue() {
+        applyLocale(Locale.UK);
+
+        picker.setDate(LocalDate.of(900, Month.MARCH, 6));
+        Assert.assertEquals("06/03/0900", picker.getInputValue());
+
+        picker.setDate(LocalDate.of(87, Month.MARCH, 6));
+        Assert.assertEquals("06/03/0087", picker.getInputValue());
+
+        applyLocale(Locale.CHINA);
+
+        picker.setDate(LocalDate.of(900, Month.MARCH, 5));
+        Assert.assertEquals("0900/3/5", picker.getInputValue());
+
+        picker.setDate(LocalDate.of(87, Month.MARCH, 5));
+        Assert.assertEquals("0087/3/5", picker.getInputValue());
+    }
+
+    @Test
+    public void setLocale_setInputValue_yearBefore1000_assertDisplayedValue() {
+        applyLocale(Locale.UK);
+
+        picker.setInputValue("6/3/900");
+        Assert.assertEquals("06/03/0900", picker.getInputValue());
+        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 6),
+                picker.getDate());
+
+        applyLocale(Locale.CHINA);
+
+        picker.setInputValue("900/3/6");
+        Assert.assertEquals("0900/3/6", picker.getInputValue());
+        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 6),
+                picker.getDate());
+    }
+
     private void enterShortYearDate(LocalDate date) {
         String formattedDate = date
                 .format(DateTimeFormatter.ofPattern("MM/dd/yy"));


### PR DESCRIPTION
## Description

Removed redundant ITs that are mostly covered by `DatePickerLocaleIT` and `DatePickerI18nIT`, see comments below.

## Type of change

- Test