### PR TITLE
refactor: remove confusing mentions of overlay

### DIFF
--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -169,16 +169,16 @@ public class ConfirmDialog extends Component
 
     /**
      * @throws UnsupportedOperationException
-     *             ConfirmDialog does not support adding styles to overlay
+     *             ConfirmDialog does not support adding styles
      */
     @Override
     public Style getStyle() {
         throw new UnsupportedOperationException(
-                "ConfirmDialog does not support adding styles to overlay");
+                "ConfirmDialog does not support adding styles");
     }
 
     /**
-     * Sets the `aria-describedby` attribute of the dialog overlay.
+     * Sets the `aria-describedby` attribute of the dialog.
      * <p>
      * By default, all elements inside the message area are linked through the
      * `aria-describedby` attribute. However, there are cases where this can
@@ -197,13 +197,13 @@ public class ConfirmDialog extends Component
     }
 
     /**
-     * Gets the `aria-describedby` attribute of the dialog overlay.
+     * Gets the `aria-describedby` attribute of the dialog.
      * <p>
      * Note that this will only return a value if
      * {@link #setAriaDescribedBy(String)} was called before.
      *
-     * @return an optional aria-describedby of the dialog overlay, or an empty
-     *         optional if no aria-describedby has been set
+     * @return an optional aria-describedby of the dialog, or an empty optional
+     *         if no aria-describedby has been set
      */
     public Optional<String> getAriaDescribedBy() {
         return Optional.ofNullable(

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -197,7 +197,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     /**
      * Creates a new menu item with the given text content and adds it to the
-     * context menu overlay.
+     * context menu.
      *
      * @param text
      *            the text content for the created menu item
@@ -208,8 +208,8 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Creates a new menu item with the given component content and to the
-     * context menu overlay.
+     * Creates a new menu item with the given component content and adds it to
+     * the context menu.
      *
      * @param component
      *            the component to add to the created menu item
@@ -220,15 +220,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given components into the context menu overlay.
+     * Adds the given components to the context menu.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements in the DOM will not be children of the
-     * {@code <vaadin-context-menu>} element, but will be inserted into an
-     * overlay that is attached into the {@code <body>}.
+     * the menu, use {@link #addItem(String)} and its overload methods instead.
      *
      * @param components
      *            the components to add
@@ -240,15 +235,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given components into the context menu overlay.
+     * Adds the given components to the context menu.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements in the DOM will not be children of the
-     * {@code <vaadin-context-menu>} element, but will be inserted into an
-     * overlay that is attached into the {@code <body>}.
+     * the menu, use {@link #addItem(String)} and its overload methods instead.
      *
      * @param components
      *            the components to add
@@ -263,7 +253,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Removes the given components from the context menu overlay.
+     * Removes the given components from the context menu.
      *
      * @param components
      *            the components to remove
@@ -281,16 +271,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given component into the context menu overlay at the given
-     * index.
+     * Adds the given component to the context menu at the given index.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements in the DOM will not be children of the
-     * {@code <vaadin-context-menu>} element, but will be inserted into an
-     * overlay that is attached into the {@code <body>}.
+     * the menu, use {@link #addItem(String)} and its overload methods instead.
      *
      * @param index
      *            the index, where the component will be added
@@ -302,16 +286,10 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * Adds the given component as the first child into the context menu
-     * overlay.
+     * Adds the given component as the first child to the context menu.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements in the DOM will not be children of the
-     * {@code <vaadin-context-menu>} element, but will be inserted into an
-     * overlay that is attached into the {@code <body>}.
+     * the menu, use {@link #addItem(String)} and its overload methods instead.
      *
      * @param component
      *            the component to add
@@ -367,8 +345,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     /**
-     * {@code opened-changed} event is sent when the overlay opened state
-     * changes.
+     * {@code opened-changed} event is sent when the opened state changes.
      */
     public static class OpenedChangeEvent<TComponent extends ContextMenuBase<TComponent, ?, ?>>
             extends ComponentEvent<TComponent> {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -46,7 +46,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
 
     /**
      * Creates a new menu item with the given text content and adds it to the
-     * sub menu overlay.
+     * sub menu.
      *
      * @param text
      *            the text content for the created menu item
@@ -58,7 +58,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
 
     /**
      * Creates a new menu item with the given component content and adds it to
-     * the sub menu overlay.
+     * the sub menu.
      *
      * @param component
      *            the component to add to the created menu item
@@ -69,14 +69,10 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Adds the given components into the sub menu overlay.
+     * Adds the given components to the sub menu.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements will be inserted into an overlay that is attached into
-     * the {@code <body>}.
+     * the menu, use {@link #addItem(String)} and its overload methods instead.
      *
      * @param components
      *            the components to add
@@ -88,7 +84,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Removes the given components from the sub menu overlay.
+     * Removes the given components from the sub menu.
      *
      * @param components
      *            the components to remove
@@ -98,21 +94,17 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Removes all components inside the sub menu overlay.
+     * Removes all components from the sub menu.
      */
     public void removeAll() {
         getMenuManager().removeAll();
     }
 
     /**
-     * Adds the given component into the sub menu overlay at the given index.
+     * Adds the given component to the sub menu at the given index.
      * <p>
      * For the common use case of having a list of high-lightable items inside
-     * the overlay, use {@link #addItem(String)} and its overload methods
-     * instead.
-     * <p>
-     * The added elements will be inserted into an overlay that is attached into
-     * the {@code <body>}.
+     * the menu, use {@link #addItem(String)} and its overload methods instead.
      *
      * @param index
      *            the index, where the component will be added
@@ -149,7 +141,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     }
 
     /**
-     * Gets the menu item component that opens this sub menu overlay.
+     * Gets the menu item component that opens this sub menu.
      *
      * @return the parent menu item of this sub menu
      */

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -49,7 +49,7 @@ import com.vaadin.flow.shared.Registration;
 
 /**
  * A Dialog is a small window that can be used to present information and user
- * interface elements in an overlay.
+ * interface elements.
  * <p>
  * Dialogs can be made modal or non-modal. A modal Dialog blocks the user from
  * interacting with the rest of the user interface while the Dialog is open, as
@@ -131,7 +131,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * `vaadin-dialog-close-action` is sent when the user clicks outside the
-     * overlay or presses the escape key.
+     * dialog or presses the escape key.
      */
     @DomEvent("vaadin-dialog-close-action")
     public static class DialogCloseActionEvent extends ComponentEvent<Dialog> {
@@ -141,55 +141,55 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Gets the top position of the overlay.
+     * Gets the top position of the dialog.
      *
-     * @return the top position of the overlay
+     * @return the top position of the dialog
      */
     public String getTop() {
         return getElement().getProperty("top");
     }
 
     /**
-     * Sets the top position of the overlay. If a unitless number is provided,
+     * Sets the top position of the dialog. If a unitless number is provided,
      * pixels are assumed.
      * <p>
-     * Note that the overlay top edge may not be the same as the viewport top
-     * edge (e.g. the "Lumo" theme defines some spacing to prevent the overlay
+     * Note that the dialog top edge may not be the same as the viewport top
+     * edge (e.g. the "Lumo" theme defines some spacing to prevent the dialog
      * from stretching all the way to the top of the viewport).
      *
      * @param top
-     *            the top position of the overlay
+     *            the top position of the dialog
      */
     public void setTop(String top) {
         getElement().setProperty("top", top);
     }
 
     /**
-     * Gets the left position of the overlay.
+     * Gets the left position of the dialog.
      *
-     * @return the left position of the overlay
+     * @return the left position of the dialog
      */
     public String getLeft() {
         return getElement().getProperty("left");
     }
 
     /**
-     * Sets the distance of the overlay from the left of its container. If a
+     * Sets the distance of the dialog from the left of its container. If a
      * unitless number is provided, pixels are assumed.
      * <p>
-     * Note that the overlay left edge may not be the same as the viewport left
-     * edge (e.g. the "Lumo" theme defines some spacing to prevent the overlay
+     * Note that the dialog left edge may not be the same as the viewport left
+     * edge (e.g. the "Lumo" theme defines some spacing to prevent the dialog
      * from stretching all the way to the left of the viewport).
      *
      * @param left
-     *            the left position of the overlay
+     *            the left position of the dialog
      */
     public void setLeft(String left) {
         getElement().setProperty("left", left);
     }
 
     /**
-     * `resize` event is sent when the user finishes resizing the overlay.
+     * `resize` event is sent when the user finishes resizing the dialog.
      */
     @DomEvent("resize")
     public static class DialogResizeEvent extends ComponentEvent<Dialog> {
@@ -212,36 +212,36 @@ public class Dialog extends Component implements HasComponents, HasSize,
         }
 
         /**
-         * Gets the width of the overlay after resize is done
+         * Gets the width of the dialog after resize is done
          *
-         * @return the width in pixels of the overlay
+         * @return the width in pixels of the dialog
          */
         public String getWidth() {
             return width;
         }
 
         /**
-         * Gets the height of the overlay after resize is done
+         * Gets the height of the dialog after resize is done
          *
-         * @return the height in pixels of the overlay
+         * @return the height in pixels of the dialog
          */
         public String getHeight() {
             return height;
         }
 
         /**
-         * Gets the left position of the overlay after resize is done
+         * Gets the left position of the dialog after resize is done
          *
-         * @return the left position in pixels of the overlay
+         * @return the left position in pixels of the dialog
          */
         public String getLeft() {
             return left;
         }
 
         /**
-         * Gets the top position of the overlay after resize is done
+         * Gets the top position of the dialog after resize is done
          *
-         * @return the top position in pixels of the overlay
+         * @return the top position in pixels of the dialog
          */
         public String getTop() {
             return top;
@@ -249,7 +249,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * `dragged` event is sent when the user finishes dragging the overlay.
+     * `dragged` event is sent when the user finishes dragging the dialog.
      */
     @DomEvent("dragged")
     public static class DialogDraggedEvent extends ComponentEvent<Dialog> {
@@ -265,18 +265,18 @@ public class Dialog extends Component implements HasComponents, HasSize,
         }
 
         /**
-         * Gets the left position of the overlay after dragging is done
+         * Gets the left position of the dialog after dragging is done
          *
-         * @return the left position in pixels of the overlay
+         * @return the left position in pixels of the dialog
          */
         public String getLeft() {
             return left;
         }
 
         /**
-         * Gets the top position of the overlay after dragging is done
+         * Gets the top position of the dialog after dragging is done
          *
-         * @return the top position in pixels of the overlay
+         * @return the top position in pixels of the dialog
          */
         public String getTop() {
             return top;
@@ -426,8 +426,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Adds a listener that is called after user finishes resizing the overlay.
-     * It is called only if resizing is enabled (see
+     * Adds a listener that is called after the user finishes resizing the
+     * dialog. It is called only if resizing is enabled (see
      * {@link Dialog#setResizable(boolean)}).
      * <p>
      * Note: By default, the component will sync the width/height and top/left
@@ -443,8 +443,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Adds a listener that is called after user finishes dragging the overlay.
-     * It is called only if dragging is enabled (see
+     * Adds a listener that is called after the user finishes dragging the
+     * dialog. It is called only if dragging is enabled (see
      * {@link Dialog#setDraggable(boolean)}).
      * <p>
      * Note: By default, the component will sync the top/left values after every
@@ -497,10 +497,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * Adds the given components into this dialog.
-     * <p>
-     * The elements in the DOM will not be children of the
-     * {@code <vaadin-dialog>} element, but will be inserted into an overlay
-     * that is attached into the {@code <body>}.
      *
      * @param components
      *            the components to add
@@ -514,10 +510,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * Adds the given component into this dialog at the given index.
-     * <p>
-     * The element in the DOM will not be child of the {@code <vaadin-dialog>}
-     * element, but will be inserted into an overlay that is attached into the
-     * {@code <body>}.
      *
      * @param index
      *            the index, where the component will be added.
@@ -904,9 +896,9 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * listeners delegate to the server-side {@link #handleClientClose()}
      * method. This serves two purposes:
      * <ul>
-     * <li>Prevent the client overlay from closing if a custom close action
+     * <li>Prevent the client dialog from closing if a custom close action
      * listener is registered</li>
-     * <li>Prevent the client overlay from closing if the server-side dialog has
+     * <li>Prevent the client dialog from closing if the server-side dialog has
      * become inert in the meantime, in which case the @ClientCallable call to
      * {@link #handleClientClose()} will never be processed</li>
      * </ul>
@@ -1110,7 +1102,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Sets the ARIA role for the overlay element, used by screen readers.
+     * Sets the ARIA role for the dialog element, used by screen readers.
      *
      * @param role
      *            the role to set
@@ -1124,7 +1116,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Gets the ARIA role for the overlay element, used by screen readers.
+     * Gets the ARIA role for the dialog element, used by screen readers.
      * Defaults to {@code dialog}.
      *
      * @return the role
@@ -1134,7 +1126,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Gets the ARIA role for the overlay element, used by screen readers.
+     * Gets the ARIA role for the dialog element, used by screen readers.
      * Defaults to {@code dialog}.
      *
      * @return the role
@@ -1208,11 +1200,11 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * @throws UnsupportedOperationException
-     *             Dialog does not support adding styles to overlay
+     *             Dialog does not support adding styles
      */
     @Override
     public Style getStyle() {
         throw new UnsupportedOperationException(
-                "Dialog does not support adding styles to overlay");
+                "Dialog does not support adding styles");
     }
 }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -173,7 +173,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * {@code opened-changed} event is sent when the overlay opened state
+     * {@code opened-changed} event is sent when the popover opened state
      * changes.
      */
     @DomEvent("opened-changed")
@@ -355,7 +355,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets the ARIA role for the overlay element, used by screen readers.
+     * Sets the ARIA role for the popover, used by screen readers.
      *
      * @param role
      *            the role to set
@@ -379,8 +379,8 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Gets the ARIA role for the popover element, used by screen readers.
-     * Defaults to {@code dialog}.
+     * Gets the ARIA role for the popover, used by screen readers. Defaults to
+     * {@code dialog}.
      *
      * @return the role
      * @deprecated Use {@link #getRole()} instead
@@ -752,14 +752,14 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets the width of the popover overlay content area.
+     * Sets the width of the popover content area.
      * <p>
      * The width should be in a format understood by the browser, e.g. "100px"
      * or "2.5em" (Using relative unit, such as percentage, will lead to
      * unexpected results).
      * <p>
      * If the provided {@code width} value is {@literal null} then width is
-     * removed, and the popover overlay is auto-sized based on the content.
+     * removed, and the popover is auto-sized based on the content.
      *
      * @param width
      *            the width to set, may be {@code null}
@@ -769,14 +769,14 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
-     * Sets the height of the popover overlay content area.
+     * Sets the height of the popover content area.
      * <p>
      * The height should be in a format understood by the browser, e.g. "100px"
      * or "2.5em" (Using relative unit, such as percentage, will lead to
      * unexpected results).
      * <p>
      * If the provided {@code height} value is {@literal null} then height is
-     * removed, and the popover overlay is auto-sized based on the content.
+     * removed, and the popover is auto-sized based on the content.
      *
      * @param height
      *            the height to set, may be {@code null}
@@ -787,11 +787,11 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
     /**
      * @throws UnsupportedOperationException
-     *             Popover does not support adding styles to overlay
+     *             Popover does not support adding styles
      */
     @Override
     public Style getStyle() {
         throw new UnsupportedOperationException(
-                "Popover does not support adding styles to overlay");
+                "Popover does not support adding styles");
     }
 }


### PR DESCRIPTION
## Description

- Remove confusing mentions of "overlay" and just use the component name instead
- Remove mentions of content being added to a separate overlay element

Part of https://github.com/vaadin/flow-components/issues/7775

## Type of change

- Refactoring