### PR TITLE
feat: add BackdropClickEvent and DetailEscapePressEvent

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/masterdetaillayout/tests/demo/CategoryView.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/masterdetaillayout/tests/demo/CategoryView.java
@@ -45,6 +45,9 @@ public class CategoryView extends MasterDetailLayout
         setMaster(createMasterContent());
         setMasterMinSize("500px");
         setDetailMinSize("300px");
+
+        addBackdropClickListener(event -> closeDetails());
+        addDetailEscapePressListener(event -> closeDetails());
     }
 
     private Component createMasterContent() {
@@ -74,6 +77,11 @@ public class CategoryView extends MasterDetailLayout
         masterLayout.setHeightFull();
 
         return masterLayout;
+    }
+
+    private void closeDetails() {
+        UI.getCurrent().navigate(CategoryView.class, new RouteParameters(
+                new RouteParam("categoryName", categoryName)));
     }
 
     @Override

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -22,7 +22,11 @@ import java.util.Optional;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
@@ -35,6 +39,7 @@ import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * MasterDetailLayout is a component for building UIs with a master (or primary)
@@ -120,7 +125,9 @@ public class MasterDetailLayout extends Component
     }
 
     /**
-     * Sets the component to be displayed in the detail area.
+     * Sets the component to be displayed in the detail area. The details area
+     * is automatically shown when the detail component is set, and hidden when
+     * the detail component is removed by setting it to {@code null}.
      *
      * @param component
      *            the component to display in the detail area, or {@code null}
@@ -464,6 +471,38 @@ public class MasterDetailLayout extends Component
         getElement().setProperty("noAnimation", !enabled);
     }
 
+    /**
+     * Adds a listener for when the backdrop of the details overlay is clicked.
+     * The backdrop is the area outside the detail area when it is shown in
+     * drawer mode. Can be used to hide the details when the backdrop is
+     * clicked.
+     *
+     * @param listener
+     *            the listener to add, not {@code null}
+     * @return a registration for removing the listener
+     */
+    public Registration addBackdropClickListener(
+            ComponentEventListener<BackdropClickEvent> listener) {
+        Objects.requireNonNull(listener, "Listener cannot be null");
+        return ComponentUtil.addListener(this, BackdropClickEvent.class,
+                listener);
+    }
+
+    /**
+     * Adds a listener for when the Escape key is pressed within the details
+     * area. Can be used to hide the details when the Escape key is pressed.
+     *
+     * @param listener
+     *            the listener to add, not {@code null}
+     * @return a registration for removing the listener
+     */
+    public Registration addDetailEscapePressListener(
+            ComponentEventListener<DetailEscapePressEvent> listener) {
+        Objects.requireNonNull(listener, "Listener cannot be null");
+        return ComponentUtil.addListener(this, DetailEscapePressEvent.class,
+                listener);
+    }
+
     @Override
     public void showRouterLayoutContent(HasElement content) {
         doSetDetail(content);
@@ -490,6 +529,34 @@ public class MasterDetailLayout extends Component
 
         if (!enabled) {
             throw new ExperimentalFeatureException();
+        }
+    }
+
+    /**
+     * Event that is fired when the backdrop of the details overlay is clicked.
+     * The backdrop is the area outside the detail area when it is shown in
+     * drawer mode. Can be used to hide the details when the backdrop is
+     * clicked.
+     */
+    @DomEvent("backdrop-click")
+    public static class BackdropClickEvent
+            extends ComponentEvent<MasterDetailLayout> {
+        public BackdropClickEvent(MasterDetailLayout source,
+                boolean fromClient) {
+            super(source, fromClient);
+        }
+    }
+
+    /**
+     * Event that is fired when the Escape key is pressed within the details
+     * area. Can be used to hide the details when the Escape key is pressed.
+     */
+    @DomEvent("detail-escape-press")
+    public static class DetailEscapePressEvent
+            extends ComponentEvent<MasterDetailLayout> {
+        public DetailEscapePressEvent(MasterDetailLayout source,
+                boolean fromClient) {
+            super(source, fromClient);
         }
     }
 }

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -24,6 +24,8 @@ import org.mockito.Mockito;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.Unit;
@@ -359,6 +361,36 @@ public class MasterDetailLayoutTest {
                 layout.getOverlayMode());
         Assert.assertFalse(
                 layout.getElement().getProperty("stackOverlay", false));
+    }
+
+    @Test
+    public void addBackdropClickListener_verifyListenerTriggered() {
+        @SuppressWarnings("unchecked")
+        ComponentEventListener<MasterDetailLayout.BackdropClickEvent> listener = Mockito
+                .mock(ComponentEventListener.class);
+
+        layout.addBackdropClickListener(listener);
+
+        MasterDetailLayout.BackdropClickEvent backdropClickEvent = new MasterDetailLayout.BackdropClickEvent(
+                layout, true);
+        ComponentUtil.fireEvent(layout, backdropClickEvent);
+
+        Mockito.verify(listener).onComponentEvent(backdropClickEvent);
+    }
+
+    @Test
+    public void addDetailEscapePressListener_verifyListenerTriggered() {
+        @SuppressWarnings("unchecked")
+        ComponentEventListener<MasterDetailLayout.DetailEscapePressEvent> listener = Mockito
+                .mock(ComponentEventListener.class);
+
+        layout.addDetailEscapePressListener(listener);
+
+        MasterDetailLayout.DetailEscapePressEvent detailEscapePressEvent = new MasterDetailLayout.DetailEscapePressEvent(
+                layout, true);
+        ComponentUtil.fireEvent(layout, detailEscapePressEvent);
+
+        Mockito.verify(listener).onComponentEvent(detailEscapePressEvent);
     }
 
     private void assertMasterContent(Component component) {


### PR DESCRIPTION
## Description

Adds events to `MasterDetailLayout` to listen for:
- when the backdrop is clicked when the details are in drawer mode
- when the Escape key is pressed in the details area

Both enable developers to hide the details on the respective event.

Part of https://github.com/vaadin/web-components/issues/9049

## Type of change

- Feature
