### PR TITLE
test: clean up test classes that extend AbstractTreeGridIT

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesPage.java
@@ -69,21 +69,17 @@ public class TreeGridBasicFeaturesPage extends Div {
         log.setId("log");
         log.setHeight("100px");
         log.setWidth("100%");
-        add(grid, new VerticalLayout(
-                setIdByText(new NativeButton("Clear log", e -> log.clear())),
-                log));
 
-        createActions();
+        var clearLog = new NativeButton("Clear log", e -> log.clear());
+        clearLog.setId("clear-log");
 
-    }
+        add(grid, new VerticalLayout(clearLog, log));
 
-    protected void createActions() {
         createDataProviderSelect();
         createHierarchyColumnSelect();
         createExpandMenu();
         createCollapseMenu();
         createListenerMenu();
-        createDisableEnableMenu();
     }
 
     private void initializeDataProviders() {
@@ -146,7 +142,7 @@ public class TreeGridBasicFeaturesPage extends Div {
         options.put("DataProviderWithNullValues", dataProviderWithNullValues);
 
         options.entrySet().forEach(entry -> {
-            addAction(entry.getKey(),
+            addButton(entry.getKey(),
                     () -> grid.setDataProvider(entry.getValue()));
         });
     }
@@ -158,7 +154,7 @@ public class TreeGridBasicFeaturesPage extends Div {
         options.put("index", HierarchicalTestBean::getIndex);
 
         options.entrySet().forEach(entry -> {
-            addAction("Set hierarchy column - " + entry.getKey(), () -> {
+            addButton("set-hierarchy-column-" + entry.getKey(), () -> {
                 grid.setHierarchyColumn(entry.getKey(), entry.getValue());
                 // reset headers
                 grid.getColumnByKey("depth").setHeader("Depth");
@@ -168,64 +164,59 @@ public class TreeGridBasicFeaturesPage extends Div {
     }
 
     private void createExpandMenu() {
-        addAction("Expand 0 | 0",
+        addButton("expand-0-0",
                 () -> grid.expand(new HierarchicalTestBean(null, 0, 0)));
 
-        addAction("Expand 1 | 1",
+        addButton("expand-1-1",
                 () -> grid.expand(new HierarchicalTestBean("/0/0", 1, 1)));
 
-        addAction("Expand 2 | 1",
+        addButton("expand-2-1",
                 () -> grid.expand(new HierarchicalTestBean("/0/0/1/1", 2, 1)));
 
-        addAction("Expand 0 | 0 recursively",
+        addButton("expand-0-0-recursively",
                 () -> grid.expandRecursively(
                         Arrays.asList(new HierarchicalTestBean(null, 0, 0)),
                         1));
     }
 
     private void createCollapseMenu() {
-        addAction("Collapse 0 | 0",
+        addButton("collapse-0-0",
                 () -> grid.collapse(new HierarchicalTestBean(null, 0, 0)));
-        addAction("Collapse 1 | 1",
+        addButton("collapse-1-1",
                 () -> grid.collapse(new HierarchicalTestBean("/0/0", 1, 1)));
-        addAction("Collapse 2 | 1", () -> grid
+        addButton("collapse-2-1", () -> grid
                 .collapse(new HierarchicalTestBean("/0/0/1/1", 2, 1)));
-        addAction("Collapse 0 | 0 recursively",
+        addButton("collapse-0-0-recursively",
                 () -> grid.collapseRecursively(
                         Arrays.asList(new HierarchicalTestBean(null, 0, 0)),
                         2));
     }
 
     private void createListenerMenu() {
-        addAction("Collapse listener",
-                () -> grid.addCollapseListener(
-                        event -> log("Item(s) collapsed (from client: "
-                                + event.isFromClient() + "): "
-                                + event.getItems().stream().findFirst()
-                                        .map(HierarchicalTestBean::toString)
-                                        .orElse("null"))));
+        addButton("add-collapse-listener", () -> {
+            grid.addCollapseListener(event -> {
+                String item = event.getItems().stream().findFirst()
+                        .map(HierarchicalTestBean::toString).orElse("null");
+                log("Item(s) collapsed (from client: %s): %s"
+                        .formatted(event.isFromClient(), item));
+            });
+        });
 
-        addAction("Expand listener", () -> grid.addExpandListener(event -> log(
-                "Item(s) expanded (from client: " + event.isFromClient() + "): "
-                        + event.getItems().stream().findFirst()
-                                .map(HierarchicalTestBean::toString)
-                                .orElse("null"))));
+        addButton("add-expand-listener", () -> {
+            grid.addExpandListener(event -> {
+                String item = event.getItems().stream().findFirst()
+                        .map(HierarchicalTestBean::toString).orElse("null");
+                log("Item(s) expanded (from client: %s): %s"
+                        .formatted(event.isFromClient(), item));
+            });
+        });
     }
 
-    private void createDisableEnableMenu() {
-        addAction("Toggle Enabled/Disabled",
-                () -> grid.setEnabled(!grid.isEnabled()));
-    }
-
-    private void addAction(String title, Runnable action) {
-        NativeButton b = new NativeButton(title, event -> action.run());
-        setIdByText(b);
+    private void addButton(String id, Runnable onClick) {
+        NativeButton b = new NativeButton(id.replace("-", " "),
+                event -> onClick.run());
+        b.setId(id);
         add(b);
-    }
-
-    private NativeButton setIdByText(NativeButton button) {
-        button.setId(button.getText().replace(" ", ""));
-        return button;
     }
 
     public class CustomTreeDataProvider

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.treegrid.it;
 
 import org.junit.Assert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
@@ -43,17 +42,6 @@ public abstract class AbstractTreeGridIT extends AbstractComponentIT {
     }
 
     /**
-     * Returns id by clearing spaces from the given text.
-     *
-     * @param id
-     *            the text to make id from
-     * @return the new id
-     */
-    protected String makeId(String id) {
-        return id.replace(" ", "");
-    }
-
-    /**
      * Finds element with id 'log' and checks if its value contains given text.
      * Uses {@link String#contains(CharSequence)} to search.
      *
@@ -72,24 +60,6 @@ public abstract class AbstractTreeGridIT extends AbstractComponentIT {
      */
     protected void clearLog() {
         executeScript("arguments[0].value=''", findElement(By.id("log")));
-    }
-
-    /**
-     * Finds element by given text by translating it to id with
-     * {@link #makeId(String)} and finding element by that id.
-     * <p>
-     * Shortcut for calling:
-     *
-     * <pre>
-     * findElement(By.id(makeId(text)))
-     * </pre>
-     *
-     * @param text
-     *            the target text
-     * @return the found element
-     */
-    protected WebElement findElementByText(String text) {
-        return findElement(By.id(makeId(text)));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesIT.java
@@ -51,59 +51,59 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
         Assert.assertEquals(3, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
 
-        findElementByText("Expand 0 | 0").click();
+        findElement(By.id("expand-0-0")).click();
         Assert.assertEquals(6, getTreeGrid().getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
 
         // expanding already expanded item should have no effect
-        findElementByText("Expand 0 | 0").click();
+        findElement(By.id("expand-0-0")).click();
         Assert.assertEquals(6, getTreeGrid().getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
 
-        findElementByText("Collapse 0 | 0").click();
+        findElement(By.id("collapse-0-0")).click();
         Assert.assertEquals(3, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
 
         // collapsing the same item twice should have no effect
-        findElementByText("Collapse 0 | 0").click();
+        findElement(By.id("collapse-0-0")).click();
         Assert.assertEquals(3, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
 
-        findElementByText("Expand 1 | 1").click();
+        findElement(By.id("expand-1-1")).click();
         // 1 | 1 not yet visible, shouldn't immediately expand anything
         Assert.assertEquals(3, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
 
-        findElementByText("Expand 0 | 0").click();
+        findElement(By.id("expand-0-0")).click();
         // 1 | 1 becomes visible and is also expanded
         Assert.assertEquals(9, getTreeGrid().getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "2 | 0", "2 | 1",
                 "2 | 2", "1 | 2" });
 
         // collapsing a leaf should have no effect
-        findElementByText("Collapse 2 | 1").click();
+        findElement(By.id("collapse-2-1")).click();
         Assert.assertEquals(9, getTreeGrid().getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "2 | 0", "2 | 1",
                 "2 | 2", "1 | 2" });
 
         // collapsing 0 | 0 should collapse the expanded 1 | 1
-        findElementByText("Collapse 0 | 0").click();
+        findElement(By.id("collapse-0-0")).click();
         Assert.assertEquals(3, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
 
         // expand 0 | 0 recursively
-        findElementByText("Expand 0 | 0 recursively").click();
+        findElement(By.id("expand-0-0-recursively")).click();
         Assert.assertEquals(15, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "1 | 0", "2 | 0" });
 
         // collapse 0 | 0 recursively
-        findElementByText("Collapse 0 | 0 recursively").click();
+        findElement(By.id("collapse-0-0-recursively")).click();
         Assert.assertEquals(3, getTreeGrid().getRowCount());
         assertCellTexts(0, 0, new String[] { "0 | 0", "0 | 1", "0 | 2" });
 
         // expanding 0 | 0 should result in 3 additional nodes after recursive
         // collapse
-        findElementByText("Expand 0 | 0").click();
+        findElement(By.id("expand-0-0")).click();
         Assert.assertEquals(6, getTreeGrid().getRowCount());
         assertCellTexts(1, 0, new String[] { "1 | 0", "1 | 1", "1 | 2" });
 
@@ -112,7 +112,7 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
 
     @Test
     public void pending_expands_cleared_when_data_provider_set() {
-        findElementByText("Expand 1 | 1").click();
+        findElement(By.id("expand-1-1")).click();
         findElement(By.id("LazyHierarchicalDataProvider")).click();
 
         getTreeGrid().expandWithClick(0);
@@ -240,12 +240,12 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
         assertTrue(getTreeGrid().hasExpandToggle(0, 0));
         assertFalse(getTreeGrid().hasExpandToggle(0, 1));
 
-        findElementByText("Set hierarchy column - depth").click();
+        findElement(By.id("set-hierarchy-column-depth")).click();
 
         assertFalse(getTreeGrid().hasExpandToggle(0, 0));
         assertTrue(getTreeGrid().hasExpandToggle(0, 1));
 
-        findElementByText("Set hierarchy column - id").click();
+        findElement(By.id("set-hierarchy-column-id")).click();
 
         assertTrue(getTreeGrid().hasExpandToggle(0, 0));
         assertFalse(getTreeGrid().hasExpandToggle(0, 1));
@@ -253,8 +253,8 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
 
     @Test
     public void expand_and_collapse_listeners() {
-        findElementByText("Expand listener").click();
-        findElementByText("Collapse listener").click();
+        findElement(By.id("add-expand-listener")).click();
+        findElement(By.id("add-collapse-listener")).click();
 
         assertFalse(
                 logContainsText("Item(s) expanded (from client: true): 0 | 0"));
@@ -275,14 +275,14 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
         assertTrue(logContainsText(
                 "Item(s) collapsed (from client: true): 0 | 0"));
 
-        findElementByText("Expand 0 | 0").click();
+        findElement(By.id("expand-0-0")).click();
 
         assertTrue(logContainsText(
                 "Item(s) expanded (from client: false): 0 | 0"));
         assertFalse(logContainsText(
                 "Item(s) collapsed (from client: false): 0 | 0"));
 
-        findElementByText("Collapse 0 | 0").click();
+        findElement(By.id("collapse-0-0")).click();
 
         assertTrue(logContainsText(
                 "Item(s) expanded (from client: false): 0 | 0"));
@@ -309,5 +309,4 @@ public class TreeGridBasicFeaturesIT extends AbstractTreeGridIT {
                 "2 | 1", "2 | 2", "1 | 1", "1 | 2", "0 | 2" });
         Assert.assertEquals(9, getTreeGrid().getRowCount());
     }
-
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandDataRequestIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandDataRequestIT.java
@@ -36,7 +36,7 @@ public class TreeGridExpandDataRequestIT extends AbstractTreeGridIT {
     }
 
     private void clickClearLog() {
-        findElement(By.id(makeId("Clear log"))).click();
+        findElement(By.id("clear-log")).click();
     }
 
     @Test


### PR DESCRIPTION
## Description

Cleanup of test classes that extend `AbstractTreeGridIT`.

Part of #7684 

## Type of change

- [x] Internal
