### PR TITLE
feat: add addSeparator to ContextMenu to align with SubMenu

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuView.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuView.java
@@ -152,10 +152,12 @@ public class ContextMenuView extends Div {
         contextMenu.addItem(checkbox, e -> message.setText(
                 "Clicked on checkbox with value: " + checkbox.getValue()));
 
+        // Separators can be added between menu items
+        contextMenu.addSeparator();
+
         // Components can also be added to the overlay
         // without creating menu items with add()
-        Component separator = new Hr();
-        contextMenu.add(separator, new Label("This is not a menu item"));
+        contextMenu.add(new Label("This is not a menu item"));
 
         addCard("ContextMenu With Components", target, message);
         target.setId("context-menu-with-components-target");

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenu.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.contextmenu;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.function.SerializableRunnable;
 
@@ -80,6 +81,13 @@ public class ContextMenu extends ContextMenuBase<ContextMenu, MenuItem, SubMenu>
     public MenuItem addItem(Component component,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         return getMenuManager().addItem(component, clickListener);
+    }
+
+    /**
+     * Adds a separator between items.
+     */
+    public void addSeparator() {
+        getMenuManager().add(new Hr());
     }
 
     @Override

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
@@ -146,6 +146,23 @@ public class ContextMenuTest {
     }
 
     @Test
+    public void addItemsAndSeparator_separatorOnlyIncludedInChildren() {
+        var contextMenu = new ContextMenu();
+        var item1 = contextMenu.addItem("foo", null);
+        contextMenu.addSeparator();
+        var item2 = contextMenu.addItem("bar", null);
+
+        var children = contextMenu.getChildren().toList();
+        var items = contextMenu.getItems();
+        Assert.assertEquals(3, children.size());
+        Assert.assertEquals(2, items.size());
+        Assert.assertEquals(item1, children.get(0));
+        Assert.assertEquals(item2, children.get(2));
+        Assert.assertEquals(item1, items.get(0));
+        Assert.assertEquals(item2, items.get(1));
+    }
+
+    @Test
     public void addItemsAndComponents_getItemsReturnsItemsOnly() {
         ContextMenu contextMenu = new ContextMenu();
 


### PR DESCRIPTION
## Description

This PR adds `addSeparator` API to `ContextMenu` in order to align with `SubMenu`.

No related issue. Related comment: https://github.com/vaadin/flow-components/pull/7357#discussion_r2066447048

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.