### PR TITLE
feat: add CrudElement.getForm, deprecate CrudElement.getEditor

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java
@@ -34,7 +34,7 @@ public class CustomGridIT extends AbstractComponentIT {
         Assert.assertFalse(crud.isEditorOpen());
         crud.openRowForEditing(0);
         Assert.assertTrue(crud.isEditorOpen());
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
 
@@ -54,7 +54,7 @@ public class CustomGridIT extends AbstractComponentIT {
         Assert.assertFalse(crud.isEditorOpen());
         crud.openRowForEditing(0);
         Assert.assertTrue(crud.isEditorOpen());
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/DetachAttachIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/DetachAttachIT.java
@@ -47,7 +47,7 @@ public class DetachAttachIT extends AbstractComponentIT {
     private void editItemAndChangeField() {
         crud = $(CrudElement.class).waitForFirst();
         crud.openRowForEditing(0);
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EditorButtonsIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EditorButtonsIT.java
@@ -45,7 +45,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
         getTestButton("disable-save-button").click();
         CrudElement crud = getCrud();
         crud.openRowForEditing(0);
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
@@ -60,7 +60,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
         crud.getNewItemButton().get().click();
         assertTrue(crud.isEditorOpen());
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
@@ -79,7 +79,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
         ButtonElement saveButton = crud.getEditorSaveButton();
         assertFalse(saveButton.isEnabled());
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
@@ -98,7 +98,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
         ButtonElement saveButton = crud.getEditorSaveButton();
         assertFalse("Save button should be disabled", saveButton.isEnabled());
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
@@ -122,7 +122,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
         assertFalse("Cancel button should be disabled",
                 cancelButton.isEnabled());
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
@@ -146,7 +146,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
         assertFalse("Delete button should be disabled",
                 deleteButton.isEnabled());
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Otto");
@@ -167,7 +167,7 @@ public class EditorButtonsIT extends AbstractComponentIT {
 
         getTestButton("add-enter-shortcut-button").click();
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue(lastNameExpected);

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EventHandlingIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/EventHandlingIT.java
@@ -87,10 +87,10 @@ public class EventHandlingIT extends AbstractComponentIT {
                 "Edit: Person{id=3, firstName='Guille', lastName='Guille'}",
                 getLastEvent());
 
-        Assert.assertEquals("Guille", crud.getEditor().$(TextFieldElement.class)
+        Assert.assertEquals("Guille", crud.getForm().$(TextFieldElement.class)
                 .withAttribute("editor-role", "first-name").first().getValue());
 
-        Assert.assertEquals("Guille", crud.getEditor().$(TextFieldElement.class)
+        Assert.assertEquals("Guille", crud.getForm().$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first().getValue());
     }
 
@@ -110,7 +110,7 @@ public class EventHandlingIT extends AbstractComponentIT {
 
         // Ensure editor is marked dirty on edit
         getTestButton("editServerItem").click();
-        crud.getEditor().$(TextFieldElement.class)
+        crud.getForm().$(TextFieldElement.class)
                 .withAttribute("editor-role", "first-name").first()
                 .setValue("Vaadin");
 
@@ -149,7 +149,7 @@ public class EventHandlingIT extends AbstractComponentIT {
     public void saveTest() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         crud.openRowForEditing(0);
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         Assert.assertTrue(lastNameField.isInvalid());
@@ -178,14 +178,14 @@ public class EventHandlingIT extends AbstractComponentIT {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         crud.getNewItemButton().get().click();
 
-        TextFieldElement firstNameField = crud.getEditor()
+        TextFieldElement firstNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "first-name").first();
 
         Assert.assertFalse(firstNameField.isInvalid());
 
         // To avoid editor being dirty
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
         lastNameField.setValue("Oladeji");
@@ -200,7 +200,7 @@ public class EventHandlingIT extends AbstractComponentIT {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         crud.openRowForEditing(1);
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
 
@@ -219,7 +219,7 @@ public class EventHandlingIT extends AbstractComponentIT {
 
         crud.getNewItemButton().get().click();
 
-        TestBenchElement editor = crud.getEditor();
+        TestBenchElement editor = crud.getForm();
         TextFieldElement firstNameField = editor.$(TextFieldElement.class)
                 .withAttribute("editor-role", "first-name").first();
         TextFieldElement lastNameField = editor.$(TextFieldElement.class)

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/ProtectedBackendIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/ProtectedBackendIT.java
@@ -84,7 +84,7 @@ public class ProtectedBackendIT extends AbstractComponentIT {
             boolean isModifyAllowed) {
         Assert.assertTrue(crud.isEditorOpen());
 
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class)
                 .withAttribute("editor-role", "last-name").first();
 

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/TemplateSupportIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/TemplateSupportIT.java
@@ -72,10 +72,10 @@ public class TemplateSupportIT extends AbstractComponentIT {
                 "Edit: Person{id=3, firstName='Guille', lastName='Guille'}",
                 getLastEvent());
 
-        Assert.assertEquals("Guille", crud.getEditor().$(TextFieldElement.class)
+        Assert.assertEquals("Guille", crud.getForm().$(TextFieldElement.class)
                 .id("firstName").getValue());
 
-        Assert.assertEquals("Guille", crud.getEditor().$(TextFieldElement.class)
+        Assert.assertEquals("Guille", crud.getForm().$(TextFieldElement.class)
                 .id("lastName").getValue());
     }
 
@@ -83,7 +83,7 @@ public class TemplateSupportIT extends AbstractComponentIT {
     public void saveTest() {
         CrudElement crud = getCrud().waitForFirst();
         crud.openRowForEditing(0);
-        TextFieldElement lastNameField = crud.getEditor()
+        TextFieldElement lastNameField = crud.getForm()
                 .$(TextFieldElement.class).id("lastName");
         lastNameField.setValue("Oladeji");
 

--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.openqa.selenium.By;
+
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
@@ -150,12 +152,36 @@ public class CrudElement extends TestBenchElement {
     }
 
     /**
-     * Gets the open editor overlay
+     * Since v25.0, returns the Crud element itself for backwards compatibility.
      *
-     * @return the open editor overlay
+     * @return the Crud element itself
+     * @deprecated Pre v25.0, this method returned either the editor overlay,
+     *             when the editor was displayed as a dialog, or the Crud
+     *             itself, when the editor was displayed inline. Since v25.0,
+     *             the overlay is not accessible as a separate element anymore,
+     *             and, regardless whether the editor is displayed as a dialog
+     *             or inline, all editor-related controls can be queried through
+     *             the Crud element itself. To specifically access the editor
+     *             fields, use {@link #getForm()} instead. To access the editor
+     *             buttons, use {@link #getEditorSaveButton()},
+     *             {@link #getEditorCancelButton()}, and
+     *             {@link #getEditorDeleteButton()}.
      */
+    @Deprecated(since = "25.0", forRemoval = true)
     public TestBenchElement getEditor() {
         return this;
+    }
+
+    /**
+     * Gets the form element that contains form fields.
+     *
+     * @return the form element
+     */
+    public TestBenchElement getForm() {
+        // Not using TestBench query here, as it would return the slot element
+        // within its shadow root
+        return wrapElement(findElement(By.cssSelector("[slot='form']")),
+                getCommandExecutor());
     }
 
     /**


### PR DESCRIPTION
## Description

Deprecates `CrudElement.getEditor` and introduces `CrudElement.getForm` as an alternative.

Fixes https://github.com/vaadin/flow-components/issues/7763

## Type of change

- Feature
