### PR TITLE
fix: do not reuse style instances between polygons

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeature.java
@@ -30,15 +30,6 @@ import com.vaadin.flow.component.map.configuration.style.Style;
  * for representation.
  */
 public class PolygonFeature extends Feature {
-
-    private static final Style DEFAULT_STYLE;
-    static {
-        final Style style = new Style();
-        style.setStroke(new Stroke("hsl(214, 100%, 48%)", 2));
-        style.setFill(new Fill("hsla(214, 100%, 60%, 0.13)"));
-        DEFAULT_STYLE = style;
-    }
-
     /**
      * Creates a new polygon feature with the default style.
      */
@@ -62,8 +53,7 @@ public class PolygonFeature extends Feature {
      */
     public PolygonFeature(List<Coordinate> coordinates) {
         setGeometry(new Polygon(coordinates));
-        // Let the polygon be visible on the map
-        setStyle(DEFAULT_STYLE);
+        setStyle(createDefaultStyle());
     }
 
     /**
@@ -145,5 +135,12 @@ public class PolygonFeature extends Feature {
             throw new IllegalArgumentException("Geometry must be a polygon");
         }
         super.setGeometry(geometry);
+    }
+
+    private static Style createDefaultStyle() {
+        Style style = new Style();
+        style.setStroke(new Stroke("hsl(214, 100%, 48%)", 2));
+        style.setFill(new Fill("hsla(214, 100%, 60%, 0.13)"));
+        return style;
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeatureTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/configuration/feature/PolygonFeatureTest.java
@@ -55,6 +55,14 @@ public class PolygonFeatureTest {
     }
 
     @Test
+    public void individualStyleInstances() {
+        PolygonFeature polygon1 = new PolygonFeature();
+        PolygonFeature polygon2 = new PolygonFeature();
+
+        Assert.assertNotEquals(polygon1.getStyle(), polygon2.getStyle());
+    }
+
+    @Test
     public void initializeWithCoordinates() {
         List<Coordinate> coordinates = List.of(outerCoordinates);
         PolygonFeature polygonFeature = new PolygonFeature(coordinates);


### PR DESCRIPTION
## Description

Currently all polygons use a static style instance by default, which would help reduce the number of configuration objects sent to the client. However that causes the following issues:
- When the style instance is used in multiple UIs, updating the style will result in an exception as only elements of the currently locked UI may be interacted with. This is similar to https://github.com/vaadin/flow-components/issues/3647 
- It would be unexpected that changing the style of a single polygon would affect all others

This change makes all polygons use an individual style instance. Maybe this could be optimized later by not having a style instance by default, and applying a default style in the client-side connector as a fallback.

## Type of change

-  Bugfix
