### PR TITLE
refactor: adjust SelectElement to make ITs pass with native popover

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
@@ -76,8 +76,7 @@ public class SelectElement extends TestBenchElement implements HasSelectByText,
 
     public Stream<ItemElement> getItemsStream() {
         openPopup();
-        List<WebElement> elements = getPropertyElement("_overlayElement")
-                .findElement(By.tagName("vaadin-select-list-box"))
+        List<WebElement> elements = getPropertyElement("_menuElement")
                 .findElements(By.tagName("vaadin-select-item"));
         if (elements.size() == 0) {
             return Stream.<ItemElement> builder().build();


### PR DESCRIPTION
## Description

Changed `getItemsStream()` to use `_menuElement` instead of `_overlayElement`, which will work both with current DOM structure and after updating the Select to use native `popover` once the new WC alpha is published.

## Type of change

- Refactor