### PR TITLE
refactor: remove HasAriaLabel method overrides from Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -332,27 +332,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
         return getElement().getProperty("withBackdrop", false);
     }
 
-    @Override
-    public void setAriaLabel(String ariaLabel) {
-        getElement().setProperty("accessibleName", ariaLabel);
-    }
-
-    @Override
-    public Optional<String> getAriaLabel() {
-        return Optional.ofNullable(getElement().getProperty("accessibleName"));
-    }
-
-    @Override
-    public void setAriaLabelledBy(String labelledBy) {
-        getElement().setProperty("accessibleNameRef", labelledBy);
-    }
-
-    @Override
-    public Optional<String> getAriaLabelledBy() {
-        return Optional
-                .ofNullable(getElement().getProperty("accessibleNameRef"));
-    }
-
     /**
      * Set {@code true} to make the popover content automatically receive focus
      * after it is opened. Modal popovers use this behavior by default.


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/pull/9878

There is no need to use `accessibleName` and `accessibleNameRef` anymore - instead ARIA attributes can should be set on the Popover itself, which is what `HasAriaLabel` interface methods already do by default, so I removed overrides.

## Type of change

- Refactor