### PR TITLE
chore: wait for navigation in side nav ITs

### DIFF
--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavIT.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
@@ -71,11 +72,7 @@ public class SideNavIT extends AbstractComponentIT {
     public void clickNavigableParent_urlChanged() {
         navigableParent.click();
 
-        waitUntil(
-                driver -> findElement(By.id("navigate-to-main-page")) != null);
-
-        Assert.assertTrue(getDriver().getCurrentUrl()
-                .contains("side-nav-test-target-view"));
+        waitUntil(ExpectedConditions.urlContains("side-nav-test-target-view"));
     }
 
     @Test
@@ -83,11 +80,7 @@ public class SideNavIT extends AbstractComponentIT {
         navigableParent.toggle();
         navigableParent.getItems().get(0).click();
 
-        waitUntil(
-                driver -> findElement(By.id("navigate-to-main-page")) != null);
-
-        Assert.assertTrue(getDriver().getCurrentUrl()
-                .contains("side-nav-test-target-view"));
+        waitUntil(ExpectedConditions.urlContains("side-nav-test-target-view"));
     }
 
     @Test
@@ -127,8 +120,8 @@ public class SideNavIT extends AbstractComponentIT {
     public void navigateToPage_correctItemIsCurrent() {
         // First navigate away from the page
         navigableParent.click();
-        waitUntil(driver -> $(NativeButtonElement.class)
-                .id("navigate-to-main-page") != null, 1);
+        waitUntil(ExpectedConditions
+                .presenceOfElementLocated(By.id("navigate-to-main-page")), 1);
 
         $(NativeButtonElement.class).id("navigate-to-main-page").click();
         waitUntil(driver -> $(SideNavElement.class).exists(), 1);


### PR DESCRIPTION
## Description

Two side nav ITs have been flaky recently in CI:
```
com.vaadin.flow.component.sidenav.tests.SideNavIT.clickChildOfNavigableParent_urlChanged
com.vaadin.flow.component.sidenav.tests.SideNavIT.clickNavigableParent_urlChanged
```

`main` and `24.8` already contain a fix, this just simplifies it a bit. Will also apply the same changes to `24.7` and `24.6` to align the changes.

## Type of change

- Internal
