### PR TITLE
chore: update outer HTML usages in unit tests

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxDataViewTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxDataViewTest.java
@@ -43,7 +43,7 @@ import com.vaadin.flow.shared.Registration;
 
 public class ListBoxDataViewTest extends AbstractComponentDataViewTest {
 
-    private static final String OUTER_HTML = "<vaadin-item>\n <span>%s</span>\n</vaadin-item>";
+    private static final String OUTER_HTML = "<vaadin-item><span>%s</span></vaadin-item>";
 
     @Test
     public void getItem_dataViewWithItems_returnsCorrectItem() {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -51,7 +51,7 @@ import com.vaadin.tests.DataProviderListenersTest;
 
 public class RadioButtonGroupTest {
 
-    private static final String OUTER_HTML = "<vaadin-radio-button>\n <label slot=\"label\"><span>%s</span></label>\n</vaadin-radio-button>";
+    private static final String OUTER_HTML = "<vaadin-radio-button><label slot=\"label\"><span>%s</span></label></vaadin-radio-button>";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataViewTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataViewTest.java
@@ -43,7 +43,7 @@ import com.vaadin.flow.shared.Registration;
 public class RadioButtonGroupDataViewTest
         extends AbstractComponentDataViewTest {
 
-    private static final String OUTER_HTML = "<vaadin-radio-button>\n <label slot=\"label\"><span>%s</span></label>\n</vaadin-radio-button>";
+    private static final String OUTER_HTML = "<vaadin-radio-button><label slot=\"label\"><span>%s</span></label></vaadin-radio-button>";
 
     @Test
     public void getItem_dataViewWithItems_returnsCorrectItem() {

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -268,13 +268,13 @@ public class SelectTest {
         select.setTextRenderer(bean -> "!" + bean.getProperty());
 
         Assert.assertEquals(
-                "<vaadin-select-item value=\"1\">\n <span>!foo</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"1\"><span>!foo</span></vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-select-item value=\"2\">\n <span>!bar</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"2\"><span>!bar</span></vaadin-select-item>",
                 getListBoxChild(1).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-select-item value=\"3\">\n <span>!baz</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"3\"><span>!baz</span></vaadin-select-item>",
                 getListBoxChild(2).getOuterHTML());
     }
 
@@ -285,21 +285,21 @@ public class SelectTest {
                 (SerializableFunction<String, Span>) Span::new));
 
         Assert.assertEquals(
-                "<vaadin-select-item value=\"1\">\n <span>foo</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"1\"><span>foo</span></vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-select-item value=\"2\">\n <span>bar</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"2\"><span>bar</span></vaadin-select-item>",
                 getListBoxChild(1).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-select-item value=\"3\">\n <span>baz</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"3\"><span>baz</span></vaadin-select-item>",
                 getListBoxChild(2).getOuterHTML());
 
         select.setItems("1", "2");
         Assert.assertEquals(
-                "<vaadin-select-item value=\"4\">\n <span>1</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"4\"><span>1</span></vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
         Assert.assertEquals(
-                "<vaadin-select-item value=\"5\">\n <span>2</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"5\"><span>2</span></vaadin-select-item>",
                 getListBoxChild(1).getOuterHTML());
     }
 
@@ -310,7 +310,7 @@ public class SelectTest {
                 (SerializableFunction<String, Span>) Span::new));
         select.setItemLabelGenerator(item -> "bar");
         Assert.assertEquals(
-                "<vaadin-select-item value=\"1\" label=\"bar\">\n <span>foo</span>\n</vaadin-select-item>",
+                "<vaadin-select-item value=\"1\" label=\"bar\"><span>foo</span></vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
     }
 
@@ -340,7 +340,7 @@ public class SelectTest {
         select.setEmptySelectionCaption("EMPTY");
 
         Assert.assertEquals(
-                "<vaadin-select-item value>\n EMPTY\n</vaadin-select-item>",
+                "<vaadin-select-item value>EMPTY</vaadin-select-item>",
                 getListBoxChild(0).getOuterHTML());
 
         validateItem(0, "EMPTY", null, true);


### PR DESCRIPTION
## Description

Fix tests that fail due to this Flow [Jsoup version bump](https://github.com/vaadin/flow/pull/21368) that causes whitespace to be stripped.

## Type of change

- Internal