### PR TITLE
refactor!: remove HasComponents from ContextMenu

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/AutoAttachedContextMenuPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/AutoAttachedContextMenuPage.java
@@ -38,7 +38,7 @@ public class AutoAttachedContextMenuPage extends Div {
                 "Target for context menu which is automatically added to the UI");
         target.setId("target-for-not-attached-context-menu");
         ContextMenu contextMenu = new ContextMenu(target);
-        contextMenu.add(new Label("Auto-attached context menu"));
+        contextMenu.addComponent(new Label("Auto-attached context menu"));
         contextMenu.setId("not-attached-context-menu");
 
         add(target);

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuClosePage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuClosePage.java
@@ -36,7 +36,7 @@ public class ContextMenuClosePage extends Div {
         NativeButton closeButton = new NativeButton("Close",
                 e -> contextMenu.close());
         closeButton.setId("close-menu");
-        contextMenu.add(new Div(closeButton));
+        contextMenu.addComponent(new Div(closeButton));
 
         Div message = new Div();
         message.setId("closed-message");

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuPage.java
@@ -48,7 +48,7 @@ public class ContextMenuPage extends Div {
         contextMenu.setTarget(target);
 
         contextMenu.setId("menu-add-component-at-index");
-        contextMenu.add(new NativeButton(), new NativeButton(),
+        contextMenu.addComponent(new NativeButton(), new NativeButton(),
                 new NativeButton());
 
         NativeButton addedButton = new NativeButton("Added Button");
@@ -84,7 +84,7 @@ public class ContextMenuPage extends Div {
         ContextMenu contextMenu = new ContextMenu();
         contextMenu.setTarget(target);
         Paragraph content = new Paragraph("Context menu test.");
-        contextMenu.add(content);
+        contextMenu.addComponent(content);
 
         Div message = new Div();
         message.setId("message");
@@ -105,7 +105,7 @@ public class ContextMenuPage extends Div {
         contextMenu.setTarget(target);
 
         Paragraph content = new Paragraph("Context menu With SetOpenOnClick.");
-        contextMenu.add(content);
+        contextMenu.addComponent(content);
 
         String current = "Current state is ";
         Div message = new Div();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuView.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuView.java
@@ -157,7 +157,7 @@ public class ContextMenuView extends Div {
 
         // Components can also be added to the overlay
         // without creating menu items with add()
-        contextMenu.add(new Label("This is not a menu item"));
+        contextMenu.addComponent(new Label("This is not a menu item"));
 
         addCard("ContextMenu With Components", target, message);
         target.setId("context-menu-with-components-target");
@@ -187,7 +187,7 @@ public class ContextMenuView extends Div {
         // Components can also be added to the submenu overlay
         // without creating menu items with add()
         subMenu.addComponentAtIndex(1, new Hr());
-        subMenu.add(new Label("This is not a menu item"));
+        subMenu.addComponent(new Label("This is not a menu item"));
 
         addCard("ContextMenu With Components in Sub Menu", target, message);
         target.setId("context-menu-with-submenu-components-target");

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/MenuItemDisableOnClickView.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/MenuItemDisableOnClickView.java
@@ -113,7 +113,7 @@ public class MenuItemDisableOnClickView extends Div {
 
         var addReEnableInSameRoundTripItem = contextMenu.addItem(
                 "Add re-enable in same round-trip item",
-                event -> contextMenu.add(item));
+                event -> contextMenu.addComponent(item));
         addReEnableInSameRoundTripItem
                 .setId("add-re-enable-in-same-round-trip-menu-item");
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
@@ -59,7 +58,7 @@ import elemental.json.JsonObject;
 @JsModule("./contextMenuConnector.js")
 @JsModule("./contextMenuTargetConnector.js")
 public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I extends MenuItemBase<C, I, S>, S extends SubMenuBase<C, I, S>>
-        extends Component implements HasComponents, HasStyle {
+        extends Component implements HasStyle {
 
     public static final String EVENT_DETAIL = "event.detail";
 
@@ -238,44 +237,9 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      *            the components to add
      * @see HasMenuItems#addItem(String, ComponentEventListener)
      * @see HasMenuItems#addItem(Component, ComponentEventListener)
-     *
-     * @deprecated Since 24.8, use {@link #addComponent(Component...)} instead
-     */
-    @Deprecated(since = "24.8")
-    @Override
-    public void add(Component... components) {
-        addComponent(components);
-    }
-
-    /**
-     * Adds the given components into the context menu overlay.
-     * <p>
-     * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements in the DOM will not be children of the
-     * {@code <vaadin-context-menu>} element, but will be inserted into an
-     * overlay that is attached into the {@code <body>}.
-     *
-     * @param components
-     *            the components to add
-     * @see HasMenuItems#addItem(String, ComponentEventListener)
-     * @see HasMenuItems#addItem(Component, ComponentEventListener)
      */
     public void addComponent(Component... components) {
         getMenuManager().addComponent(components);
-    }
-
-    /**
-     * @inheritDoc
-     *
-     * @deprecated Since 24.8, use {@link #addComponent(Collection)} instead
-     */
-    @Deprecated(since = "24.8")
-    @Override
-    public void add(Collection<Component> components) {
-        addComponent(components);
     }
 
     /**
@@ -302,17 +266,11 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * @inheritDoc
-     *
-     * @deprecated Since 24.8, use {@link #addItem(String)} instead
+     * Removes the given components from the context menu overlay.
+     * 
+     * @param components
+     *            the components to remove
      */
-    @Deprecated(since = "24.8")
-    @Override
-    public void add(String text) {
-        HasComponents.super.add(text);
-    }
-
-    @Override
     public void remove(Component... components) {
         getMenuManager().remove(components);
     }
@@ -321,7 +279,6 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      * Removes all the child components. This also removes all the items added
      * with {@link #addItem(String)} and its overload methods.
      */
-    @Override
     public void removeAll() {
         getMenuManager().removeAll();
     }
@@ -343,7 +300,6 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      * @param component
      *            the component to add
      */
-    @Override
     public void addComponentAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);
     }
@@ -363,9 +319,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      * @param component
      *            the component to add
      */
-    @Override
     public void addComponentAsFirst(Component component) {
-        HasComponents.super.addComponentAsFirst(component);
+        getMenuManager().addComponentAtIndex(0, component);
     }
 
     /**
@@ -377,10 +332,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Gets the child components of this component. This includes components
-     * added with {@link #add(Component...)} and the {@link MenuItem} components
-     * created with {@link #addItem(String)} and its overload methods. This
-     * doesn't include the components added to the sub menus of this context
-     * menu.
+     * added with {@link #addComponent(Component...)} and the {@link MenuItem}
+     * components created with {@link #addItem(String)} and its overload
+     * methods. This doesn't include the components added to the sub menus of
+     * this context menu.
      *
      * @return the child components of this component
      */

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/HasMenuItems.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/HasMenuItems.java
@@ -43,8 +43,6 @@ public interface HasMenuItems extends Serializable {
      *            not add listener
      * @return the added {@link MenuItem} component
      * @see #addItem(Component, ComponentEventListener)
-     * @see ContextMenu#add(Component...)
-     * @see SubMenu#add(Component...)
      */
     MenuItem addItem(String text,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener);
@@ -60,8 +58,6 @@ public interface HasMenuItems extends Serializable {
      *            not add listener
      * @return the added {@link MenuItem} component
      * @see #addItem(String, ComponentEventListener)
-     * @see ContextMenu#add(Component...)
-     * @see SubMenu#add(Component...)
      */
     MenuItem addItem(Component component,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener);

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -88,7 +88,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
     public I addItem(String text) {
         I menuItem = itemGenerator.apply(menu, contentReset);
         menuItem.setText(text);
-        add(menuItem);
+        addComponent(menuItem);
         return menuItem;
     }
 
@@ -101,7 +101,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      */
     public I addItem(Component component) {
         I menuItem = itemGenerator.apply(menu, contentReset);
-        add(menuItem);
+        addComponent(menuItem);
         menuItem.add(component);
         return menuItem;
     }
@@ -156,23 +156,6 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      *            components to add
      * @see #remove(Component...)
      * @see #addComponentAtIndex(int, Component)
-     * @deprecated Since 24.8, use {@link #addComponent(Component...)} instead
-     */
-    @Deprecated(since = "24.8")
-    public void add(Component... components) {
-        addComponent(components);
-    }
-
-    /**
-     * Adds components to the (sub)menu.
-     * <p>
-     * The components are added into the content as is, they are not wrapped as
-     * menu items.
-     *
-     * @param components
-     *            components to add
-     * @see #remove(Component...)
-     * @see #addComponentAtIndex(int, Component)
      */
     public void addComponent(Component... components) {
         if (parentMenuItem != null && parentMenuItem.isCheckable()) {
@@ -195,7 +178,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      *
      * @param components
      *            components to remove
-     * @see #add(Component...)
+     * @see #addComponent(Component...)
      */
     public void remove(Component... components) {
         Objects.requireNonNull(components,
@@ -237,7 +220,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      * @param component
      *            component to insert
      *
-     * @see #add(Component...)
+     * @see #addComponent(Component...)
      * @see #remove(Component...)
      */
     public void addComponentAtIndex(int index, Component component) {
@@ -259,7 +242,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      * <p>
      * Children consist of components and items.
      *
-     * @see #add(Component...)
+     * @see #addComponent(Component...)
      * @see #addItem(Component)
      *
      * @see #getItems()

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -51,7 +51,6 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      * @param text
      *            the text content for the created menu item
      * @return the created menu item
-     * @see #add(Component...)
      */
     public I addItem(String text) {
         return getMenuManager().addItem(text);
@@ -64,31 +63,9 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      * @param component
      *            the component to add to the created menu item
      * @return the created menu item
-     * @see #add(Component...)
      */
     public I addItem(Component component) {
         return getMenuManager().addItem(component);
-    }
-
-    /**
-     * Adds the given components into the sub menu overlay.
-     * <p>
-     * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements will be inserted into an overlay that is attached into
-     * the {@code <body>}.
-     *
-     * @param components
-     *            the components to add
-     * @see HasMenuItems#addItem(String, ComponentEventListener)
-     * @see HasMenuItems#addItem(Component, ComponentEventListener)
-     * @deprecated Since 24.8, use {@link #addComponent(Component...)} instead
-     */
-    @Deprecated(since = "24.8")
-    public void add(Component... components) {
-        addComponent(components);
     }
 
     /**
@@ -115,7 +92,6 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      *
      * @param components
      *            the components to remove
-     * @see #add(Component...)
      */
     public void remove(Component... components) {
         getMenuManager().remove(components);
@@ -123,8 +99,6 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
 
     /**
      * Removes all components inside the sub menu overlay.
-     *
-     * @see #add(Component...)
      */
     public void removeAll() {
         getMenuManager().removeAll();
@@ -144,7 +118,6 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
      *            the index, where the component will be added
      * @param component
      *            the component to add
-     * @see #add(Component...)
      */
     public void addComponentAtIndex(int index, Component component) {
         getMenuManager().addComponentAtIndex(index, component);
@@ -152,10 +125,10 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
 
     /**
      * Gets the child components of this sub menu. This includes components
-     * added with {@link #add(Component...)} and the {@link MenuItem} components
-     * created with {@link #addItem(String)} and its overload methods. This
-     * doesn't include the components added to the main context menu or any
-     * other sub menus it may have.
+     * added with {@link #addComponent(Component...)} and the {@link MenuItem}
+     * components created with {@link #addItem(String)} and its overload
+     * methods. This doesn't include the components added to the main context
+     * menu or any other sub menus it may have.
      *
      * @return the child components of this sub menu
      */

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
@@ -46,14 +46,14 @@ public class ContextMenuTest {
         ContextMenu contextMenu = new ContextMenu();
         contextMenu.setTarget(new Label("target"));
 
-        contextMenu.add(label1, label2);
+        contextMenu.addComponent(label1, label2);
 
         List<Component> children = contextMenu.getChildren()
                 .collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
         Assert.assertThat(children, CoreMatchers.hasItems(label1, label2));
 
-        contextMenu.add(label3);
+        contextMenu.addComponent(label3);
         children = contextMenu.getChildren().collect(Collectors.toList());
         Assert.assertEquals(3, children.size());
         Assert.assertThat(children,
@@ -128,12 +128,12 @@ public class ContextMenuTest {
         MenuItem item1 = contextMenu.addItem("foo", null);
 
         Label label1 = new Label("foo");
-        contextMenu.add(label1);
+        contextMenu.addComponent(label1);
 
         MenuItem item2 = contextMenu.addItem("bar", null);
 
         Label label2 = new Label("bar");
-        contextMenu.add(label2);
+        contextMenu.addComponent(label2);
 
         List<Component> children = contextMenu.getChildren()
                 .collect(Collectors.toList());
@@ -169,12 +169,12 @@ public class ContextMenuTest {
         MenuItem item1 = contextMenu.addItem("foo", null);
 
         Label label1 = new Label("foo");
-        contextMenu.add(label1);
+        contextMenu.addComponent(label1);
 
         MenuItem item2 = contextMenu.addItem("bar", null);
 
         Label label2 = new Label("bar");
-        contextMenu.add(label2);
+        contextMenu.addComponent(label2);
 
         List<MenuItem> items = contextMenu.getItems();
         Assert.assertEquals(2, items.size());
@@ -207,7 +207,7 @@ public class ContextMenuTest {
     public void serializeContextMenu() throws IOException {
         NativeButton menuButton = new NativeButton();
         ContextMenu menu = new ContextMenu(menuButton);
-        menu.add(new Label());
+        menu.addComponent(new Label());
         ObjectOutputStream out = new ObjectOutputStream(
                 new ByteArrayOutputStream());
         out.writeObject(menu);

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
@@ -67,7 +67,7 @@ public class MenuManagerTest {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent) {
             @Override
-            public void add(Component... components) {
+            public void addComponent(Component... components) {
                 Stream.of(components).forEach(addedComponents::add);
             }
         };
@@ -164,7 +164,7 @@ public class MenuManagerTest {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent);
 
-        manager.add(component1, component2);
+        manager.addComponent(component1, component2);
 
         List<Component> children = manager.getChildren()
                 .collect(Collectors.toList());
@@ -182,7 +182,7 @@ public class MenuManagerTest {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent);
 
-        manager.add(Mockito.mock(Component.class));
+        manager.addComponent(Mockito.mock(Component.class));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class MenuManagerTest {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent);
 
-        manager.add(component1, component2);
+        manager.addComponent(component1, component2);
 
         manager.remove(component1, component2);
 
@@ -224,7 +224,7 @@ public class MenuManagerTest {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent);
 
-        manager.add(component1, component2);
+        manager.addComponent(component1, component2);
 
         manager.removeAll();
 
@@ -246,7 +246,7 @@ public class MenuManagerTest {
         manager = new MenuManager<ContextMenu, MenuItem, SubMenu>(menu, reset,
                 factory, MenuItem.class, parent);
 
-        manager.add(component1, component2);
+        manager.addComponent(component1, component2);
         manager.addComponentAtIndex(1, component3);
 
         List<Component> children = manager.getChildren()
@@ -291,7 +291,7 @@ public class MenuManagerTest {
         Mockito.when(factory.apply(menu, reset)).thenReturn(item);
 
         manager.addItem("foo");
-        manager.add(component);
+        manager.addComponent(component);
         manager.addItem("bar");
 
         Assert.assertEquals(2, manager.getItems().size());

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
@@ -51,7 +51,7 @@ public class SubMenuTest {
         Label label2 = new Label("Label 2");
         Label label3 = new Label("Label 3");
 
-        subMenu.add(label1, label2);
+        subMenu.addComponent(label1, label2);
         verifyChildren(subMenu, label1, label2);
 
         subMenu.addComponentAtIndex(1, label3);
@@ -101,12 +101,12 @@ public class SubMenuTest {
         MenuItem item1 = subMenu.addItem("foo");
 
         Label label1 = new Label("foo");
-        subMenu.add(label1);
+        subMenu.addComponent(label1);
 
         MenuItem item2 = subMenu.addItem("bar");
 
         Label label2 = new Label("bar");
-        subMenu.add(label2);
+        subMenu.addComponent(label2);
 
         verifyChildren(subMenu, item1, label1, item2, label2);
     }
@@ -116,12 +116,12 @@ public class SubMenuTest {
         MenuItem item1 = subMenu.addItem("foo");
 
         Label label1 = new Label("foo");
-        subMenu.add(label1);
+        subMenu.addComponent(label1);
 
         MenuItem item2 = subMenu.addItem("bar");
 
         Label label2 = new Label("bar");
-        subMenu.add(label2);
+        subMenu.addComponent(label2);
 
         verifyItems(subMenu, item1, item2);
     }
@@ -147,7 +147,7 @@ public class SubMenuTest {
         subMenu.removeAll();
         Assert.assertFalse(parentItem.isParentItem());
 
-        subMenu.add(new Label());
+        subMenu.addComponent(new Label());
         Assert.assertTrue(parentItem.isParentItem());
         subMenu.removeAll();
         Assert.assertFalse(parentItem.isParentItem());
@@ -187,7 +187,7 @@ public class SubMenuTest {
 
         Stream<Consumer<SubMenu>> addOperations = Stream.of(
         //@formatter:off
-                menu -> menu.add(new Div()),
+                menu -> menu.addComponent(new Div()),
                 menu -> menu.addItem("foo"),
                 menu -> menu.addItem(new Div()),
                 menu -> menu.addItem("foo", e -> {}),

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewContextMenuPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewContextMenuPage.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.grid.contextmenu.GridMenuItem;
-import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.data.bean.PeopleGenerator;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -87,7 +86,7 @@ public class GridViewContextMenuPage extends LegacyTestView {
                     new PeopleGenerator().createPerson(items.size() + 1));
             dataProvider.refreshAll();
         });
-        insert.getSubMenu().add(new Hr());
+        insert.getSubMenu().addSeparator();
         insert.getSubMenu().addItem("Insert a row below", event -> {
             Optional<Person> item = event.getItem();
             if (!item.isPresent()) {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarClosePage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarClosePage.java
@@ -34,7 +34,7 @@ public class MenuBarClosePage extends Div {
         final NativeButton closeButton = new NativeButton("Close",
                 e -> menuBar.close());
         closeButton.setId("close-button");
-        submenu.add(new Div(new Span("menu contents"), closeButton));
+        submenu.addComponent(new Div(new Span("menu contents"), closeButton));
         add(menuBar);
     }
 }


### PR DESCRIPTION
## Description

Removes the `HasComponents` interface from `ContextMenu` / `SubMenu` and drops the deprecated `add` method in favor of `addComponent`.

Closes https://github.com/vaadin/flow-components/issues/5532

## Type of change

- Breaking change