### PR TITLE
fix: update class name based on flow change

### DIFF
--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/test/java/com/vaadin/flow/component/icon/tests/SvgIconTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.icon.SvgIcon;
+import com.vaadin.flow.server.DownloadEvent;
 import com.vaadin.flow.server.DownloadHandler;
-import com.vaadin.flow.server.DownloadRequest;
 import com.vaadin.flow.server.StreamResource;
 
 public class SvgIconTest {
@@ -197,9 +197,9 @@ public class SvgIconTest {
     private static DownloadHandler getDownloadHandler() {
         return new DownloadHandler() {
             @Override
-            public void handleDownloadRequest(DownloadRequest downloadRequest) {
+            public void handleDownloadRequest(DownloadEvent downloadEvent) {
                 try {
-                    downloadRequest.getOutputStream().write(
+                    downloadEvent.getOutputStream().write(
                             "<svg></svg>".getBytes(StandardCharsets.UTF_8));
                 } catch (IOException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
## Description

Updates references to `DownloadRequest` class to `DownloadEvent` in order to reflect the renaming on Flow. 

Fixes the compilation error on main.

Related Flow commit: https://github.com/vaadin/flow/commit/5c8ab80d57fd4b4d16d014a07c882441da7afac3

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.