### PR TITLE
test: handle stale element reference exception in CustomEditorIT

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
@@ -437,12 +438,14 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
 
     private void clickToggleCellVisibleButton() {
         waitUntil(driver -> {
-            var button = $(TestBenchElement.class)
-                    .id("toggleCustomEditorVisibilityButton");
-            return button.isDisplayed();
+            try {
+                var toggleButton = $(TestBenchElement.class)
+                        .id("toggleCustomEditorVisibilityButton");
+                toggleButton.click();
+                return true;
+            } catch (StaleElementReferenceException e) {
+                return false;
+            }
         });
-        var toggleButton = $(TestBenchElement.class)
-                .id("toggleCustomEditorVisibilityButton");
-        toggleButton.click();
     }
 }


### PR DESCRIPTION
The fix for the `StaleElementReferenceException` added in https://github.com/vaadin/flow-components/pull/7536 is not effective ([build](https://bender.vaadin.com/buildConfiguration/VaadinFlowComponents_WcFcNightlyValidation/706118?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true)), as it can still occur if the element is removed in between getting the button reference and checking `isDisplayed` on it:
https://github.com/vaadin/flow-components/blob/b0cb2b0c31076164a41dd76addcb6e2aa45cb5a3/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java#L439-L443

This makes the method handle the exception and retry in an interval until it works. Seems to resolve the issue in this [manually started build](https://bender.vaadin.com/buildConfiguration/VaadinFlowComponents_WcFcNightlyValidation/706430) at least.