### PR TITLE
chore: improve DatePickerElement JavaDoc

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -208,11 +208,9 @@ public class DatePickerElement extends TestBenchElement
     }
 
     /**
-     * Gets the content of the first date picker overlay on the page Should only
-     * be used with a single date picker at a time, there is no check that the
-     * overlay belongs to this specific date picker
+     * Gets the content of the date picker overlay.
      *
-     * @return
+     * @return the overlay content element
      */
     public OverlayContentElement getOverlayContent() {
         return $(OverlayContentElement.class).first();


### PR DESCRIPTION
## Description

Remove some obsolete information on `DatePickerElement.getOverlayContent`.
