### PR TITLE
feat!: context menu test bench improvements

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/AbstractContextMenuIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/AbstractContextMenuIT.java
@@ -102,8 +102,4 @@ public abstract class AbstractContextMenuIT extends AbstractComponentIT {
         return wrap(TestBenchElement.class,
                 menu.findElement(By.cssSelector(":scope > [slot='overlay']")));
     }
-
-    protected void openSubMenu(ContextMenuItemElement parentItem) {
-        parentItem.openSubMenu();
-    }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuCloseIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuCloseIT.java
@@ -21,23 +21,28 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.contextmenu.testbench.ContextMenuElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("vaadin-context-menu/close")
 public class ContextMenuCloseIT extends AbstractContextMenuIT {
 
+    private TestBenchElement target;
+
     @Before
     public void init() {
         open();
+        target = $(TestBenchElement.class).id("context-menu-target");
     }
 
     @Test
     public void closeOnClick_openedChangeListener_isFromClientTrue() {
-        rightClickOn("context-menu-target");
-        verifyOpened();
+        ContextMenuElement contextMenu = ContextMenuElement
+                .openByRightClick(target);
 
         clickBody();
-        verifyClosedAndRemoved();
+        contextMenu.waitUntilClosed();
 
         WebElement message = findElement(By.id("closed-message"));
         Assert.assertEquals("Closed from client: true", message.getText());
@@ -45,11 +50,11 @@ public class ContextMenuCloseIT extends AbstractContextMenuIT {
 
     @Test
     public void closeProgrammatically_openedChangeListener_isFromClientFalse() {
-        rightClickOn("context-menu-target");
-        verifyOpened();
+        ContextMenuElement contextMenu = ContextMenuElement
+                .openByRightClick(target);
 
         leftClickOn("close-menu");
-        verifyClosedAndRemoved();
+        contextMenu.waitUntilClosed();
 
         WebElement message = findElement(By.id("closed-message"));
         Assert.assertEquals("Closed from client: false", message.getText());
@@ -57,17 +62,16 @@ public class ContextMenuCloseIT extends AbstractContextMenuIT {
 
     @Test
     public void reopen_closeOnClick_openedChangeListener_isFromClientTrue() {
-        rightClickOn("context-menu-target");
-        verifyOpened();
+        ContextMenuElement contextMenu = ContextMenuElement
+                .openByRightClick(target);
 
         leftClickOn("close-menu");
-        verifyClosedAndRemoved();
+        contextMenu.waitUntilClosed();
 
-        rightClickOn("context-menu-target");
-        verifyOpened();
+        contextMenu = ContextMenuElement.openByRightClick(target);
 
         clickBody();
-        verifyClosedAndRemoved();
+        contextMenu.waitUntilClosed();
 
         WebElement message = findElement(By.id("closed-message"));
         Assert.assertEquals("Closed from client: true", message.getText());

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuDemoIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuDemoIT.java
@@ -42,40 +42,38 @@ public class ContextMenuDemoIT extends AbstractContextMenuIT {
 
     @Test
     public void openAndCloseBasicContextMenu_contentIsRendered() {
-        verifyClosedAndRemoved();
-
-        rightClickOn("basic-context-menu-target");
-        verifyOpened();
+        ContextMenuElement contextMenu = ContextMenuElement
+                .openByRightClick($("*").id("basic-context-menu-target"));
+        List<ContextMenuItemElement> menuItems = contextMenu.getMenuItems();
 
         Assert.assertArrayEquals(new String[] { "First menu item",
                 "Second menu item", "Disabled menu item" },
-                getMenuItemCaptions());
+                getMenuItemCaptions(menuItems));
 
         Assert.assertFalse("The last item is supposed to be disabled",
-                getMenuItems().get(2).isEnabled());
+                menuItems.get(2).isEnabled());
 
-        $("body").first().click();
-        verifyClosedAndRemoved();
+        clickBody();
+        contextMenu.waitUntilClosed();
     }
 
     @Test
     public void openAndCloseContextMenuWithComponents_contentIsRendered() {
-        verifyClosedAndRemoved();
-
-        rightClickOn("context-menu-with-components-target");
-        verifyOpened();
+        ContextMenuElement contextMenu = ContextMenuElement.openByRightClick(
+                $("*").id("context-menu-with-components-target"));
+        List<ContextMenuItemElement> menuItems = contextMenu.getMenuItems();
 
         Assert.assertArrayEquals(new String[] { "First menu item", "Checkbox" },
-                getMenuItemCaptions());
-        Assert.assertTrue(getMenuContent().$("hr").exists());
-        WebElement span = getMenuContent().$("span").first();
+                getMenuItemCaptions(menuItems));
+        Assert.assertTrue(getMenuContent(contextMenu).$("hr").exists());
+        WebElement span = getMenuContent(contextMenu).$("span").first();
         Assert.assertEquals("This is not a menu item", span.getText());
 
-        WebElement checkbox = getMenuItems().get(1)
+        WebElement checkbox = menuItems.get(1)
                 .findElement(By.tagName("vaadin-checkbox"));
         checkbox.click();
-        $("body").first().click();
-        verifyClosedAndRemoved();
+        clickBody();
+        contextMenu.waitUntilClosed();
         WebElement message = findElement(
                 By.id("context-menu-with-components-message"));
         Assert.assertEquals("Clicked on checkbox with value: true",
@@ -84,84 +82,76 @@ public class ContextMenuDemoIT extends AbstractContextMenuIT {
 
     @Test
     public void hierarchicalContextMenu_openSubMenus() {
-        verifyClosedAndRemoved();
-
-        rightClickOn("hierarchical-menu-target");
+        ContextMenuElement contextMenu = ContextMenuElement
+                .openByRightClick($("*").id("hierarchical-menu-target"));
         verifyNumberOfMenus(1);
 
-        openSubMenu(getMenuItems().get(1));
+        ContextMenuElement subMenu = contextMenu.getMenuItems().get(1)
+                .openSubMenu();
         verifyNumberOfMenus(2);
 
-        List<ContextMenuElement> menus = getAllMenus();
-        openSubMenu(getMenuItems(menus.get(1)).get(1));
-
+        ContextMenuElement subSubMenu = subMenu.getMenuItems().get(1)
+                .openSubMenu();
         verifyNumberOfMenus(3);
-        menus = getAllMenus();
-        getMenuItems(menus.get(2)).get(0).click();
+
+        subSubMenu.getMenuItems().get(0).click();
+        contextMenu.waitUntilClosed();
 
         Assert.assertEquals("Clicked on the third item",
                 $("span").id("hierarchical-menu-message").getText());
-
-        verifyClosedAndRemoved();
     }
 
     @Test
     public void checkableMenuItems() {
-        verifyClosedAndRemoved();
+        ContextMenuElement contextMenu = ContextMenuElement
+                .openByRightClick($("*").id("checkable-menu-items-target"));
 
-        rightClickOn("checkable-menu-items-target");
-        verifyOpened();
-
-        List<ContextMenuItemElement> items = getMenuItems();
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(0), false);
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(1), true);
+        List<ContextMenuItemElement> items = contextMenu.getMenuItems();
+        Assert.assertFalse(items.get(0).isChecked());
+        Assert.assertTrue(items.get(1).isChecked());
 
         items.get(1).click();
+        contextMenu.waitUntilClosed();
 
         Assert.assertEquals("Unselected option 2",
                 $("span").id("checkable-menu-items-message").getText());
-        verifyClosedAndRemoved();
 
-        rightClickOn("checkable-menu-items-target");
-        verifyOpened();
+        contextMenu = ContextMenuElement
+                .openByRightClick($("*").id("checkable-menu-items-target"));
 
-        items = getMenuItems();
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(0), false);
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(1), false);
+        items = contextMenu.getMenuItems();
+        Assert.assertFalse(items.get(0).isChecked());
+        Assert.assertFalse(items.get(1).isChecked());
 
         items.get(0).click();
+        contextMenu.waitUntilClosed();
 
         Assert.assertEquals("Selected option 1",
                 $("span").id("checkable-menu-items-message").getText());
-        verifyClosedAndRemoved();
 
-        rightClickOn("checkable-menu-items-target");
-        verifyOpened();
+        contextMenu = ContextMenuElement
+                .openByRightClick($("*").id("checkable-menu-items-target"));
 
-        items = getMenuItems();
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(0), true);
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(1), false);
-
-        items.get(2).click();
-        verifyOpened();
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(2), false);
+        items = contextMenu.getMenuItems();
+        Assert.assertTrue(items.get(0).isChecked());
+        Assert.assertFalse(items.get(1).isChecked());
 
         items.get(2).click();
-        verifyOpened();
-        ContextMenuPageIT.assertCheckedInClientSide(items.get(2), true);
+        Assert.assertTrue(contextMenu.isOpen());
+        Assert.assertFalse(items.get(2).isChecked());
+
+        items.get(2).click();
+        Assert.assertTrue(contextMenu.isOpen());
+        Assert.assertTrue(items.get(2).isChecked());
     }
 
     @Test
     public void subMenuHasComponents_componentsAreNotItems() {
-        verifyClosedAndRemoved();
+        ContextMenuElement contextMenu = ContextMenuElement.openByRightClick(
+                $("*").id("context-menu-with-submenu-components-target"));
+        ContextMenuElement subMenu = contextMenu.getMenuItems().get(1)
+                .openSubMenu();
 
-        rightClickOn("context-menu-with-submenu-components-target");
-        verifyOpened();
-
-        openSubMenu(getMenuItems().get(1));
-        verifyNumberOfMenus(2);
-
-        ContextMenuElement subMenu = getAllMenus().get(1);
         TestBenchElement menuContent = getMenuContent(subMenu);
         TestBenchElement menuListBox = menuContent
                 .$("vaadin-context-menu-list-box").first();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuIT.java
@@ -35,115 +35,105 @@ import com.vaadin.testbench.TestBenchElement;
 @TestPath("vaadin-context-menu/sub-menu-test")
 public class SubMenuIT extends AbstractContextMenuIT {
 
+    TestBenchElement target;
+
     @Before
     public void init() {
         open();
-        verifyClosedAndRemoved();
+        target = $("*").id("target");
     }
 
     @Test
     public void addItemToSubMenu_subMenuRendered_clickListenerWorks() {
-        rightClickOn("target");
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
         verifyNumberOfMenus(1);
 
-        openSubMenu(getMenuItems().get(0));
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
         verifyNumberOfMenus(2);
 
-        List<ContextMenuElement> menus = getAllMenus();
-        ContextMenuItemElement subItem = getMenuItems(menus.get(1)).get(0);
+        ContextMenuItemElement subItem = subMenu.getMenuItems().get(0);
         Assert.assertEquals("bar", subItem.getText());
 
         subItem.click();
-        verifyClosedAndRemoved();
+        menu.waitUntilClosed();
         assertMessage("bar");
     }
 
     @Test
     public void openAndCloseSubMenu_addContent_contentUpdatedAndFunctional() {
-        rightClickOn("target");
-        openSubMenu(getMenuItems().get(0));
-        verifyNumberOfMenus(2);
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        menu.getMenuItems().get(0).openSubMenu();
         clickBody();
-        verifyClosedAndRemoved();
+        menu.waitUntilClosed();
 
         clickElementWithJs("add-item");
         clickElementWithJs("add-item");
 
-        rightClickOn("target");
+        menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
 
-        openSubMenu(getMenuItems().get(0));
-        verifyNumberOfMenus(2);
-
-        List<ContextMenuElement> menus = getAllMenus();
-        List<ContextMenuItemElement> subMenuItems = getMenuItems(menus.get(1));
+        List<ContextMenuItemElement> subMenuItems = subMenu.getMenuItems();
         String[] menuItemCaptions = getMenuItemCaptions(subMenuItems);
         Assert.assertArrayEquals(new String[] { "bar", "0", "1" },
                 menuItemCaptions);
 
         subMenuItems.get(1).click();
-        verifyClosedAndRemoved();
+        menu.waitUntilClosed();
         assertMessage("0");
     }
 
     @Test
     public void openAndCloseSubMenu_addSubSubMenu_contentUpdatedAndFunctional() {
-        rightClickOn("target");
-        openSubMenu(getMenuItems().get(0));
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        menu.getMenuItems().get(0).openSubMenu();
         clickBody();
-        verifyClosedAndRemoved();
+        menu.waitUntilClosed();
 
         clickElementWithJs("add-sub-sub-menu");
 
-        rightClickOn("target");
+        menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
+        ContextMenuElement subSubMenu = subMenu.getMenuItems().get(0)
+                .openSubMenu();
 
-        openSubMenu(getMenuItems().get(0));
-        verifyNumberOfMenus(2);
-
-        openSubMenu(getMenuItems(getAllMenus().get(1)).get(0));
-        verifyNumberOfMenus(3);
-
-        List<ContextMenuElement> menus = getAllMenus();
-        List<ContextMenuItemElement> subMenuItems = getMenuItems(menus.get(2));
-        String[] menuItemCaptions = getMenuItemCaptions(subMenuItems);
+        List<ContextMenuItemElement> subSubMenuItems = subSubMenu
+                .getMenuItems();
+        String[] menuItemCaptions = getMenuItemCaptions(subSubMenuItems);
         Assert.assertArrayEquals(new String[] { "0" }, menuItemCaptions);
 
-        subMenuItems.get(0).click();
-        verifyClosedAndRemoved();
+        subSubMenuItems.get(0).click();
+        menu.waitUntilClosed();
         assertMessage("0");
     }
 
     @Test
     public void openAndCloseSubMenu_removeAll_noSubMenu_stylesUpdated() {
-        rightClickOn("target");
-        ContextMenuItemElement parent = getMenuItems().get(0);
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuItemElement parent = menu.getMenuItems().get(0);
         assertHasPopup(parent, true);
 
-        openSubMenu(parent);
+        parent.hover();
         verifyNumberOfMenus(2);
 
         clickBody();
-        verifyClosedAndRemoved();
+        menu.waitUntilClosed();
 
         clickElementWithJs("remove-all");
-        rightClickOn("target");
+        menu = ContextMenuElement.openByRightClick(target);
 
-        parent = getMenuItems().get(0);
+        parent = menu.getMenuItems().get(0);
         assertHasPopup(parent, false);
 
-        openSubMenu(parent);
+        // Should not open a submenu, only the main menu remains
+        parent.hover();
         verifyNumberOfMenus(1);
     }
 
     @Test
     public void componentInsideSubMenu_addComponent_componentIsInSubmenu() {
         findElement(By.id("add-component")).click();
-        rightClickOn("target");
-
-        openSubMenu(getMenuItems().get(0));
-
-        verifyNumberOfMenus(2);
-
-        ContextMenuElement subMenu = getAllMenus().get(1);
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
 
         WebElement firstItem = getMenuContent(subMenu)
                 .$("vaadin-context-menu-list-box").first()
@@ -157,53 +147,36 @@ public class SubMenuIT extends AbstractContextMenuIT {
     @Test
     public void checkableItemInsideSubMenu_addCheckableItem_itemIsInSubmenu() {
         findElement(By.id("add-checkable-component")).click();
-        rightClickOn("target");
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
 
-        openSubMenu(getMenuItems().get(0));
-
-        verifyNumberOfMenus(2);
-
-        ContextMenuElement subMenu = getAllMenus().get(1);
-
-        WebElement checkableItem = getMenuContent(subMenu)
-                .$("vaadin-context-menu-list-box").first()
-                .findElements(By.xpath("./*")).get(1);
+        ContextMenuItemElement checkableItem = subMenu.getMenuItem("checkable")
+                .orElseThrow();
 
         // verify checkable item
-        Assert.assertEquals("vaadin-context-menu-item",
-                checkableItem.getTagName().toLowerCase(Locale.ENGLISH));
-        Assert.assertEquals("checkable", checkableItem.getText());
-        Assert.assertEquals("",
-                checkableItem.getDomAttribute("menu-item-checked"));
+        Assert.assertTrue(checkableItem.isChecked());
 
         // uncheck the item
         checkableItem.click();
 
-        verifyClosedAndRemoved();
+        menu.waitUntilClosed();
 
         // We should have a message about selected item:
         assertMessage("Checkable item is false");
 
         // verify that the item is not checked in UI now
-        rightClickOn("target");
+        menu = ContextMenuElement.openByRightClick(target);
+        subMenu = menu.getMenuItems().get(0).openSubMenu();
 
-        openSubMenu(getMenuItems().get(0));
+        checkableItem = subMenu.getMenuItem("checkable").orElseThrow();
 
-        verifyNumberOfMenus(2);
-
-        subMenu = getAllMenus().get(1);
-
-        checkableItem = getMenuContent(subMenu)
-                .$("vaadin-context-menu-list-box").first()
-                .findElements(By.xpath("./*")).get(1);
-
-        Assert.assertNull(checkableItem.getDomAttribute("menu-item-checked"));
+        Assert.assertFalse(checkableItem.isChecked());
     }
 
     @Test
     public void clickParentItem_menuNotClosed() {
-        rightClickOn("target");
-        getMenuItems().get(0).click();
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        menu.getMenuItems().get(0).click();
         verifyOpened();
     }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/src/main/java/com/vaadin/flow/component/contextmenu/testbench/ContextMenuItemElement.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/src/main/java/com/vaadin/flow/component/contextmenu/testbench/ContextMenuItemElement.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.component.contextmenu.testbench;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.TimeoutException;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -29,12 +33,17 @@ import com.vaadin.testbench.elementsbase.Element;
 public class ContextMenuItemElement extends TestBenchElement {
 
     /**
-     * Open the potential sub menu of this item by hovering. If there is a sub
-     * menu, it can be used to access the sub menu items after opening the last
-     * {@code ContextMenuOverlayElement}.
+     * Open the submenu of this item by hovering over it. Returns the submenu
+     * after it has opened, which can be used to access the items in the
+     * submenu.
+     *
+     * @return the submenu element.
+     * @throws NoSuchElementException
+     *             if no submenu is opened for this item.
      */
-    public void openSubMenu() {
+    public ContextMenuElement openSubMenu() {
         hover();
+        return getSubMenu();
     }
 
     /**
@@ -44,5 +53,30 @@ public class ContextMenuItemElement extends TestBenchElement {
      */
     public boolean isChecked() {
         return hasAttribute("menu-item-checked");
+    }
+
+    private ContextMenuElement getMenu() {
+        TestBenchElement listBox = getPropertyElement("parentElement");
+        TestBenchElement overlayContent = listBox
+                .getPropertyElement("parentElement");
+        TestBenchElement menu = overlayContent
+                .getPropertyElement("parentElement");
+
+        return menu.wrap(ContextMenuElement.class);
+    }
+
+    private ContextMenuElement getSubMenu() {
+        ContextMenuElement menu = getMenu();
+        By submenuLocator = By.cssSelector(":scope > [slot='submenu'][opened]");
+
+        try {
+            // Wait for the submenu to be opened
+            waitUntil(driver -> menu.findElement(submenuLocator));
+        } catch (TimeoutException e) {
+            throw new NoSuchElementException(
+                    "No sub menu opened for this menu item.");
+        }
+
+        return menu.findElement(submenuLocator).wrap(ContextMenuElement.class);
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/src/main/java/com/vaadin/flow/component/contextmenu/testbench/ContextMenuOverlayElement.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/src/main/java/com/vaadin/flow/component/contextmenu/testbench/ContextMenuOverlayElement.java
@@ -26,27 +26,31 @@ import com.vaadin.testbench.elementsbase.Element;
  * <code>&lt;vaadin-context-menu-overlay&gt;</code> element.
  *
  * @author Vaadin Ltd
- *
+ * @deprecated Use {@link ContextMenuElement} instead.
  */
-@Element("vaadin-context-menu-overlay")
+@Element("vaadin-context-menu")
+@Deprecated(since = "25.0", forRemoval = true)
 public class ContextMenuOverlayElement extends TestBenchElement {
 
     /**
      * Get the first menu item matching the caption.
      *
      * @return Optional menu item.
+     * @deprecated Use {@link ContextMenuElement#getMenuItem(String)} instead.
      */
+    @Deprecated(since = "25.0", forRemoval = true)
     public Optional<ContextMenuItemElement> getMenuItem(String caption) {
-        return getMenuItems().stream()
-                .filter(item -> item.getText().equals(caption)).findFirst();
+        return wrap(ContextMenuElement.class).getMenuItem(caption);
     }
 
     /**
      * Get the items of this context menu overlay.
      *
      * @return List of menu items.
+     * @deprecated Use {@link ContextMenuElement#getMenuItems()} instead.
      */
+    @Deprecated(since = "25.0", forRemoval = true)
     public List<ContextMenuItemElement> getMenuItems() {
-        return $(ContextMenuItemElement.class).all();
+        return wrap(ContextMenuElement.class).getMenuItems();
     }
 }


### PR DESCRIPTION
## Description

Improves the TestBench API for `ContextMenu`:
- Modified `ContextMenuElement.openByRightClick()` to wait for a menu to open and return it. Throws an exception if no menu opens (behavior change).
- Added `ContextMenuElement.getMenuItems()` to get all items from a menu
- Added `ContextMenuElement.getMenuItem(string)` to find an item by text
- Added `ContextMenuElement.waitUntilClosed()` to wait until a context menu has finished closing. Throws an exception if the menu does not close
- Modified `ContextMenuItemElement.openSubMenu()` to wait for a submenu to open and return it. Throws an exception if no menu opens (behavior change).

Also deprecates `ContextMenuOverlayElement`. The class is now a proxy to `ContextMenuElement` and should thus keep working as before.

Fixes https://github.com/vaadin/flow-components/issues/7520

## Type of change

- Feature
