### PR TITLE
test: try to reduce flakyness in CustomEditorIT

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -436,6 +436,11 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
     }
 
     private void clickToggleCellVisibleButton() {
+        waitUntil(driver -> {
+            var button = $(TestBenchElement.class)
+                    .id("toggleCustomEditorVisibilityButton");
+            return button.isDisplayed();
+        });
         var toggleButton = $(TestBenchElement.class)
                 .id("toggleCustomEditorVisibilityButton");
         toggleButton.click();


### PR DESCRIPTION
## Description

After the latest changes, some tests in `CustomEditorIT` became [flaky](https://bender.vaadin.com/buildConfiguration/FlowComponents_Snapshot/702786?buildTab=tests#%2Fintegration-tests). It seems that the button is not yet fully rendered by the time the test tries to perform a click on it, so it errors as it has a stale reference to the element. Trying to solve it with a `waitUntil` invocation.

## Type of change

Tests