### PR TITLE
chore: Set disposition to inline for all rendering components

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/Avatar.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 
 import elemental.json.JsonObject;
@@ -269,7 +270,12 @@ public class Avatar extends Component
      * Sets the image for the avatar.
      * <p>
      * Setting the image as a resource with this method resets the image URL
-     * that was set with {@link Avatar#setImage(String)}
+     * that was set with {@link Avatar#setImage(String)}.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @see Avatar#setImage(String)
      * @param downloadHandler
@@ -280,6 +286,11 @@ public class Avatar extends Component
             imageResource = null;
             getElement().removeAttribute("img");
             return;
+        }
+        if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            handler.inline();
         }
         imageResource = new StreamResourceRegistry.ElementStreamResource(
                 downloadHandler, getElement());

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -47,6 +47,7 @@ import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.shared.Registration;
 
@@ -223,7 +224,12 @@ public class AvatarGroup extends Component implements HasOverlayClassName,
          * Sets the image for the avatar.
          * <p>
          * Setting the image as a resource with this method resets the image URL
-         * that was set with {@link AvatarGroupItem#setImage(String)}
+         * that was set with {@link AvatarGroupItem#setImage(String)}.
+         * <p>
+         * Sets the <code>Content-Disposition</code> header to
+         * <code>inline</code> for pre-defined download handlers, created by
+         * factory methods in {@link DownloadHandler}, as well as for other
+         * {@link AbstractDownloadHandler} implementations.
          *
          * @see AvatarGroupItem#setImage(String)
          * @param downloadHandler
@@ -234,6 +240,11 @@ public class AvatarGroup extends Component implements HasOverlayClassName,
             if (downloadHandler == null) {
                 unsetResource();
                 return;
+            }
+            if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {
+                // change disposition to inline in pre-defined handlers,
+                // where it is 'attachment' by default
+                handler.inline();
             }
 
             setImageResource(new StreamResourceRegistry.ElementStreamResource(

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.icon;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 
 /**
@@ -91,7 +92,12 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
     }
 
     /**
-     * Creates an SVG icon with the given download handler resource
+     * Creates an SVG icon with the given download handler resource.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param src
      *            the download handler resource
@@ -102,7 +108,12 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
     }
 
     /**
-     * Creates an SVG icon with the given download handler resource
+     * Creates an SVG icon with the given download handler resource.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param src
      *            the download handler resource
@@ -190,11 +201,21 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
     /**
      * Defines the source of the icon from the given {@link DownloadHandler} The
      * resource must contain a valid SVG element.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param src
      *            the source value, not null
      */
     public void setSrc(DownloadHandler src) {
+        if (src instanceof AbstractDownloadHandler<?> handler) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            handler.inline();
+        }
         getElement().setAttribute("src",
                 new StreamResourceRegistry.ElementStreamResource(src,
                         getElement()));
@@ -202,6 +223,11 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
 
     /**
      * Defines the src and the symbol to be used in the icon.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param src
      *            the source of the icon sprite file, not null

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Assets.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Assets.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.map;
 import java.io.Serializable;
 
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 
 /**
@@ -31,8 +32,11 @@ public class Assets {
         private Asset(String fileName, String resourcePath) {
             this.fileName = fileName;
             this.resource = null;
-            this.handler = DownloadHandler.forClassResource(getClass(),
-                    resourcePath, fileName);
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            this.handler = DownloadHandler
+                    .forClassResource(getClass(), resourcePath, fileName)
+                    .inline();
         }
 
         @Deprecated(since = "24.8", forRemoval = true)
@@ -45,6 +49,11 @@ public class Assets {
         private Asset(String fileName, DownloadHandler handler) {
             this.fileName = fileName;
             this.resource = null;
+            if (handler instanceof AbstractDownloadHandler<?> preDefinedHandler) {
+                // change disposition to inline in pre-defined handlers,
+                // where it is 'attachment' by default
+                preDefinedHandler.inline();
+            }
             this.handler = handler;
         }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/style/Icon.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/style/Icon.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vaadin.flow.component.map.configuration.Constants;
 import com.vaadin.flow.component.map.configuration.Feature;
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 
 /**
@@ -239,6 +240,11 @@ public class Icon extends ImageStyle {
          * @see Icon#getImgHandler()
          */
         public void setImg(DownloadHandler imgHandler) {
+            if (imgHandler instanceof AbstractDownloadHandler<?> handler) {
+                // change disposition to inline in pre-defined handlers,
+                // where it is 'attachment' by default
+                handler.inline();
+            }
             this.imgHandler = imgHandler;
         }
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.shared.Registration;
 
@@ -183,7 +184,7 @@ public class MessageListItem implements Serializable {
 
     /**
      * Appends the provided text to the message's text content.
-     * 
+     *
      * @param text
      *            the text to append to the message's text content
      */
@@ -442,6 +443,11 @@ public class MessageListItem implements Serializable {
      * <p>
      * Setting the image as a resource with this method overrides the image URL
      * set with {@link MessageListItem#setUserImage(String)}.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param downloadHandler
      *            download handler for the image resource, or {@code null} to
@@ -452,6 +458,11 @@ public class MessageListItem implements Serializable {
         if (downloadHandler == null) {
             unsetResource();
             return;
+        }
+        if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            handler.inline();
         }
 
         setUserImageResource(new StreamResourceRegistry.ElementStreamResource(

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetImageWrapper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetImageWrapper.java
@@ -69,10 +69,13 @@ public class SheetImageWrapper extends SheetOverlayWrapper
     @Override
     public DownloadHandler getResourceHandler() {
         if (handler == null) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
             handler = DownloadHandler
                     .fromInputStream(downloadEvent -> new DownloadResponse(
                             new ByteArrayInputStream(data), "download",
-                            MIMEType, data.length), getId());
+                            MIMEType, data.length), getId())
+                    .inline();
         }
 
         return handler;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -99,6 +99,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.pro.licensechecker.LicenseChecker;
@@ -3591,6 +3592,11 @@ public class Spreadsheet extends Component
             resources.remove(key);
             getElement().removeAttribute("resource-" + key);
         } else {
+            if (resource instanceof AbstractDownloadHandler<?> handler) {
+                // change disposition to inline in pre-defined handlers,
+                // where it is 'attachment' by default
+                handler.inline();
+            }
             resources.put(key, resource.toString());
             getElement().setProperty("resources",
                     Serializer.serialize(new ArrayList<>(resources.keySet())));


### PR DESCRIPTION
Sets pre-defined download handlers to use Content-Disposition=inline in components that render data on web page.

Related-to https://github.com/vaadin/flow/pulls/21456