### PR TITLE
fix: set empty header until header component is visible (#7517) (CP: 24.6)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
@@ -15,14 +15,10 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.Arrays;
-
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.Grid.Column;
-import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
 
@@ -33,26 +29,44 @@ import com.vaadin.flow.router.Route;
 public class GridHeaderRowWithComponentsPage extends Div {
 
     public GridHeaderRowWithComponentsPage() {
-        Grid<String> grid = new Grid<>();
-        grid.setId("grid");
-        grid.setItems(Arrays.asList("Item 1", "Item 2", "Item 3"));
-        Column<String> column = grid.addColumn(ValueProvider.identity());
+        var grid = new Grid<String>();
+        grid.setItems("Item 1", "Item 2", "Item 3");
+        var column1 = grid.addColumn(ValueProvider.identity());
+        var column2 = grid.addColumn(ValueProvider.identity());
         add(grid);
 
-        HeaderRow row1 = grid.appendHeaderRow();
-        row1.getCell(column).setComponent(new Label("foo"));
-        HeaderRow row2 = grid.appendHeaderRow();
-        row2.getCell(column).setComponent(new Label("bar"));
+        var headerRow1 = grid.appendHeaderRow();
+        headerRow1.getCell(column1).setComponent(new NativeLabel("foo"));
+        var initiallyHiddenHeader1 = new NativeLabel("Initially hidden foo");
+        initiallyHiddenHeader1.setVisible(false);
+        headerRow1.getCell(column2).setComponent(initiallyHiddenHeader1);
 
-        NativeButton button = new NativeButton(
+        var headerRow2 = grid.appendHeaderRow();
+        headerRow2.getCell(column1).setComponent(new NativeLabel("bar"));
+        var initiallyHiddenHeader2 = new NativeLabel("Initially hidden bar");
+        initiallyHiddenHeader2.setVisible(false);
+        headerRow2.getCell(column2).setComponent(initiallyHiddenHeader2);
+
+        var button = new NativeButton(
                 "Prepend header, set first text and then component");
         button.setId("set-both-text-and-component");
         button.addClickListener(event -> {
-            HeaderRow topRow = grid.prependHeaderRow();
-            topRow.getCell(column).setText("this is text");
-            topRow.getCell(column).setComponent(new Label("this is component"));
+            var topRow = grid.prependHeaderRow();
+            topRow.getCell(column1).setText("this is text");
+            topRow.getCell(column1)
+                    .setComponent(new NativeLabel("this is component"));
         });
         add(button);
-    }
 
+        var toggleCol2HeadersVisible = new NativeButton(
+                "Toggle col2 headers visible");
+        toggleCol2HeadersVisible.addClickListener(event -> {
+            initiallyHiddenHeader1
+                    .setVisible(!initiallyHiddenHeader1.isVisible());
+            initiallyHiddenHeader2
+                    .setVisible(!initiallyHiddenHeader2.isVisible());
+        });
+        toggleCol2HeadersVisible.setId("toggle-col-2-headers-visible");
+        add(toggleCol2HeadersVisible);
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -109,9 +109,17 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
                 ? HtmlUtils.escape(getBottomLevelColumn().getInternalId())
                 : null;
 
-        grid.getElement().executeJs(
-                "this.$connector.setHeaderRenderer($0, { content: $1, showSorter: $2, sorterPath: $3 })",
-                this.getElement(), headerContent, showSorter, sorterPath);
+        var jsExpression = "this.$connector.setHeaderRenderer($0, { content: $1, showSorter: $2, sorterPath: $3 });";
+        // The JS execution of setting the actual header component will be
+        // delayed until when the header is set visible. Therefore, we
+        // explicitly set the header empty if the header component is initially
+        // hidden.
+        if (headerComponent != null && !headerComponent.isVisible()) {
+            grid.getElement().executeJs(jsExpression, getElement(), "",
+                    showSorter, sorterPath);
+        }
+        grid.getElement().executeJs(jsExpression, getElement(), headerContent,
+                showSorter, sorterPath);
     }
 
     private void scheduleFooterRendering() {


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/flow-components/pull/7517 to v24.6.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.