### PR TITLE
refactor: auto remove overlays on closed event

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/FeaturesDiyIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/FeaturesDiyIT.java
@@ -113,7 +113,7 @@ public class FeaturesDiyIT extends AbstractComponentIT {
     }
 
     public void assertDialogClosed() {
-        Assert.assertFalse(getConfirmDialog().isPresent());
+        waitForElementNotPresent(By.tagName("vaadin-confirm-dialog"));
     }
 
     private void clickConfirm() {

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/StylingIT.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/tests/StylingIT.java
@@ -87,8 +87,7 @@ public class StylingIT extends AbstractComponentIT {
     }
 
     private TestBenchElement getOverlay() {
-        return ((TestBenchElement) getConfirmDialog()
-                .getPropertyElement("_overlayElement"));
+        return getConfirmDialog().getPropertyElement("_overlayElement");
     }
 
     private String getOverlayClassName() {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/AbstractDialogIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/AbstractDialogIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dialog.tests;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+
+import com.vaadin.flow.component.dialog.testbench.DialogElement;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+public abstract class AbstractDialogIT extends AbstractComponentIT {
+    protected List<DialogElement> getDialogs() {
+        return $(DialogElement.class).withAttribute("opened").all();
+    }
+
+    protected DialogElement getDialog() {
+        List<DialogElement> dialogs = getDialogs();
+        if (dialogs.isEmpty()) {
+            Assert.fail("No dialogs found");
+        }
+        return dialogs.get(0);
+    }
+
+    protected void verifyNumberOfDialogs(int expected) {
+        try {
+            waitUntil(driver -> getDialogs().size() == expected);
+        } catch (TimeoutException exception) {
+            Assert.fail("Expected " + expected + " dialogs, but found "
+                    + getDialogs().size());
+        }
+    }
+
+    protected void verifyOpened() {
+        waitForElementPresent(By.cssSelector("vaadin-dialog[opened]"));
+    }
+
+    protected void verifyClosed() {
+        waitForElementNotPresent(By
+                .cssSelector("vaadin-dialog[opened], vaadin-dialog[closing]"));
+    }
+
+    protected void verifyClosedAndRemoved() {
+        waitForElementNotPresent(By.cssSelector("vaadin-dialog"));
+    }
+
+    protected TestBenchElement getOverlayComponent(DialogElement dialog) {
+        // returns vaadin-dialog-overlay from vaadin-dialog shadow root, which
+        // overlays the whole page
+        return dialog.$("*").id("overlay");
+    }
+
+    protected TestBenchElement getOverlayPart(DialogElement dialog) {
+        // returns the overlay part from vaadin-dialog-overlay shadow root,
+        // which is effectively the visible dialog window
+        return getOverlayComponent(dialog).$("*").id("overlay");
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/CloseListenerReopenDialogIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/CloseListenerReopenDialogIT.java
@@ -22,10 +22,9 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/close-listener-reopen-dialog")
-public class CloseListenerReopenDialogIT extends AbstractComponentIT {
+public class CloseListenerReopenDialogIT extends AbstractDialogIT {
 
     @Test
     public void reopenDialog_closeActionListenerIsCalled() {
@@ -33,10 +32,7 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
 
         waitForElementPresent(By.id("open"));
         findElement(By.id("open")).click();
-
-        // Dialog is opened
-        Assert.assertTrue(
-                isElementPresent(By.cssSelector("vaadin-dialog[opened]")));
+        verifyOpened();
 
         // try to close dialog
         closeDialog();
@@ -46,6 +42,7 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
 
         // close dialog via button
         $("button").id("close").click();
+        verifyClosedAndRemoved();
 
         // reopen
         findElement(By.id("open")).click();
@@ -59,21 +56,18 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
     }
 
     @Test
-    public void reopenDialog_removeCloseListener_dialogIsClosed()
-            throws InterruptedException {
+    public void reopenDialog_removeCloseListener_dialogIsClosed() {
         open();
 
         findElement(By.id("open")).click();
-
-        // Dialog is opened
-        Assert.assertTrue(
-                isElementPresent(By.cssSelector("vaadin-dialog[opened]")));
+        verifyOpened();
 
         // try to close dialog
         closeDialog();
 
         // close dialog via button
         $("button").id("close").click();
+        verifyClosedAndRemoved();
 
         // remove close listener
         findElement(By.id("remove")).click();
@@ -83,10 +77,7 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
 
         // try to close dialog
         closeDialog();
-
-        // Dialog should be closed
-        waitUntilNot(driver -> isElementPresent(
-                By.cssSelector("vaadin-dialog[opened]")));
+        verifyClosedAndRemoved();
     }
 
     @Test
@@ -94,19 +85,15 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
         open();
 
         findElement(By.id("open")).click();
+        verifyOpened();
 
         findElement(By.id("open-sub")).click();
 
-        // Two dialogs are opened
-        Assert.assertEquals("Expected two dialogs", 2,
-                findElements(By.cssSelector("vaadin-dialog[opened]")).size());
+        verifyNumberOfDialogs(2);
 
         closeDialog();
 
-        // One dialog is opened
-        waitUntil(
-                driver -> findElements(By.cssSelector("vaadin-dialog[opened]"))
-                        .size() == 1);
+        verifyNumberOfDialogs(1);
 
         // close action listener prints its info message
         Assert.assertEquals(

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterIT.java
@@ -24,10 +24,9 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/header-footer")
-public class DialogHeaderFooterIT extends AbstractComponentIT {
+public class DialogHeaderFooterIT extends AbstractDialogIT {
 
     private static final String OPEN_DIALOG_BUTTON = "open-dialog-button";
     private static final String CLOSE_DIALOG_BUTTON = "close-dialog-button";
@@ -60,7 +59,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     @Test
     public void openedDialog_headerTitleIsSet_titleRendered() {
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(ADD_HEADER_TITLE_BUTTON);
 
@@ -71,7 +70,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void openedDialogWithHeaderTitle_headerTitleIsUnset_noTitleRendered() {
         clickButton(ADD_HEADER_TITLE_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(REMOVE_HEADER_TITLE_BUTTON);
 
@@ -99,7 +98,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void autoAttachedDialogWithHeaderContent_dialogReopened_contentIsRendered() {
         clickButton(ADD_HEADER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(CLOSE_DIALOG_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
 
@@ -111,7 +110,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
         clickButton(ATTACH_DIALOG_BUTTON);
         clickButton(ADD_HEADER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(CLOSE_DIALOG_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
 
@@ -122,7 +121,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void openedDialogWithHeaderContent_anotherContentIsAdded_allElementsAreRendered() {
         clickButton(ADD_HEADER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(ADD_SECOND_HEADER_CONTENT_BUTTON);
 
@@ -134,7 +133,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void openedDialogWithHeaderContent_removeContent_noContentIsRendered() {
         clickButton(ADD_HEADER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(REMOVE_HEADER_CONTENT_BUTTON);
 
@@ -146,7 +145,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
         clickButton(ADD_HEADER_CONTENT_BUTTON);
         clickButton(ADD_SECOND_HEADER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(REMOVE_ALL_HEADER_CONTENTS_BUTTON);
 
@@ -175,7 +174,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void autoAttachedDialogWithFooterContent_dialogReopened_contentIsRendered() {
         clickButton(ADD_FOOTER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(CLOSE_DIALOG_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
 
@@ -187,7 +186,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
         clickButton(ATTACH_DIALOG_BUTTON);
         clickButton(ADD_FOOTER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(CLOSE_DIALOG_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
 
@@ -198,7 +197,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void openedDialogWithFooterContent_anotherContentIsAdded_allElementsAreRendered() {
         clickButton(ADD_FOOTER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(ADD_SECOND_FOOTER_CONTENT_BUTTON);
 
@@ -210,7 +209,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
     public void openedDialogWithFooterContent_removeContent_noContentIsRendered() {
         clickButton(ADD_FOOTER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(REMOVE_FOOTER_CONTENT_BUTTON);
 
@@ -222,7 +221,7 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
         clickButton(ADD_FOOTER_CONTENT_BUTTON);
         clickButton(ADD_SECOND_FOOTER_CONTENT_BUTTON);
         clickButton(OPEN_DIALOG_BUTTON);
-        verifyDialogOpened();
+        verifyOpened();
         clickButton(MOVE_BUTTONS_BUTTON);
         clickButton(REMOVE_ALL_FOOTER_CONTENTS_BUTTON);
 
@@ -246,10 +245,6 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
                 dialog.getText().contains(text));
     }
 
-    private void verifyDialogOpened() {
-        waitForElementPresent(By.cssSelector("vaadin-dialog[opened]"));
-    }
-
     private void verifyContentRendered(String content) {
         waitUntil(c -> {
             try {
@@ -261,9 +256,5 @@ public class DialogHeaderFooterIT extends AbstractComponentIT {
                 return false;
             }
         });
-    }
-
-    private WebElement getDialog() {
-        return findElement(By.cssSelector("vaadin-dialog[opened]"));
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -22,12 +22,10 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
-import com.vaadin.flow.component.dialog.testbench.DialogElement;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog-view")
-public class DialogIT extends AbstractComponentIT {
+public class DialogIT extends AbstractDialogIT {
 
     @Test
     public void openAndCloseConfirmationDialog_buttonsRenderedWithClickListeners() {
@@ -37,12 +35,12 @@ public class DialogIT extends AbstractComponentIT {
 
         findElement(By.id("confirmation-dialog-button")).click();
         getDialog().findElements(By.tagName("vaadin-button")).get(0).click();
-        verifyDialogClosed();
+        verifyClosedAndRemoved();
         Assert.assertEquals("Confirmed!", message.getText());
 
         findElement(By.id("confirmation-dialog-button")).click();
         getDialog().findElements(By.tagName("vaadin-button")).get(1).click();
-        verifyDialogClosed();
+        verifyClosedAndRemoved();
         Assert.assertEquals("Cancelled...", message.getText());
     }
 
@@ -51,13 +49,13 @@ public class DialogIT extends AbstractComponentIT {
         open();
 
         findElement(By.id("server-side-close-dialog-button")).click();
-        verifyDialogOpened();
+        verifyOpened();
 
         executeScript("document.body.click()");
-        verifyDialogOpened();
+        verifyOpened();
 
         new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
-        verifyDialogClosed();
+        verifyClosedAndRemoved();
 
         Assert.assertEquals("Closed from server-side",
                 findElement(By.id("server-side-close-dialog-message"))
@@ -86,17 +84,4 @@ public class DialogIT extends AbstractComponentIT {
 
         Assert.assertEquals("rgba(255, 0, 0, 1)", element.getCssValue("color"));
     }
-
-    private DialogElement getDialog() {
-        return $(DialogElement.class).withAttribute("opened").first();
-    }
-
-    private void verifyDialogClosed() {
-        waitForElementNotPresent(By.cssSelector("vaadin-dialog[opened]"));
-    }
-
-    private void verifyDialogOpened() {
-        waitForElementPresent(By.cssSelector("vaadin-dialog[opened]"));
-    }
-
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithClassNamesIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithClassNamesIT.java
@@ -23,10 +23,9 @@ import com.vaadin.flow.component.dialog.testbench.DialogElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/dialog-class-names-test")
-public class DialogWithClassNamesIT extends AbstractComponentIT {
+public class DialogWithClassNamesIT extends AbstractDialogIT {
 
     @Before
     public void init() {
@@ -38,7 +37,7 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("open").click();
 
         DialogElement dialog = getDialog();
-        TestBenchElement overlay = getOverlay();
+        TestBenchElement overlay = getOverlayComponent(dialog);
 
         String overlayClassNames = overlay.getDomAttribute("class");
         String dialogClassNames = dialog.getDomAttribute("class");
@@ -53,7 +52,7 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("add").click();
 
         DialogElement dialog = getDialog();
-        TestBenchElement overlay = getOverlay();
+        TestBenchElement overlay = getOverlayComponent(dialog);
 
         String overlayClassNames = overlay.getDomAttribute("class");
         String dialogClassNames = dialog.getDomAttribute("class");
@@ -68,7 +67,7 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("clear").click();
 
         DialogElement dialog = getDialog();
-        TestBenchElement overlay = getOverlay();
+        TestBenchElement overlay = getOverlayComponent(dialog);
 
         String overlayClassNames = overlay.getDomAttribute("class");
         String dialogClassNames = dialog.getDomAttribute("class");
@@ -78,7 +77,7 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
     }
 
     @Test
-    public void openDialog_overlayChagedClassNameAfterSecondOpening() {
+    public void openDialog_overlayChangedClassNameAfterSecondOpening() {
         $(NativeButtonElement.class).id("open").click();
         $(NativeButtonElement.class).id("clear").click();
         $(NativeButtonElement.class).id("add").click();
@@ -88,20 +87,12 @@ public class DialogWithClassNamesIT extends AbstractComponentIT {
         $(NativeButtonElement.class).id("open").click();
 
         DialogElement dialog = getDialog();
-        TestBenchElement overlay = getOverlay();
+        TestBenchElement overlay = getOverlayComponent(dialog);
 
         String overlayClassNames = overlay.getDomAttribute("class");
         String dialogClassNames = dialog.getDomAttribute("class");
 
         Assert.assertEquals("added", dialogClassNames);
         Assert.assertEquals("added", overlayClassNames);
-    }
-
-    private DialogElement getDialog() {
-        return $(DialogElement.class).first();
-    }
-
-    private TestBenchElement getOverlay() {
-        return getDialog().$("vaadin-dialog-overlay").first();
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutIT.java
@@ -218,6 +218,8 @@ public class DialogWithShortcutIT extends AbstractComponentIT {
 
     private void validateShortcutEvent(int indexFromTop, int eventCounter,
             String eventSourceId) {
+        waitForElementPresent(By.cssSelector("#%s div:nth-child(%d)".formatted(
+                DialogWithShortcutPage.EVENT_LOG, indexFromTop + 1)));
         final WebElement latestEvent = eventLog.findElements(By.tagName("div"))
                 .get(indexFromTop);
         Assert.assertEquals("Invalid latest event",

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithTemplateIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithTemplateIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.dialog.testbench.DialogElement;
 import com.vaadin.flow.component.html.testbench.DivElement;
@@ -28,10 +27,9 @@ import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/dialog-template-test")
-public class DialogWithTemplateIT extends AbstractComponentIT {
+public class DialogWithTemplateIT extends AbstractDialogIT {
 
     @Before
     public void init() {
@@ -41,10 +39,9 @@ public class DialogWithTemplateIT extends AbstractComponentIT {
     @Test
     public void openDialog_clickThreeTimes_containerIsUpdated() {
         $(NativeButtonElement.class).id("open").click();
+        verifyOpened();
 
-        waitForElementPresent(By.cssSelector("vaadin-dialog[opened]"));
-        DialogElement dialog = $(DialogElement.class).first();
-
+        DialogElement dialog = getDialog();
         TestBenchElement template = dialog.$("vaadin-dialog-flow-test-template")
                 .first();
         NativeButtonElement btn = template.$(NativeButtonElement.class).first();

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/InitiallyOpenedDialogPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/InitiallyOpenedDialogPageIT.java
@@ -21,10 +21,9 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/initial-dialog-open")
-public class InitiallyOpenedDialogPageIT extends AbstractComponentIT {
+public class InitiallyOpenedDialogPageIT extends AbstractDialogIT {
 
     @Before
     public void init() {
@@ -33,7 +32,7 @@ public class InitiallyOpenedDialogPageIT extends AbstractComponentIT {
 
     @Test
     public void openDialogDuringPageLoad() {
-        waitForElementPresent(By.cssSelector("vaadin-dialog[opened]"));
+        verifyOpened();
 
         Assert.assertTrue(isElementPresent(By.id("nested-component")));
     }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/ModalityDialogsPageIT.java
@@ -25,11 +25,9 @@ import com.vaadin.flow.component.dialog.testbench.DialogElement;
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/dialog-modality")
-public class ModalityDialogsPageIT extends AbstractComponentIT {
+public class ModalityDialogsPageIT extends AbstractDialogIT {
 
     @Before
     public void init() {
@@ -41,50 +39,40 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
     @Test
     public void openNonModalDialog_logButtonClickable() {
         $(NativeButtonElement.class).id("open-non-modal-dialog").click();
-
-        Assert.assertTrue("No dialog opened", $(DialogElement.class).exists());
-        Assert.assertEquals("Only one dialog expected", 1,
-                $(DialogElement.class).all().size());
+        verifyNumberOfDialogs(1);
 
         $(NativeButtonElement.class).id("log").click();
 
-        Assert.assertTrue("Dialog should not have closed",
-                $(DialogElement.class).exists());
+        verifyOpened();
         Assert.assertEquals("Click should have resulted in a log message", 1,
                 $(DivElement.class).id(LOG_ID).$("div").all().size());
 
-        $(DialogElement.class).first().$(NativeButtonElement.class).first()
-                .click();
+        getDialog().$(NativeButtonElement.class).first().click();
 
-        Assert.assertFalse("Dialog should have closed",
-                $(DialogElement.class).exists());
+        verifyClosedAndRemoved();
     }
 
     @Test
     public void openModalDialog_removeBackdrop_logClickNotAccepted() {
         $(NativeButtonElement.class).id("open-modal-dialog").click();
-        final DivElement backdrop = $(DialogElement.class).first().$("*")
-                .id("overlay").$(DivElement.class).id("backdrop");
+        final DivElement backdrop = getDialog().$("*").id("overlay")
+                .$(DivElement.class).id("backdrop");
 
         executeScript("arguments[0].remove()", backdrop);
 
         Assert.assertFalse("Backdrop was not removed from dom",
-                $(DialogElement.class).first().$(TestBenchElement.class)
-                        .id("overlay").$(DivElement.class)
+                getOverlayComponent(getDialog()).$(DivElement.class)
                         .withAttribute("id", "backdrop").exists());
 
         $(NativeButtonElement.class).id("log").click();
 
-        Assert.assertTrue("Dialog should not have closed",
-                $(DialogElement.class).exists());
+        verifyOpened();
         Assert.assertEquals("Click on button should not generate a log message",
                 0, $(DivElement.class).id(LOG_ID).$("div").all().size());
 
-        $(DialogElement.class).first().$(NativeButtonElement.class).id("close")
-                .click();
+        getDialog().$(NativeButtonElement.class).id("close").click();
 
-        Assert.assertFalse("Dialog should have closed",
-                $(DialogElement.class).exists());
+        verifyClosedAndRemoved();
 
         $(NativeButtonElement.class).id("log").click();
 
@@ -101,8 +89,7 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
         // Click anything to close dialog
         $("body").first().click();
-        Assert.assertFalse("Dialog should be closed",
-                $(DialogElement.class).first().isOpen());
+        verifyClosed();
 
         // Now that dialog is closed, verify that click events work
         $(NativeButtonElement.class).id("log").click();
@@ -114,13 +101,12 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
     public void openModalDialog_openNonModalOnTop_nonModalCanBeUsed() {
         $(NativeButtonElement.class).id("open-modal-dialog").click();
 
-        final DialogElement first = $(DialogElement.class).first();
-        first.$(NativeButtonElement.class).id("open-sub").click();
+        final DialogElement dialog = getDialog();
+        dialog.$(NativeButtonElement.class).id("open-sub").click();
 
-        waitUntil(driver -> $(DialogElement.class).all().size() == 2);
+        verifyNumberOfDialogs(2);
 
-        final DialogElement subDialog = $(DialogElement.class).all().stream()
-                .filter(dialog -> !dialog.equals(first)).findFirst().get();
+        final DialogElement subDialog = getDialogs().get(1);
         subDialog.$(NativeButtonElement.class).id("log-sub").click();
 
         Assert.assertEquals("Click should have resulted in a log message", 1,
@@ -128,20 +114,20 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
         subDialog.$(NativeButtonElement.class).id("close-sub").click();
 
-        first.$(NativeButtonElement.class).id("close").click();
+        dialog.$(NativeButtonElement.class).id("close").click();
+
+        verifyClosedAndRemoved();
     }
 
     @Test
     public void openModalDialog_hideComponent_logClickAccepted() {
         $(NativeButtonElement.class).id("open-modal-dialog").click();
 
-        $(DialogElement.class).first().$(NativeButtonElement.class).id("hide")
-                .click();
+        getDialog().$(NativeButtonElement.class).id("hide").click();
 
-        Assert.assertTrue("Dialog should not have closed",
-                $(DialogElement.class).exists());
+        verifyOpened();
         Assert.assertFalse("Dialog should be hidden",
-                $(DialogElement.class).first().isDisplayed());
+                getDialog().isDisplayed());
 
         $(NativeButtonElement.class).id("log").click();
 
@@ -150,10 +136,8 @@ public class ModalityDialogsPageIT extends AbstractComponentIT {
 
         $(NativeButtonElement.class).id("show").click();
 
-        $(DialogElement.class).first().$(NativeButtonElement.class).id("close")
-                .click();
+        getDialog().$(NativeButtonElement.class).id("close").click();
 
-        Assert.assertFalse("Dialog should have closed",
-                $(DialogElement.class).exists());
+        verifyClosedAndRemoved();
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/SubDialogOpenedOnOpenedChangeIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/SubDialogOpenedOnOpenedChangeIT.java
@@ -15,17 +15,15 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-dialog/sub-dialog-opened-on-opened-change")
-public class SubDialogOpenedOnOpenedChangeIT extends AbstractComponentIT {
+public class SubDialogOpenedOnOpenedChangeIT extends AbstractDialogIT {
 
     @Before
     public void init() {
@@ -40,7 +38,9 @@ public class SubDialogOpenedOnOpenedChangeIT extends AbstractComponentIT {
         waitForElementPresent(By.id("close-main-dialog-and-open-sub-dialog"));
         findElement(By.id("close-main-dialog-and-open-sub-dialog")).click();
 
-        WebElement output = findElement(By.id("output"));
-        Assert.assertEquals("Detached", output.getText());
+        waitUntil(driver -> {
+            WebElement output = findElement(By.id("output"));
+            return "Detached".equals(output.getText());
+        });
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayAutoAddController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayAutoAddController.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.shared.Registration;
@@ -62,11 +63,13 @@ public class OverlayAutoAddController<C extends Component>
         // The event needs to be allowed for inert components so that closing
         // from the server still works. This requires double-checking that the
         // component is actually in a closed state on the server.
+        // Also allow the event on disabled components, as LoginOverlay for
+        // example disables itself on the login event.
         component.getElement().addEventListener("closed", event -> {
             if (!isOpened()) {
                 handleClose();
             }
-        }).allowInert();
+        }).allowInert().setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayAutoAddController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayAutoAddController.java
@@ -48,13 +48,25 @@ public class OverlayAutoAddController<C extends Component>
         this.component = component;
         this.isModalSupplier = isModalSupplier;
 
+        // Automatically add the component to the UI when it is opened.
         component.getElement().addPropertyChangeListener("opened", event -> {
             if (isOpened()) {
                 handleOpen();
-            } else {
-                handleClose();
             }
         });
+
+        // Automatically remove the component from the UI after the overlay's
+        // closing animation has finished. This way auto-removal works by first
+        // setting `opened` on the client-side to `false` and then waiting for
+        // the `closed` event from the client-side.
+        // The event needs to be allowed for inert components so that closing
+        // from the server still works. This requires double-checking that the
+        // component is actually in a closed state on the server.
+        component.getElement().addEventListener("closed", event -> {
+            if (!isOpened()) {
+                handleClose();
+            }
+        }).allowInert();
     }
 
     /**

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/src/test/java/com/vaadin/flow/component/login/tests/OverlayIT.java
@@ -89,7 +89,7 @@ public class OverlayIT extends AbstractComponentIT {
         loginOverlay.getPasswordField().setValue("value");
         loginOverlay.submit();
 
-        Assert.assertFalse($(LoginOverlayElement.class).exists());
+        waitUntil(driver -> !$(LoginOverlayElement.class).exists());
     }
 
     @Test


### PR DESCRIPTION
## Description

After refactoring overlay components such as Dialog to keep their overlay in the shadow root the overlay's closing animation will not be shown if the component is immediately removed when it's opened state changes (previously removing the component would still keep the overlay in the document body until the animation was finished). For components that auto-add / auto-remove themselves to / from the UI when they are opened / closed that means that the closing animation is currently skipped.

This changes `OverlayAutoAddController` and affected components (Dialog, ConfirmDialog, Notification, LoginOverlay) to auto-remove on the `closed` event, which is fired after the closing animation has finished, instead of when the opened state changes.

## Type of change

- Refactor