### PR TITLE
feat: add addClosedListener to Dialog

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -286,8 +286,12 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * {@code opened-changed} event is sent when the overlay opened state
-     * changes.
+     * Event that is fired when the dialog's opened state changes.
+     * <p>
+     * Note that this event fires immediately when the opened property changes,
+     * which, when closing the dialog, is before the closing animation has
+     * finished. To wait for the animation to finish, listen for the
+     * {@link ClosedEvent} event.
      */
     public static class OpenedChangeEvent extends ComponentEvent<Dialog> {
         private final boolean opened;
@@ -299,6 +303,17 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
         public boolean isOpened() {
             return opened;
+        }
+    }
+
+    /**
+     * Event that is fired after the dialog's closing animation has finished.
+     * Can be used to remove a dialog from the UI afterward.
+     */
+    @DomEvent("closed")
+    public static class ClosedEvent extends ComponentEvent<Dialog> {
+        public ClosedEvent(Dialog source, boolean fromClient) {
+            super(source, fromClient);
         }
     }
 
@@ -969,7 +984,12 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Add a lister for event fired by the {@code opened-changed} events.
+     * Add a listener for when the dialog's opened state changes.
+     * <p>
+     * Note that this event fires immediately when the opened property changes,
+     * which, when closing the dialog, is before the closing animation has
+     * finished. To wait for the animation to finish, use
+     * {@link #addClosedListener(ComponentEventListener)}.
      *
      * @param listener
      *            the listener to add
@@ -978,6 +998,19 @@ public class Dialog extends Component implements HasComponents, HasSize,
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
         return addListener(OpenedChangeEvent.class, listener);
+    }
+
+    /**
+     * Add a lister for when the dialog's closing animation has finished. Can be
+     * used to remove the dialog from the UI afterward.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a Registration for removing the event listener
+     */
+    public Registration addClosedListener(
+            ComponentEventListener<ClosedEvent> listener) {
+        return addListener(ClosedEvent.class, listener);
     }
 
     /**
@@ -996,8 +1029,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * {@inheritDoc}
      * <p>
      * Note: To listen for closing the dialog, you should use
-     * {@link #addOpenedChangeListener(ComponentEventListener)}, as the
-     * component is not necessarily removed from the DOM when closing.
+     * {@link #addClosedListener(ComponentEventListener)}, as the component is
+     * not necessarily removed from the DOM when closing.
      */
     @Override
     public Registration addDetachListener(

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Key;
@@ -34,7 +35,12 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.server.VaadinSession;
+
+import elemental.json.Json;
 
 /**
  * Unit tests for the Dialog.
@@ -418,6 +424,23 @@ public class DialogTest {
 
         Assert.assertEquals("10px", dialog.getTop());
         Assert.assertEquals("20px", dialog.getLeft());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void addClosedListener_listenerInvokedOnClose() {
+        Dialog dialog = new Dialog();
+        ComponentEventListener<Dialog.ClosedEvent> listener = Mockito
+                .mock(ComponentEventListener.class);
+        dialog.addClosedListener(listener);
+
+        Element element = dialog.getElement();
+        dialog.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(
+                        new DomEvent(element, "closed", Json.createObject()));
+
+        Mockito.verify(listener, Mockito.times(1))
+                .onComponentEvent(Mockito.any(Dialog.ClosedEvent.class));
     }
 
     private void fakeClientResponse() {


### PR DESCRIPTION
## Description

Allows to listen for when a Dialog's closing animation has finished. When conditionally rendering dialogs this allows to wait until the closing animation has finished before removing the component from the UI, which does not work when using `addOpenedChangedListener`.

Part of https://github.com/vaadin/flow-components/issues/7793

## Type of change

- Feature
