### PR TITLE
refactor: use model.hasChildren in hierarchy column renderer

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/HierarchyColumnComponentRenderer.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/HierarchyColumnComponentRenderer.java
@@ -44,9 +44,6 @@ public class HierarchyColumnComponentRenderer<COMPONENT extends Component, SOURC
                 grid.expand(List.of(item), true);
             }
         });
-
-        withProperty("children",
-                item -> grid.getDataCommunicator().hasChildren(item));
     }
 
     @Override
@@ -58,7 +55,7 @@ public class HierarchyColumnComponentRenderer<COMPONENT extends Component, SOURC
         var clickListener = "e => requestAnimationFrame(() => { e.defaultPrevented && onClick(e) })";
 
         return "<vaadin-grid-tree-toggle @click=${" + clickListener
-                + "} class=${item.cssClassName} .leaf=${!item.children} .expanded=${model.expanded} .level=${model.level}>"
+                + "} class=${item.cssClassName} .leaf=${!model.hasChildren} .expanded=${model.expanded} .level=${model.level}>"
                 + super.getTemplateExpression() + "</vaadin-grid-tree-toggle>";
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -615,10 +615,8 @@ public class TreeGrid<T> extends Grid<T>
      */
     public Column<T> addHierarchyColumn(ValueProvider<T, ?> valueProvider) {
         Column<T> column = addColumn(LitRenderer.<T> of(
-                "<vaadin-grid-tree-toggle @click=${onClick} .leaf=${!item.children} .expanded=${model.expanded} .level=${model.level}>"
+                "<vaadin-grid-tree-toggle @click=${onClick} .leaf=${!model.hasChildren} .expanded=${model.expanded} .level=${model.level}>"
                         + "${item.name}</vaadin-grid-tree-toggle>")
-                .withProperty("children",
-                        item -> getDataCommunicator().hasChildren(item))
                 .withProperty("name", value -> {
                     Object name = valueProvider.apply(value);
                     return name == null ? "" : String.valueOf(name);


### PR DESCRIPTION
## Description

The PR updates the hierarchy column Lit renderer to use the newly introduced `model.hasChildren` instead of defining its own `children` property, which should slightly reduce network traffic by avoiding the transmission of duplicate information.

Related to https://github.com/vaadin/web-components/pull/9956

## Type of change

- [x] Refactor
