### PR TITLE
fix: add popover to UI modal component again

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -707,9 +707,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
         // Target's JavaScript needs to be executed on each attach,
         // because Flow creates a new client-side element
-        if (target.getUI().isPresent()) {
-            onTargetAttach(target.getUI().get());
-        }
+        target.getUI().ifPresent(this::onTargetAttach);
         targetAttachRegistration = target
                 .addAttachListener(e -> onTargetAttach(e.getUI()));
         targetDetachRegistration = target.addDetachListener(e -> {

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -708,10 +708,10 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         // Target's JavaScript needs to be executed on each attach,
         // because Flow creates a new client-side element
         if (target.getUI().isPresent()) {
-            onTargetAttach();
+            onTargetAttach(target.getUI().get());
         }
         targetAttachRegistration = target
-                .addAttachListener(e -> onTargetAttach());
+                .addAttachListener(e -> onTargetAttach(e.getUI()));
         targetDetachRegistration = target.addDetachListener(e -> {
             removeFromUiIfAutoAdded();
         });
@@ -720,16 +720,29 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     private void removeFromUiIfAutoAdded() {
         if (autoAddedToTheUi) {
             autoAddedToTheUi = false;
-            getElement().removeFromParent();
+            // Remove the popover from the UI
+            // When using HasComponents.removeAll on the popover's parent, the
+            // parent's children are cleared before sending detach events to the
+            // children and clearing the parent reference from the children. If
+            // the popover and its target are both children of the same parent,
+            // then running Element.removeFromParent in the target's detach
+            // listener will fail, as the popover still has a parent reference,
+            // but the parent does not have it as a child anymore. Thus, check
+            // beforehand if the parent still has the popover as a child.
+            Optional<Component> maybeParent = getParent();
+            if (maybeParent.isPresent() && maybeParent.get().getChildren()
+                    .anyMatch(child -> child == this)) {
+                getElement().removeFromParent();
+            }
         }
     }
 
-    private void onTargetAttach() {
+    private void onTargetAttach(UI ui) {
         if (target != null) {
             if (getElement().getNode().getParent() == null) {
                 // Remove the popover from its current state tree
                 getElement().removeFromTree(false);
-                target.getElement().getParent().appendChild(getElement());
+                ui.addToModalComponent(this);
                 autoAddedToTheUi = true;
             }
             getElement().executeJs("this.target = $0", target.getElement());

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -39,6 +39,10 @@ public class PopoverAutoAddTest {
         session = Mockito.mock(VaadinSession.class);
         Mockito.when(session.hasLock()).thenReturn(true);
         ui.getInternals().setSession(session);
+        VaadinSession.setCurrent(session);
+        Mockito.when(session.getErrorHandler()).thenReturn(event -> {
+            throw new RuntimeException(event.getThrowable());
+        });
     }
 
     @After
@@ -83,6 +87,19 @@ public class PopoverAutoAddTest {
 
         fakeClientResponse();
         Assert.assertNull(popover.getElement().getParent());
+    }
+
+    @Test
+    public void setTarget_removeAll_noException() {
+        Div target = new Div();
+        Popover popover = new Popover();
+        popover.setTarget(target);
+        ui.add(target);
+
+        ui.removeAll();
+
+        Assert.assertNull(popover.getElement().getParent());
+        Assert.assertEquals(0, ui.getChildren().count());
     }
 
     @Test


### PR DESCRIPTION
## Description

As part of working on https://github.com/vaadin/flow-components/pull/7563, popover was changed so that it auto-adds itself to the same parent as the target. Then it was discovered (https://github.com/vaadin/flow-components/pull/7563#discussion_r2128026091) that this breaks popovers from working in grid component renderers, so the approach was changed to run auto-add outside of `beforeClientResponse`. However the change for adding the popover to the target's parent was not reverted. Thus popovers are not working in grid's at the moment. There is also an exception when using `HasComponents.removeAll` that occurs as a side effect of having both the target and the popover in the same parent node.

This reverts popovers to be auto-added to the current UI modal. It also adds a check to make `HasComponents.removeAll` work in case the target and the popover end up in the same parent for some other reason.

Fixes https://github.com/vaadin/flow-components/issues/7637

## Type of change

- Bugfix
