### PR TITLE
refactor: ensure $connector.set skips null items

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -366,10 +366,17 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     for (let i = 0; i < updatedPageCount; i++) {
       let page = firstPage + i;
       let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
-      cache[page] = slice;
+      cache[page] ??= [];
 
-      grid.$connector.doSelection(slice.filter((item) => item.selected));
-      grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
+      for (let j = 0; j < slice.length; j++) {
+        const item = slice[j];
+        if (item != null) {
+          cache[page][j] = item;
+        }
+      }
+
+      grid.$connector.doSelection(slice.filter((item) => item != null && item.selected));
+      grid.$connector.doDeselection(slice.filter((item) => item != null && !item.selected && selectedKeys[item.key]));
 
       const updatedItems = updateGridCache(page);
       if (updatedItems) {


### PR DESCRIPTION
## Description

The PR updates `$connector.set` to skip null elements, which may be sent by HierarchicalDataCommunicator as placeholders for unchanged items to optimize network traffic.

Part of https://github.com/vaadin/flow/issues/21989

## Type of change

- [x] Refactor
