### PR TITLE
test: rename tree grid test and make it extend AbstractComponentIT

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridSelectComponentColumnAfterExpandPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridSelectComponentColumnAfterExpandPage.java
@@ -22,12 +22,9 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.router.Route;
 
-@Route(SelectComponentColumnAfterExpandPage.VIEW)
-public class SelectComponentColumnAfterExpandPage extends Div {
-
-    public static final String VIEW = "vaadin-grid/select-component-column-after-expand";
-
-    public SelectComponentColumnAfterExpandPage() {
+@Route("vaadin-grid/treegrid-select-component-column-after-expand")
+public class TreeGridSelectComponentColumnAfterExpandPage extends Div {
+    public TreeGridSelectComponentColumnAfterExpandPage() {
         TreeGrid<String> grid = new TreeGrid<>();
         grid.addHierarchyColumn(String::toString).setHeader("HierarchyColumn");
         grid.addComponentColumn(Span::new).setHeader("ComponentColumn");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridSelectComponentColumnAfterExpandIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridSelectComponentColumnAfterExpandIT.java
@@ -16,13 +16,22 @@
 package com.vaadin.flow.component.treegrid.it;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 
-@TestPath(SelectComponentColumnAfterExpandPage.VIEW)
-public class SelectComponentColumnAfterExpandIT extends AbstractTreeGridIT {
+@TestPath("vaadin-grid/treegrid-select-component-column-after-expand")
+public class TreeGridSelectComponentColumnAfterExpandIT extends AbstractComponentIT {
+    private TreeGridElement treeGrid;
+
+    @Before
+    public void init() {
+        open();
+        treeGrid = $(TreeGridElement.class).first();
+    }
 
     /**
      * <a href="https://github.com/vaadin/vaadin-flow-components/issues/376">
@@ -30,24 +39,18 @@ public class SelectComponentColumnAfterExpandIT extends AbstractTreeGridIT {
      */
     @Test
     public void select_after_expand_should_not_remove_item_text() {
-        open();
-        setupTreeGrid();
         assertExpectedValuesWhenExpanded();
-        Assert.assertEquals(4, getTreeGrid().getRowCount());
-        click("collapse-button");
-        Assert.assertEquals(1, getTreeGrid().getRowCount());
-        click("expand-button");
-        click("select-button");
+        Assert.assertEquals(4, treeGrid.getRowCount());
+        clickElementWithJs("collapse-button");
+        Assert.assertEquals(1, treeGrid.getRowCount());
+        clickElementWithJs("expand-button");
+        clickElementWithJs("select-button");
         assertExpectedValuesWhenExpanded();
-    }
-
-    private void click(String id) {
-        findElement(By.id(id)).click();
     }
 
     private void assertCellText(int rowIndex, int collIndex, String expected) {
         Assert.assertEquals(expected,
-                getTreeGrid().getCellWaitForRow(rowIndex, collIndex).getText());
+                treeGrid.getCellWaitForRow(rowIndex, collIndex).getText());
     }
 
     private void assertRowText(int rowIndex, String expected) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridSelectComponentColumnAfterExpandIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridSelectComponentColumnAfterExpandIT.java
@@ -24,7 +24,8 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-grid/treegrid-select-component-column-after-expand")
-public class TreeGridSelectComponentColumnAfterExpandIT extends AbstractComponentIT {
+public class TreeGridSelectComponentColumnAfterExpandIT
+        extends AbstractComponentIT {
     private TreeGridElement treeGrid;
 
     @Before


### PR DESCRIPTION
## Description

- Renamed `SelectComponentColumnAfterExpandIT` to `TreeGridSelectComponentColumnAfterExpandIT`
- Updated it to extend `AbstractComponentIT` instead of `AbstractTreeGridIT` since it used only initialization logic

Part of #7684 

## Type of change

- [x] Internal
