### PR TITLE
test: update DatePicker ITs to not rely on overlay element

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerCustomFormatIT.java
@@ -280,9 +280,8 @@ public class DatePickerCustomFormatIT extends AbstractComponentIT {
                 DatePickerCustomFormatPage.OLD_REFERENCE_DATE_WITH_SHORT_FORMAT_OUTPUT);
 
         $(DatePickerElement.class).id(id).click();
-        waitForElementPresent(By.tagName("vaadin-date-picker-overlay"));
+        waitForElementVisible(By.tagName("vaadin-date-picker-overlay-content"));
         $(DatePickerElement.class).id(id).sendKeys(Keys.ESCAPE);
-        waitForElementNotPresent(By.tagName("vaadin-date-picker-overlay"));
 
         String todayString = LocalDate.now()
                 .format(DateTimeFormatter.ISO_LOCAL_DATE);

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -40,7 +40,7 @@ public class DatePickerIT extends AbstractComponentIT {
     @Test
     public void openSimpleDatePickerFromServer_overlayVisible() {
         scrollIntoViewAndClick(findElement(By.id("open-simple-picker")));
-        waitForElementVisible(By.tagName("vaadin-date-picker-overlay"));
+        waitForElementVisible(By.tagName("vaadin-date-picker-overlay-content"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Updated DatePicker ITs to not rely on the overlay element in order to make them pass also with native popover.

One remaining IT that will be updated together with bumping WC version is the `InjectedDatePickerI18nIT`.

## Type of change

- Test