### PR TITLE
fix: Delegate to original upload handler methods

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadTest.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
 import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
@@ -134,11 +135,46 @@ public class UploadTest {
 
         Assert.assertFalse(upload.isUploading());
 
-        // when the upload starts
-        UploadHandler handler = event ->
-        // then the upload is in progress
-        Assert.assertTrue(upload.isUploading());
-        upload.setUploadHandler(handler);
+        UploadHandler customHandler = Mockito.spy(new UploadHandler() {
+            @Override
+            public void handleUploadRequest(UploadEvent event) {
+                // when the upload starts,
+                // then the upload is in progress
+                Assert.assertTrue(upload.isUploading());
+            }
+
+            @Override
+            public long getRequestSizeMax() {
+                return 111L;
+            }
+
+            @Override
+            public long getFileSizeMax() {
+                return 222L;
+            }
+
+            @Override
+            public long getFileCountMax() {
+                return 333L;
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return "custom-postfix";
+            }
+
+            @Override
+            public boolean isAllowInert() {
+                return true;
+            }
+
+            @Override
+            public DisabledUpdateMode getDisabledUpdateMode() {
+                return DisabledUpdateMode.ALWAYS;
+            }
+        });
+
+        upload.setUploadHandler(customHandler);
 
         Mockito.verify(owner).setAttribute(Mockito.anyString(),
                 captor.capture());
@@ -147,11 +183,26 @@ public class UploadTest {
                 .getValue();
         Assert.assertNotNull(elementStreamResource);
 
-        // when the upload handling is completed
-        elementStreamResource.getElementRequestHandler().handleRequest(request,
-                response, session, owner);
+        UploadHandler uploadHandlerWrapper = (UploadHandler) elementStreamResource
+                .getElementRequestHandler();
+        uploadHandlerWrapper.handleRequest(request, response, session, owner);
+        // when the upload handling is completed,
         // then the upload is not in progress anymore
         Assert.assertFalse(upload.isUploading());
+
+        // verify that the original methods of custom handler were called
+        Mockito.verify(customHandler)
+                .handleUploadRequest(Mockito.any(UploadEvent.class));
+        Mockito.verify(customHandler).responseHandled(Mockito.anyBoolean(),
+                Mockito.any(VaadinResponse.class));
+        Assert.assertEquals(111L, uploadHandlerWrapper.getRequestSizeMax());
+        Assert.assertEquals(222L, uploadHandlerWrapper.getFileSizeMax());
+        Assert.assertEquals(333L, uploadHandlerWrapper.getFileCountMax());
+        Assert.assertEquals("custom-postfix",
+                uploadHandlerWrapper.getUrlPostfix());
+        Assert.assertTrue(uploadHandlerWrapper.isAllowInert());
+        Assert.assertEquals(DisabledUpdateMode.ALWAYS,
+                uploadHandlerWrapper.getDisabledUpdateMode());
     }
 
     @Test
@@ -221,6 +272,7 @@ public class UploadTest {
     @SuppressWarnings("unchecked")
     private Element setupMockElement(UI ui) {
         Element owner = Mockito.mock(Element.class);
+        Mockito.when(owner.isEnabled()).thenReturn(true);
         Component componentOwner = Mockito.mock(Component.class);
         Mockito.when(owner.getComponent())
                 .thenReturn(Optional.of(componentOwner));


### PR DESCRIPTION
## Description

The following upload handler's overrides are ignored, e.g. custom url prefix is not taken into account (as well as other default methods in `UploadHandler`):
```java
        InMemoryUploadHandler inMemoryUploadHandler = new InMemoryUploadHandler(
                (uploadMetadata, bytes) -> {
                    // handle Uploaded data here
                }) {
            @Override
            public String getUrlPostfix() {
                return "custom-url-postfix";
            }

            // other overrides
        };
        upload.setUploadHandler(inMemoryUploadHandler);
```

This change wraps the original upload handler so that the wrapper delegates all methods to original handler, not only the handleUploadRequest.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.
