### PR TITLE
test: simplify assertCellTexts method

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
@@ -19,17 +19,16 @@ import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 public abstract class AbstractTreeGridIT extends AbstractComponentIT {
 
-    private TreeGridElement grid;
+    private TreeGridElement treeGrid;
 
     public void setupTreeGrid() {
         waitUntil(e -> $(TreeGridElement.class).exists(), 2);
-        grid = $(TreeGridElement.class).first();
+        treeGrid = $(TreeGridElement.class).first();
     }
 
     /**
@@ -39,7 +38,7 @@ public abstract class AbstractTreeGridIT extends AbstractComponentIT {
      * @return the optional grid element
      */
     protected TreeGridElement getTreeGrid() {
-        return grid;
+        return treeGrid;
     }
 
     /**
@@ -94,42 +93,30 @@ public abstract class AbstractTreeGridIT extends AbstractComponentIT {
 
     /**
      * Asserts that TreeGrid contains same texts in cells as the given
-     * {@code cellTexts} starting from given {@code startRowIndex} and
+     * {@code expectedCellTexts} starting from given {@code startRowIndex} and
      * {@code cellIndex}.
      *
      * @param startRowIndex
      *            First row index. Starts from 0.
      * @param cellIndex
      *            the first cell index. Starts from 0.
-     * @param cellTexts
+     * @param expectedCellTexts
      *            Expected cell texts
      */
     protected void assertCellTexts(int startRowIndex, int cellIndex,
-            String... cellTexts) {
-        int index = startRowIndex;
-        for (String cellText : cellTexts) {
-            assertCellText(index, cellIndex, cellText);
-            index++;
-        }
-    }
+            String... expectedCellTexts) {
+        int rowIndex = startRowIndex;
 
-    private void assertCellText(int rowIndex, int cellIndex,
-            String expectedText) {
-        if (!((grid.getFirstVisibleRowIndex() <= rowIndex
-                && rowIndex <= grid.getLastVisibleRowIndex()))) {
-            grid.scrollToFlatRowAndWait(rowIndex);
-        }
-        GridColumnElement column = grid.getVisibleColumns().get(cellIndex);
-        try {
-            waitUntil(
-                    test -> grid.hasRow(rowIndex) && expectedText.equals(
-                            grid.getRow(rowIndex).getCell(column).getText()),
-                    2);
-        } catch (Exception e) {
-            Assert.fail(String.format(
-                    "Expected cell text [%s] but got %s in row %s cell %s",
-                    expectedText, e.getClass().getSimpleName(), rowIndex,
-                    cellIndex));
+        for (String expectedText : expectedCellTexts) {
+            String actualText = treeGrid.getCell(rowIndex, cellIndex).getText();
+
+            Assert.assertEquals(
+                    "Expected cell text [%s] but got %s in row %s cell %s"
+                            .formatted(expectedText, actualText, rowIndex,
+                                    cellIndex),
+                    expectedText, actualText);
+
+            rowIndex++;
         }
     }
 }


### PR DESCRIPTION
## Description

The scrolling logic that the `assertCellTexts` method includes is already implemented in `TreeGridElement#getCell` which the method also calls.

Part of #7684 

## Type of change

- [x] Internal
