### PR TITLE
fix: add root cache existence check when returning data

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -931,7 +931,7 @@
           if ((cache[root] && cache[root][page]) || page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
             delete rootPageCallbacks[page];
 
-            if (cache[root][page]) {
+            if (cache[root] && cache[root][page]) {
               // Cached data is available, resolve the callback
               callback(cache[root][page]);
             } else {


### PR DESCRIPTION
## Description

Original issue prevented grid items to be properly rendered once grid was reopened (in a dialog) and items re-set to new ones. 
Bug started to appear with the introduction of 14.12.8, but the underlying issue has been there for a while it seems. 
Targeting only 14.3 here, because latest branch already has same kind of check for this method.

Basically, there was a missing null / undefined check for cache. 

Fixes # (issue)

https://github.com/vaadin/flow-components/issues/7623

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
  - No tests needed in my opinion
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

