### PR TITLE
test: add test coverage for $server.updateExpandedState

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree-toggle.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-tree-toggle.test.ts
@@ -1,0 +1,72 @@
+import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import {
+  init,
+  setRootItems,
+  getBodyCellContent,
+  expandItems,
+} from './shared.js';
+import type { FlowGrid, Item } from './shared.js';
+import type { GridTreeToggle } from '@vaadin/grid/vaadin-grid-tree-toggle.js';
+
+describe('grid connector - tree toggle', () => {
+  let grid: FlowGrid;
+
+  function getTreeToggle(rowIndex: number): GridTreeToggle | null | undefined {
+    return getBodyCellContent(grid, rowIndex, 0)?.querySelector('vaadin-grid-tree-toggle');
+  }
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-tree-column path="name"></vaadin-grid-tree-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    const rootItems: Item[] = [
+      { key: '0', name: 'foo', children: true },
+      { key: '1', name: 'bar', children: true },
+    ]
+
+    setRootItems(grid.$connector, rootItems);
+    expandItems(grid.$connector, [rootItems[1]]);
+
+    await nextFrame();
+  });
+
+  it('should make a server request when expanding item with click', () => {
+    getTreeToggle(0)?.click();
+    expect(grid.$server.updateExpandedState).to.be.calledOnce;
+    expect(grid.$server.updateExpandedState.firstCall.args[0]).to.equal('0');
+    expect(grid.$server.updateExpandedState.firstCall.args[1]).to.be.true;
+  });
+
+  it('should make a server request when expanding item with keyboard', async () => {
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.$server.updateExpandedState).to.be.calledOnce;
+    expect(grid.$server.updateExpandedState.firstCall.args[0]).to.equal('0');
+    expect(grid.$server.updateExpandedState.firstCall.args[1]).to.be.true;
+  });
+
+  it('should make a server request when collapsing item with click', () => {
+    getTreeToggle(1)?.click();
+    expect(grid.$server.updateExpandedState).to.be.calledOnce;
+    expect(grid.$server.updateExpandedState.firstCall.args[0]).to.equal('1');
+    expect(grid.$server.updateExpandedState.firstCall.args[1]).to.be.false;
+  });
+
+  it('should make a server request when collapsing item with keyboard', async () => {
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.$server.updateExpandedState).to.be.calledOnce;
+    expect(grid.$server.updateExpandedState.firstCall.args[0]).to.equal('0');
+    expect(grid.$server.updateExpandedState.firstCall.args[1]).to.be.true;
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -36,6 +36,7 @@ export type GridServer = {
   deselect: ((key: string) => void) & sinon.SinonSpy;
   deselectAll: () => void & sinon.SinonSpy;
   setDetailsVisible: ((key: string) => void) & sinon.SinonSpy;
+  updateExpandedState: ((key: string, expanded: boolean) => void) & sinon.SinonSpy;
   setRequestedRange: ((firstIndex: number, size: number) => void) & sinon.SinonSpy;
   setParentRequestedRanges: ((ranges: { firstIndex: number; size: number; parentKey: string }[]) => void) &
     sinon.SinonSpy;
@@ -47,6 +48,7 @@ export type Item = {
   key: string;
   name?: string;
   price?: number,
+  children?: boolean;
   selectable?: boolean;
   selected?: boolean;
   detailsOpened?: boolean;
@@ -97,6 +99,7 @@ export function init(grid: FlowGrid): void {
     deselect: sinon.spy(),
     deselectAll: sinon.spy(),
     setDetailsVisible: sinon.spy(),
+    updateExpandedState: sinon.spy(),
     setRequestedRange: sinon.spy(),
     setParentRequestedRanges: sinon.spy(),
     sortersChanged: sinon.spy(),


### PR DESCRIPTION
## Description

Adds WTR tests to cover `$server.updateExpandedState` calls in gridConnector.

Part of #7684 

## Type of change

- [x] Internal
