### PR TITLE
refactor: deprecate legacy TestBench APIs

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -238,6 +238,11 @@ public class TreeGridElement extends GridElement {
      * visible expanded rows.
      *
      * @return the number of expanded rows
+     * @deprecated since 24.9 and will be removed in Vaadin 25 where expanded
+     *             items will no longer be available on the client-side, as
+     *             hierarchy management is being moved to the server-side.
+     *             Instead, it's recommended to assert the actual presence of
+     *             expanded rows in the grid by checking row content.
      */
     public long getNumberOfExpandedRows() {
         waitUntilLoadingFinished();
@@ -281,6 +286,10 @@ public class TreeGridElement extends GridElement {
      *
      * @return <code>true</code> if grid is loading expanded rows,
      *         <code>false</code> otherwise
+     * @deprecated since 24.9 and will be removed in Vaadin 25 where explicit
+     *             waiting for expanded rows to load will no longer be required,
+     *             as full hierarchy will be returned in a single batch from the
+     *             server.
      */
     public boolean isLoadingExpandedRows() {
         return (Boolean) executeScript(

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -244,6 +244,7 @@ public class TreeGridElement extends GridElement {
      *             Instead, it's recommended to assert the actual presence of
      *             expanded rows in the grid by checking row content.
      */
+    @Deprecated(since = "24.9", forRemoval = true)
     public long getNumberOfExpandedRows() {
         waitUntilLoadingFinished();
         return (long) executeScript("return arguments[0].expandedItems.length;",
@@ -291,6 +292,7 @@ public class TreeGridElement extends GridElement {
      *             as full hierarchy will be returned in a single batch from the
      *             server.
      */
+    @Deprecated(since = "24.9", forRemoval = true)
     public boolean isLoadingExpandedRows() {
         return (Boolean) executeScript(
                 "return !!arguments[0].$connector ? (arguments[0].$connector.hasEnsureSubCacheQueue() || arguments[0].$connector.hasParentRequestQueue()) : arguments[0]._dataProviderController.isLoading()",


### PR DESCRIPTION
## Description

Deprecates TreeGridElement's `getNumberOfExpandedRows` and `isLoadingExpandedRows` with the intention of removing them in Vaadin 25 where hierarchy management is being moved to the server-side.

Fixes #7735 

## Type of change

- [x] Refactor
