### PR TITLE
test: add throws clause to Upload test

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
@@ -119,7 +119,8 @@ public class UploadTest {
     }
 
     @Test
-    public void uploadWithCustomHandler_doUpload_activeUploadsIsChanged_from0to1_from1to0() {
+    public void uploadWithCustomHandler_doUpload_activeUploadsIsChanged_from0to1_from1to0()
+            throws IOException {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         VaadinSession session = Mockito.mock(VaadinSession.class);


### PR DESCRIPTION
## Description

The changes in https://github.com/vaadin/flow/pull/21439 introduced an `IOException` throws clause to the `ElementRequestHandler#handleRequest` method, which caused a compilation error in the `vaadin-upload-flow` module for an unhandled exception in one of the tests. Adding a throws clause to such testing method fixes the issue.
