### PR TITLE
test: add assertion for aria-level attribute

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
@@ -95,8 +95,8 @@ public abstract class AbstractTreeGridIT extends AbstractComponentIT {
         int rowIndex = startRowIndex;
         for (boolean expectedState : expectedStates) {
             Assert.assertEquals(
-                    "Row with index " + rowIndex
-                            + " has unexpected expanded state",
+                    "Row with index %d has unexpected expanded state"
+                            .formatted(rowIndex),
                     String.valueOf(expectedState),
                     treeGrid.getExpandToggleElement(rowIndex, 0)
                             .getDomProperty("expanded"));
@@ -108,11 +108,18 @@ public abstract class AbstractTreeGridIT extends AbstractComponentIT {
         int rowIndex = startRowIndex;
         for (int expectedState : expectedStates) {
             Assert.assertEquals(
-                    "Row with index " + rowIndex
-                            + " has unexpected level state",
+                    "Row with index %d has unexpected level"
+                            .formatted(rowIndex),
                     String.valueOf(expectedState),
                     treeGrid.getExpandToggleElement(rowIndex, 0)
                             .getDomProperty("level"));
+
+            Assert.assertEquals(
+                    "Row with index %d has unexpected aria-level value"
+                            .formatted(rowIndex),
+                    String.valueOf(expectedState + 1),
+                    treeGrid.getRow(rowIndex).getDomAttribute("aria-level"));
+
             rowIndex++;
         }
     }


### PR DESCRIPTION
## Description

The PR adds the assertion for the `aria-level` attribute to `AbstractTreeGridIT#assertRowLevel` to ensure its test coverage.

Extracted from #7676 

## Type of change

- [x] Internal
