### PR TITLE
chore: replace usages of Assert.assertThat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,11 +227,6 @@
                 <version>${poi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>5.6.0</version>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.avatar.tests;
 
-import static org.hamcrest.CoreMatchers.startsWith;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +56,8 @@ public class AvatarGroupIT extends AbstractComponentIT {
         clickElementWithJs("set-items-with-resource");
         String imageUrl = $(AvatarGroupElement.class).first()
                 .getAvatarElement(0).getPropertyString("img");
-        Assert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
+        Assert.assertTrue("Image URL should start with 'VAADIN/dynamic'",
+                imageUrl.startsWith("VAADIN/dynamic"));
         checkLogsForErrors(); // would fail if the image wasn't hosted
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -151,7 +150,8 @@ public class CheckboxGroupTest {
         array.set(0, disabledKey);
 
         group.getElement().setPropertyJson("value", array);
-        Assert.assertThat(group.getValue(), IsEmptyCollection.empty());
+        Assert.assertTrue("Group value should be empty",
+                group.getValue().isEmpty());
         Assert.assertTrue(events.isEmpty());
 
         array = Json.createArray();
@@ -162,7 +162,8 @@ public class CheckboxGroupTest {
         Assert.assertEquals(1, events.size());
 
         ValueChangeEvent<Set<String>> event = events.get(0);
-        Assert.assertThat(event.getOldValue(), IsEmptyCollection.empty());
+        Assert.assertTrue("Event old value should be empty",
+                event.getOldValue().isEmpty());
         Assert.assertEquals(Collections.singleton("enabled"), event.getValue());
     }
 
@@ -184,8 +185,10 @@ public class CheckboxGroupTest {
 
         checkboxGroup.setItems("Foo", "Baz");
 
-        Assert.assertThat(checkboxGroup.getValue(), IsEmptyCollection.empty());
-        Assert.assertThat(capture.get(), IsEmptyCollection.empty());
+        Assert.assertTrue("Checkbox group value should be empty",
+                checkboxGroup.getValue().isEmpty());
+        Assert.assertTrue("Captured value should be empty",
+                capture.get().isEmpty());
     }
 
     @Test
@@ -206,8 +209,10 @@ public class CheckboxGroupTest {
 
         checkboxGroup.deselectAll();
 
-        Assert.assertThat(checkboxGroup.getValue(), IsEmptyCollection.empty());
-        Assert.assertThat(capture.get(), IsEmptyCollection.empty());
+        Assert.assertTrue("Checkbox group value should be empty",
+                checkboxGroup.getValue().isEmpty());
+        Assert.assertTrue("Captured value should be empty",
+                capture.get().isEmpty());
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
@@ -21,7 +21,6 @@ import static com.vaadin.flow.component.combobox.test.FilteringPage.SWITCH_TO_UN
 
 import java.util.List;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -113,9 +112,9 @@ public class FilteringIT extends AbstractComboBoxIT {
 
         waitUntil(driver -> getNonEmptyOverlayContents().size() == 11);
 
-        getNonEmptyOverlayContents().forEach(item -> Assert.assertThat(
-                "Unexpected item found after filtering.", item,
-                CoreMatchers.startsWith("Item 2")));
+        getNonEmptyOverlayContents().forEach(item -> Assert.assertTrue(
+                "Unexpected item found after filtering.",
+                item.startsWith("Item 2")));
     }
 
     @Test
@@ -254,10 +253,10 @@ public class FilteringIT extends AbstractComboBoxIT {
                     + "Expected the items to be already filtered synchronously in client-side.",
                     expectedCount, items.size());
             items.forEach(item -> {
-                Assert.assertThat(
+                Assert.assertTrue(
                         "Found an item which doesn't match the filter. "
                                 + "Expected the items to be already filtered synchronously in client-side.",
-                        item, CoreMatchers.containsString(filter));
+                        item.contains(filter));
             });
         } else {
             Assert.assertEquals("Expected server-side filtering, so there "
@@ -266,9 +265,9 @@ public class FilteringIT extends AbstractComboBoxIT {
 
             waitUntil(driver -> getNonEmptyOverlayContents().size() > 0);
             getNonEmptyOverlayContents().forEach(rendered -> {
-                Assert.assertThat(
+                Assert.assertTrue(
                         "Item which doesn't match the filter was found after server-side filtering.",
-                        rendered, CoreMatchers.containsString(filter));
+                        rendered.contains(filter));
             });
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -310,8 +309,8 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         waitUntil(driver -> getNonEmptyOverlayContents().size() > 0);
 
         getNonEmptyOverlayContents().forEach(rendered -> {
-            Assert.assertThat(rendered,
-                    CoreMatchers.containsString("Born: 10"));
+            Assert.assertTrue("Expected rendered to contain 'Born: 10'",
+                    rendered.contains("Born: 10"));
         });
     }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,22 +50,26 @@ public class ContextMenuTest {
         List<Component> children = contextMenu.getChildren()
                 .collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span2));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span2));
 
         contextMenu.addComponent(span3);
         children = contextMenu.getChildren().collect(Collectors.toList());
         Assert.assertEquals(3, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span2, span3));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span2));
+        Assert.assertTrue(children.contains(span3));
 
         contextMenu.remove(span2);
         children = contextMenu.getChildren().collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span3));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span3));
 
         contextMenu.remove(span1);
         children = contextMenu.getChildren().collect(Collectors.toList());
         Assert.assertEquals(1, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span3));
+        Assert.assertTrue(children.contains(span3));
 
         contextMenu.removeAll();
         children = contextMenu.getChildren().collect(Collectors.toList());

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
@@ -19,7 +19,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -53,8 +52,8 @@ public class DateTimePickerIT extends AbstractComponentIT {
     public void selectDateTime() {
         picker.setDateTime(LocalDateTime.of(1985, 1, 10, 13, 51));
 
-        Assert.assertThat(message.getText(),
-                CoreMatchers.containsString("1985-01-10 13:51:00"));
+        Assert.assertTrue("Message should contain the selected date-time",
+                message.getText().contains("1985-01-10 13:51:00"));
 
         picker.clear();
 
@@ -66,16 +65,16 @@ public class DateTimePickerIT extends AbstractComponentIT {
         picker.setDate(LocalDate.of(1985, 1, 11));
         // message should not have date yet as time is still unset
         // (DateTimePicker value should still be null)
-        Assert.assertThat(message.getText(),
-                CoreMatchers.not(CoreMatchers.containsString("1985-01-11")));
+        Assert.assertFalse("Message should not contain date when time is unset",
+                message.getText().contains("1985-01-11"));
 
         picker.setTime(LocalTime.of(14, 42));
-        Assert.assertThat(message.getText(),
-                CoreMatchers.containsString("1985-01-11 14:42"));
+        Assert.assertTrue("Message should contain the complete date-time",
+                message.getText().contains("1985-01-11 14:42"));
 
         picker.setDate(LocalDate.of(1987, 4, 10));
-        Assert.assertThat(message.getText(),
-                CoreMatchers.containsString("1987-04-10 14:42"));
+        Assert.assertTrue("Message should contain the updated date-time",
+                message.getText().contains("1987-04-10 14:42"));
 
         picker.setDate(null);
         Assert.assertEquals("No date is selected", message.getText());
@@ -114,8 +113,8 @@ public class DateTimePickerIT extends AbstractComponentIT {
         button.click();
         waitUntil(webDriver -> message.getText().contains("2019-10"));
         // check value change message from server
-        Assert.assertThat(message.getText(),
-                CoreMatchers.containsString("2019-10-15 09:40"));
+        Assert.assertTrue("Message should contain the server-set date-time",
+                message.getText().contains("2019-10-15 09:40"));
         // check values of date-time-picker, date-picker and time-picker
         Assert.assertEquals(LocalDateTime.of(2019, 10, 15, 9, 40),
                 picker.getDateTime());

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -93,11 +93,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -15,12 +15,8 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-
 import java.util.List;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -195,7 +191,8 @@ public class DialogTestPageIT extends AbstractComponentIT {
     private void assertDialogContent(String expected) {
         List<WebElement> dialogs = getDialogs();
         String content = dialogs.iterator().next().getText();
-        Assert.assertThat(content, CoreMatchers.containsString(expected));
+        Assert.assertTrue("Dialog content should contain: " + expected,
+                content.contains(expected));
     }
 
     private List<WebElement> getDialogs() {
@@ -221,9 +218,10 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Long endpoint = contentPadding + contentMargin;
 
-        assertThat("Content didn't have a with over the padding and margin",
-                getLongValue(content.getCssValue("width")),
-                greaterThan(endpoint));
+        Long actualWidth = getLongValue(content.getCssValue("width"));
+        Assert.assertTrue(
+                "Content didn't have a width over the padding and margin",
+                actualWidth > endpoint);
     }
 
     @Test

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -71,22 +70,26 @@ public class DialogTest {
         List<Component> children = dialog.getChildren()
                 .collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span2));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span2));
 
         dialog.add(span3);
         children = dialog.getChildren().collect(Collectors.toList());
         Assert.assertEquals(3, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span2, span3));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span2));
+        Assert.assertTrue(children.contains(span3));
 
         dialog.remove(span2);
         children = dialog.getChildren().collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span3));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span3));
 
         span1.getElement().removeFromParent();
         children = dialog.getChildren().collect(Collectors.toList());
         Assert.assertEquals(1, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span3));
+        Assert.assertTrue(children.contains(span3));
 
         dialog.removeAll();
         children = dialog.getChildren().collect(Collectors.toList());

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -138,12 +138,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-core</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -159,11 +153,6 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jol</groupId>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/AddingColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/AddingColumnsIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,12 +97,12 @@ public class AddingColumnsIT extends AbstractComponentIT {
 
     private void assertCellContentsContain(String expectedFirstRow,
             String expectedSecondRow) {
-        MatcherAssert.assertThat(
-                TestHelper.stripComments(grid.getCell(0, 0).getInnerHTML()),
-                CoreMatchers.containsString(expectedFirstRow));
-        MatcherAssert.assertThat(
-                TestHelper.stripComments(grid.getCell(1, 0).getInnerHTML()),
-                CoreMatchers.containsString(expectedSecondRow));
+        Assert.assertTrue("First row should contain expected content",
+                TestHelper.stripComments(grid.getCell(0, 0).getInnerHTML())
+                        .contains(expectedFirstRow));
+        Assert.assertTrue("Second row should contain expected content",
+                TestHelper.stripComments(grid.getCell(1, 0).getInnerHTML())
+                        .contains(expectedSecondRow));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ComponentColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ComponentColumnsIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -80,8 +79,8 @@ public class ComponentColumnsIT extends AbstractComponentIT {
 
     private void assertCellContains(GridElement grid, int rowIndex,
             int colIndex, String expected) {
-        Assert.assertThat(grid.getCell(rowIndex, colIndex).getInnerHTML(),
-                CoreMatchers.containsString(expected));
+        Assert.assertTrue("Expected cell content to contain: " + expected, grid
+                .getCell(rowIndex, colIndex).getInnerHTML().contains(expected));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -210,23 +209,22 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
 
     private void assertHeaderComponentsAreRendered() {
         List<String> headerContents = getHeaderContents();
-        headerContents.forEach(content -> Assert.assertThat(
-                "Span components should be rendered in the headers", content,
-                CoreMatchers.containsString("<span>foo</span>")));
-        headerContents.forEach(content -> Assert.assertThat(
+        headerContents.forEach(content -> Assert.assertTrue(
+                "Span components should be rendered in the headers",
+                content.contains("<span>foo</span>")));
+        headerContents.forEach(content -> Assert.assertFalse(
                 "Header components should have overridden the header texts",
-                content, CoreMatchers.not(CoreMatchers.containsString("bar"))));
+                content.contains("bar")));
     }
 
     private void assertHeaderTextsAreRendered() {
         List<String> headerContents = getHeaderContents();
-        headerContents.forEach(content -> Assert.assertThat(
+        headerContents.forEach(content -> Assert.assertTrue(
                 "The text that was set should be rendered in the headers",
-                content, CoreMatchers.containsString("bar")));
-        headerContents.forEach(content -> Assert.assertThat(
+                content.contains("bar")));
+        headerContents.forEach(content -> Assert.assertFalse(
                 "The text should override the previously set components",
-                content,
-                CoreMatchers.not(CoreMatchers.containsString("<span>"))));
+                content.contains("<span>")));
     }
 
     @Test
@@ -241,10 +239,10 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
                 "There should be one header cell for multiselection checkbox "
                         + "and another for the header",
                 2, headerCells.size());
-        Assert.assertThat(
+        Assert.assertTrue(
                 "The first header cell should contain the multiselection checkbox",
-                headerCells.get(0).getDomProperty("innerHTML"),
-                CoreMatchers.containsString("vaadin-checkbox"));
+                headerCells.get(0).getDomProperty("innerHTML")
+                        .contains("vaadin-checkbox"));
         Assert.assertEquals(
                 "The second header cell should contain the set text", "0",
                 headerCells.get(1).getText());
@@ -368,8 +366,9 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
     private void assertHeaderHasGridSorter(int headerIndexFromTop) {
         List<WebElement> headerCells = getHeaderCells();
         WebElement cellWithSorter = headerCells.get(headerIndexFromTop);
-        Assert.assertThat(cellWithSorter.getDomProperty("innerHTML"),
-                CoreMatchers.containsString("vaadin-grid-sorter"));
+        Assert.assertTrue("Cell should contain vaadin-grid-sorter",
+                cellWithSorter.getDomProperty("innerHTML")
+                        .contains("vaadin-grid-sorter"));
 
         Assert.assertTrue("Only one header should have the sorting indicators",
                 headerCells.stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -110,8 +109,8 @@ public class GridTestPageIT extends AbstractComponentIT {
         // verify that the properties needed for the details row are not loaded
         items.forEach((row, map) -> {
             Assert.assertEquals("Item " + row, map.get("col0"));
-            Assert.assertThat(map.keySet(),
-                    CoreMatchers.not(CoreMatchers.hasItem("detailsProperty")));
+            Assert.assertFalse("detailsProperty should not be loaded initially",
+                    map.keySet().contains("detailsProperty"));
         });
 
         // click on the cell to open the details row
@@ -129,8 +128,9 @@ public class GridTestPageIT extends AbstractComponentIT {
                 Assert.assertEquals("Details opened! 0",
                         map.get(detailsProperty));
             } else {
-                Assert.assertThat(map.keySet(), CoreMatchers
-                        .not(CoreMatchers.hasItem("detailsProperty")));
+                Assert.assertFalse(
+                        "detailsProperty should not be loaded for other rows",
+                        map.keySet().contains("detailsProperty"));
             }
         });
     }
@@ -143,8 +143,8 @@ public class GridTestPageIT extends AbstractComponentIT {
         // verify that the nodeId of the details row is not loaded
         items.forEach((row, map) -> {
             Assert.assertEquals("Item " + row, map.get("col0"));
-            Assert.assertThat(map.keySet(),
-                    CoreMatchers.not(CoreMatchers.hasItem("nodeId")));
+            Assert.assertFalse("nodeId should not be loaded initially",
+                    map.keySet().contains("nodeId"));
         });
 
         // click on the cell to open the details row
@@ -178,8 +178,9 @@ public class GridTestPageIT extends AbstractComponentIT {
          */
         Map<String, Map<String, ?>> items = getItems(driver, grid);
         items.forEach((row, map) -> {
-            Assert.assertThat(map.keySet(),
-                    CoreMatchers.not(CoreMatchers.hasItem("col0")));
+            Assert.assertFalse(
+                    "col0 key should not be present after column removal",
+                    map.keySet().contains("col0"));
             Assert.assertEquals("Item " + row, map.get("col1"));
             Assert.assertEquals(String.valueOf(row),
                     String.valueOf(map.get("col2")));
@@ -194,10 +195,11 @@ public class GridTestPageIT extends AbstractComponentIT {
          */
         items = getItems(driver, grid);
         items.forEach((row, map) -> {
-            Assert.assertThat(map.keySet(),
-                    CoreMatchers.not(CoreMatchers.hasItem("col0")));
-            Assert.assertThat(map.keySet(),
-                    CoreMatchers.not(CoreMatchers.hasItem("col1")));
+            Assert.assertFalse("col0 key should not be present",
+                    map.keySet().contains("col0"));
+            Assert.assertFalse(
+                    "col1 key should not be present after column removal",
+                    map.keySet().contains("col1"));
             Assert.assertEquals(String.valueOf(row),
                     String.valueOf(map.get("col2")));
         });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.component.grid.it;
 
 import static com.vaadin.flow.component.grid.it.ItemClickListenerPage.GRID_FILTER_FOCUSABLE_HEADER;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,11 +50,13 @@ public class ItemClickListenerIT extends AbstractComponentIT {
 
         String yCoord = getDoubleClickMessage();
 
-        Assert.assertThat(Integer.parseInt(yCoord),
-                CoreMatchers.allOf(
-                        Matchers.greaterThan(firstRow.getLocation().getY()),
-                        Matchers.lessThan(firstRow.getLocation().getY()
-                                + firstRow.getSize().getHeight())));
+        int yCoordInt = Integer.parseInt(yCoord);
+        Assert.assertTrue(
+                "Y coordinate should be greater than first row location",
+                yCoordInt > firstRow.getLocation().getY());
+        Assert.assertTrue("Y coordinate should be less than first row bottom",
+                yCoordInt < firstRow.getLocation().getY()
+                        + firstRow.getSize().getHeight());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,28 +36,28 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
     @Test
     public void refresh_componentRendered() {
         getDriver().navigate().refresh();
-        Assert.assertThat(
+        Assert.assertTrue(
                 "Unexpected cell content after refreshing with @PreserveOnRefresh.",
-                getGrid().getCell(0, 0).getInnerHTML(),
-                CoreMatchers.containsString("<span>foo</span>"));
+                getGrid().getCell(0, 0).getInnerHTML()
+                        .contains("<span>foo</span>"));
     }
 
     @Test
     public void refresh_headerComponentRendered() {
         getDriver().navigate().refresh();
-        Assert.assertThat(
+        Assert.assertTrue(
                 "Unexpected header content after refreshing with @PreserveOnRefresh.",
-                getGrid().getHeaderCell(0).getInnerHTML(),
-                CoreMatchers.containsString("<span>header</span>"));
+                getGrid().getHeaderCell(0).getInnerHTML()
+                        .contains("<span>header</span>"));
     }
 
     @Test
     public void refresh_footerComponentRendered() {
         getDriver().navigate().refresh();
-        Assert.assertThat(
+        Assert.assertTrue(
                 "Unexpected footer content after refreshing with @PreserveOnRefresh.",
-                getGrid().getFooterCell(0).getInnerHTML(),
-                CoreMatchers.containsString("<span>footer</span>"));
+                getGrid().getFooterCell(0).getInnerHTML()
+                        .contains("<span>footer</span>"));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/TextRendererIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/TextRendererIT.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.grid.it;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -42,7 +41,8 @@ public class TextRendererIT extends AbstractComponentIT {
         // self check: click is handled with a result on the client side
         String classNames = findElement(By.tagName("vaadin-grid"))
                 .getDomAttribute("class");
-        Assert.assertThat(classNames, CoreMatchers.containsString("refreshed"));
+        Assert.assertTrue("Expected classNames to contain 'refreshed'",
+                classNames.contains("refreshed"));
 
         Set<String> cellsAfterRefresh = findElements(
                 By.tagName("vaadin-grid-cell-content")).stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeComponentColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeComponentColumnsIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,8 +113,8 @@ public class TreeComponentColumnsIT extends AbstractComponentIT {
 
     private void assertCellContains(GridElement grid, int rowIndex,
             int colIndex, String expected) {
-        Assert.assertThat(grid.getCell(rowIndex, colIndex).getInnerHTML(),
-                CoreMatchers.containsString(expected));
+        Assert.assertTrue("Expected cell content to contain: " + expected, grid
+                .getCell(rowIndex, colIndex).getInnerHTML().contains(expected));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
-import org.hamcrest.core.StringContains;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -169,8 +168,8 @@ public class TreeGridHugeTreeIT extends AbstractTreeGridIT {
             String cellText = grid.getCell(i, 0).getText();
             if (cellText.contains("Dad")) {
                 String sonText = grid.getCell(i + 1, 0).getText();
-                Assert.assertThat(sonText + " is not a Son item", sonText,
-                        StringContains.containsString("Son"));
+                Assert.assertTrue(sonText + " is not a Son item",
+                        sonText.contains("Son"));
 
             }
         }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -651,11 +650,10 @@ public class HeaderFooterTest {
                 "The cell prepended on top of a joined cell should be "
                         + "a parent for the same column elements",
                 2, bottomChildColumns.size());
-        Assert.assertThat(
-                "The cell prepended on top of a joined cell should be "
-                        + "a parent for the same column elements",
-                bottomChildColumns,
-                CoreMatchers.hasItems(firstColumn, secondColumn));
+        Assert.assertTrue("The child columns should contain firstColumn",
+                bottomChildColumns.contains(firstColumn));
+        Assert.assertTrue("The child columns should contain secondColumn",
+                bottomChildColumns.contains(secondColumn));
     }
 
     @Test

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.listbox.test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -83,16 +81,16 @@ public class ListBoxIT extends AbstractComponentIT {
 
     private void assertMessage(String oldValue, String newValue,
             boolean fromClient) {
-        Assert.assertThat(
+        String messageText = message.getText();
+        Assert.assertTrue(
                 "The message should show the old and new values of the ListBox "
                         + "after selection changes",
-                message.getText(), containsString(
+                messageText.contains(
                         String.format("from %s to %s", oldValue, newValue)));
-        Assert.assertThat(
+        Assert.assertTrue(
                 "The message should indicate that the event is from "
                         + (fromClient ? "client" : "server"),
-                message.getText(),
-                containsString("from client: " + fromClient));
+                messageText.contains("from client: " + fromClient));
     }
 
     @Test
@@ -136,12 +134,12 @@ public class ListBoxIT extends AbstractComponentIT {
         String nameText = spans.get(0).getText();
         String stockText = spans.get(1).getText();
 
-        Assert.assertThat(
+        Assert.assertTrue(
                 "First child inside the item should contain the name of the item",
-                nameText, containsString(itemName));
-        Assert.assertThat(
+                nameText.contains(itemName));
+        Assert.assertTrue(
                 "Second child inside the item should display the amount of items in stock",
-                stockText, containsString("In stock"));
+                stockText.contains("In stock"));
 
         try {
             int stock = Integer
@@ -171,9 +169,9 @@ public class ListBoxIT extends AbstractComponentIT {
         List<WebElement> spans = item.findElements(By.tagName("span"));
         String nameText = spans.get(0).getText();
 
-        Assert.assertThat(
+        Assert.assertTrue(
                 "First child inside the item should contain the name of the item",
-                nameText, containsString(itemName));
+                nameText.contains(itemName));
     }
 
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -446,9 +445,9 @@ public class MultiSelectListBoxTest {
                 "The selectedValues property had different length than expected.",
                 selectedValues.length(), indices.length);
         for (int index : indices) {
-            Assert.assertThat(
+            Assert.assertTrue(
                     "The selectedValues property didn't contain expected value.",
-                    actualIndices, CoreMatchers.hasItem(index));
+                    actualIndices.contains(index));
         }
     }
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
@@ -15,13 +15,10 @@
  */
 package com.vaadin.flow.component.messages.tests;
 
-import static org.hamcrest.CoreMatchers.startsWith;
-
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -169,7 +166,8 @@ public class MessageListIT extends AbstractComponentIT {
         getLogEntries(Level.WARNING); // message logs before setting resource
         clickElementWithJs("setImageAsStreamResource");
         String imageUrl = messageList.getMessageElements().get(0).getUserImg();
-        MatcherAssert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
+        Assert.assertTrue("Image URL should start with 'VAADIN/dynamic'",
+                imageUrl.startsWith("VAADIN/dynamic"));
         // would fail if the avatar.png image wasn't hosted
         checkLogsForErrors(message -> message.contains("test.jpg"));
     }
@@ -233,7 +231,8 @@ public class MessageListIT extends AbstractComponentIT {
         getLogEntries(Level.WARNING); // message logs before setting resource
         clickElementWithJs("setImageAsDownloadHandler");
         String imageUrl = messageList.getMessageElements().get(0).getUserImg();
-        MatcherAssert.assertThat(imageUrl, startsWith("VAADIN/dynamic"));
+        Assert.assertTrue("Image URL should start with 'VAADIN/dynamic'",
+                imageUrl.startsWith("VAADIN/dynamic"));
         checkLogsForErrors(); // would fail if the image wasn't hosted
     }
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -15,12 +15,9 @@
  */
 package com.vaadin.flow.component.messages.tests;
 
-import static org.hamcrest.CoreMatchers.startsWith;
-
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -100,8 +97,9 @@ public class MessageListTest {
         item1.setUserImage("foo/bar");
         item1.setUserImageResource(new StreamResource("message-list-img",
                 () -> getClass().getResourceAsStream("baz/qux")));
-        MatcherAssert.assertThat(item1.getUserImage(),
-                startsWith("VAADIN/dynamic"));
+        String userImage = item1.getUserImage();
+        Assert.assertTrue("User image should start with 'VAADIN/dynamic'",
+                userImage.startsWith("VAADIN/dynamic"));
     }
 
     @Test
@@ -121,8 +119,9 @@ public class MessageListTest {
                 DownloadHandler.fromInputStream(data -> new DownloadResponse(
                         getClass().getResourceAsStream("baz/qux"),
                         "message-list-img", null, -1)));
-        MatcherAssert.assertThat(item1.getUserImage(),
-                startsWith("VAADIN/dynamic"));
+        String userImage = item1.getUserImage();
+        Assert.assertTrue("User image should start with 'VAADIN/dynamic'",
+                userImage.startsWith("VAADIN/dynamic"));
     }
 
     @Test

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -72,22 +71,29 @@ public class NotificationTest {
         List<Component> children = notification.getChildren()
                 .collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span2));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span2));
 
         notification.add(span3);
         children = notification.getChildren().collect(Collectors.toList());
         Assert.assertEquals(3, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span2, span3));
+        Assert.assertTrue(children.contains(span1));
+        Assert.assertTrue(children.contains(span2));
+        Assert.assertTrue(children.contains(span3));
 
         notification.remove(span2);
         children = notification.getChildren().collect(Collectors.toList());
         Assert.assertEquals(2, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span1, span3));
+        Assert.assertTrue("Children should contain span1",
+                children.contains(span1));
+        Assert.assertTrue("Children should contain span3",
+                children.contains(span3));
 
         span1.getElement().removeFromParent();
         children = notification.getChildren().collect(Collectors.toList());
         Assert.assertEquals(1, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(span3));
+        Assert.assertTrue("Children should contain span3",
+                children.contains(span3));
 
         notification.removeAll();
         children = notification.getChildren().collect(Collectors.toList());
@@ -103,9 +109,10 @@ public class NotificationTest {
         List<Component> children = notification.getChildren()
                 .collect(Collectors.toList());
         Assert.assertEquals(1, children.size());
-        Assert.assertThat(children, CoreMatchers.hasItems(container2));
-        Assert.assertThat(children,
-                CoreMatchers.not(CoreMatchers.hasItem(container1)));
+        Assert.assertTrue("Children should contain container2",
+                children.contains(container2));
+        Assert.assertFalse("Children should not contain container1",
+                children.contains(container1));
     }
 
     @Test

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarTest.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarTest.java
@@ -15,9 +15,7 @@
  */
 package com.vaadin.flow.component.progressbar.tests;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,9 +35,12 @@ public class ProgressBarTest {
 
         ProgressBar progressBar = new ProgressBar();
 
-        assertThat("initial min is wrong", progressBar.getMin(), is(0.0));
-        assertThat("initial max is wrong", progressBar.getMax(), is(1.0));
-        assertThat("initial value is wrong", progressBar.getValue(), is(0.0));
+        Assert.assertEquals("initial min is wrong", 0.0, progressBar.getMin(),
+                0.0);
+        Assert.assertEquals("initial max is wrong", 1.0, progressBar.getMax(),
+                0.0);
+        Assert.assertEquals("initial value is wrong", 0.0,
+                progressBar.getValue(), 0.0);
     }
 
     @Test
@@ -49,9 +50,12 @@ public class ProgressBarTest {
 
         ProgressBar progressBar = new ProgressBar(min, max);
 
-        assertThat("initial min is wrong", progressBar.getMin(), is(min));
-        assertThat("initial max is wrong", progressBar.getMax(), is(max));
-        assertThat("initial value is wrong", progressBar.getValue(), is(min));
+        Assert.assertEquals("initial min is wrong", min, progressBar.getMin(),
+                0.0);
+        Assert.assertEquals("initial max is wrong", max, progressBar.getMax(),
+                0.0);
+        Assert.assertEquals("initial value is wrong", min,
+                progressBar.getValue(), 0.0);
     }
 
     @Test
@@ -62,9 +66,12 @@ public class ProgressBarTest {
 
         ProgressBar progressBar = new ProgressBar(min, max, value);
 
-        assertThat("initial min is wrong", progressBar.getMin(), is(min));
-        assertThat("initial max is wrong", progressBar.getMax(), is(max));
-        assertThat("initial value is wrong", progressBar.getValue(), is(value));
+        Assert.assertEquals("initial min is wrong", min, progressBar.getMin(),
+                0.0);
+        Assert.assertEquals("initial max is wrong", max, progressBar.getMax(),
+                0.0);
+        Assert.assertEquals("initial value is wrong", value,
+                progressBar.getValue(), 0.0);
     }
 
     @Test
@@ -122,12 +129,14 @@ public class ProgressBarTest {
         double value = 25;
 
         ProgressBar progressBar = new ProgressBar(min, max);
-        assertThat("initial value is wrong", progressBar.getValue(), is(min));
+        Assert.assertEquals("initial value is wrong", min,
+                progressBar.getValue(), 0.0);
         progressBar.setValue(value);
 
-        assertThat("min is wrong", progressBar.getMin(), is(min));
-        assertThat("max is wrong", progressBar.getMax(), is(max));
-        assertThat("updated value is wrong", progressBar.getValue(), is(value));
+        Assert.assertEquals("min is wrong", min, progressBar.getMin(), 0.0);
+        Assert.assertEquals("max is wrong", max, progressBar.getMax(), 0.0);
+        Assert.assertEquals("updated value is wrong", value,
+                progressBar.getValue(), 0.0);
     }
 
     @Test
@@ -137,12 +146,14 @@ public class ProgressBarTest {
         double value = 42;
 
         ProgressBar progressBar = new ProgressBar(min, max, value);
-        assertThat("initial value is wrong", progressBar.getValue(), is(value));
+        Assert.assertEquals("initial value is wrong", value,
+                progressBar.getValue(), 0.0);
         progressBar.setValue(min);
 
-        assertThat("min is wrong", progressBar.getMin(), is(min));
-        assertThat("max is wrong", progressBar.getMax(), is(max));
-        assertThat("updated value is wrong", progressBar.getValue(), is(min));
+        Assert.assertEquals("min is wrong", min, progressBar.getMin(), 0.0);
+        Assert.assertEquals("max is wrong", max, progressBar.getMax(), 0.0);
+        Assert.assertEquals("updated value is wrong", min,
+                progressBar.getValue(), 0.0);
     }
 
     @Test
@@ -152,12 +163,14 @@ public class ProgressBarTest {
         double value = 66;
 
         ProgressBar progressBar = new ProgressBar(min, max, value);
-        assertThat("initial value is wrong", progressBar.getValue(), is(value));
+        Assert.assertEquals("initial value is wrong", value,
+                progressBar.getValue(), 0.0);
         progressBar.setValue(max);
 
-        assertThat("min is wrong", progressBar.getMin(), is(min));
-        assertThat("max is wrong", progressBar.getMax(), is(max));
-        assertThat("updated value is wrong", progressBar.getValue(), is(max));
+        Assert.assertEquals("min is wrong", min, progressBar.getMin(), 0.0);
+        Assert.assertEquals("max is wrong", max, progressBar.getMax(), 0.0);
+        Assert.assertEquals("updated value is wrong", max,
+                progressBar.getValue(), 0.0);
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -80,11 +80,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.17</version>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -64,11 +64,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -82,11 +82,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.17</version>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutAssertions.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutAssertions.java
@@ -15,10 +15,7 @@
  */
 package com.vaadin.flow.component.splitlayout.tests;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import org.junit.Assert;
 
 import com.vaadin.flow.component.splitlayout.testbench.SplitLayoutElement;
 import com.vaadin.testbench.TestBenchElement;
@@ -37,9 +34,14 @@ class SplitLayoutAssertions {
         int expectedWidth = (int) Math
                 .round((layoutWidth - splitterWidth) * percentage / 100);
 
-        assertThat(childWidth,
-                allOf(greaterThanOrEqualTo(expectedWidth - MARGIN),
-                        lessThanOrEqualTo(expectedWidth + MARGIN)));
+        Assert.assertTrue(
+                "Child width " + childWidth + " should be >= "
+                        + (expectedWidth - MARGIN),
+                childWidth >= expectedWidth - MARGIN);
+        Assert.assertTrue(
+                "Child width " + childWidth + " should be <= "
+                        + (expectedWidth + MARGIN),
+                childWidth <= expectedWidth + MARGIN);
     }
 
     public static void assertChildHeightInPercentage(
@@ -52,8 +54,13 @@ class SplitLayoutAssertions {
         int expectedHeight = (int) Math
                 .round((layoutHeight - splitterHeight) * percentage / 100);
 
-        assertThat(childHeight,
-                allOf(greaterThanOrEqualTo(expectedHeight - MARGIN),
-                        lessThanOrEqualTo(expectedHeight + MARGIN)));
+        Assert.assertTrue(
+                "Child height " + childHeight + " should be >= "
+                        + (expectedHeight - MARGIN),
+                childHeight >= expectedHeight - MARGIN);
+        Assert.assertTrue(
+                "Child height " + childHeight + " should be <= "
+                        + (expectedHeight + MARGIN),
+                childHeight <= expectedHeight + MARGIN);
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergedCellFrozenIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergedCellFrozenIT.java
@@ -8,9 +8,7 @@
  */
 package com.vaadin.flow.component.spreadsheet.test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,10 +35,10 @@ public class MergedCellFrozenIT extends AbstractSpreadsheetIT {
         String cellText = "Merged cells in frozen area";
 
         var d2 = spreadsheet.getCellAt("D2");
-        assertThat(d2.getValue(), equalTo(cellText));
+        Assert.assertEquals(cellText, d2.getValue());
 
         String left = d2.getCssValue("left");
-        assertThat(left, equalTo("0px"));
+        Assert.assertEquals("0px", left);
 
         testBench().resizeViewPortTo(WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2);
 
@@ -51,10 +49,10 @@ public class MergedCellFrozenIT extends AbstractSpreadsheetIT {
         Thread.sleep(1000);
 
         d2 = spreadsheet.getCellAt("D2");
-        assertThat(d2.getValue(), equalTo(cellText));
+        Assert.assertEquals(cellText, d2.getValue());
 
         left = d2.getCssValue("left");
-        assertThat(left, equalTo("0px"));
+        Assert.assertEquals("0px", left);
     }
 
     @Test
@@ -67,7 +65,7 @@ public class MergedCellFrozenIT extends AbstractSpreadsheetIT {
         String cellText = "5";
 
         var e8 = spreadsheet.getCellAt("E8");
-        assertThat(e8.getValue(), equalTo(cellText));
+        Assert.assertEquals(cellText, e8.getValue());
 
         String originalLeft = e8.getCssValue("left");
 
@@ -80,9 +78,9 @@ public class MergedCellFrozenIT extends AbstractSpreadsheetIT {
         Thread.sleep(1000);
 
         e8 = spreadsheet.getCellAt("E8");
-        assertThat(e8.getValue(), equalTo(cellText));
+        Assert.assertEquals(cellText, e8.getValue());
 
-        assertThat(e8.getCssValue("left"), equalTo(originalLeft));
+        Assert.assertEquals(originalLeft, e8.getCssValue("left"));
     }
 
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergedCellNarrowFirstColumnIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergedCellNarrowFirstColumnIT.java
@@ -8,13 +8,11 @@
  */
 package com.vaadin.flow.component.spreadsheet.test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -41,7 +39,7 @@ public class MergedCellNarrowFirstColumnIT extends AbstractSpreadsheetIT {
         String cellText = "123456";
 
         var a2 = spreadsheet.getCellAt("A2");
-        assertThat(a2.getValue(), equalTo(cellText));
+        Assert.assertEquals(cellText, a2.getValue());
 
         String cellSelector = String.format(".col%d.row%d.cell", 1, 2);
         List<WebElement> elements = findElementsInShadowRoot(
@@ -57,10 +55,10 @@ public class MergedCellNarrowFirstColumnIT extends AbstractSpreadsheetIT {
 
         var cellElement = underlyingCell.wrap(SheetCellElement.class);
 
-        assertThat(cellElement.getValue(), equalTo(cellText));
+        Assert.assertEquals(cellText, cellElement.getValue());
 
         String overFlow = cellElement.getCssValue("overflow");
-        assertThat(overFlow, not(equalTo("visible")));
+        Assert.assertNotEquals("visible", overFlow);
     }
 
 }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/TabsIT.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/TabsIT.java
@@ -15,10 +15,9 @@
  */
 package com.vaadin.flow.component.tabs.tests;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -49,12 +48,12 @@ public class TabsIT extends AbstractComponentIT {
         WebElement tab3 = layout.findElement(By.id("tab3"));
         WebElement page1 = layout.findElement(By.id("page1"));
         assertFalse(isElementPresent(By.id("page3")));
-        assertThat(page1.getCssValue("display"), is("block"));
+        Assert.assertEquals("block", page1.getCssValue("display"));
 
         scrollIntoViewAndClick(tab3);
 
         assertFalse(isElementPresent(By.id("page1")));
         WebElement page3 = layout.findElement(By.id("page3"));
-        assertThat(page3.getCssValue("display"), is("block"));
+        Assert.assertEquals("block", page3.getCssValue("display"));
     }
 }

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabTest.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.tabs.tests;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 import org.junit.Assert;
@@ -35,8 +34,9 @@ public class TabTest {
     @Test
     public void shouldCreateEmptyTabWithDefaultState() throws Exception {
 
-        assertThat("Initial label is invalid", tab.getLabel(), is(""));
-        assertThat("Initial flexGrow is invalid", tab.getFlexGrow(), is(0.0));
+        Assert.assertEquals("Initial label is invalid", "", tab.getLabel());
+        Assert.assertEquals("Initial flexGrow is invalid", 0.0,
+                tab.getFlexGrow(), 0.0);
     }
 
     @Test
@@ -45,15 +45,16 @@ public class TabTest {
 
         tab = new Tab(label);
 
-        assertThat("Initial label is invalid", tab.getLabel(), is(label));
-        assertThat("Initial flexGrow is invalid", tab.getFlexGrow(), is(0.0));
+        Assert.assertEquals("Initial label is invalid", label, tab.getLabel());
+        Assert.assertEquals("Initial flexGrow is invalid", 0.0,
+                tab.getFlexGrow(), 0.0);
     }
 
     @Test
     public void shouldSetFlexGrow() throws Exception {
         tab.setFlexGrow(1);
 
-        assertThat("flexGrow is invalid", tab.getFlexGrow(), is(1.0));
+        Assert.assertEquals("flexGrow is invalid", 1.0, tab.getFlexGrow(), 0.0);
     }
 
     @Test

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.flow.component.tabs.tests;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,13 +41,14 @@ public class TabsTest {
     public void createTabsInDefaultState() {
         Tabs tabs = new Tabs();
 
-        assertThat("Initial tab count is invalid", tabs.getTabCount(), is(0));
-        assertThat("Initial orientation is invalid", tabs.getOrientation(),
-                is(Tabs.Orientation.HORIZONTAL));
-        assertThat("Initial selected index is invalid", tabs.getSelectedIndex(),
-                is(-1));
-        assertThat("Initial child count is invalid", tabs.getSelectedTab(),
-                CoreMatchers.nullValue());
+        Assert.assertEquals("Initial tab count is invalid", 0,
+                tabs.getTabCount());
+        Assert.assertEquals("Initial orientation is invalid",
+                Tabs.Orientation.HORIZONTAL, tabs.getOrientation());
+        Assert.assertEquals("Initial selected index is invalid", -1,
+                tabs.getSelectedIndex());
+        Assert.assertNull("Initial child count is invalid",
+                tabs.getSelectedTab());
     }
 
     @Test
@@ -61,13 +58,14 @@ public class TabsTest {
         Tab tab3 = new Tab("Tab three");
         Tabs tabs = new Tabs(tab1, tab2, tab3);
 
-        assertThat("Initial tab count is invalid", tabs.getTabCount(), is(3));
-        assertThat("Initial orientation is invalid", tabs.getOrientation(),
-                is(Tabs.Orientation.HORIZONTAL));
-        assertThat("Initial selected tab is invalid", tabs.getSelectedTab(),
-                is(tab1));
-        assertThat("Initial selected index is invalid", tabs.getSelectedIndex(),
-                is(0));
+        Assert.assertEquals("Initial tab count is invalid", 3,
+                tabs.getTabCount());
+        Assert.assertEquals("Initial orientation is invalid",
+                Tabs.Orientation.HORIZONTAL, tabs.getOrientation());
+        Assert.assertEquals("Initial selected tab is invalid", tab1,
+                tabs.getSelectedTab());
+        Assert.assertEquals("Initial selected index is invalid", 0,
+                tabs.getSelectedIndex());
     }
 
     @Test
@@ -76,8 +74,8 @@ public class TabsTest {
 
         tabs.setOrientation(Tabs.Orientation.VERTICAL);
 
-        assertThat("Orientation is invalid", tabs.getOrientation(),
-                is(Tabs.Orientation.VERTICAL));
+        Assert.assertEquals("Orientation is invalid", Tabs.Orientation.VERTICAL,
+                tabs.getOrientation());
     }
 
     @Test
@@ -89,8 +87,10 @@ public class TabsTest {
 
         tabs.setSelectedTab(tab2);
 
-        assertThat("Selected tab is invalid", tabs.getSelectedTab(), is(tab2));
-        assertThat("Selected index is invalid", tabs.getSelectedIndex(), is(1));
+        Assert.assertEquals("Selected tab is invalid", tab2,
+                tabs.getSelectedTab());
+        Assert.assertEquals("Selected index is invalid", 1,
+                tabs.getSelectedIndex());
     }
 
     @Test
@@ -102,8 +102,10 @@ public class TabsTest {
 
         tabs.setSelectedIndex(2);
 
-        assertThat("Selected tab is invalid", tabs.getSelectedTab(), is(tab3));
-        assertThat("Selected index is invalid", tabs.getSelectedIndex(), is(2));
+        Assert.assertEquals("Selected tab is invalid", tab3,
+                tabs.getSelectedTab());
+        Assert.assertEquals("Selected index is invalid", 2,
+                tabs.getSelectedIndex());
     }
 
     @Test
@@ -164,9 +166,12 @@ public class TabsTest {
 
         tabs.setFlexGrowForEnclosedTabs(1.5);
 
-        assertThat("flexGrow of tab1 is invalid", tab1.getFlexGrow(), is(1.5));
-        assertThat("flexGrow of tab2 is invalid", tab2.getFlexGrow(), is(1.5));
-        assertThat("flexGrow of tab3 is invalid", tab3.getFlexGrow(), is(1.5));
+        Assert.assertEquals("flexGrow of tab1 is invalid", 1.5,
+                tab1.getFlexGrow(), 0.0);
+        Assert.assertEquals("flexGrow of tab2 is invalid", 1.5,
+                tab2.getFlexGrow(), 0.0);
+        Assert.assertEquals("flexGrow of tab3 is invalid", 1.5,
+                tab3.getFlexGrow(), 0.0);
     }
 
     @Test

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -15,13 +15,10 @@
  */
 package com.vaadin.flow.component.upload.tests;
 
-import static org.junit.Assert.assertThat;
-
 import java.io.File;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -153,14 +150,16 @@ public class UploadIT extends AbstractUploadIT {
         getUpload().upload(tempFile);
 
         List<LogEntry> logList1 = getLogEntries(Level.SEVERE);
-        assertThat("There should have no severe message in the console",
-                logList1.size(), CoreMatchers.is(0));
+        Assert.assertEquals(
+                "There should have no severe message in the console", 0,
+                logList1.size());
 
         WebElement upload = getUpload();
         executeScript("arguments[0]._removeFile()", upload);
         List<LogEntry> logList2 = getLogEntries(Level.SEVERE);
-        assertThat("There should have no severe message in the console",
-                logList2.size(), CoreMatchers.is(0));
+        Assert.assertEquals(
+                "There should have no severe message in the console", 0,
+                logList2.size());
     }
 
     @Test

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/TemporaryFileFactoryTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/TemporaryFileFactoryTest.java
@@ -15,12 +15,9 @@
  */
 package com.vaadin.flow.component.upload.tests;
 
-import static org.hamcrest.CoreMatchers.containsString;
-
 import java.io.File;
 import java.io.IOException;
 
-import org.hamcrest.core.IsNot;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,6 +31,7 @@ public class TemporaryFileFactoryTest {
         File testFile = temporaryFileFactory.createFile("test");
         String fileName = testFile.getName();
 
-        Assert.assertThat(fileName, IsNot.not(containsString("test")));
+        Assert.assertFalse("File name should not contain 'test'",
+                fileName.contains("test"));
     }
 }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListIT.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -156,8 +154,8 @@ public class VirtualListIT extends AbstractComponentIT {
 
         // all the remaining items should be empty
         for (int i = lastReceivedKey; i < items.length(); i++) {
-            MatcherAssert.assertThat(items.get(i),
-                    CoreMatchers.instanceOf(JsonNull.class));
+            Assert.assertTrue("Item at index " + i + " should be JsonNull",
+                    items.get(i) instanceof JsonNull);
         }
 
         scrollToBottom(list);
@@ -264,8 +262,9 @@ public class VirtualListIT extends AbstractComponentIT {
 
         assertListContainsMaxItems(items.size(), 25);
 
-        MatcherAssert.assertThat(list.getDomProperty("innerText"), CoreMatchers
-                .not(CoreMatchers.containsString("the-placeholder")));
+        String innerText = list.getDomProperty("innerText");
+        Assert.assertFalse("Inner text should not contain 'the-placeholder'",
+                innerText.contains("the-placeholder"));
 
         // Scroll to bottom and set an attribute when a placeholder becomes
         // visible.
@@ -294,10 +293,10 @@ public class VirtualListIT extends AbstractComponentIT {
         waitUntil(driver -> list.getDomProperty("innerText")
                 .contains("Person 100"));
 
-        MatcherAssert.assertThat(
+        String listInnerText = list.getDomProperty("innerText");
+        Assert.assertFalse(
                 "The VirtualList shouldn't display any placeholders after the data is loaded",
-                list.getDomProperty("innerText"), CoreMatchers
-                        .not(CoreMatchers.containsString("the-placeholder")));
+                listInnerText.contains("the-placeholder"));
 
         assertListContainsMaxItems(items.size(), 25);
     }
@@ -399,10 +398,9 @@ public class VirtualListIT extends AbstractComponentIT {
             int endingIndex, String itemLabelprefix) {
 
         for (int i = startingIndex; i < endingIndex; i++) {
-            MatcherAssert.assertThat(
+            Assert.assertTrue(
                     "Object at index " + i + " is null, when it shouldn't be",
-                    items.get(i),
-                    CoreMatchers.not(CoreMatchers.instanceOf(JsonNull.class)));
+                    !(items.get(i) instanceof JsonNull));
             Assert.assertEquals(itemLabelprefix + (i + 1),
                     getPropertyString(items.getObject(i), "label"));
         }
@@ -412,9 +410,9 @@ public class VirtualListIT extends AbstractComponentIT {
             int endingIndex) {
 
         for (int i = startingIndex; i < endingIndex; i++) {
-            MatcherAssert.assertThat(
+            Assert.assertTrue(
                     "Object at index " + i + " is not null, when it should be",
-                    items.get(i), CoreMatchers.instanceOf(JsonNull.class));
+                    items.get(i) instanceof JsonNull);
         }
     }
 


### PR DESCRIPTION
## Description

- Replace usages of the deprecated `Assert.assertThat` method
- Also replaces other usages of hamcrest matchers in favor of plain JUnit assertions
- Remove hamcrest dependency from POM files

## Type of change

- Internal