### PR TITLE
test: remove menu-bar not animated styles from ITs

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/frontend/menu-bar-not-animated-styles.css
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/frontend/menu-bar-not-animated-styles.css
@@ -1,6 +1,0 @@
-vaadin-menu-bar-overlay[opening],
-vaadin-menu-bar-overlay[closing],
-vaadin-menu-bar-overlay[opening]::part(overlay),
-vaadin-menu-bar-overlay[closing]::part(overlay) {
-  animation: none !important;
-}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarClassNamesPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarClassNamesPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.menubar.tests;
 
 import com.vaadin.flow.component.contextmenu.MenuItem;
-import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
@@ -24,7 +23,6 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.router.Route;
 
-@CssImport("./menu-bar-not-animated-styles.css")
 @Route("vaadin-menu-bar/menu-bar-class-names")
 public class MenuBarClassNamesPage extends Div {
 

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarThemePage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarThemePage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.menubar.tests;
 
 import com.vaadin.flow.component.contextmenu.MenuItem;
-import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
@@ -24,7 +23,6 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.router.Route;
 
-@CssImport("./menu-bar-not-animated-styles.css")
 @Route("vaadin-menu-bar/menu-bar-theme")
 public class MenuBarThemePage extends Div {
 


### PR DESCRIPTION
## Description

These styles are no longer needed after the fix for `requestAnimationFrame`: https://github.com/vaadin/flow/pull/21872.
Confirmed that all tests are passing locally after removing these.

## Type of change

- Test