### PR TITLE
chore: fix allowed char pattern usage

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeButtonProvider.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeButtonProvider.java
@@ -41,7 +41,7 @@ public class ValueChangeModeButtonProvider {
         field.setTitle("ValueChangeTimeout");
         field.setPattern("[0-9]*");
         field.setMaxLength(4);
-        field.setAllowedCharPattern("[0-9]*");
+        field.setAllowedCharPattern("[0-9]");
         field.addThemeVariants(LUMO_ALIGN_RIGHT, LUMO_SMALL);
         field.setValue(elementWithChangeMode.getValueChangeTimeout() + "");
         field.addValueChangeListener(this::onTimeoutChange);


### PR DESCRIPTION
## Description

Fixes an invalid usage of `setAllowedCharPattern` in a text area integration test that otherwise causes a client-side error.

## Type of change

- Internal