### PR TITLE
chore: show custom buttons in ConfirmDialog ITs

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/FeaturesDiy.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/tests/FeaturesDiy.java
@@ -92,6 +92,7 @@ public class FeaturesDiy extends Features {
         });
         cancelButton.getElement().setAttribute("theme", "tertiary");
         dialog.setCancelButton(cancelButton);
+        dialog.setCancelable(true);
 
         return dialog;
     }
@@ -121,6 +122,7 @@ public class FeaturesDiy extends Features {
         });
         discardButton.getElement().setAttribute("theme", "error tertiary");
         dialog.setRejectButton(discardButton);
+        dialog.setRejectable(true);
 
         Button cancelButton = new Button("Cancel");
         cancelButton.setId("cancelDiy");
@@ -130,6 +132,7 @@ public class FeaturesDiy extends Features {
         });
         cancelButton.getElement().setAttribute("theme", "tertiary");
         dialog.setCancelButton(cancelButton);
+        dialog.setCancelable(true);
 
         return dialog;
     }


### PR DESCRIPTION
## Description

`FeaturesDiy` creates confirm dialogs with custom buttons, but custom cancel or reject buttons are not visible because they need to be explicitly made visible using the respective API. The buttons work in tests as the elements get added to the dialog, they are just invisible. Let's make them visible, otherwise the examples look broken.

## Type of change

- Internal