### PR TITLE
test: update ComboBox ITs to get item elements from scroller

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -39,8 +39,8 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
         executeScript("arguments[0].removeAttribute('disabled');", element);
     }
 
-    protected void assertItemSelected(String label) {
-        Optional<TestBenchElement> itemElement = getItemElements().stream()
+    protected void assertItemSelected(ComboBoxElement combo, String label) {
+        Optional<TestBenchElement> itemElement = getItemElements(combo).stream()
                 .filter(element -> getItemLabel(element).equals(label))
                 .findFirst();
         Assert.assertTrue(
@@ -73,16 +73,16 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
         return list;
     }
 
-    protected void assertRendered(String innerHTML) {
+    protected void assertRendered(ComboBoxElement comboBox, String innerHTML) {
         try {
             waitUntil(driver -> {
-                List<String> contents = getOverlayContents();
+                List<String> contents = getOverlayContents(comboBox);
                 return contents.size() > 0 && contents.get(0).length() > 0;
             });
         } catch (TimeoutException e) {
             Assert.fail("Timeout: no items with text content rendered.");
         }
-        List<String> overlayContents = getOverlayContents();
+        List<String> overlayContents = getOverlayContents(comboBox);
         Optional<String> matchingItem = overlayContents.stream()
                 .filter(s -> s.equals(innerHTML)).findFirst();
         Assert.assertTrue(
@@ -94,8 +94,9 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
                 matchingItem.isPresent());
     }
 
-    protected void assertNotRendered(String innerHTML) {
-        List<String> overlayContents = getOverlayContents();
+    protected void assertNotRendered(ComboBoxElement comboBox,
+            String innerHTML) {
+        List<String> overlayContents = getOverlayContents(comboBox);
         Optional<String> matchingItem = overlayContents.stream()
                 .filter(s -> s.equals(innerHTML)).findFirst();
         Assert.assertFalse(
@@ -104,19 +105,21 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
                 matchingItem.isPresent());
     }
 
-    protected void assertComponentRendered(String componentHtml) {
-        assertRendered(componentHtml);
+    protected void assertComponentRendered(ComboBoxElement comboBox,
+            String componentHtml) {
+        assertRendered(comboBox, componentHtml);
     }
 
     // Gets the innerHTML of all the actually rendered item elements.
     // There's more items loaded though.
-    protected List<String> getOverlayContents() {
-        return getItemElements().stream().map(this::getItemLabel)
+    protected List<String> getOverlayContents(ComboBoxElement comboBox) {
+        return getItemElements(comboBox).stream().map(this::getItemLabel)
                 .collect(Collectors.toList());
     }
 
-    protected List<String> getNonEmptyOverlayContents() {
-        return getOverlayContents().stream()
+    protected List<String> getNonEmptyOverlayContents(
+            ComboBoxElement comboBox) {
+        return getOverlayContents(comboBox).stream()
                 .filter(rendered -> !rendered.isEmpty())
                 .collect(Collectors.toList());
     }
@@ -126,8 +129,8 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
         return stripComments(innerHtml);
     }
 
-    protected List<TestBenchElement> getItemElements() {
-        return getOverlay().$("vaadin-combo-box-item").all().stream()
+    protected List<TestBenchElement> getItemElements(ComboBoxElement comboBox) {
+        return getScroller(comboBox).$("vaadin-combo-box-item").all().stream()
                 .filter(element -> !element.hasAttribute("hidden"))
                 .collect(Collectors.toList());
     }
@@ -141,15 +144,16 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
                 .executeAsyncScript("requestAnimationFrame(arguments[0])");
     }
 
-    protected void waitUntilTextInContent(String text) {
+    protected void waitUntilTextInContent(ComboBoxElement comboBox,
+            String text) {
         waitUntil(e -> {
-            List<String> overlayContents = getOverlayContents();
+            List<String> overlayContents = getOverlayContents(comboBox);
             return overlayContents.stream().anyMatch(s -> s.contains(text));
         });
     }
 
-    protected TestBenchElement getOverlay() {
-        return $("vaadin-combo-box-overlay").first();
+    protected TestBenchElement getScroller(ComboBoxElement comboBox) {
+        return (TestBenchElement) comboBox.getPropertyElement("_scroller");
     }
 
     protected void clickButton(String id) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearItemsIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClearItemsIT.java
@@ -35,7 +35,7 @@ public class ClearItemsIT extends AbstractComboBoxIT {
     @Test
     public void loadItems_setEmptyDataSet_open_loadingStateResolved() {
         combo.openPopup();
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         combo.closePopup();
         clickButton("set-empty-data-provider");
         combo.openPopup();
@@ -46,7 +46,7 @@ public class ClearItemsIT extends AbstractComboBoxIT {
     @Test
     public void loadItems_clearAndRefreshDataProvider_open_loadingStateResolved() {
         combo.openPopup();
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         combo.closePopup();
         clickButton("clear-and-refresh-data-provider");
         combo.openPopup();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxClientSideDataRangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxClientSideDataRangeIT.java
@@ -67,7 +67,7 @@ public class ComboBoxClientSideDataRangeIT extends AbstractComboBoxIT {
         // Scroll to the end page by page.
         for (int i = 0; i < ITEMS_COUNT; i += pageSize) {
             scrollToItem(comboBox, i);
-            waitUntilTextInContent("Item " + i);
+            waitUntilTextInContent(comboBox, "Item " + i);
 
             if (i < maxLoadedItemsCount) {
                 int page = i / pageSize;
@@ -85,7 +85,7 @@ public class ComboBoxClientSideDataRangeIT extends AbstractComboBoxIT {
         // Scroll to the beginning page by page.
         for (int i = ITEMS_COUNT - 1; i >= 0; i -= pageSize) {
             scrollToItem(comboBox, i);
-            waitUntilTextInContent("Item " + i);
+            waitUntilTextInContent(comboBox, "Item " + i);
             assertLoadedItemsCount(String.format(
                     "Should have %s items loaded after scrolling to the index %s from the end",
                     maxLoadedItemsCount, i), maxLoadedItemsCount, comboBox);
@@ -99,7 +99,7 @@ public class ComboBoxClientSideDataRangeIT extends AbstractComboBoxIT {
         // Scroll to the end.
         int lastIndex = ITEMS_COUNT - 1;
         scrollToItem(comboBox, lastIndex);
-        waitUntilTextInContent("Item " + lastIndex);
+        waitUntilTextInContent(comboBox, "Item " + lastIndex);
         assertLoadedItemsCount(String.format(
                 "Should have %s items loaded after jumping to the end",
                 pageSize), pageSize, comboBox);
@@ -107,7 +107,7 @@ public class ComboBoxClientSideDataRangeIT extends AbstractComboBoxIT {
         // Scroll to the beginning page by page.
         for (int i = lastIndex; i >= 0; i -= pageSize) {
             scrollToItem(comboBox, i);
-            waitUntilTextInContent("Item " + i);
+            waitUntilTextInContent(comboBox, "Item " + i);
 
             if (lastIndex - i < maxLoadedItemsCount) {
                 int page = (lastIndex - i) / pageSize;
@@ -125,7 +125,7 @@ public class ComboBoxClientSideDataRangeIT extends AbstractComboBoxIT {
         // Scroll to the end page by page.
         for (int i = 0; i < ITEMS_COUNT; i += pageSize) {
             scrollToItem(comboBox, i);
-            waitUntilTextInContent("Item " + i);
+            waitUntilTextInContent(comboBox, "Item " + i);
             assertLoadedItemsCount(String.format(
                     "Should have %s items loaded after scrolling to the index %s from the beginning",
                     maxLoadedItemsCount, i), maxLoadedItemsCount, comboBox);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
@@ -253,23 +253,23 @@ public class ComboBoxIT extends AbstractComboBoxIT {
         Assert.assertEquals(
                 "First page should be loaded after opening overlay.", 50,
                 getLoadedItems(comboBox).size());
-        assertRendered();
+        assertRendered(comboBox);
 
         scrollToItem(comboBox, 50);
         Assert.assertEquals("Second page should be loaded after scrolling.",
                 100, getLoadedItems(comboBox).size());
     }
 
-    private void assertRendered() {
+    private void assertRendered(ComboBoxElement comboBox) {
         try {
             waitUntil(driver -> {
-                List<String> items = getRenderedItems();
+                List<String> items = getRenderedItems(comboBox);
                 return items.size() > 0 && items.get(0).length() > 0;
             });
         } catch (TimeoutException e) {
             Assert.fail("Timeout: no items with text content rendered.");
         }
-        List<String> items = getRenderedItems();
+        List<String> items = getRenderedItems(comboBox);
         Assert.assertTrue("Expected more than 10 items to be rendered.",
                 items.size() > 10);
         items.forEach(item -> {
@@ -282,8 +282,8 @@ public class ComboBoxIT extends AbstractComboBoxIT {
         });
     }
 
-    private List<String> getRenderedItems() {
-        return getItemElements().stream()
+    private List<String> getRenderedItems(ComboBoxElement comboBox) {
+        return getItemElements(comboBox).stream()
                 .map(element -> element.getPropertyString("innerHTML"))
                 .collect(Collectors.toList());
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxLitRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxLitRendererIT.java
@@ -63,7 +63,7 @@ public class ComboBoxLitRendererIT extends AbstractComboBoxIT {
     }
 
     private void assertHasItem(String type, String name) {
-        Assert.assertTrue(getOverlayContents().stream().anyMatch(text -> {
+        Assert.assertTrue(getOverlayContents(combo).stream().anyMatch(text -> {
             return text.contains(type) && text.contains(name);
         }));
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -134,7 +134,7 @@ public class ComboBoxPageIT extends AbstractComboBoxIT {
         // opens the dropdown
         clickElementWithJs(input);
 
-        WebElement item = getItemElements().get(0);
+        WebElement item = getItemElements(combo).get(0);
         WebElement button = item.findElement(By.cssSelector("button"));
         clickElementWithJs(button);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComponentRendererIT.java
@@ -73,7 +73,7 @@ public class ComponentRendererIT extends AbstractComboBoxIT {
                 .id("multiple-pages-of-items");
 
         comboBox.openPopup();
-        waitUntilTextInContent("Song");
+        waitUntilTextInContent(comboBox, "Song");
 
         for (int i = 0; i < 600; i += 50) {
             scrollToItem(comboBox, i);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
@@ -59,7 +59,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
     @Test
     public void typeAndEnterExistingValue_noCustomValueChanges() {
         combo.sendKeys("foo");
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         combo.sendKeys(Keys.ENTER);
         assertCustomValueChanges();
     }
@@ -67,7 +67,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
     @Test
     public void typeAndEnterExistingValue_valueChanged() {
         combo.sendKeys("foo");
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         combo.sendKeys(Keys.ENTER);
         assertValueChanges("foo");
     }
@@ -84,7 +84,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
     @Test
     public void enterExistingValue_clearAndEnter_noCustomValueChange() {
         combo.sendKeys("foo");
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         combo.sendKeys(Keys.ENTER);
         repeatKey(Keys.BACK_SPACE, 3);
         combo.sendKeys(Keys.ENTER);
@@ -94,7 +94,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
     @Test
     public void enterExistingValue_clearAndEnter_valueChangedToNull() {
         combo.sendKeys("foo");
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         combo.sendKeys(Keys.ENTER);
         repeatKey(Keys.BACK_SPACE, 3);
         combo.sendKeys(Keys.ENTER);
@@ -120,13 +120,13 @@ public class CustomValueIT extends AbstractComboBoxIT {
         assertValueChanges("bar");
 
         combo.openPopup();
-        waitUntilTextInContent("bar");
+        waitUntilTextInContent(combo, "bar");
         assertLoadedItemsCount(
                 "Expected 2 items to be loaded after adding the custom value",
                 2, combo);
-        assertRendered("foo");
-        assertRendered("bar");
-        assertItemSelected("bar");
+        assertRendered(combo, "foo");
+        assertRendered(combo, "bar");
+        assertItemSelected(combo, "bar");
 
         repeatKey(Keys.BACK_SPACE, 3);
         combo.sendKeys("foo", Keys.ENTER);
@@ -134,7 +134,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
         assertValueChanges("bar", "foo");
         combo.openPopup();
         assertLoadedItemsCount("Expected 2 items to be loaded", 2, combo);
-        assertItemSelected("foo");
+        assertItemSelected(combo, "foo");
 
         combo.sendKeys("baz", Keys.ENTER);
         assertCustomValueChanges("bar", "foobaz");
@@ -143,7 +143,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "Expected 3 items to be loaded after adding the custom value",
                 3, combo);
-        assertItemSelected("foobaz");
+        assertItemSelected(combo, "foobaz");
 
         repeatKey(Keys.BACK_SPACE, 6);
         combo.sendKeys(Keys.ENTER);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -53,7 +53,7 @@ public class DetachReattachIT extends AbstractComboBoxIT {
     @Test
     public void openComboBox_detach_reattach_open_itemsLoaded() {
         combo.openPopup();
-        assertRendered("foo");
+        assertRendered(combo, "foo");
         clickButton("detach");
         clickButton("attach");
         combo = $(ComboBoxElement.class).first();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
@@ -82,7 +82,7 @@ public class FilteringIT extends AbstractComboBoxIT {
         box.openPopup();
         clickButton("add-items");
         box.openPopup();
-        assertRendered("Item 8");
+        assertRendered(box, "Item 8");
         assertClientSideFilter(false);
     }
 
@@ -110,9 +110,9 @@ public class FilteringIT extends AbstractComboBoxIT {
                 + "should be no filtered items until server has responded.", 0,
                 items.size());
 
-        waitUntil(driver -> getNonEmptyOverlayContents().size() == 11);
+        waitUntil(driver -> getNonEmptyOverlayContents(box).size() == 11);
 
-        getNonEmptyOverlayContents().forEach(item -> Assert.assertTrue(
+        getNonEmptyOverlayContents(box).forEach(item -> Assert.assertTrue(
                 "Unexpected item found after filtering.",
                 item.startsWith("Item 2")));
     }
@@ -136,23 +136,23 @@ public class FilteringIT extends AbstractComboBoxIT {
         box.openPopup();
         box.setFilter("0");
         box.setFilter("");
-        waitUntil(driver -> getNonEmptyOverlayContents().size() > 0);
-        assertRendered("Item 0");
+        waitUntil(driver -> getNonEmptyOverlayContents(box).size() > 0);
+        assertRendered(box, "Item 0");
     }
 
     @Test
     public void configureFilterInDataProvider_setDataProvider_serverSideFiltering() {
         box = $(ComboBoxElement.class).id("filterable-data-provider");
         box.openPopup();
-        assertRendered("foo");
+        assertRendered(box, "foo");
         List<String> filteredItems = setFilterAndGetImmediateResults("f");
         Assert.assertEquals("Expected server-side filtering, so there "
                 + "should be no filtered items until server has responded.", 0,
                 filteredItems.size());
 
-        waitUntil(driver -> getNonEmptyOverlayContents().size() == 1);
-        waitUntil(driver -> getOverlayContents().get(0).equals("filtered"));
-        assertRendered("filtered");
+        waitUntil(driver -> getNonEmptyOverlayContents(box).size() == 1);
+        waitUntil(driver -> getOverlayContents(box).get(0).equals("filtered"));
+        assertRendered(box, "filtered");
     }
 
     @Test
@@ -163,8 +163,8 @@ public class FilteringIT extends AbstractComboBoxIT {
         assertItemsNotLoaded();
 
         box.setFilter("foo");
-        waitUntil(driver -> getNonEmptyOverlayContents().size() == 1);
-        assertRendered("Item 0");
+        waitUntil(driver -> getNonEmptyOverlayContents(box).size() == 1);
+        assertRendered(box, "Item 0");
 
         box.setFilter("");
         assertItemsNotLoaded();
@@ -263,8 +263,8 @@ public class FilteringIT extends AbstractComboBoxIT {
                     + "should be no filtered items until server has responded.",
                     0, items.size());
 
-            waitUntil(driver -> getNonEmptyOverlayContents().size() > 0);
-            getNonEmptyOverlayContents().forEach(rendered -> {
+            waitUntil(driver -> getNonEmptyOverlayContents(box).size() > 0);
+            getNonEmptyOverlayContents(box).forEach(rendered -> {
                 Assert.assertTrue(
                         "Item which doesn't match the filter was found after server-side filtering.",
                         rendered.contains(filter));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -79,7 +79,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, stringBox);
-        assertRendered("Item 10");
+        assertRendered(stringBox, "Item 10");
     }
 
     @Test
@@ -88,18 +88,18 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         stringBox.openPopup();
 
         stringBox.setFilter("Item 11");
-        assertRendered("Item 11");
-        assertNotRendered("Item 2");
+        assertRendered(stringBox, "Item 11");
+        assertNotRendered(stringBox, "Item 2");
 
         stringBox.setFilter("Item 111");
-        assertRendered("Item 111");
-        assertNotRendered("Item 2");
+        assertRendered(stringBox, "Item 111");
+        assertNotRendered(stringBox, "Item 2");
     }
 
     @Test
     public void clickItem_valueChanged() {
         stringBox.openPopup();
-        getItemElements().get(2).click();
+        getItemElements(stringBox).get(2).click();
         assertMessage("Item 2");
     }
 
@@ -112,7 +112,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
                 "The selected value should be displayed in the ComboBox's TextField",
                 "Item 10", getTextFieldValue(stringBox));
         stringBox.openPopup();
-        assertItemSelected("Item 10");
+        assertItemSelected(stringBox, "Item 10");
     }
 
     @Test
@@ -125,7 +125,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         stringBox.openPopup();
         // Make sure the item is in the viewport / rendered
         scrollToItem(stringBox, 10);
-        assertItemSelected("Item 10");
+        assertItemSelected(stringBox, "Item 10");
     }
 
     @Test
@@ -164,7 +164,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         removeDisabledAttribute(stringBox);
         stringBox.openPopup();
 
-        getItemElements().get(4).click();
+        getItemElements(stringBox).get(4).click();
         assertMessage("");
     }
 
@@ -177,11 +177,11 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
                 180, pagesizeBox);
 
         scrollToItem(pagesizeBox, 200);
-        waitUntilTextInContent("Item 200");
+        waitUntilTextInContent(pagesizeBox, "Item 200");
 
         assertLoadedItemsCount("Expected two pages to be loaded.", 360,
                 pagesizeBox);
-        assertRendered("Item 200");
+        assertRendered(pagesizeBox, "Item 200");
     }
 
     @Test
@@ -191,7 +191,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         clickButton("change-pagesize");
         pagesizeBox.openPopup();
-        waitUntilTextInContent("Item");
+        waitUntilTextInContent(pagesizeBox, "Item");
         assertLoadedItemsCount(
                 "After opening the ComboBox, the first 'pageSize' amount "
                         + "of items should be loaded (with updated pageSize: 100).",
@@ -202,7 +202,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "Expected two pages to be loaded (with updated pageSize 100).",
                 200, pagesizeBox);
-        assertRendered("Item 100");
+        assertRendered(pagesizeBox, "Item 100");
     }
 
     @Test
@@ -210,9 +210,9 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
         clickButton("item-label-generator");
         beanBox.openPopup();
-        assertRendered("Born 3");
+        assertRendered(beanBox, "Born 3");
 
-        getItemElements().get(5).click();
+        getItemElements(beanBox).get(5).click();
         Assert.assertEquals("Born 5", getTextFieldValue(beanBox));
 
         assertLoadedItemsCount("Only the first page should be loaded.", 50,
@@ -224,7 +224,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
         clickButton("component-renderer");
         beanBox.openPopup();
-        assertComponentRendered("<h4>Person 4</h4>");
+        assertComponentRendered(beanBox, "<h4>Person 4</h4>");
         assertLoadedItemsCount("Only the first page should be loaded.", 50,
                 beanBox);
     }
@@ -235,7 +235,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         clickButton("data-provider");
         beanBox.openPopup();
 
-        assertRendered("Changed 6");
+        assertRendered(beanBox, "Changed 6");
         assertLoadedItemsCount("Only the first page should be loaded.", 50,
                 beanBox);
     }
@@ -245,8 +245,8 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         clickButton("item-label-generator");
         clickButton("component-renderer");
         beanBox.openPopup();
-        assertComponentRendered("<h4>Person 4</h4>");
-        getItemElements().get(7).click();
+        assertComponentRendered(beanBox, "<h4>Person 4</h4>");
+        getItemElements(beanBox).get(7).click();
         Assert.assertEquals("Born 7", getTextFieldValue(beanBox));
 
     }
@@ -258,7 +258,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
         Assert.assertEquals(
                 "Expected the item to be updated after calling refreshItem().",
-                "Updated", getOverlayContents().get(0));
+                "Updated", getOverlayContents(beanBox).get(0));
     }
 
     @Test
@@ -266,9 +266,9 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
         clickButton("remove-item");
         beanBox.openPopup();
-        assertNotRendered("Person 2");
-        assertRendered("Person 1");
-        assertRendered("Person 3");
+        assertNotRendered(beanBox, "Person 2");
+        assertRendered(beanBox, "Person 1");
+        assertRendered(beanBox, "Person 3");
     }
 
     @Test
@@ -276,18 +276,18 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
         beanBox.setFilter("person 2");
 
-        waitUntil(driver -> getNonEmptyOverlayContents().size() > 5);
+        waitUntil(driver -> getNonEmptyOverlayContents(beanBox).size() > 5);
 
-        getNonEmptyOverlayContents().forEach(rendered -> {
+        getNonEmptyOverlayContents(beanBox).forEach(rendered -> {
             Assert.assertTrue(rendered.contains("Person 2"));
         });
 
         beanBox.setFilter("oN 330");
 
-        waitUntil(driver -> getOverlayContents().size() == 1);
+        waitUntil(driver -> getOverlayContents(beanBox).size() == 1);
 
         Assert.assertEquals("Unexpected item after filtering.", "Person 330",
-                getNonEmptyOverlayContents().get(0));
+                getNonEmptyOverlayContents(beanBox).get(0));
     }
 
     @Test
@@ -306,9 +306,9 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         filterBox.setFilter("10");
 
-        waitUntil(driver -> getNonEmptyOverlayContents().size() > 0);
+        waitUntil(driver -> getNonEmptyOverlayContents(filterBox).size() > 0);
 
-        getNonEmptyOverlayContents().forEach(rendered -> {
+        getNonEmptyOverlayContents(filterBox).forEach(rendered -> {
             Assert.assertTrue("Expected rendered to contain 'Born: 10'",
                     rendered.contains("Born: 10"));
         });
@@ -347,7 +347,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, callbackBox);
-        assertRendered("Item 0");
+        assertRendered(callbackBox, "Item 0");
 
         // Now backend request should take place to init the data communicator
         Assert.assertEquals("1", lazySizeRequestCountSpan.getText());
@@ -358,7 +358,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "There should be 100 items after loading two pages", 100,
                 callbackBox);
-        assertRendered("Item 60");
+        assertRendered(callbackBox, "Item 60");
     }
 
     @Test
@@ -368,9 +368,9 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, templateBox);
-        assertRendered("Item 8");
+        assertRendered(templateBox, "Item 8");
 
-        getItemElements().get(8).click();
+        getItemElements(templateBox).get(8).click();
         assertMessage("Item 8");
 
         templateBox.openPopup();
@@ -379,7 +379,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "There should be 100 items after loading two pages", 100,
                 templateBox);
-        assertRendered("Item 50");
+        assertRendered(templateBox, "Item 50");
     }
 
     @Test // https://github.com/vaadin/vaadin-combo-box-flow/issues/216
@@ -388,7 +388,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         stringBox.openPopup();
         stringBox.setFilter(item);
-        waitUntil(driver -> getNonEmptyOverlayContents().size() == 1);
+        waitUntil(driver -> getNonEmptyOverlayContents(stringBox).size() == 1);
         stringBox.selectByText(item);
 
         clickButton("set-current-value");
@@ -402,7 +402,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         String item = "Item 151";
         stringBox.openPopup();
         stringBox.setFilter(item);
-        waitUntil(driver -> getNonEmptyOverlayContents().size() == 1);
+        waitUntil(driver -> getNonEmptyOverlayContents(stringBox).size() == 1);
         stringBoxAutoOpenDisabled.selectByText(item);
         assertMessage(item);
         Assert.assertEquals(item,
@@ -418,47 +418,47 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
 
         scrollToItem(beanBox, 300);
-        waitUntilTextInContent("<h4>Person 300</h4>");
+        waitUntilTextInContent(beanBox, "<h4>Person 300</h4>");
 
         scrollToItem(beanBox, 0);
-        waitUntilTextInContent("<h4>Person 0</h4>");
+        waitUntilTextInContent(beanBox, "<h4>Person 0</h4>");
 
-        assertComponentRendered("<h4>Person 0</h4>");
-        assertComponentRendered("<h4>Person 4</h4>");
-        assertComponentRendered("<h4>Person 7</h4>");
+        assertComponentRendered(beanBox, "<h4>Person 0</h4>");
+        assertComponentRendered(beanBox, "<h4>Person 4</h4>");
+        assertComponentRendered(beanBox, "<h4>Person 7</h4>");
     }
 
     @Test
     public void scrollDown_scrollUp_selectionRetained() {
         beanBox.sendKeys("Person 0");
-        waitUntilTextInContent("Person 0");
+        waitUntilTextInContent(beanBox, "Person 0");
         beanBox.sendKeys(Keys.ENTER);
 
         beanBox.openPopup();
-        waitUntilTextInContent("Person 0");
+        waitUntilTextInContent(beanBox, "Person 0");
 
         int scrollIndex = 600;
         scrollToItem(beanBox, scrollIndex);
-        waitUntilTextInContent("Person " + scrollIndex);
+        waitUntilTextInContent(beanBox, "Person " + scrollIndex);
 
         Assert.assertTrue(
                 "First item should not be loaded after scrolling down enough",
                 getLoadedItems(beanBox).size() < scrollIndex);
 
         scrollToItem(beanBox, 0);
-        waitUntilTextInContent("Person 0");
+        waitUntilTextInContent(beanBox, "Person 0");
 
-        assertItemSelected("Person 0");
+        assertItemSelected(beanBox, "Person 0");
     }
 
     @Test
     public void filtering_filterRetained() {
         beanBox.sendKeys("Person 1");
-        waitUntilTextInContent("Person 1");
+        waitUntilTextInContent(beanBox, "Person 1");
         beanBox.sendKeys(Keys.ENTER);
 
         beanBox.sendKeys("11");
-        waitUntilTextInContent("Person 111");
+        waitUntilTextInContent(beanBox, "Person 111");
 
         String filterText = (String) executeScript(
                 "return arguments[0].focusElement.value", beanBox);
@@ -470,7 +470,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     public void customPageSize_pageSizePopulatedToDataCommunicator() {
         lazyCustomPageSize.openPopup();
         scrollToItem(lazyCustomPageSize, 100);
-        waitUntilTextInContent("100");
+        waitUntilTextInContent(lazyCustomPageSize, "100");
         // page size should be 42
         assertMessage("42");
 
@@ -478,7 +478,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         lazyCustomPageSize.closePopup();
         lazyCustomPageSize.openPopup();
         scrollToItem(lazyCustomPageSize, 300);
-        waitUntilTextInContent("300");
+        waitUntilTextInContent(lazyCustomPageSize, "300");
         // page size should be 41
         assertMessage("41");
     }
@@ -499,7 +499,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         scrollToItem(disabledLazyLoadingBox, 100);
         assertLoadedItemsCount("Scrolling down should load further pages", 100,
                 disabledLazyLoadingBox);
-        assertRendered("99");
+        assertRendered(disabledLazyLoadingBox, "99");
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
@@ -72,8 +72,8 @@ public class SetItemsLaterIT extends AbstractComboBoxIT {
 
         assertLoadedItemsCount("ComboBox should have loaded 2 items", 2,
                 comboBox);
-        assertRendered("foo");
-        assertRendered("bar");
+        assertRendered(comboBox, "foo");
+        assertRendered(comboBox, "bar");
     }
 
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/AbstractItemCountComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/AbstractItemCountComboBoxIT.java
@@ -57,7 +57,7 @@ public abstract class AbstractItemCountComboBoxIT extends AbstractComboBoxIT {
     protected void doScroll(int itemToScroll, int expectedItems,
             String expectedItemText, RangeLog... rangeLogs) {
         scrollToItem(comboBoxElement, itemToScroll);
-        waitUntilTextInContent(expectedItemText);
+        waitUntilTextInContent(comboBoxElement, expectedItemText);
         verifyFetchForUndefinedItemCountCallback(rangeLogs);
         verifyItemsCount(expectedItems);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/FilterConverterComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/FilterConverterComboBoxIT.java
@@ -64,7 +64,7 @@ public class FilterConverterComboBoxIT extends AbstractComboBoxIT {
 
         scrollToItem(definedCountComboBox, 499);
 
-        waitUntilTextInContent("Item 499");
+        waitUntilTextInContent(definedCountComboBox, "Item 499");
     }
 
     @Test
@@ -85,10 +85,10 @@ public class FilterConverterComboBoxIT extends AbstractComboBoxIT {
 
         scrollToItem(unknownCountComboBox, 199);
 
-        waitUntilTextInContent("Item 199");
+        waitUntilTextInContent(unknownCountComboBox, "Item 199");
 
         scrollToItem(unknownCountComboBox, 399);
 
-        waitUntilTextInContent("Item 399");
+        waitUntilTextInContent(unknownCountComboBox, "Item 399");
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountCallbackComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountCallbackComboBoxIT.java
@@ -47,7 +47,7 @@ public class ItemCountCallbackComboBoxIT extends AbstractItemCountComboBoxIT {
         verifyItemsCount(5800);
 
         scrollToItem(comboBoxElement, 5800);
-        waitUntilTextInContent("Callback Item " + 5799);
+        waitUntilTextInContent(comboBoxElement, "Callback Item " + 5799);
 
         verifyItemsCount(5800);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountEstimateComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountEstimateComboBoxIT.java
@@ -50,7 +50,7 @@ public class ItemCountEstimateComboBoxIT extends AbstractItemCountComboBoxIT {
 
         verifyItemsCount(undefinedCountBackendItemsCount);
         scrollToItem(comboBoxElement, undefinedCountBackendItemsCount - 1);
-        waitUntilTextInContent(
+        waitUntilTextInContent(comboBoxElement,
                 "Callback Item " + (undefinedCountBackendItemsCount - 1));
 
         // check that new estimate is not applied after item count is known
@@ -58,7 +58,7 @@ public class ItemCountEstimateComboBoxIT extends AbstractItemCountComboBoxIT {
 
         verifyItemsCount(undefinedCountBackendItemsCount);
         scrollToItem(comboBoxElement, undefinedCountBackendItemsCount - 1);
-        waitUntilTextInContent(
+        waitUntilTextInContent(comboBoxElement,
                 "Callback Item " + (undefinedCountBackendItemsCount - 1));
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountEstimateIncreaseComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountEstimateIncreaseComboBoxIT.java
@@ -86,7 +86,7 @@ public class ItemCountEstimateIncreaseComboBoxIT
 
         // Open the combo box drop down and scroll again to last item
         scrollToItem(comboBoxElement, unknownCountBackendItemsCount - 1);
-        waitUntilTextInContent(
+        waitUntilTextInContent(comboBoxElement,
                 "Callback Item " + (unknownCountBackendItemsCount - 1));
 
         // since the end was reached, only a reset() to data provider will reset
@@ -95,7 +95,7 @@ public class ItemCountEstimateIncreaseComboBoxIT
         verifyItemsCount(unknownCountBackendItemsCount);
         // Open the combo box drop down and scroll again to last item
         scrollToItem(comboBoxElement, unknownCountBackendItemsCount - 1);
-        waitUntilTextInContent(
+        waitUntilTextInContent(comboBoxElement,
                 "Callback Item " + (unknownCountBackendItemsCount - 1));
     }
 


### PR DESCRIPTION
## Description

Currently, ComboBox ITs rely on `vaadin-combo-box-overlay` present in the body to get item elements. This will not work with native popover. Updated helpers to pass combo-box instance explicitly - which is needed for cases where there are multiple combo-boxes on the page like in `LazyLoadingIT`, and changed to query items from the `_scroller` element.

## Type of change

- Test