### PR TITLE
fix: do not delay auto-adding Popover by `beforeClientResponse` 

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dialog-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-flow-components-test-util</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/main/java/com/vaadin/flow/component/popover/tests/PopoverView.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/main/java/com/vaadin/flow/component/popover/tests/PopoverView.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.popover.tests;
 
+import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.popover.Popover;
@@ -54,7 +55,22 @@ public class PopoverView extends Div {
                 event -> popover.setCloseOnOutsideClick(false));
         disableCloseOnOutsideClick.setId("disable-close-on-outside-click");
 
+        NativeButton openDialog = new NativeButton("Open dialog and set target",
+                event -> {
+                    var dialog = new Dialog();
+                    var close = new NativeButton("Close", e -> dialog.close());
+                    close.setId("close-dialog");
+                    dialog.add(close);
+                    dialog.open();
+                    popover.setTarget(target);
+                });
+        openDialog.setId("open-dialog");
+
+        NativeButton removePopover = new NativeButton("Remove popover",
+                event -> remove(popover));
+        removePopover.setId("remove-popover");
+
         add(popover, clearTarget, detachTarget, attachTarget, disableCloseOnEsc,
-                disableCloseOnOutsideClick, target);
+                disableCloseOnOutsideClick, removePopover, openDialog, target);
     }
 }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/PopoverIT.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/PopoverIT.java
@@ -135,6 +135,20 @@ public class PopoverIT extends AbstractComponentIT {
         Assert.assertTrue(popover.isOpen());
     }
 
+    @Test
+    public void openDialogAndSetTarget_closeDialog_popoverOpens() {
+        // Clear the target and remove the popover first to ensure the popover
+        // is auto-added when the dialog opens
+        clickElementWithJs("clear-target");
+        clickElementWithJs("remove-popover");
+
+        clickElementWithJs("open-dialog");
+        clickElementWithJs("close-dialog");
+
+        clickTarget();
+        checkPopoverIsOpened();
+    }
+
     private void clickTarget() {
         clickElementWithJs("popover-target");
     }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/PopoverIT.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/PopoverIT.java
@@ -145,6 +145,8 @@ public class PopoverIT extends AbstractComponentIT {
         clickElementWithJs("open-dialog");
         clickElementWithJs("close-dialog");
 
+        waitForElementNotPresent(By.tagName("vaadin-dialog-overlay"));
+
         clickTarget();
         checkPopoverIsOpened();
     }


### PR DESCRIPTION
## Description

If a popover tries to auto-add itself when another modal element is opened, it may end up being added as a child of said element. That can be problematic in case the target element is not part of the parent modal element and, when the modal is closed, the popover instance is removed with its parent and interacting with the target element won't work as expected.

This fix adds a detach listener to popover and tries to reattach it in case of:
- the popover instance has been auto-added
- the target element is present
- the target element is still attached to the page

Fixes #7505

## Type of change

- Bugfix
