### PR TITLE
refactor: deprecate Board

### DIFF
--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @Tag("vaadin-board")
 @NpmPackage(value = "@vaadin/board", version = "25.0.0-alpha15")
 @JsModule("@vaadin/board/src/vaadin-board.js")
-@Deprecated(since = "25.0.0", forRemoval = true)
+@Deprecated(since = "25.0", forRemoval = true)
 public class Board extends Component
         implements HasSize, HasStyle, HasOrderedComponents {
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Board.java
@@ -24,11 +24,14 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * Row consists of four columns, and can contain up to four components taking
  * one column each, or fewer components with multiple columns each as long as
  * sum of columns stays less than or equal to four.
- * <p>
+ *
+ * @deprecated Board is deprecated and will be removed in Vaadin 26. Consider
+ *             using Dashboard as an alternative.
  */
 @Tag("vaadin-board")
 @NpmPackage(value = "@vaadin/board", version = "25.0.0-alpha15")
 @JsModule("@vaadin/board/src/vaadin-board.js")
+@Deprecated(since = "25.0.0", forRemoval = true)
 public class Board extends Component
         implements HasSize, HasStyle, HasOrderedComponents {
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @Tag("vaadin-board-row")
 @NpmPackage(value = "@vaadin/board", version = "25.0.0-alpha15")
 @JsModule("@vaadin/board/src/vaadin-board-row.js")
-@Deprecated(since = "25.0.0", forRemoval = true)
+@Deprecated(since = "25.0", forRemoval = true)
 public class Row extends Component
         implements HasStyle, HasSize, HasOrderedComponents {
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
@@ -26,11 +26,13 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * taking one column each, or fewer components with multiple columns each as
  * long as sum of columns stays less than or equal to four.
  *
- * <p>
+ * @deprecated Board Row is deprecated and will be removed in Vaadin 26.
+ *             Consider using Dashboard as an alternative.
  */
 @Tag("vaadin-board-row")
 @NpmPackage(value = "@vaadin/board", version = "25.0.0-alpha15")
 @JsModule("@vaadin/board/src/vaadin-board-row.js")
+@Deprecated(since = "25.0.0", forRemoval = true)
 public class Row extends Component
         implements HasStyle, HasSize, HasOrderedComponents {
 


### PR DESCRIPTION
## Description

Deprecate `Board` with the intention to remove it in Vaadin 26;

Part of https://github.com/vaadin/web-components/issues/9741

## Type of change

- Refactor