### PR TITLE
chore: upgrade commons-lang3 to resolve vulnerable dependency (23.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2025-48924

