### PR TITLE
chore: fix download handler compilation error

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetImageWrapper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetImageWrapper.java
@@ -72,7 +72,7 @@ public class SheetImageWrapper extends SheetOverlayWrapper
             handler = DownloadHandler
                     .fromInputStream(downloadEvent -> new DownloadResponse(
                             new ByteArrayInputStream(data), "download",
-                            MIMEType, data.length), getId());
+                            MIMEType, data.length));
         }
 
         return handler;


### PR DESCRIPTION
## Description

The signature for `DownloadHandler.fromInputStream` has changed in the latest Flow snapshot, so that it now takes a transfer progress listener as second parameter. Looks like an ID can not be passed anymore, so I removed it.

## Type of change

- Internal