### PR TITLE
test: try improve flaky spreadsheet ITs

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -359,7 +359,7 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     public void setLocale(Locale locale) {
         ComboBoxElement localeSelect = $(ComboBoxElement.class)
                 .id("localeSelect");
-        localeSelect.selectByText(locale.getDisplayName());
+        localeSelect.selectByText(locale.getDisplayName(Locale.ENGLISH));
     }
 
     public void loadTestFixture(TestFixtures fixture) {
@@ -562,6 +562,21 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
         findElementInShadowRoot(By.cssSelector(".addressfield")).clear();
         findElementInShadowRoot(By.cssSelector(".addressfield")).sendKeys(cell);
         new Actions(getDriver()).sendKeys(Keys.RETURN).perform();
+    }
+
+    /**
+     * Suppresses the overlay that appears when hovering over a cell with an
+     * invalid formula. The overlay can appear when using setCellValue, and can
+     * cause subsequent button clicks to fail. Can be used in tests that enter
+     * invalid formulas in cells to test the invalid formular indicator (though
+     * obviously not in tests that check the overlay itself).
+     */
+    public void suppressInvalidFormulaCommentOverlay() {
+        executeScript("""
+                arguments[0].addEventListener("mouseover", e => {
+                  e.stopPropagation();
+                }, true);
+                """, getSpreadsheetInShadowRoot());
     }
 
     // Context menu helpers

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaFormatIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaFormatIT.java
@@ -162,8 +162,12 @@ public class FormulaFormatIT extends AbstractSpreadsheetIT {
 
         // The invalid formula overlay can block subsequent clicks
         // Move the mouse cursor to some other element to hide it first
+        waitUntil(driver -> $("*")
+                .withClassName("comment-overlay-invalidformula").exists());
         TestBenchElement button = $("vaadin-button").id("freezePane");
         new Actions(driver).moveToElement(button).perform();
+        waitUntil(driver -> !$("*")
+                .withClassName("comment-overlay-invalidformula").exists());
 
         addFreezePane(); // Sheet content is reloaded
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaFormatIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FormulaFormatIT.java
@@ -13,13 +13,11 @@ import java.util.Locale;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.spreadsheet.testbench.SheetCellElement;
 import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("vaadin-spreadsheet")
 public class FormulaFormatIT extends AbstractSpreadsheetIT {
@@ -28,6 +26,7 @@ public class FormulaFormatIT extends AbstractSpreadsheetIT {
     public void init() {
         open();
         createNewSpreadsheet();
+        suppressInvalidFormulaCommentOverlay();
     }
 
     @Test
@@ -156,18 +155,7 @@ public class FormulaFormatIT extends AbstractSpreadsheetIT {
     @Test
     public void formulaFormatting_addFreezePaneWhileACellHasAnInvalidFormula_cellStillHasInvalidFormulaIndicator()
             throws InterruptedException {
-        SheetCellElement a1 = $(SpreadsheetElement.class).first()
-                .getCellAt("A1");
-        a1.setValue("=a");
-
-        // The invalid formula overlay can block subsequent clicks
-        // Move the mouse cursor to some other element to hide it first
-        waitUntil(driver -> $("*")
-                .withClassName("comment-overlay-invalidformula").exists());
-        TestBenchElement button = $("vaadin-button").id("freezePane");
-        new Actions(driver).moveToElement(button).perform();
-        waitUntil(driver -> !$("*")
-                .withClassName("comment-overlay-invalidformula").exists());
+        setCellValue("A1", "=a");
 
         addFreezePane(); // Sheet content is reloaded
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/GenericIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/GenericIT.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
 import com.vaadin.flow.testutil.TestPath;
@@ -36,11 +35,17 @@ public class GenericIT extends AbstractSpreadsheetIT {
         final var a1 = getSpreadsheet().getCellAt("A1");
         a1.setValue("X");
 
-        new Actions(getDriver()).sendKeys(Keys.ARROW_RIGHT)
-                .sendKeys(Keys.ARROW_RIGHT).sendKeys(Keys.ARROW_DOWN)
-                .sendKeys(Keys.ARROW_DOWN).sendKeys(Keys.ARROW_LEFT)
-                .sendKeys(Keys.ARROW_UP).sendKeys("Y").sendKeys(Keys.RETURN)
-                .sendKeys(Keys.ENTER).build().perform();
+        // Using individual commands seems less flaky than batching them
+        // together
+        getSpreadsheet().sendKeys(Keys.ARROW_RIGHT);
+        getSpreadsheet().sendKeys(Keys.ARROW_RIGHT);
+        getSpreadsheet().sendKeys(Keys.ARROW_DOWN);
+        getSpreadsheet().sendKeys(Keys.ARROW_DOWN);
+        getSpreadsheet().sendKeys(Keys.ARROW_LEFT);
+        getSpreadsheet().sendKeys(Keys.ARROW_UP);
+        getSpreadsheet().sendKeys("Y");
+        getSpreadsheet().sendKeys(Keys.RETURN);
+        getSpreadsheet().sendKeys(Keys.ENTER);
 
         final var c2 = getSpreadsheet().getCellAt("C2");
         Assert.assertEquals("X", a1.getValue());

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/HiddenAndFrozenIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/HiddenAndFrozenIT.java
@@ -32,7 +32,6 @@ public class HiddenAndFrozenIT extends AbstractSpreadsheetIT {
 
     @Test
     public void freezePane_sheetWithHiddenAndFrozenRowsAndColumns_freezePanePositionedCorrectly() {
-        getDriver().manage().window().maximize();
         assertFreezePanePositionedCorrectly("hidden_and_frozen.xlsx", 11, 9,
                 "O15");
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/RemoveInsertRowIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/RemoveInsertRowIT.java
@@ -26,6 +26,7 @@ public class RemoveInsertRowIT extends AbstractSpreadsheetIT {
     public void init() {
         open();
         createNewSpreadsheet();
+        suppressInvalidFormulaCommentOverlay();
     }
 
     @Test


### PR DESCRIPTION
Fixes some issues with flaky Spreadsheet ITs:
- Prevent the invalid formula overlay from showing up as it otherwise can block subsequent clicks on buttons
- Increased browser size in a test to allow making assertions on an otherwise invisible cell
- Changed a set of steps for testing keyboard controls to be more reliable