### PR TITLE
docs: clarify labels rotation behavior

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Labels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Labels.java
@@ -225,6 +225,11 @@ public class Labels extends AbstractConfigurationObject {
      * at <a href="http://www.highcharts.com/docs/chart-concepts/axes">Axis
      * docs</a> => What axis should I use?
      * </p>
+     *
+     * <p>
+     * Please note that defining a step will disable the auto rotation of
+     * labels. If you want to rotate the labels, you need to also set the
+     * desired rotation angle using the {@link #setRotation(Number)} method.
      */
     public void setStep(Number step) {
         this.step = step;


### PR DESCRIPTION
## Description

Adds a new paragraph to the `Labels#setStep(Number)` method to clarify the behavior of the auto rotation feature when a step value is defined. Auto rotation is disabled when a step is defined.

Fixes #7654

## Type of change

- Documentation