### PR TITLE
chore: add spring pre-releases repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,22 @@
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+        </repository>
+        <repository>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -275,6 +291,22 @@
             </snapshots>
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
+        </pluginRepository>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </pluginRepository>
+        <pluginRepository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
         </pluginRepository>
         <pluginRepository>
             <releases>


### PR DESCRIPTION
## Description

Flow bumped Spring-Boot to 4.0.0-SNAPSHOT, so we need their pre-releases Maven repos to resolve the dependencies.

## Type of change

- Internal