### PR TITLE
fix: serialize rotation as number if possible

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Labels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Labels.java
@@ -8,6 +8,8 @@
  */
 package com.vaadin.flow.component.charts.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.vaadin.flow.component.charts.model.serializers.LabelsRotationSerializer;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 public class Labels extends AbstractConfigurationObject {
@@ -325,6 +327,7 @@ public class Labels extends AbstractConfigurationObject {
         this.zIndex = zIndex;
     }
 
+    @JsonSerialize(using = LabelsRotationSerializer.class)
     public String getRotation() {
         return rotation;
     }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/LabelsRotationSerializer.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/LabelsRotationSerializer.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model.serializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.vaadin.flow.component.charts.model.Labels;
+
+/**
+ * Serializer for {@link Labels#getRotation()}. Attempts to serialize the
+ * rotation value as a number, otherwise falls back to writing it as a string to
+ * support values like "auto".
+ */
+public class LabelsRotationSerializer extends JsonSerializer<String> {
+    @Override
+    public void serialize(String value, JsonGenerator gen,
+            SerializerProvider serializers) throws IOException {
+        if (value == null) {
+            return;
+        }
+
+        try {
+            double d = Double.parseDouble(value);
+            gen.writeNumber(d);
+        } catch (NumberFormatException e) {
+            gen.writeString(value);
+        }
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/LabelsSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/LabelsSerializationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vaadin.flow.component.charts.model.Labels;
+import com.vaadin.flow.component.charts.util.ChartSerialization;
+
+public class LabelsSerializationTest {
+
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        objectMapper = ChartSerialization.createObjectMapper();
+    }
+
+    @Test
+    public void testRotation_isParsableAsNumber_serializedAsNumber()
+            throws JsonProcessingException {
+        Labels labels = new Labels();
+        labels.setRotation("90");
+        String json = objectMapper.writeValueAsString(labels);
+        Assert.assertTrue("Rotation should be serialized as a number",
+                json.contains("\"rotation\":90.0"));
+    }
+
+    @Test
+    public void testRotation_isNotParsableAsNumber_serializedAsString()
+            throws JsonProcessingException {
+        Labels labels = new Labels();
+        labels.setRotation("auto");
+        String json = objectMapper.writeValueAsString(labels);
+        Assert.assertTrue("Rotation should be serialized as a string",
+                json.contains("\"rotation\":\"auto\""));
+    }
+
+    @Test
+    public void testRotation_isNull_notSerialized()
+            throws JsonProcessingException {
+        Labels labels = new Labels();
+        labels.setRotation((String) null);
+        String json = objectMapper.writeValueAsString(labels);
+        Assert.assertFalse("Rotation should not be serialized",
+                json.contains("\"rotation\""));
+    }
+}


### PR DESCRIPTION
## Description

`Labels.getRotation` is stored and serialized as a string. Normally that works fine, and Highcharts parses the property as a number. However it doesn't work if you also configure `Labels.setStep` - in this case the property must be a number for rotation to work.

This adds a custom serializer for the property that attempts to serialize as number if a number can be parsed, otherwise it falls back to string serialization.

Fixes https://github.com/vaadin/flow-components/issues/7538

## Type of change

- Bugfix
