### PR TITLE
test: avoid relying on TreeGridElement#getNumberOfExpandedRows (part 2)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
@@ -119,25 +119,17 @@ public class TreeGridHugeTreeIT extends AbstractTreeGridIT {
 
         TreeGridElement grid = getTreeGrid();
 
-        waitUntil(tets -> grid.getNumberOfExpandedRows() == 99);
-
         // assuming cache size to be visible row count + buffer before/after
         // assuming buffer to match visible row count
         int assumedCachedSize = (grid.getLastVisibleRowIndex()
                 - grid.getFirstVisibleRowIndex()) * 3;
-        waitUntil(test -> !grid.isLoadingExpandedRows(), 20);
         String[] cellTexts = new String[assumedCachedSize];
         for (int i = 0; i < assumedCachedSize; i++) {
             cellTexts[i] = grid.getCellWaitForRow(i, 0).getText();
         }
         grid.scrollToRowAndWait(0);
-
         grid.collapseWithClick(1);
-        waitUntil(tets -> grid.getNumberOfExpandedRows() == 98);
-
         grid.expandWithClick(1);
-        waitUntil(tets -> grid.getNumberOfExpandedRows() == 99);
-        waitUntil(test -> !grid.isLoadingExpandedRows(), 25);
 
         assertCellTexts(0, 0, cellTexts);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridItemDetailsRendererIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridItemDetailsRendererIT.java
@@ -41,7 +41,6 @@ public class TreeGridItemDetailsRendererIT extends AbstractTreeGridIT {
     @Test
     public void treegridItemDetails_openDetailsInDifferentLevels() {
         getTreeGrid().expandWithClick(1);
-        waitUntil(test -> getTreeGrid().getNumberOfExpandedRows() == 2);
 
         getTreeGrid().getCell(1, 0).click();
         Assert.assertTrue(getTreeGrid().isDetailsOpen(1));
@@ -61,7 +60,6 @@ public class TreeGridItemDetailsRendererIT extends AbstractTreeGridIT {
     @Test
     public void treegridItemDetails_collapseRoot_rememberOpenedDetails() {
         getTreeGrid().expandWithClick(1);
-        waitUntil(test -> getTreeGrid().getNumberOfExpandedRows() == 2);
 
         getTreeGrid().getCell(1, 0).click();
         Assert.assertTrue(getTreeGrid().isDetailsOpen(1));
@@ -74,7 +72,6 @@ public class TreeGridItemDetailsRendererIT extends AbstractTreeGridIT {
     @Test
     public void treegridItemDetails_collapseLevel1_rememberOpenedDetails() {
         getTreeGrid().expandWithClick(1);
-        waitUntil(test -> getTreeGrid().getNumberOfExpandedRows() == 2);
 
         getTreeGrid().getCell(2, 0).click();
         Assert.assertTrue(getTreeGrid().isDetailsOpen(2));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
@@ -37,7 +37,6 @@ public class TreeGridPageSizeIT extends AbstractTreeGridIT {
     public void treegridWithPageSize10_changeTo80_revertBackTo10() {
         TreeGridElement grid = getTreeGrid();
 
-        waitUntil(test -> grid.getNumberOfExpandedRows() == 12, 1);
         // assert here only minimum required fetches
         assertLogContainsFetch(0, 3, "root");
         assertLogContainsFetch(0, 3, "Granddad 0");
@@ -60,7 +59,6 @@ public class TreeGridPageSizeIT extends AbstractTreeGridIT {
         blur();
         button.click();
 
-        waitUntil(test -> grid.getNumberOfExpandedRows() == 12, 1);
         // assert here only minimum required fetches
         assertLogContainsFetch(0, 3, "root");
         assertLogContainsFetch(0, 3, "Granddad 0");
@@ -80,7 +78,6 @@ public class TreeGridPageSizeIT extends AbstractTreeGridIT {
         blur();
         button.click();
 
-        waitUntil(test -> grid.getNumberOfExpandedRows() == 12, 1);
         // assert here only minimum required fetches
         assertLogContainsFetch(0, 3, "root");
         assertLogContainsFetch(0, 3, "Granddad 0");


### PR DESCRIPTION
## Description

Integration tests should not rely on TestBench methods – such as `TreeGridElement#getNumberOfExpandedRows` – that require client-side access to expanded items. The `expandedItems` array will no longer be available on the client after `HierarchicalDataCommunicator` is refactored to support a flat hierarchy.

Part of #7684 

## Type of change

- [x] Internal
