### PR TITLE
fix: interrupt all uploads

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadInterruptView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadInterruptView.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload.tests;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-upload/interrupt")
+public class UploadInterruptView extends Div {
+
+    public UploadInterruptView() {
+        Div output = new Div();
+        output.setId("test-output");
+        Div eventsOutput = new Div();
+        eventsOutput.setId("test-events-output");
+
+        MultiFileMemoryBuffer buffer = new SlowMultiFileMemoryBuffer();
+        Upload upload = new Upload(buffer);
+        upload.setAcceptedFileTypes(".txt");
+        upload.addStartedListener(event -> {
+            if (isInterruptableFile(event.getFileName())) {
+                event.getUpload().interruptUpload();
+            }
+        });
+        upload.addFailedListener(event -> {
+            eventsOutput.add("-failed");
+            output.add("FAILED:" + event.getFileName() + ","
+                    + event.getReason().getMessage());
+        });
+        upload.addSucceededListener(event -> eventsOutput.add("-succeeded"));
+        upload.addAllFinishedListener(event -> eventsOutput.add("-finished"));
+
+        add(upload, output, eventsOutput);
+    }
+
+    private static boolean isInterruptableFile(String fileName) {
+        return fileName != null && fileName.endsWith(".interrupt.txt");
+    }
+
+    // Returns an OutputStream that delays write operations for uploads. The
+    // delay ensures that the interruption flag is set before uploads completion
+    // so that the test can verify all uploads failed.
+    private static class SlowMultiFileMemoryBuffer
+            extends MultiFileMemoryBuffer {
+        @Override
+        public OutputStream receiveUpload(String fileName, String MIMEType) {
+            OutputStream outputStream = super.receiveUpload(fileName, MIMEType);
+            if (isInterruptableFile(fileName)) {
+                // Also delay the interrupted file to allow other uploads to
+                // start
+                return new SlowOutputStream(outputStream, 500);
+            }
+            {
+                return new SlowOutputStream(outputStream, 1000);
+            }
+        }
+    }
+
+    private static class SlowOutputStream extends FilterOutputStream {
+
+        private final int delay;
+
+        SlowOutputStream(OutputStream delegate, int delay) {
+            super(delegate);
+            this.delay = delay;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            try {
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted", e);
+            }
+            super.write(b, off, len);
+        }
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadInterruptIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadInterruptIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload.tests;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.upload.testbench.UploadElement;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-upload/interrupt")
+public class UploadInterruptIT extends AbstractUploadIT {
+
+    private UploadElement upload;
+    private WebElement uploadOutput;
+    private WebElement eventsOutput;
+
+    @Before
+    public void init() {
+        open();
+        upload = $(UploadElement.class).waitForFirst();
+        uploadOutput = $("div").id("test-output");
+        eventsOutput = $("div").id("test-events-output");
+    }
+
+    @Test
+    public void uploadMultipleFiles_interruptUpload_allOngoingUploadsInterrupted()
+            throws Exception {
+
+        List<File> files = List.of(createTempFile("txt"), createTempFile("txt"),
+                createTempFile("interrupt.txt"), createTempFile("txt"),
+                createTempFile("txt"));
+
+        upload.uploadMultiple(files, 10);
+
+        Assert.assertEquals("Expected all uploads to be interrupted",
+                "-failed-failed-failed-failed-failed-finished",
+                eventsOutput.getText());
+
+        files.forEach(file -> Assert.assertTrue(
+                "Expected upload of " + file.getName() + " to be failed",
+                uploadOutput.getText().contains(
+                        "FAILED:" + file.getName() + ",Upload interrupted")));
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -80,7 +80,7 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     }
 
     private StreamVariable streamVariable;
-    private boolean interrupted = false;
+    private volatile boolean interrupted = false;
 
     private int activeUploads = 0;
     private boolean uploading;
@@ -458,7 +458,7 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
      * The interruption will be done by the receiving thread so this method will
      * return immediately and the actual interrupt will happen a bit later.
      * <p>
-     * Note! this will interrupt all uploads in multi-upload mode.
+     * Note! this will interrupt all ongoing uploads in multi-upload mode.
      */
     public void interruptUpload() {
         if (isUploading()) {
@@ -468,7 +468,9 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
 
     private void endUpload() {
         activeUploads--;
-        interrupted = false;
+        if (activeUploads == 0) {
+            interrupted = false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Ensures that all ongoing uploads are interrupted when the application triggers interrupt on the Upload component.

## Type of change

- Bugfix
