### PR TITLE
fix: make fetching data possible when virtual list is inert

### DIFF
--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/InertVirtualListPage.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/InertVirtualListPage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.virtuallist.tests;
+
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.virtuallist.VirtualList;
+import com.vaadin.flow.dom.ElementUtil;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-virtual-list/inert")
+public class InertVirtualListPage extends Div {
+
+    public InertVirtualListPage() {
+        var virtualList = new VirtualList<String>();
+        var items = IntStream.range(0, 10).mapToObj(i -> "Item " + i).toList();
+        virtualList.setItems(items);
+        ElementUtil.setInert(virtualList.getElement(), true);
+        add(virtualList);
+    }
+}

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/InertVirtualListIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/InertVirtualListIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.virtuallist.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.virtuallist.testbench.VirtualListElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import elemental.json.JsonType;
+
+@TestPath("vaadin-virtual-list/inert")
+public class InertVirtualListIT extends AbstractComponentIT {
+
+    private VirtualListElement virtualList;
+
+    @Before
+    public void init() {
+        open();
+        var loadingIndicator = findElement(By.className("v-loading-indicator"));
+        waitUntil(driver -> !loadingIndicator.isDisplayed());
+        virtualList = $(VirtualListElement.class).waitForFirst();
+    }
+
+    @Test
+    public void inertVirtualList_itemsAreRendered() {
+        var items = VirtualListHelpers.getItems(getDriver(), virtualList);
+        Assert.assertTrue(items.length() > 0);
+        for (var i = 0; i < items.length(); i++) {
+            Assert.assertNotEquals(JsonType.NULL, items.get(i).getType());
+        }
+    }
+}

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.component.virtuallist.paging.PagelessDataCommunicator;
 import com.vaadin.flow.data.binder.HasDataProvider;
 import com.vaadin.flow.data.provider.ArrayUpdater;
@@ -301,6 +302,7 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
         setRenderer(renderer);
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setRequestedRange(int start, int length) {
         getDataCommunicator().setRequestedRange(start, length);


### PR DESCRIPTION
## Description

This PR adds `AllowInert` annotation to the data fetching method used from the client. This fixes the case where the items are not rendered when the virtual list is inert.

Fixes #7672 

Depends on https://github.com/vaadin/flow-components/pull/7726

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.