### PR TITLE
refactor: use modern setViewportRange method

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -1341,8 +1341,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * Called by the client-side connector, delegates to data controller
      */
     @ClientCallable
-    private void setRequestedRange(int start, int length, String filter) {
-        dataController.setRequestedRange(start, length, filter);
+    private void setViewportRange(int start, int length, String filter) {
+        dataController.setViewportRange(start, length, filter);
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -245,7 +245,7 @@ class ComboBoxDataController<TItem>
     void reset() {
         lastFilter = null;
         if (dataCommunicator != null) {
-            dataCommunicator.setRequestedRange(0, 0);
+            dataCommunicator.setViewportRange(0, 0);
             dataCommunicator.reset();
         }
         comboBox.runBeforeClientResponse(ui -> ui.getPage().executeJs(
@@ -269,7 +269,7 @@ class ComboBoxDataController<TItem>
     /**
      * Called when the client-side connector requests data
      */
-    void setRequestedRange(int start, int length, String filter) {
+    void setViewportRange(int start, int length, String filter) {
         // If the filter is null, which indicates that the combo box was closed
         // before, then reset the data communicator to force sending an update
         // to the client connector. This covers an edge-case when using an empty
@@ -283,7 +283,7 @@ class ComboBoxDataController<TItem>
         if (lastFilter == null) {
             dataCommunicator.reset();
         }
-        dataCommunicator.setRequestedRange(start, length);
+        dataCommunicator.setViewportRange(start, length);
         filterSlot.accept(filter);
     }
 
@@ -605,7 +605,7 @@ class ComboBoxDataController<TItem>
             removeLazyOpenRegistration();
             dataCommunicator.setFetchEnabled(true);
             if (!comboBox.isAutoOpen()) {
-                setRequestedRange(0, comboBox.getPageSize(),
+                setViewportRange(0, comboBox.getPageSize(),
                         comboBox.getFilter());
             }
         }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -29,7 +29,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
       const count = endIndex - startIndex;
       const filter = params.filter;
 
-      comboBox.$server.setRequestedRange(startIndex, count, filter);
+      comboBox.$server.setViewportRange(startIndex, count, filter);
       lastFilterSentToServer = filter;
       if (dataCommunicatorResetNeeded) {
         comboBox.$server.resetDataCommunicator();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxSpringDataTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxSpringDataTest.java
@@ -86,7 +86,7 @@ public class ComboBoxSpringDataTest {
 
             return filteredData(filterString);
         });
-        comboBox.getDataController().setRequestedRange(0, 50, "J");
+        comboBox.getDataController().setViewportRange(0, 50, "J");
 
         List<Person> items = comboBox.getLazyDataView().getItems().toList();
         Assert.assertEquals(2, items.size());

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboboxSerializableTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboboxSerializableTest.java
@@ -33,20 +33,20 @@ public class ComboboxSerializableTest extends ClassesSerializableTest {
     }
 
     @Test
-    public void setItems_callSetRequestedRange_comboBoxSerializable()
+    public void setItems_callSetViewportRange_comboBoxSerializable()
             throws Throwable {
         final ComboBox<String> comboBox = new ComboBox<>();
         comboBox.setItems(List.of("Item 1", "Item 2"));
-        callSetRequestedRange(comboBox, 0, 2, "");
+        callSetViewportRange(comboBox, 0, 2, "");
         serializeAndDeserialize(comboBox);
     }
 
-    private void callSetRequestedRange(ComboBox<String> comboBox, int start,
+    private void callSetViewportRange(ComboBox<String> comboBox, int start,
             int length, String filter)
             throws NoSuchMethodException, IllegalAccessException,
             IllegalArgumentException, InvocationTargetException {
-        Method method = ComboBoxBase.class.getDeclaredMethod(
-                "setRequestedRange", int.class, int.class, String.class);
+        Method method = ComboBoxBase.class.getDeclaredMethod("setViewportRange",
+                int.class, int.class, String.class);
         method.setAccessible(true);
         method.invoke(comboBox, start, length, filter);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
@@ -42,14 +42,14 @@ public class MultiSelectComboBoxFilteringTest {
                 IntStream.range(0, 100).mapToObj(i -> "Item " + i).toList());
         comboBox.setItems(items);
 
-        comboBox.getDataController().setRequestedRange(0, 50, "foo");
+        comboBox.getDataController().setViewportRange(0, 50, "foo");
         fakeClientCommunication();
         Assert.assertFalse((Boolean) comboBox.getElement()
                 .getPropertyRaw("_clientSideFilter"));
 
         items.add("foo");
         comboBox.getDataProvider().refreshAll();
-        comboBox.getDataController().setRequestedRange(0, 50, "");
+        comboBox.getDataController().setViewportRange(0, 50, "");
         fakeClientCommunication();
         Assert.assertFalse((Boolean) comboBox.getElement()
                 .getPropertyRaw("_clientSideFilter"));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTestHelper.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTestHelper.java
@@ -31,11 +31,11 @@ final class ComboBoxDataViewTestHelper {
         try {
             // Reset the client filter on server side as though it's sent from
             // client
-            Method setRequestedRangeMethod = ComboBoxBase.class
-                    .getDeclaredMethod("setRequestedRange", int.class,
-                            int.class, String.class);
-            setRequestedRangeMethod.setAccessible(true);
-            setRequestedRangeMethod.invoke(comboBox, 0, comboBox.getPageSize(),
+            Method setViewportRangeMethod = ComboBoxBase.class
+                    .getDeclaredMethod("setViewportRange", int.class, int.class,
+                            String.class);
+            setViewportRangeMethod.setAccessible(true);
+            setViewportRangeMethod.invoke(comboBox, 0, comboBox.getPageSize(),
                     clientFilter);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -137,7 +137,7 @@ public class ComboBoxLazyDataViewTest {
         final AtomicInteger itemCount = new AtomicInteger(0);
         dataView.addItemCountChangeListener(
                 event -> itemCount.set(event.getItemCount()));
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
 
         ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -28,14 +28,14 @@ describe('grid connector - data range', () => {
   }
 
   function expectRequestedRange(range: [number, number]) {
-    expect(grid.$server.setRequestedRange).to.be.calledOnce;
-    expect(grid.$server.setRequestedRange.args[0]).to.eql(range);
+    expect(grid.$server.setViewportRange).to.be.calledOnce;
+    expect(grid.$server.setViewportRange.args[0]).to.eql(range);
   }
 
   function processRequestedRange() {
-    const range = grid.$server.setRequestedRange.args[0];
+    const range = grid.$server.setViewportRange.args[0];
     setRootItemsRange(range[0], range[1]);
-    grid.$server.setRequestedRange.resetHistory();
+    grid.$server.setViewportRange.resetHistory();
   }
 
   beforeEach(async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -62,7 +62,7 @@ describe('grid connector', () => {
       grid.clearCache();
       await nextFrame();
 
-      expect(grid.$server.setRequestedRange.called).to.be.false;
+      expect(grid.$server.setViewportRange.called).to.be.false;
     });
   });
 
@@ -86,9 +86,9 @@ describe('grid connector', () => {
         // Request a range of items at the top
         clear(grid.$connector, 0, 50);
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setRequestedRange).to.be.calledOnceWith(0, 50);
+        expect(grid.$server.setViewportRange).to.be.calledOnceWith(0, 50);
         setRootItems(grid.$connector, items, 0, 50);
-        grid.$server.setRequestedRange.resetHistory();
+        grid.$server.setViewportRange.resetHistory();
       });
 
       it('should request new items after incomplete confirm', async () => {
@@ -100,7 +100,7 @@ describe('grid connector', () => {
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
         // Grid should have requested for the missing items
-        expect(grid.$server.setRequestedRange).to.be.calledOnceWith(0, 50);
+        expect(grid.$server.setViewportRange).to.be.calledOnceWith(0, 50);
       });
 
       it('should not request for new items after complete confirm', async () => {
@@ -112,7 +112,7 @@ describe('grid connector', () => {
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
 
         // Grid should not have request for items
-        expect(grid.$server.setRequestedRange).to.be.not.called;
+        expect(grid.$server.setViewportRange).to.be.not.called;
       });
     });
 
@@ -122,9 +122,9 @@ describe('grid connector', () => {
         clear(grid.$connector, 50, 50);
         grid.scrollToIndex(50);
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setRequestedRange).to.have.been.calledOnceWith(25, 75);
+        expect(grid.$server.setViewportRange).to.have.been.calledOnceWith(25, 75);
         setRootItems(grid.$connector, items, 25, 75);
-        grid.$server.setRequestedRange.resetHistory();
+        grid.$server.setViewportRange.resetHistory();
       });
 
       it('should request for items if part of the last range was cleared', async () => {
@@ -136,12 +136,12 @@ describe('grid connector', () => {
         clear(grid.$connector, 50, grid.pageSize);
         setRootItems(grid.$connector, items, 0, 50);
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setRequestedRange).to.not.have.been.called;
+        expect(grid.$server.setViewportRange).to.not.have.been.called;
 
         // Scroll down again, should reload the range because part of it was cleared
         grid.scrollToIndex(50);
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setRequestedRange).to.have.been.calledOnceWith(25, 75);
+        expect(grid.$server.setViewportRange).to.have.been.calledOnceWith(25, 75);
       });
 
       it('should not request for items if data outside of the last range was cleared', async () => {
@@ -153,12 +153,12 @@ describe('grid connector', () => {
         clear(grid.$connector, 75, grid.pageSize);
         grid.$connector.confirm(-1);
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setRequestedRange).to.not.have.been.called;
+        expect(grid.$server.setViewportRange).to.not.have.been.called;
 
         // Scroll down again, should not reload the range because nothing from it was cleared
         grid.scrollToIndex(50);
         await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setRequestedRange).to.not.have.been.called;
+        expect(grid.$server.setViewportRange).to.not.have.been.called;
       });
     });
   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -37,7 +37,7 @@ export type GridServer = {
   deselectAll: () => void & sinon.SinonSpy;
   setDetailsVisible: ((key: string) => void) & sinon.SinonSpy;
   updateExpandedState: ((key: string, expanded: boolean) => void) & sinon.SinonSpy;
-  setRequestedRange: ((firstIndex: number, size: number) => void) & sinon.SinonSpy;
+  setViewportRange: ((firstIndex: number, size: number) => void) & sinon.SinonSpy;
   setParentRequestedRanges: ((ranges: { firstIndex: number; size: number; parentKey: string }[]) => void) &
     sinon.SinonSpy;
   sortersChanged: ((sorters: { path: string, direction: string }[]) => void) & sinon.SinonSpy;
@@ -100,7 +100,7 @@ export function init(grid: FlowGrid): void {
     deselectAll: sinon.spy(),
     setDetailsVisible: sinon.spy(),
     updateExpandedState: sinon.spy(),
-    setRequestedRange: sinon.spy(),
+    setViewportRange: sinon.spy(),
     setParentRequestedRanges: sinon.spy(),
     sortersChanged: sinon.spy(),
     setShiftKeyDown: sinon.spy()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1375,7 +1375,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         public void initialize() {
             initConnector();
             updateSelectionModeOnClient();
-            setRequestedRange(0, getPageSize());
+            setViewportRange(0, getPageSize());
         }
     }
 
@@ -3063,7 +3063,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         getElement()
                 .executeJs("if (this.$connector) { this.$connector.reset() }");
         getDataCommunicator().setPageSize(pageSize);
-        setRequestedRange(0, pageSize);
+        setViewportRange(0, pageSize);
         getDataCommunicator().reset();
     }
 
@@ -3841,7 +3841,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
-    private void setRequestedRange(int start, int length) {
+    private void setViewportRange(int start, int length) {
         if (length > 500 && length / getPageSize() > 10 && isAllRowsVisible()) {
             throw new IllegalArgumentException(
                     "Attempted to fetch more items from server than allowed in one go. "
@@ -3852,7 +3852,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                             + "reason this is not an option, increase the page size of the grid so that rendering "
                             + "every item at once doesn't result in a request for over 10 pages.");
         }
-        getDataCommunicator().setRequestedRange(start, length);
+        getDataCommunicator().setViewportRange(start, length);
     }
 
     @ClientCallable
@@ -5092,7 +5092,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         int preloadedItemsCount = lastIndexPageEndIndex - targetPageStartIndex
                 + 1;
         // Preload the items
-        setRequestedRange(targetPageStartIndex, preloadedItemsCount);
+        setViewportRange(targetPageStartIndex, preloadedItemsCount);
 
         // Scroll to the requested index
         getElement().callJsFunction("scrollToIndex", rowIndex);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -182,7 +182,7 @@ public class TreeGrid<T> extends Grid<T>
         public void initialize() {
             initConnector();
             updateSelectionModeOnClient();
-            getDataCommunicator().setRequestedRange(0, getPageSize());
+            getDataCommunicator().setViewportRange(0, getPageSize());
         }
     }
 
@@ -1128,7 +1128,7 @@ public class TreeGrid<T> extends Grid<T>
         }
         int pageSize = getPageSize();
         int firstRootIndex = indexes[0] - indexes[0] % pageSize;
-        getDataCommunicator().setRequestedRange(firstRootIndex, pageSize);
+        getDataCommunicator().setViewportRange(firstRootIndex, pageSize);
         String joinedIndexes = Arrays.stream(indexes).mapToObj(String::valueOf)
                 .collect(Collectors.joining(","));
         getUI().ifPresent(ui -> ui.beforeClientResponse(this,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -234,7 +234,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     const delay = grid._hasData ? rootRequestDelay : 0;
 
     rootRequestDebouncer = Debouncer.debounce(rootRequestDebouncer, timeOut.after(delay), () => {
-      grid.$connector.fetchPage((firstIndex, size) => grid.$server.setRequestedRange(firstIndex, size), page, root);
+      grid.$connector.fetchPage((firstIndex, size) => grid.$server.setViewportRange(firstIndex, size), page, root);
     });
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -38,38 +38,38 @@ public class GridScrollTest {
     @Test
     public void scrollToStart_preloadOnePage() {
         grid.scrollToIndex(0);
-        Assert.assertEquals("0-50", getRequestedRange(grid));
+        Assert.assertEquals("0-50", getViewportRange(grid));
     }
 
     @Test
     public void scrollToEnd_preloadOnePage() {
         grid.scrollToIndex(950);
-        Assert.assertEquals("950-1000", getRequestedRange(grid));
+        Assert.assertEquals("950-1000", getViewportRange(grid));
     }
 
     @Test
     public void scrollToStartOfPage_preloadOnePage() {
         grid.scrollToIndex(500);
-        Assert.assertEquals("500-550", getRequestedRange(grid));
+        Assert.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test
     public void scrollToSecondIndexOfPage_preloadOnePage() {
         grid.scrollToIndex(501);
-        Assert.assertEquals("500-550", getRequestedRange(grid));
+        Assert.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test
     public void scrollToSecondLastIndexOfPage_preloadTwoPages() {
         grid.scrollToIndex(499);
-        Assert.assertEquals("450-550", getRequestedRange(grid));
+        Assert.assertEquals("450-550", getViewportRange(grid));
     }
 
     @Test
     public void smallPageSize_scrollToIndex_preloadMultiplePages() {
         grid.setPageSize(5);
         grid.scrollToIndex(499);
-        Assert.assertEquals("495-540", getRequestedRange(grid));
+        Assert.assertEquals("495-540", getViewportRange(grid));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class GridScrollTest {
         grid.setItems(items);
 
         grid.scrollToItem(items.get(500));
-        Assert.assertEquals("500-550", getRequestedRange(grid));
+        Assert.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class GridScrollTest {
                 .setItemIndexProvider((item, query) -> items.indexOf(item));
 
         grid.scrollToItem(items.get(500));
-        Assert.assertEquals("500-550", getRequestedRange(grid));
+        Assert.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test
@@ -118,15 +118,15 @@ public class GridScrollTest {
                 () -> grid.scrollToItem("Not present"));
     }
 
-    private String getRequestedRange(Grid<String> grid) {
+    private String getViewportRange(Grid<String> grid) {
         try {
             var communicator = grid.getDataCommunicator();
-            var requestedRangeField = communicator.getClass()
-                    .getDeclaredField("requestedRange");
-            requestedRangeField.setAccessible(true);
-            Range requestedRange = (Range) requestedRangeField
+            var viewportRangeField = communicator.getClass()
+                    .getDeclaredField("viewportRange");
+            viewportRangeField.setAccessible(true);
+            Range viewportRange = (Range) viewportRangeField
                     .get(communicator);
-            return requestedRange.getStart() + "-" + requestedRange.getEnd();
+            return viewportRange.getStart() + "-" + viewportRange.getEnd();
 
         } catch (Exception e) {
             return "";

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollTest.java
@@ -124,8 +124,7 @@ public class GridScrollTest {
             var viewportRangeField = communicator.getClass()
                     .getDeclaredField("viewportRange");
             viewportRangeField.setAccessible(true);
-            Range viewportRange = (Range) viewportRangeField
-                    .get(communicator);
+            Range viewportRange = (Range) viewportRangeField.get(communicator);
             return viewportRange.getStart() + "-" + viewportRange.getEnd();
 
         } catch (Exception e) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -92,33 +92,33 @@ public class GridTest {
     }
 
     @Test
-    public void setSmallPageSize_callSetRequestedRangeWithLengthLargerThan500_doesNotThrowException() {
+    public void setSmallPageSize_callSetViewportRangeWithLengthLargerThan500_doesNotThrowException() {
         final Grid<String> grid = new Grid<>();
 
         grid.setPageSize(10);
-        callSetRequestedRange(grid, 0, 600);
+        callSetViewportRange(grid, 0, 600);
     }
 
     @Test
-    public void setAllRowsVisible_setLargePageSize_callSetRequestedRangeWithLengthLargerThan500_doesNotThrowException() {
+    public void setAllRowsVisible_setLargePageSize_callSetViewportRangeWithLengthLargerThan500_doesNotThrowException() {
         final Grid<String> grid = new Grid<>();
 
         grid.setPageSize(100);
         grid.setAllRowsVisible(true);
-        callSetRequestedRange(grid, 0, 600);
+        callSetViewportRange(grid, 0, 600);
     }
 
     @Test
-    public void setAllRowsVisible_setSmallPageSize_callSetRequestedRangeWithLengthSmallerThan500_doesNotThrowException() {
+    public void setAllRowsVisible_setSmallPageSize_callSetViewportRangeWithLengthSmallerThan500_doesNotThrowException() {
         final Grid<String> grid = new Grid<>();
 
         grid.setPageSize(10);
         grid.setAllRowsVisible(true);
-        callSetRequestedRange(grid, 0, 400);
+        callSetViewportRange(grid, 0, 400);
     }
 
     @Test
-    public void setAllRowsVisible_setSmallPageSize_callSetRequestedRangeWithLengthLargerThan500_throwsException() {
+    public void setAllRowsVisible_setSmallPageSize_callSetViewportRangeWithLengthLargerThan500_throwsException() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage(
                 "Attempted to fetch more items from server than allowed in one go");
@@ -127,7 +127,7 @@ public class GridTest {
 
         grid.setPageSize(10);
         grid.setAllRowsVisible(true);
-        callSetRequestedRange(grid, 0, 600);
+        callSetViewportRange(grid, 0, 600);
     }
 
     @Test
@@ -144,10 +144,10 @@ public class GridTest {
         Assert.assertFalse(grid.getElement().hasProperty("accessibleName"));
     }
 
-    private void callSetRequestedRange(Grid<String> grid, int start,
+    private void callSetViewportRange(Grid<String> grid, int start,
             int length) {
         try {
-            Method method = Grid.class.getDeclaredMethod("setRequestedRange",
+            Method method = Grid.class.getDeclaredMethod("setViewportRange",
                     int.class, int.class);
             method.setAccessible(true);
             method.invoke(grid, start, length);
@@ -157,7 +157,7 @@ public class GridTest {
             if (e.getCause() instanceof IllegalArgumentException) {
                 throw (IllegalArgumentException) e.getCause();
             }
-            Assert.fail("Could not call Grid.setRequestedRange");
+            Assert.fail("Could not call Grid.setViewportRange");
         }
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyDataViewTest.java
@@ -65,7 +65,7 @@ public class GridLazyDataViewTest {
         final AtomicInteger itemCount = new AtomicInteger(0);
         dataView.addItemCountChangeListener(
                 event -> itemCount.set(event.getItemCount()));
-        grid.getDataCommunicator().setRequestedRange(0, 50);
+        grid.getDataCommunicator().setViewportRange(0, 50);
 
         dataView.setItemCountCallback(query -> 2);
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererTestComponentWrapper.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererTestComponentWrapper.java
@@ -129,7 +129,7 @@ public class LitRendererTestComponentWrapper extends Div
     @Override
     public void setItems(Collection<String> items) {
         HasDataProvider.super.setItems(items);
-        dataCommunicator.setRequestedRange(0, items.size());
+        dataCommunicator.setViewportRange(0, items.size());
     }
 
     @Override

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -302,8 +302,8 @@ public class VirtualList<T> extends Component implements HasDataProvider<T>,
     }
 
     @ClientCallable(DisabledUpdateMode.ALWAYS)
-    private void setRequestedRange(int start, int length) {
-        getDataCommunicator().setRequestedRange(start, length);
+    private void setViewportRange(int start, int length) {
+        getDataCommunicator().setViewportRange(start, length);
     }
 
     /**

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/resources/frontend/virtualListConnector.js
@@ -37,7 +37,7 @@ window.Vaadin.Flow.virtualListConnector = {
       if (lastRequestedRange[0] != first || lastRequestedRange[1] != last) {
         lastRequestedRange = [first, last];
         const count = 1 + last - first;
-        list.$server.setRequestedRange(first, count);
+        list.$server.setViewportRange(first, count);
       }
     };
 


### PR DESCRIPTION
## Description

This PR updates the codebase to use the modern `setViewportRange` method, which replaces the deprecated `setRequestedRange`.

Follow-up to  https://github.com/vaadin/flow/issues/21875

## Type of change

- [x] Refactor
