### PR TITLE
feat: add addClosedListener to ConfirmDialog

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -65,7 +65,13 @@ public class ConfirmDialog extends Component
         implements HasSize, HasStyle, HasOrderedComponents {
 
     /**
-     * `confirm` is sent when the user clicks Confirm button
+     * Event that is fired when the user clicks the Confirm button
+     * <p>
+     * Note that the event is fired before the dialog's closing animation has
+     * finished. When manually adding / removing the dialog to / from the UI,
+     * use the {@link ClosedEvent} to wait with the removal until the animation
+     * has finished. When relying on the auto-add behavior by just calling
+     * {@link #open()} or {@link #setOpened(boolean)}, this is not necessary.
      */
     @DomEvent("confirm")
     public static class ConfirmEvent extends ComponentEvent<ConfirmDialog> {
@@ -75,7 +81,13 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * `reject` is sent when the user clicks Reject button
+     * Event that is fired when the user clicks the Reject button
+     * <p>
+     * Note that the event is fired before the dialog's closing animation has
+     * finished. When manually adding / removing the dialog to / from the UI,
+     * use the {@link ClosedEvent} to wait with the removal until the animation
+     * has finished. When relying on the auto-add behavior by just calling
+     * {@link #open()} or {@link #setOpened(boolean)}, this is not necessary.
      */
     @DomEvent("reject")
     public static class RejectEvent extends ComponentEvent<ConfirmDialog> {
@@ -85,12 +97,29 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * `cancel` is sent when the user clicks Cancel button or presses Escape
-     * key. `cancel` is not sent if Cancel button is hidden
+     * Event that is fired when the user clicks the Cancel button or presses
+     * Escape. The event is not sent if the Cancel button is hidden.
+     * <p>
+     * Note that the event is fired before the dialog's closing animation has
+     * finished. When manually adding / removing the dialog to / from the UI,
+     * use the {@link ClosedEvent} to wait with the removal until the animation
+     * has finished. When relying on the auto-add behavior by just calling
+     * {@link #open()} or {@link #setOpened(boolean)}, this is not necessary.
      */
     @DomEvent("cancel")
     public static class CancelEvent extends ComponentEvent<ConfirmDialog> {
         public CancelEvent(ConfirmDialog source, boolean fromClient) {
+            super(source, fromClient);
+        }
+    }
+
+    /**
+     * Event that is fired after the dialog's closing animation has finished.
+     * Can be used to remove a dialog from the UI afterward.
+     */
+    @DomEvent("closed")
+    public static class ClosedEvent extends ComponentEvent<ConfirmDialog> {
+        public ClosedEvent(ConfirmDialog source, boolean fromClient) {
             super(source, fromClient);
         }
     }
@@ -484,7 +513,17 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Adds `confirm` event listener
+     * Adds a listener for when the user clicks the Confirm button.
+     * <p>
+     * Note: The event is fired before the dialog's closing animation has
+     * finished. When manually adding or removing the dialog to or from the UI,
+     * use the {@link ClosedEvent} to wait with the removal until the animation
+     * has finished. When relying on the auto-add behavior by just calling
+     * {@link #open()} or {@link #setOpened(boolean)}, this is not necessary.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a Registration for removing the event listener
      */
     public Registration addConfirmListener(
             ComponentEventListener<ConfirmEvent> listener) {
@@ -507,7 +546,18 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Adds `cancel` event listener
+     * Adds a listener for when the user clicks the Cancel button or presses
+     * Escape.
+     * <p>
+     * Note: The event is fired before the dialog's closing animation has
+     * finished. When manually adding or removing the dialog to or from the UI,
+     * use the {@link ClosedEvent} to wait with the removal until the animation
+     * has finished. When relying on the auto-add behavior by just calling
+     * {@link #open()} or {@link #setOpened(boolean)}, this is not necessary.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a Registration for removing the event listener
      */
     public Registration addCancelListener(
             ComponentEventListener<CancelEvent> listener) {
@@ -529,11 +579,34 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Adds `reject` event listener
+     * Adds a listener for when the user clicks the Reject button.
+     * <p>
+     * Note: The event is fired before the dialog's closing animation has
+     * finished. When manually adding or removing the dialog to or from the UI,
+     * use the {@link ClosedEvent} to wait with the removal until the animation
+     * has finished. When relying on the auto-add behavior by just calling
+     * {@link #open()} or {@link #setOpened(boolean)}, this is not necessary.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a Registration for removing the event listener
      */
     public Registration addRejectListener(
             ComponentEventListener<RejectEvent> listener) {
         return ComponentUtil.addListener(this, RejectEvent.class, listener);
+    }
+
+    /**
+     * Add a lister for when the dialog's closing animation has finished. Can be
+     * used to remove the dialog from the UI afterward.
+     *
+     * @param listener
+     *            the listener to add
+     * @return a Registration for removing the event listener
+     */
+    public Registration addClosedListener(
+            ComponentEventListener<ClosedEvent> listener) {
+        return ComponentUtil.addListener(this, ClosedEvent.class, listener);
     }
 
     /**

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTest.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTest.java
@@ -17,6 +17,14 @@ package com.vaadin.flow.component.confirmdialog;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+
+import elemental.json.Json;
 
 public class ConfirmDialogTest {
 
@@ -59,5 +67,22 @@ public class ConfirmDialogTest {
         confirmDialog.setHeight(null);
         Assert.assertNull(confirmDialog.getHeight());
         Assert.assertNull(confirmDialog.getElement().getProperty("height"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void addClosedListener_listenerInvokedOnClose() {
+        ConfirmDialog dialog = new ConfirmDialog();
+        ComponentEventListener<ConfirmDialog.ClosedEvent> listener = Mockito
+                .mock(ComponentEventListener.class);
+        dialog.addClosedListener(listener);
+
+        Element element = dialog.getElement();
+        dialog.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(
+                        new DomEvent(element, "closed", Json.createObject()));
+
+        Mockito.verify(listener, Mockito.times(1))
+                .onComponentEvent(Mockito.any(ConfirmDialog.ClosedEvent.class));
     }
 }


### PR DESCRIPTION
## Description

Allows to listen for when a ConfirmDialog's closing animation has finished. When conditionally rendering dialogs this allows to wait until the closing animation has finished before removing the component from the UI, which does not work when using listeners for the `confirm`, `cancel` or `reject` events.

Closes https://github.com/vaadin/flow-components/issues/7793

## Type of change

- Feature
