### PR TITLE
chore: add vite config for merged ITs

### DIFF
--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -169,8 +169,7 @@ function copyFolderRecursiveSync(source, target, replaceCall) {
   }
 }
 
-// Create an index.html. Useful for monkey patching
-async function createFrontendIndex() {
+async function createProjectFiles() {
   if (/^14/.test(version)) {
     const javaFolder = `${itFolder}/src/main/java/com/vaadin`;
     const servicesFolder = `${itFolder}/src/main/resources/META-INF/services`
@@ -182,6 +181,7 @@ async function createFrontendIndex() {
     const frontendFolder = `${itFolder}/frontend`;
     fs.mkdirSync(frontendFolder, { recursive: true });
     copyFileSync(`${templateDir}/index.html`, `${frontendFolder}`);
+    copyFileSync(`${templateDir}/vite.config.ts`, `${itFolder}`);
   }
 }
 
@@ -224,7 +224,7 @@ async function main() {
   await computeVersion();
   await computeModules();
   await copySources();
-  await createFrontendIndex();
+  await createProjectFiles();
   await createPom();
 }
 

--- a/scripts/templates/vite.config.ts
+++ b/scripts/templates/vite.config.ts
@@ -1,0 +1,10 @@
+// @ts-ignore can not be resolved until NPM packages are installed
+import { defineConfig, UserConfigFn } from 'vite';
+// @ts-ignore can not be resolved until Flow generates base Vite config
+import { vaadinConfig } from './vite.generated';
+import { sharedConfig, mergeConfigs } from '../shared/shared-vite-config';
+
+export default defineConfig((env) => mergeConfigs(
+  vaadinConfig(env),
+  sharedConfig(env)
+));


### PR DESCRIPTION
## Description

Adds a Vite config for running merged ITs. This allows configuring the ITs to use a local web-components checkout by adding a respective `.env` file.

## Type of change

- Internal