### PR TITLE
chore: fix test compilation error

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
@@ -29,6 +29,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/internal/OverlayAutoAddControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/internal/OverlayAutoAddControllerTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.shared.internal;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +28,8 @@ import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
 import com.vaadin.flow.server.VaadinSession;
+
+import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class OverlayAutoAddControllerTest {

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.concurrent.NotThreadSafe;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -37,6 +36,8 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.server.VaadinSession;
+
+import net.jcip.annotations.NotThreadSafe;
 
 /**
  * Unit tests for the Notification.

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.notification.tests;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,6 +25,8 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
+
+import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class NotificationTest {


### PR DESCRIPTION
## Description

https://github.com/vaadin/flow/pull/21664 removed a dependency, which transitively pulled in a dependency from which we were using the `javax.annotation.concurrent.NotThreadSafe` annotation in some tests. Now those tests don't compile.

This updates tests to use `net.jcip.annotations.NotThreadSafe` instead, which is used in most of the other tests that set up a current UI. I also couldn't find any mention that JUnit or Surefire support `javax.annotation.concurrent.NotThreadSafe`, so this might be the correct choice anyway.

## Type of change

- Internal