### PR TITLE
refactor: remove custom Dialog shortcut registration

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutPage.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutPage.java
@@ -41,7 +41,6 @@ public class DialogWithShortcutPage extends VerticalLayout {
     public static final String MODELESS_SHORTCUT_LISTEN_ON_DIALOG = "modeless-shortcur-listen-on-dialog";
     public static final String LISTEN_ON_DIALOG = "listen-on-dialog";
     public static final String LISTEN_ON_DIALOG_ALLOW_DEFAULT = "listen-on-dialog-allow-default";
-    public static final String SHORTCUT_ON_UI = "shortcut-on-ui";
     public static final String DIALOG_ID = "dialog";
     public static final String REUSABLE_DIALOG = "reusable-dialog";
     public static final String UI_ID = "ui-id";
@@ -73,10 +72,6 @@ public class DialogWithShortcutPage extends VerticalLayout {
                 e -> createAndOpenDialog(true, false));
         dialogWithShortcutListenOnDialogAllowBrowserDefault
                 .setId(LISTEN_ON_DIALOG_ALLOW_DEFAULT);
-        final NativeButton dialogWithShortcutOnUi = new NativeButton(
-                "Dialog with shortcut on UI",
-                e -> createAndOpenDialog(false, true));
-        dialogWithShortcutOnUi.setId(SHORTCUT_ON_UI);
         final NativeButton reusableDialogButton = new NativeButton(
                 "Reusable dialog", event -> {
                     if (reusableDialog == null) {
@@ -87,7 +82,7 @@ public class DialogWithShortcutPage extends VerticalLayout {
                 });
         reusableDialogButton.setId(REUSABLE_DIALOG);
         add(modelessWithShortcutOnUi, modelessWithShortcutListenOnDialog,
-                dialogWithShortcutOnUi, dialogWithShortcutListenOnDialog,
+                dialogWithShortcutListenOnDialog,
                 dialogWithShortcutListenOnDialogAllowBrowserDefault,
                 reusableDialogButton);
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutIT.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.dialog.tests;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -49,7 +48,6 @@ public class DialogWithShortcutIT extends AbstractComponentIT {
 
     // #7799
     @Test
-    @Ignore("flaky test see https://github.com/vaadin/flow-components/issues/777")
     public void dialogOpenedWithListenOnShortcut_sameShortcutListeningOnUi_focusDecidesWhichIsExecuted() {
         openDialogButton = $(NativeButtonElement.class)
                 .id(DialogWithShortcutPage.LISTEN_ON_DIALOG);
@@ -69,7 +67,6 @@ public class DialogWithShortcutIT extends AbstractComponentIT {
     }
 
     @Test
-    @Ignore("flaky test see https://github.com/vaadin/flow-components/issues/777")
     public void dialogOpenedWithShortcutNoListenOn_sameShortcutListeningOnUi_bothExecuted() {
         openDialogButton = $(NativeButtonElement.class)
                 .id(DialogWithShortcutPage.SHORTCUT_ON_UI);
@@ -80,16 +77,15 @@ public class DialogWithShortcutIT extends AbstractComponentIT {
 
         pressShortcutKey(getFirstDialogInput());
         // last event is on dialog
-        validateLatestShortcutEventOnDialog(2, 0);
-        validateShortcutEvent(1, 1, DialogWithShortcutPage.UI_BUTTON);
+        validateLatestShortcutEventOnDialog(1, 0);
+        validateShortcutEvent(1, 0, DialogWithShortcutPage.UI_BUTTON);
 
         closeDialog();
         pressShortcutKey(uiLevelButton);
-        validateLatestShortcutEvent(3, DialogWithShortcutPage.UI_BUTTON);
+        validateLatestShortcutEvent(2, DialogWithShortcutPage.UI_BUTTON);
     }
 
     @Test
-    @Ignore("flaky test see https://github.com/vaadin/flow-components/issues/777")
     public void dialogOpenedWithListenOnShortcut_dialogReopened_oldShortcutStillWorks() {
         openDialogButton = $(NativeButtonElement.class)
                 .id(DialogWithShortcutPage.REUSABLE_DIALOG);
@@ -102,23 +98,19 @@ public class DialogWithShortcutIT extends AbstractComponentIT {
         pressShortcutKey(getFirstDialogInput());
         validateLatestShortcutEventOnDialog(1, 0);
 
-        pressShortcutKey(uiLevelButton);
-        validateLatestShortcutEvent(2, DialogWithShortcutPage.UI_BUTTON);
-
         closeDialog();
 
         pressShortcutKey(uiLevelButton);
-        validateLatestShortcutEvent(3, DialogWithShortcutPage.UI_BUTTON);
+        validateLatestShortcutEvent(2, DialogWithShortcutPage.UI_BUTTON);
 
         openNewDialog();
 
         pressShortcutKey(getFirstDialogInput());
-        validateLatestShortcutEventOnDialog(4, 0);
+        validateLatestShortcutEventOnDialog(3, 0);
     }
 
     // vaadin/vaadin-dialog#229
     @Test
-    @Ignore("flaky test see https://github.com/vaadin/flow-components/issues/777")
     public void twoModelessDialogsOpenedWithSameShortcutKeyOnListenOn_dialogWithFocusExecuted() {
         openDialogButton = $(NativeButtonElement.class)
                 .id(DialogWithShortcutPage.MODELESS_SHORTCUT_LISTEN_ON_DIALOG);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithShortcutIT.java
@@ -67,25 +67,6 @@ public class DialogWithShortcutIT extends AbstractComponentIT {
     }
 
     @Test
-    public void dialogOpenedWithShortcutNoListenOn_sameShortcutListeningOnUi_bothExecuted() {
-        openDialogButton = $(NativeButtonElement.class)
-                .id(DialogWithShortcutPage.SHORTCUT_ON_UI);
-        pressShortcutKey(uiLevelButton);
-        validateLatestShortcutEvent(0, DialogWithShortcutPage.UI_BUTTON);
-
-        openNewDialog();
-
-        pressShortcutKey(getFirstDialogInput());
-        // last event is on dialog
-        validateLatestShortcutEventOnDialog(1, 0);
-        validateShortcutEvent(1, 0, DialogWithShortcutPage.UI_BUTTON);
-
-        closeDialog();
-        pressShortcutKey(uiLevelButton);
-        validateLatestShortcutEvent(2, DialogWithShortcutPage.UI_BUTTON);
-    }
-
-    @Test
     public void dialogOpenedWithListenOnShortcut_dialogReopened_oldShortcutStillWorks() {
         openDialogButton = $(NativeButtonElement.class)
                 .id(DialogWithShortcutPage.REUSABLE_DIALOG);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Shortcuts;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -1088,10 +1087,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
 
-        // vaadin/flow#7799,vaadin/vaadin-dialog#229
-        // as the locator is stored inside component's attributes, no need to
-        // remove the data as it should live as long as the component does
-        Shortcuts.setShortcutListenOnElement(OVERLAY_LOCATOR_JS, this);
         initHeaderFooterRenderer();
         updateVirtualChildNodeIds();
         registerClientCloseHandler();

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -29,12 +29,9 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Key;
-import com.vaadin.flow.component.Shortcuts;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
@@ -244,29 +241,6 @@ public class DialogTest {
         // modeless is false and modal is true by default
         Assert.assertFalse("modal can be set to false",
                 !dialog.getElement().getProperty("modeless", false));
-    }
-
-    // vaadin/flow#7799,vaadin/vaadin-dialog#229
-    @Test
-    public void dialogAttached_targetedWithShortcutListenOn_addsJsExecutionForTransportingShortcutEvents() {
-        Dialog dialog = new Dialog();
-        dialog.open();
-        // there are a 6 invocations pending after opening a dialog (???) clear
-        // those first
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().dumpPendingJavaScriptInvocations();
-
-        // adding a shortcut with listenOn(dialog) makes flow pass events from
-        // overlay to dialog so that shortcuts inside dialog work
-        Shortcuts.addShortcutListener(dialog, event -> {
-        }, Key.KEY_A).listenOn(dialog);
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-
-        final List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = ui
-                .getInternals().dumpPendingJavaScriptInvocations();
-        Assert.assertEquals(
-                "Shortcut transferring invocation should be pending", 1,
-                pendingJavaScriptInvocations.size());
     }
 
     private void addDivAtIndex(int index) {


### PR DESCRIPTION
## Description

Removes the workaround for making shortcut registrations register on the overlay, now that the overlay is part of the dialog. Also restores shortcut ITs.

Part of https://github.com/vaadin/flow-components/issues/7775

## Type of change

- Refactoring