### PR TITLE
chore: dedupe dependencies when using local web components

### DIFF
--- a/shared/web-components-vite-plugin.ts
+++ b/shared/web-components-vite-plugin.ts
@@ -36,7 +36,7 @@ export function useLocalWebComponents(webComponentsRepoPath: string): PluginOpti
       };
     },
     resolveId(id: string) {
-      if (/^(@vaadin)/.test(id)) {
+      if (id.startsWith('@vaadin')) {
         return this.resolve(path.join(nodeModulesPath, id));
       }
     }

--- a/shared/web-components-vite-plugin.ts
+++ b/shared/web-components-vite-plugin.ts
@@ -22,11 +22,21 @@ export function useLocalWebComponents(webComponentsRepoPath: string): PluginOpti
           watch: {
             ignored: [`!${nodeModulesPath}/**`]
           }
+        },
+        // The following dependencies are imported both in the external web-components, and in Flow application sources.
+        // Vite always resolves dependencies from where they are imported, so these dependencies would then be bundled
+        // twice. To avoid that, use dedupe. Dedupe only works for non-optimized dependencies, so they also need to be
+        // excluded from optimization / pre-bundling.
+        optimizeDeps: {
+          exclude: ['lit', 'lit-html', 'ol']
+        },
+        resolve: {
+          dedupe: ['lit', 'lit-html', 'ol'],
         }
       };
     },
-    resolveId(id) {
-      if (/^(@polymer|@vaadin)/.test(id)) {
+    resolveId(id: string) {
+      if (/^(@vaadin)/.test(id)) {
         return this.resolve(path.join(nodeModulesPath, id));
       }
     }


### PR DESCRIPTION
## Description

Currently dependencies imported both from web-components and somewhere in the Flow integration test sources are loaded / bundled twice, which can result in errors, for example when one of those dependency uses `instanceof` checks. We also load Lit twice at the moment due to that.

This change de-dupes some common dependencies, so that only one version is loaded.

## Type of change

- Internal