### PR TITLE
fix: upload handlers always end with /upload

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -727,7 +727,12 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     public void setUploadHandler(UploadHandler handler) {
         Objects.requireNonNull(handler, "UploadHandler cannot be null");
         StreamResourceRegistry.ElementStreamResource elementStreamResource = new StreamResourceRegistry.ElementStreamResource(
-                handler, this.getElement());
+                handler, this.getElement()) {
+            @Override
+            public String getName() {
+                return "upload";
+            }
+        };
         runBeforeClientResponse(ui -> getElement().setAttribute("target",
                 elementStreamResource));
         if (!hasListener(UploadStartEvent.class)

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/UploadTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/UploadTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.SerializableConsumer;
+
+import net.jcip.annotations.NotThreadSafe;
+
+@NotThreadSafe
+public class UploadTest {
+
+    @Test
+    public void uploadHandlerSet_generatedUrlEndsWithUpload() {
+        UI original = UI.getCurrent();
+        UI ui = Mockito.mock(UI.class);
+        UI.setCurrent(ui);
+        Mockito.when(ui.getUIId()).thenReturn(5);
+
+        try {
+            Upload testUpload = new Upload((event) -> {
+            }) {
+                @Override
+                void runBeforeClientResponse(SerializableConsumer<UI> command) {
+                    command.accept(Mockito.mock(UI.class));
+                }
+            };
+
+            testUpload.setUploadHandler(event -> {
+            });
+
+            String targetUploadUrl = testUpload.getElement()
+                    .getAttribute("target");
+            Assert.assertTrue("Upload url should end with 'upload'",
+                    targetUploadUrl.endsWith("upload"));
+        } finally {
+            UI.setCurrent(original);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Description

To be compatible with Receivers,
UploadHandlers used with Upload
component are registered with
the getUrlPostfix `upload`.

Fixes vaadin/flow#21689

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x]  I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.
