### PR TITLE
fix: use frozen panel size to calculate the visible rows/cols on scroll

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -686,6 +686,7 @@ public class SheetWidget extends Panel {
                 updateRowGrouping();
 
                 resetCellContents();
+                relayoutSheet(false);
                 loaded = true;
             }
         });
@@ -762,31 +763,29 @@ public class SheetWidget extends Panel {
             final int rightBound = leftFrozenPanelWidth + scrollLeft
                     + scrollViewWidth + actionHandler.getColumnBufferSize();
 
-            int leftEdgeChange = newFirstColumnPosition - firstColumnPosition;
             int rightEdgeChange = newLastColumnPosition - lastColumnPosition;
             firstColumnPosition = newFirstColumnPosition;
             lastColumnPosition = newLastColumnPosition;
 
             // always call handle scroll left, otherwise
             // expanding groups with layouts does not work
-            handleHorizontalScrollLeft(scrollLeft);
+            handleHorizontalScroll(scrollLeft, hScrollDiff);
             updateCells(0, -1);
 
             if (rightEdgeChange < 0 || hScrollDiff > 0
                     || (lastColumnIndex < actionHandler.getMaxColumns()
                             && lastColumnPosition < rightBound)) {
-                handleHorizontalScrollRight(scrollLeft);
                 updateCells(0, 1);
             }
 
+            handleVerticalScroll(scrollTop, vScrollDiff);
+
             if (topEdgeChange > 0 || vScrollDiff < 0) {
-                handleVerticalScrollUp(scrollTop);
                 updateCells(-1, 0);
             }
             if (bottomEdgeChange != 0 || vScrollDiff > 0
                     || (lastRowIndex < actionHandler.getMaxRows()
                             && lastRowPosition < bottomBound)) {
-                handleVerticalScrollDown(scrollTop);
                 updateCells(1, 0);
             }
             resetRowAndColumnStyles();
@@ -2992,7 +2991,7 @@ public class SheetWidget extends Panel {
      * handler (if needed).
      */
     private void onSheetScroll() {
-        int scrollTop = topFrozenPanelHeight + sheet.getScrollTop();
+        int scrollTop = sheet.getScrollTop();
         int scrollLeft = sheet.getScrollLeft();
         int vScrollDiff = scrollTop - previousScrollTop;
         int hScrollDiff = scrollLeft - previousScrollLeft;
@@ -3007,21 +3006,13 @@ public class SheetWidget extends Panel {
             if (Math.abs(
                     hScrollDiff) > (actionHandler.getColumnBufferSize() / 2)) {
                 previousScrollLeft = scrollLeft;
-                if (hScrollDiff > 0) {
-                    handleHorizontalScrollRight(scrollLeft);
-                } else if (hScrollDiff < 0) {
-                    handleHorizontalScrollLeft(scrollLeft);
-                }
+                handleHorizontalScroll(scrollLeft, hScrollDiff);
             }
 
             if (Math.abs(
                     vScrollDiff) > (actionHandler.getRowBufferSize() / 2)) {
                 previousScrollTop = scrollTop;
-                if (vScrollDiff > 0) {
-                    handleVerticalScrollDown(scrollTop);
-                } else if (vScrollDiff < 0) {
-                    handleVerticalScrollUp(scrollTop);
-                }
+                handleVerticalScroll(scrollTop, vScrollDiff);
             }
             requester.trigger();
         } catch (Throwable t) {
@@ -3310,15 +3301,49 @@ public class SheetWidget extends Panel {
         }
     }
 
-    private void handleHorizontalScrollLeft(int scrollLeft) {
+    /**
+     * Handles horizontal scrolling in the spreadsheet. It calculates the
+     * visible columns and updates the column headers accordingly.
+     * 
+     * The method takes the current scroll position and the difference since the
+     * last update to determine how many columns to display.
+     * 
+     * @param scrollLeft
+     *            the current scroll position from the left
+     * @param scrollDiff
+     *            the difference in scroll position since the last update
+     */
+    private void handleHorizontalScroll(int scrollLeft, int scrollDiff) {
+        if (scrollDiff == 0) {
+            return; // no scroll
+        }
+
         int columnBufferSize = actionHandler.getColumnBufferSize();
         int leftBound = scrollLeft - columnBufferSize;
-        int rightBound = scrollLeft + scrollViewWidth + columnBufferSize;
+        int rightBound = leftFrozenPanelWidth + scrollLeft + scrollViewWidth
+                + columnBufferSize;
 
         if (leftBound < 0) {
             leftBound = 0;
         }
 
+        if (scrollDiff > 0) {
+            handleHorizontalScrollRight(leftBound, rightBound);
+        } else {
+            handleHorizontalScrollLeft(leftBound, rightBound);
+        }
+
+    }
+
+    /**
+     * Handles horizontal scrolling to the left in the sheet.
+     *
+     * @param leftBound
+     *            the left bound of the visible area
+     * @param rightBound
+     *            the right bound of the visible area
+     */
+    private void handleHorizontalScrollLeft(int leftBound, int rightBound) {
         int maxFirstColumn = horizontalSplitPosition + 1; // hSP is 0 when no
         while (firstColumnPosition > leftBound
                 && firstColumnIndex > maxFirstColumn) {
@@ -3355,15 +3380,7 @@ public class SheetWidget extends Panel {
      *
      * @param scrollLeft
      */
-    private void handleHorizontalScrollRight(int scrollLeft) {
-        int columnBufferSize = actionHandler.getColumnBufferSize();
-        int leftBound = scrollLeft - columnBufferSize;
-        int rightBound = scrollLeft + scrollViewWidth + columnBufferSize;
-
-        if (leftBound < 0) {
-            leftBound = 0;
-        }
-
+    private void handleHorizontalScrollRight(int leftBound, int rightBound) {
         final int maximumCols = actionHandler.getMaxColumns();
         while (lastColumnPosition < rightBound
                 && lastColumnIndex < maximumCols) {
@@ -3389,15 +3406,50 @@ public class SheetWidget extends Panel {
         resetColHeaders();
     }
 
-    private void handleVerticalScrollDown(int scrollTop) {
+    /**
+     * Handles vertical scrolling in the spreadsheet. It calculates the visible
+     * rows and updates the row headers accordingly.
+     * 
+     * The method takes the current scroll position and the difference since the
+     * last update to determine how many rows to display.
+     * 
+     * @param scrollTop
+     *            the current scroll position from the top
+     * @param scrollDiff
+     *            the difference in scroll position since the last update
+     */
+    private void handleVerticalScroll(int scrollTop, int scrollDiff) {
+        if (scrollDiff == 0) {
+            return; // no scroll
+        }
+
         int rowBufferSize = actionHandler.getRowBufferSize();
         int topBound = scrollTop - rowBufferSize;
-        int bottomBound = scrollTop + scrollViewHeight + rowBufferSize;
+        int bottomBound = topFrozenPanelHeight + scrollTop + scrollViewHeight
+                + rowBufferSize;
 
         if (topBound < 0) {
             topBound = 0;
         }
 
+        if (scrollDiff > 0) {
+            handleVerticalScrollDown(topBound, bottomBound);
+        } else {
+            handleVerticalScrollUp(topBound, bottomBound);
+        }
+
+    }
+
+    /**
+     * Calculates viewed cells after a scroll down. Runs the escalator for row
+     * headers.
+     *
+     * @param topBound
+     *            the top bound of the visible area
+     * @param bottomBound
+     *            the bottom bound of the visible area
+     */
+    private void handleVerticalScrollDown(int topBound, int bottomBound) {
         final int maximumRows = actionHandler.getMaxRows();
         while (lastRowPosition < bottomBound && lastRowIndex < maximumRows) {
             if ((firstRowPosition + getRowHeight(firstRowIndex)) < topBound) {
@@ -3417,15 +3469,16 @@ public class SheetWidget extends Panel {
         resetRowHeaders();
     }
 
-    private void handleVerticalScrollUp(int scrollTop) {
-        int rowBufferSize = actionHandler.getRowBufferSize();
-        int topBound = scrollTop - rowBufferSize;
-        int bottomBound = scrollTop + scrollViewHeight + rowBufferSize;
-
-        if (topBound < 0) {
-            topBound = 0;
-        }
-
+    /**
+     * Calculates viewed cells after a scroll up. Runs the escalator for row
+     * headers.
+     *
+     * @param topBound
+     *            the top bound of the visible area
+     * @param bottomBound
+     *            the bottom bound of the visible area
+     */
+    private void handleVerticalScrollUp(int topBound, int bottomBound) {
         int maxTopRow = verticalSplitPosition + 1; // vSP is 0 when no split
         while (firstRowPosition > topBound && firstRowIndex > maxTopRow) {
             if ((lastRowPosition - getRowHeight(lastRowIndex)) > bottomBound) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/CustomEditorRowFixture.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/CustomEditorRowFixture.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.tests.fixtures;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
+import com.vaadin.flow.component.textfield.TextField;
+
+public class CustomEditorRowFixture implements SpreadsheetFixture {
+
+    static final int COMPONENT_ROW_INDEX = 1;
+
+    @Override
+    public void loadFixture(final Spreadsheet spreadsheet) {
+        spreadsheet.setSpreadsheetComponentFactory(new CustomEditorFactory());
+        spreadsheet.setColumnWidth(0, 200);
+        spreadsheet.setShowCustomEditorOnFocus(true);
+    }
+
+    private static class CustomEditorFactory
+            implements SpreadsheetComponentFactory {
+
+        private final Map<Integer, TextField> textFields = new HashMap<>();
+
+        @Override
+        public Component getCustomComponentForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            if (rowIndex != 0 || columnIndex != 0) {
+                return null;
+            }
+
+            Button toggleCustomEditorVisibilityButton = new Button(
+                    "Toggle custom editor", event -> {
+                        spreadsheet.setShowCustomEditorOnFocus(
+                                !spreadsheet.isShowCustomEditorOnFocus());
+                    });
+            toggleCustomEditorVisibilityButton
+                    .setId("toggleCustomEditorVisibilityButton");
+            return toggleCustomEditorVisibilityButton;
+        }
+
+        @Override
+        public Component getCustomEditorForCell(Cell cell, final int rowIndex,
+                final int columnIndex, final Spreadsheet spreadsheet,
+                Sheet sheet) {
+            if (!sheet.getSheetName().equals("Sheet1")
+                    || rowIndex != COMPONENT_ROW_INDEX) {
+                return null;
+            }
+            if (!textFields.containsKey(columnIndex)) {
+                var textField = new TextField();
+
+                textField.addValueChangeListener(
+                        e -> spreadsheet.refreshCells(spreadsheet.createCell(
+                                rowIndex, columnIndex, e.getValue())));
+                textField.setId("textField" + rowIndex + columnIndex);
+                textFields.put(columnIndex, textField);
+            }
+            return textFields.get(columnIndex);
+        }
+
+        @Override
+        public void onCustomEditorDisplayed(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet,
+                Component customEditor) {
+            if (cell == null) {
+                return;
+            }
+
+            if (customEditor instanceof TextField editor) {
+                editor.setValue( cell.getStringCellValue());
+            }
+        }
+    }
+
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/TestFixtures.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/TestFixtures.java
@@ -37,6 +37,7 @@ public enum TestFixtures {
     Rename(RenameFixture.class),
     CreateSheet(SheetsFixture.class),
     CustomEditor(SimpleCustomEditorFixture.class),
+    CustomEditorRow(CustomEditorRowFixture.class),
     Styles(StylesFixture.class),
     LockCell(LockCellFixture.class),
     CustomComponent(CustomComponentFixture.class),

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -354,6 +354,85 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
         }
     }
 
+    @Test
+    public void customEditorInFrozenCells_persistsValueOnVariousKeyActions()
+            throws Exception {
+        createNewSpreadsheet();
+        loadTestFixture(TestFixtures.CustomEditorRow);
+        // Freeze 2 rows and 15 columns
+        addFreezePane(10, 2);
+
+        performKeyboardTestsToCell("A");
+        performKeyboardTestsToCell("J");
+        performKeyboardTestsToCell("K");
+
+        getSpreadsheet().scrollLeft(1000);
+        performKeyboardTestsToCell("AI");
+    }
+
+    @Test
+    public void customEditorAlwaysVisibleInFrozenCells_persistsValue()
+            throws Exception {
+        createNewSpreadsheet();
+        loadTestFixture(TestFixtures.CustomEditorRow);
+        // Toggle custom editor visibility to always show
+        $("vaadin-button").id("toggleCustomEditorVisibilityButton").click();
+        getCommandExecutor().waitForVaadin();
+        addFreezePane(15, 2);
+
+        performKeyboardTestsToCell("A");
+        performKeyboardTestsToCell("J");
+        performKeyboardTestsToCell("K");
+
+        getSpreadsheet().scrollLeft(1000);
+        performKeyboardTestsToCell("AI");
+    }
+
+    private void performKeyboardTestsToCell(String column) {
+        final String cellAddress = column + "2";
+
+        clickCell(cellAddress);
+        var maybeEditor = getInputInCustomEditorFromCell(cellAddress);
+        Assert.assertTrue(maybeEditor.isPresent());
+
+        var editor = maybeEditor.get();
+
+        // Test Esc with arrow keys persistence on cell
+        editor.click();
+        editor.setProperty("value", "");
+        editor.sendKeys("EscWithArrowKeys", Keys.ESCAPE, Keys.ARROW_DOWN);
+        getCommandExecutor().waitForVaadin();
+        clickCell(cellAddress);
+        Assert.assertEquals("EscWithArrowKeys", getFormulaFieldValue());
+
+        // Test ENTER key persistence on cell
+        clickCell(cellAddress);
+        editor.setProperty("value", "");
+        editor.sendKeys("EnterTest", Keys.ENTER);
+        getCommandExecutor().waitForVaadin();
+        clickCell(cellAddress);
+        Assert.assertEquals("EnterTest", getFormulaFieldValue());
+
+        // Test TAB key persistence on cell
+        clickCell(cellAddress);
+        editor.click();
+        editor.setProperty("value", "");
+        editor.sendKeys("TabTest", Keys.TAB);
+        getCommandExecutor().waitForVaadin();
+        clickCell(cellAddress);
+        Assert.assertEquals("TabTest", getFormulaFieldValue());
+
+        // Test SHIFT+TAB persistence on A2
+        clickCell(cellAddress);
+        editor.click();
+        editor.setProperty("value", "");
+        editor.sendKeys("ShiftTabTest", Keys.chord(Keys.SHIFT, Keys.TAB));
+        getCommandExecutor().waitForVaadin();
+        clickCell(cellAddress);
+        Assert.assertEquals("ShiftTabTest", getFormulaFieldValue());
+
+    }
+
     private void toggleCheckboxValue(String cellAddress) {
         clickCell(cellAddress);
         getEditorElement("input").click();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/FreezePaneIT.java
@@ -11,6 +11,8 @@ package com.vaadin.flow.component.spreadsheet.test;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.spreadsheet.testbench.SheetHeaderElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -93,6 +95,67 @@ public class FreezePaneIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("1", firstRowHeader.getText());
         Assert.assertEquals("0px",
                 firstRowHeader.getWrappedElement().getCssValue("top"));
+    }
+
+    @Test
+    public void freezeAndResizeColumn_numberOfRenderedColumnsUnchanged()
+            throws Exception {
+        createNewSpreadsheet();
+        // Freeze 5 rows and 10 columns
+        addFreezePane(10, 5);
+
+        // Count rendered column headers before resize
+        int countBefore = getHeaderCount(".ch");
+
+        resizeFirstColumn();
+
+        // Count rendered column headers after resize
+        int countAfter = getHeaderCount(".ch");
+
+        Assert.assertEquals(
+                "Number of rendered columns should remain the same after resize",
+                countBefore, countAfter);
+    }
+
+    @Test
+    public void freezeAndResizeColumn_numberOfRenderedRowsUnchanged()
+            throws Exception {
+        createNewSpreadsheet();
+        int spreadsheetHeight = getSpreadsheet().getSize().getHeight();
+        // Count rendered column headers before resize
+        int countBefore = getHeaderCount(".rh");
+
+        // Freeze 5 rows and 10 columns
+        addFreezePane(10, 20);
+
+        resizeFirstColumn();
+
+        // Scroll a few rows down on the bottom-right panel after resize
+        getSpreadsheet().scroll(500);
+        getSpreadsheet().scroll(0);
+
+        // Count rendered column headers after resize
+        int countAfter = getHeaderCount(".bottom-left-pane.sheet > .rh");
+
+        Assert.assertEquals("Height should be the same", spreadsheetHeight,
+                getSpreadsheet().getSize().getHeight());
+        Assert.assertEquals(
+                "Number of rendered rows should remain the same after resize",
+                countBefore, countAfter);
+    }
+
+    private int getHeaderCount(String selector) {
+        var headers = findElementsInShadowRoot(By.cssSelector(selector));
+        return headers.size();
+    }
+
+    private void resizeFirstColumn() {
+        // Resize first column slightly by dragging its header edge
+        var spreadsheet = getSpreadsheet();
+        var resizeHandle = spreadsheet.getColumnHeader(1).getResizeHandle();
+        var target = spreadsheet.getColumnHeader(2);
+        new Actions(driver).dragAndDrop(resizeHandle, target).perform();
+        getCommandExecutor().waitForVaadin();
     }
 
 }


### PR DESCRIPTION
## Description

Use the top and left frozen panel size to calculate the number of headers and rows to be rendered when the user scrolls. Currently, the size of the frozen panels are not accounted which causes some of the columns and rows to not be rendered even when there's available space for that.

Fixes #7507

## Type of change

- Bugfix