### PR TITLE
chore: copy data provider test classes from flow repo

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -18,13 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-            <version>${flow.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataViewTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataViewTest.java
@@ -27,7 +27,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
-import com.vaadin.flow.data.provider.AbstractComponentDataViewTest;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderListener;
@@ -39,6 +38,7 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
 
 public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataViewTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataViewTest.java
@@ -17,8 +17,8 @@ package com.vaadin.flow.component.checkbox.dataview;
 
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
-import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
 
 public class CheckboxGroupListDataViewTest
         extends AbstractListDataViewListenerTest {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -18,13 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-            <version>${flow.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -34,12 +34,12 @@ import com.vaadin.flow.component.shared.HasOverlayClassName;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.shared.Registration;
-import com.vaadin.tests.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.MockUI;
 
 import elemental.json.Json;
 
@@ -271,7 +271,7 @@ public abstract class ComboBoxBaseTest {
     @Test
     public void setDataProvider_inMemoryDataProvider_fetchesEagerly() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
-        DataCommunicatorTest.MockUI ui = new DataCommunicatorTest.MockUI();
+        MockUI ui = new MockUI();
         ui.add(comboBox);
 
         DataProvider<String, String> dataProvider = Mockito
@@ -308,7 +308,7 @@ public abstract class ComboBoxBaseTest {
     @Test
     public void setDataProvider_backendDataProvider_fetchesOnOpened() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
-        DataCommunicatorTest.MockUI ui = new DataCommunicatorTest.MockUI();
+        MockUI ui = new MockUI();
         ui.add(comboBox);
 
         DataProvider<String, String> dataProvider = Mockito.spy(DataProvider
@@ -349,7 +349,7 @@ public abstract class ComboBoxBaseTest {
         DataProviderListenersTest
                 .checkOldListenersRemovedOnComponentAttachAndDetach(
                         createComboBox(Object.class), 2, 2, new int[] { 1, 3 },
-                        new DataCommunicatorTest.MockUI());
+                        new MockUI());
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
@@ -23,14 +23,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class MultiSelectComboBoxFilteringTest {
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
 
     @Before
     public void setUp() {
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -29,10 +29,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.combobox.ComboBox;
-import com.vaadin.flow.data.provider.AbstractComponentDataViewTest;
-import com.vaadin.flow.data.provider.CustomInMemoryDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderListener;
@@ -43,11 +40,14 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
+import com.vaadin.tests.dataprovider.CustomInMemoryDataProvider;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
 
     private ComboBox<String> comboBox;
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -57,7 +57,7 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         dataProvider = new CustomInMemoryDataProvider<>(items);
         comboBox = getComponent();
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(comboBox);
         dataView = comboBox.setItems(dataProvider, textFilter -> item -> true);
         component = comboBox;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -35,10 +35,10 @@ import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.tests.dataprovider.MockUI;
 
 import elemental.json.JsonValue;
 
@@ -53,7 +53,7 @@ public class ComboBoxLazyDataViewTest {
     private String[] items = { "foo", "bar", "baz" };
     private ComboBoxLazyDataView<String> dataView;
     private ComboBox<String> comboBox;
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
     private DataCommunicator<String> dataCommunicator;
     private ArrayUpdater arrayUpdater;
     private SerializableConsumer<DataCommunicator.Filter<String>> filterSlot;
@@ -87,7 +87,7 @@ public class ComboBoxLazyDataViewTest {
                         .count());
 
         comboBox = new ComboBox<>();
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(comboBox);
 
         ArrayUpdater.Update update = new ArrayUpdater.Update() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -25,24 +25,24 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.combobox.ComboBox;
-import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.DataCommunicator;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
 
     private List<String> items;
     private ComboBoxListDataView<String> dataView;
     private ComboBox<String> component;
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
 
     @Before
     public void init() {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         component = new ComboBox<>();
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(component);
 
         dataView = component.setItems(items);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>vaadin-testbench-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractComponentDataViewTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractComponentDataViewTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dataprovider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.data.provider.AbstractDataView;
+import com.vaadin.flow.data.provider.DataView;
+import com.vaadin.flow.data.provider.HasDataView;
+import com.vaadin.flow.data.provider.InMemoryDataProvider;
+import com.vaadin.flow.data.provider.ItemCountChangeEvent;
+
+// Originally from com.vaadin.flow.data.provider.AbstractComponentDataViewTest
+// If this breaks, check there for updates
+
+/**
+ * Abstract test class that contains the common tests for all generic data view
+ * component's implementations, i.e. which extends {@link AbstractDataView} and
+ * doesn't contain an in-memory or lazy specific API. Concrete implementations
+ * of this class should provide a particular component to be tested as a
+ * {@link HasDataView} implementation.
+ */
+public abstract class AbstractComponentDataViewTest {
+
+    protected List<String> items;
+    protected InMemoryDataProvider<String> dataProvider;
+    protected DataView<String> dataView;
+    protected HasDataView<String, ?, ? extends DataView<String>> component;
+
+    @Before
+    public void init() {
+        items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
+        dataProvider = new CustomInMemoryDataProvider<>(items);
+        component = getVerifiedComponent();
+        dataView = component.setItems(dataProvider);
+    }
+
+    @Test
+    public void getItems_noFiltersSet_allItemsObtained() {
+        Stream<String> allItems = dataView.getItems();
+        Assert.assertArrayEquals("Unexpected data set", items.toArray(),
+                allItems.toArray());
+    }
+
+    @Test
+    public void getItems_filtersSet_filteredItemsObtained() {
+        dataProvider.setFilter(item -> item.equals("first"));
+        Assert.assertArrayEquals("Unexpected data set after filtering",
+                new String[] { "first" }, dataView.getItems().toArray());
+    }
+
+    @Test
+    public void getItems_sortingSet_sortedItemsObtained() {
+        dataProvider.setSortComparator(String::compareToIgnoreCase);
+        Assert.assertArrayEquals("Unexpected items sorting",
+                new String[] { "first", "last", "middle" },
+                dataView.getItems().toArray());
+    }
+
+    @Test
+    public void addItemCountChangeListener_fireEvent_listenerNotified() {
+        AtomicInteger fired = new AtomicInteger(0);
+        dataView.addItemCountChangeListener(
+                event -> fired.compareAndSet(0, event.getItemCount()));
+
+        ComponentUtil.fireEvent((Component) component,
+                new ItemCountChangeEvent<>((Component) component, 10, false));
+
+        Assert.assertEquals(10, fired.get());
+    }
+
+    protected abstract HasDataView<String, ?, ? extends DataView<String>> getComponent();
+
+    private HasDataView<String, ?, ? extends DataView<String>> getVerifiedComponent() {
+        HasDataView<String, ?, ? extends DataView<String>> component = getComponent();
+        if (component instanceof Component) {
+            return component;
+        }
+        throw new IllegalArgumentException(String.format(
+                "Component subclass is expected, but was given a '%s'",
+                component.getClass().getSimpleName()));
+    }
+
+    protected static class Item {
+        private long id;
+        private String value;
+
+        public Item(long id) {
+            this.id = id;
+        }
+
+        public Item(long id, String value) {
+            this.id = id;
+            this.value = value;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Item item = (Item) o;
+            return id == item.id && Objects.equals(value, item.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, value);
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractListDataViewListenerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractListDataViewListenerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dataprovider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.data.provider.AbstractListDataView;
+import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.flow.function.SerializablePredicate;
+
+// Originally from com.vaadin.flow.data.provider.AbstractListDataViewListenerTest
+// If this breaks, check there for updates
+
+public abstract class AbstractListDataViewListenerTest {
+
+    @Test
+    public void addItemCountChangeListener_itemsCountChanged_listenersAreNotified() {
+        String[] items = new String[] { "item1", "item2", "item3", "item4" };
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+        AbstractListDataView<String> dataView = component
+                .setItems(new ArrayList<>(Arrays.asList(items)));
+
+        AtomicInteger invocationCounter = new AtomicInteger(0);
+
+        dataView.addItemCountChangeListener(
+                event -> invocationCounter.incrementAndGet());
+
+        UI ui = new MockUI();
+        ui.add((Component) component);
+
+        dataView.setFilter("one"::equals);
+        dataView.setFilter(null);
+        dataView.addItemAfter("item5", "item4");
+        dataView.addItemBefore("item0", "item1");
+        dataView.addItem("last");
+        dataView.removeItem("item0");
+
+        fakeClientCall(ui);
+
+        Assert.assertEquals(
+                "Unexpected number of item count change listener invocations "
+                        + "occurred",
+                1, invocationCounter.get());
+    }
+
+    @Test
+    public void addItemCountChangeListener_itemsCountNotChanged_listenersAreNotNotified() {
+        String[] items = new String[] { "item1", "item2", "item3", "item4" };
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+        AbstractListDataView<String> dataView = component.setItems(items);
+
+        AtomicBoolean invocationChecker = new AtomicBoolean(false);
+
+        UI ui = new MockUI();
+        ui.add((Component) component);
+
+        // Make initial item count change
+        fakeClientCall(ui);
+
+        dataView.addItemCountChangeListener(
+                event -> invocationChecker.getAndSet(true));
+
+        dataView.setSortComparator(String::compareTo);
+
+        // Make item count change after sort. No event should be sent as item
+        // count stays the same.
+        fakeClientCall(ui);
+
+        Assert.assertFalse("Unexpected item count listener invocation",
+                invocationChecker.get());
+    }
+
+    @Test
+    public void addItemCountChangeListener_itemsCountChanged_newItemCountSuppliedInEvent() {
+        String[] items = new String[] { "item1", "item2", "item3", "item4" };
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+        AbstractListDataView<String> dataView = component.setItems(items);
+
+        AtomicBoolean invocationChecker = new AtomicBoolean(false);
+
+        UI ui = new MockUI();
+        ui.add((Component) component);
+
+        // Make initial item count event
+        fakeClientCall(ui);
+
+        dataView.addItemCountChangeListener(event -> {
+            Assert.assertEquals("Unexpected item count", 1,
+                    event.getItemCount());
+            Assert.assertFalse(event.isItemCountEstimated());
+            invocationChecker.set(true);
+        });
+
+        dataView.setFilter("item1"::equals);
+
+        // Item count change should be sent as item count has changed after
+        // filtering.
+        fakeClientCall(ui);
+
+        Assert.assertTrue("Item count change never called",
+                invocationChecker.get());
+    }
+
+    @Test
+    public void setItems_setNewItemsToComponent_filteringAndSortingRemoved() {
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+
+        AbstractListDataView<String> listDataView = component.setItems("item1",
+                "item2", "item3");
+
+        SerializablePredicate<String> filter = "item2"::equals;
+
+        listDataView.setFilter(filter);
+
+        Assert.assertEquals("Unexpected filtered item count", 1,
+                listDataView.getItemCount());
+
+        listDataView = component.setItems("item1", "item2", "item3");
+
+        Assert.assertEquals("Non-filtered item count expected", 3,
+                listDataView.getItemCount());
+    }
+
+    protected abstract HasListDataView<String, ? extends AbstractListDataView<String>> getComponent();
+
+    private void fakeClientCall(UI ui) {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    private HasListDataView<String, ? extends AbstractListDataView<String>> getVerifiedComponent() {
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getComponent();
+        if (component instanceof Component) {
+            return component;
+        }
+        throw new IllegalArgumentException(String.format(
+                "Component subclass is expected, but was given a '%s'",
+                component.getClass().getSimpleName()));
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/CustomInMemoryDataProvider.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/CustomInMemoryDataProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dataprovider;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.vaadin.flow.data.provider.AbstractDataProvider;
+import com.vaadin.flow.data.provider.InMemoryDataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.SerializablePredicate;
+
+// Originally from com.vaadin.flow.data.provider.CustomInMemoryDataProvider
+// If this breaks, check there for updates
+
+public class CustomInMemoryDataProvider<T>
+        extends AbstractDataProvider<T, SerializablePredicate<T>>
+        implements InMemoryDataProvider<T> {
+
+    private List<T> items;
+    private SerializablePredicate<T> filter = in -> true;
+    private SerializableComparator<T> comparator;
+
+    public CustomInMemoryDataProvider(List<T> items) {
+        this.items = items;
+    }
+
+    @Override
+    public SerializablePredicate<T> getFilter() {
+        return filter;
+    }
+
+    @Override
+    public void setFilter(SerializablePredicate<T> filter) {
+        this.filter = filter;
+        refreshAll();
+    }
+
+    @Override
+    public SerializableComparator<T> getSortComparator() {
+        return comparator;
+    }
+
+    @Override
+    public void setSortComparator(SerializableComparator<T> comparator) {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public int size(Query<T, SerializablePredicate<T>> query) {
+        return (int) items.stream().filter(filter).count();
+    }
+
+    @Override
+    public Stream<T> fetch(Query<T, SerializablePredicate<T>> query) {
+        Stream<T> filteredStream = items.stream().filter(filter);
+        if (this.comparator != null) {
+            filteredStream = filteredStream.sorted(this.comparator);
+        }
+        return filteredStream.skip(query.getOffset()).limit(query.getLimit());
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/DataProviderListenersTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/DataProviderListenersTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.tests;
+package com.vaadin.tests.dataprovider;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/MockUI.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/MockUI.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dataprovider;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.flow.server.VaadinSession;
+
+// Originally from com.vaadin.flow.data.provider.DataCommunicationTest.MockUI
+// If this breaks, check there for updates
+public class MockUI extends UI {
+
+    public MockUI() {
+        this(findOrcreateSession());
+    }
+
+    public MockUI(VaadinSession session) {
+        getInternals().setSession(session);
+        setCurrent(this);
+    }
+
+    @Override
+    protected void init(VaadinRequest request) {
+        // Do nothing
+    }
+
+    private static VaadinSession findOrcreateSession() {
+        VaadinSession session = VaadinSession.getCurrent();
+        if (session == null) {
+            MockService service = Mockito.mock(MockService.class);
+            Mockito.when(service.getRouteRegistry())
+                    .thenReturn(Mockito.mock(RouteRegistry.class));
+            session = new AlwaysLockedVaadinSession(service);
+            VaadinSession.setCurrent(session);
+        }
+        return session;
+    }
+
+    private static class MockService extends VaadinServletService {
+
+        @Override
+        public RouteRegistry getRouteRegistry() {
+            return super.getRouteRegistry();
+        }
+    }
+
+    private static class AlwaysLockedVaadinSession extends MockVaadinSession {
+
+        private AlwaysLockedVaadinSession(VaadinService service) {
+            super(service);
+            lock();
+        }
+
+    }
+
+    private static class MockVaadinSession extends VaadinSession {
+        /*
+         * Used to make sure there's at least one reference to the mock session
+         * while it's locked. This is used to prevent the session from being
+         * eaten by GC in tests where @Before creates a session and sets it as
+         * the current instance without keeping any direct reference to it. This
+         * pattern has a chance of leaking memory if the session is not unlocked
+         * in the right way, but it should be acceptable for testing use.
+         */
+        private static final ThreadLocal<MockVaadinSession> referenceKeeper = new ThreadLocal<>();
+
+        private MockVaadinSession(VaadinService service) {
+            super(service);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            closeCount++;
+        }
+
+        public int getCloseCount() {
+            return closeCount;
+        }
+
+        @Override
+        public Lock getLockInstance() {
+            return lock;
+        }
+
+        @Override
+        public void lock() {
+            super.lock();
+            referenceKeeper.set(this);
+        }
+
+        @Override
+        public void unlock() {
+            super.unlock();
+            referenceKeeper.remove();
+        }
+
+        private int closeCount;
+
+        private ReentrantLock lock = new ReentrantLock();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -18,13 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-            <version>${flow.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-dnd</artifactId>
             <version>${flow.version}</version>
             <scope>provided</scope>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -25,13 +25,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.selection.MultiSelect;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class AbstractGridMultiSelectionModelSelectedItemsTest {
 
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
     private Grid<String> grid;
     private String item1;
     private String item2;
@@ -65,7 +65,7 @@ public class AbstractGridMultiSelectionModelSelectedItemsTest {
         selectionModel = ((AbstractGridMultiSelectionModel<String>) grid
                 .getSelectionModel());
 
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(grid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -32,13 +32,14 @@ import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.provider.*;
 import com.vaadin.flow.data.selection.SelectionListener;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class AbstractGridMultiSelectionModelTest {
 
     private Set<String> selected;
     private Set<String> deselected;
     private Grid<String> grid;
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
 
     @Before
     public void setup() {
@@ -62,7 +63,7 @@ public class AbstractGridMultiSelectionModelTest {
             }
         };
 
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(grid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -25,12 +25,12 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.treegrid.TreeGrid;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
     private TreeGrid<String> treeGrid;
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
 
     @Before
     public void setup() {
@@ -41,7 +41,7 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 root -> Collections.emptyList());
         treeGrid.setSelectionMode(Grid.SelectionMode.MULTI);
 
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(treeGrid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -26,9 +26,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.tests.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class GridTest {
 
@@ -88,8 +88,7 @@ public class GridTest {
     public void dataProviderListeners_gridAttachedAndDetached_oldDataProviderListenerRemoved() {
         DataProviderListenersTest
                 .checkOldListenersRemovedOnComponentAttachAndDetach(
-                        new Grid<>(), 2, 2, new int[] { 0, 2 },
-                        new DataCommunicatorTest.MockUI());
+                        new Grid<>(), 2, 2, new int[] { 0, 2 }, new MockUI());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
@@ -20,14 +20,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.treegrid.TreeGrid;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class TreeGridTest {
 
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
     private TreeGrid<Item> treeGrid;
 
     @Before
@@ -42,7 +42,7 @@ public class TreeGridTest {
                 treeData);
         treeGrid.setDataProvider(treeDataProvider);
 
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(treeGrid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridDataViewTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.data.provider.AbstractComponentDataViewTest;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -38,6 +37,7 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
 
 public class GridDataViewTest extends AbstractComponentDataViewTest {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyDataViewTest.java
@@ -24,14 +24,14 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class GridLazyDataViewTest {
 
     private GridLazyDataView<String> dataView;
     private Grid<String> grid;
-    private DataCommunicatorTest.MockUI ui;
+    private MockUI ui;
 
     @Before
     public void setup() {
@@ -43,7 +43,7 @@ public class GridLazyDataViewTest {
                 }, query -> 3);
 
         grid = new Grid<>();
-        ui = new DataCommunicatorTest.MockUI();
+        ui = new MockUI();
         ui.add(grid);
 
         dataView = grid.setItems(dataProvider);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridListDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridListDataViewTest.java
@@ -26,9 +26,9 @@ import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.data.provider.AbstractListDataView;
-import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
 
 public class GridListDataViewTest extends AbstractListDataViewListenerTest {
 

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -18,13 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-            <version>${flow.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -29,8 +29,8 @@ import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.component.shared.HasTooltip;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
-import com.vaadin.tests.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class ListBoxUnitTest {
 
@@ -187,7 +187,7 @@ public class ListBoxUnitTest {
         DataProviderListenersTest
                 .checkOldListenersRemovedOnComponentAttachAndDetach(
                         new ListBox<>(), 1, 1, new int[] { 0, 1 },
-                        new DataCommunicatorTest.MockUI());
+                        new MockUI());
     }
 
     @Test

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxDataViewTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxDataViewTest.java
@@ -28,7 +28,6 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxDataView;
-import com.vaadin.flow.data.provider.AbstractComponentDataViewTest;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderListener;
@@ -40,6 +39,7 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
 
 public class ListBoxDataViewTest extends AbstractComponentDataViewTest {
 

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxListDataViewTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/dataview/ListBoxListDataViewTest.java
@@ -17,8 +17,8 @@ package com.vaadin.flow.component.listbox.test.dataview;
 
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.data.provider.AbstractListDataView;
-import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
 
 public class ListBoxListDataViewTest extends AbstractListDataViewListenerTest {
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -18,13 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-            <version>${flow.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -41,13 +41,13 @@ import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataVi
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.component.shared.SelectionPreservationMode;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.tests.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.DataProviderListenersTest;
+import com.vaadin.tests.dataprovider.MockUI;
 
 public class RadioButtonGroupTest {
 
@@ -471,7 +471,7 @@ public class RadioButtonGroupTest {
         DataProviderListenersTest
                 .checkOldListenersRemovedOnComponentAttachAndDetach(
                         new RadioButtonGroup<>(), 1, 1, new int[] { 0, 1 },
-                        new DataCommunicatorTest.MockUI());
+                        new MockUI());
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataViewTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataViewTest.java
@@ -27,7 +27,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
-import com.vaadin.flow.data.provider.AbstractComponentDataViewTest;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderListener;
@@ -39,6 +38,7 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
 
 public class RadioButtonGroupDataViewTest
         extends AbstractComponentDataViewTest {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataViewTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataViewTest.java
@@ -17,8 +17,8 @@ package com.vaadin.flow.component.radiobutton.dataview;
 
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
-import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
 
 public class RadioButtonGroupListDataViewTest
         extends AbstractListDataViewListenerTest {

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -18,13 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-            <version>${flow.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectDataViewTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectDataViewTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.select.Select;
-import com.vaadin.flow.data.provider.AbstractComponentDataViewTest;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderListener;
@@ -38,6 +37,7 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
 
 public class SelectDataViewTest extends AbstractComponentDataViewTest {
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectListDataViewTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/data/SelectListDataViewTest.java
@@ -17,8 +17,8 @@ package com.vaadin.flow.component.select.data;
 
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.data.provider.AbstractListDataView;
-import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
 
 public class SelectListDataViewTest extends AbstractListDataViewListenerTest {
 


### PR DESCRIPTION
## Description

Move common test classes from the `flow-data` module to this repo and remove  the `flow-data` test jar dependency.

This also fixed an issue with `AbstractListDataViewListenerTest`, which had a non-working mock UI implementation, which is fixed by using the one duplicated from `DataCommunicatorTest.MockUI`.

Classes added:
- `AbstractComponentDataViewTest`
- `AbstractListDataViewListenerTest`
- `CustomInMemoryDataProvider`
- `DataCommunicatorTest.MockUI` as `MockUI`

## Type of change

- Internal