### PR TITLE
chore: load Lumo theme when running merged ITs

### DIFF
--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -218,6 +218,14 @@ async function copySources() {
     // copy java sources
     copyFolderRecursiveSync(`${parent}/${id}-integration-tests/src`, `${itFolder}`);
   });
+
+  // Always copy LumoAppShell, so that merged ITs run with Lumo theme applied. Some ITs do not work property with
+  // base styles alone.
+  fs.mkdirSync(`${itFolder}/src/main/java/com/vaadin/flow/theme/lumo`, { recursive: true });
+  copyFileSync(
+    'vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/src/main/java/com/vaadin/flow/theme/lumo/LumoAppShell.java',
+    `${itFolder}/src/main/java/com/vaadin/flow/theme/lumo/LumoAppShell.java`,
+  );
 }
 
 async function main() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ContextMenuIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ContextMenuIT.java
@@ -10,7 +10,6 @@ package com.vaadin.flow.component.spreadsheet.test;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -31,7 +30,6 @@ public class ContextMenuIT extends AbstractSpreadsheetIT {
     }
 
     @Test
-    @Ignore
     public void documentScroll_overlayPosition() {
         // Make sure to use a small enough viewport so that the document needs
         // to be scrolled to see the cell


### PR DESCRIPTION
## Description

Currently the Lumo theme is not consistently applied when running merged ITs, which causes individual ITs to fail. 

The Lumo theme currently is only applied when merged ITs include the `vaadin-lumo-theme-flow-integration-tests` module, which has the `LumoAppShell` class with the necessary `@Theme` annotation.

This modifies the `mergeITs.js` script to always use `LumoAppShell` so that the Lumo theme is always applied regardless which modules are merged.

Long term we probably need more tweaks, as running individual IT modules in dev mode also shouldn't load a theme in theory, since there is no `@Theme` annotation in any of the IT modules. For now created https://github.com/vaadin/flow/issues/22014 to figure out how Flow should actually behave.

## Type of change

- Internal