### PR TITLE
chore: add name tag to module [skip ci]

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spreadsheet-flow-client</artifactId>
+    <name>Vaadin Spreadsheet Flow Client</name>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
this is needed when doing the maven central release