### PR TITLE
refactor: simplify connector set and clear

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
@@ -487,8 +487,15 @@ public class GridTestPageIT extends AbstractComponentIT {
     public static Map<String, Map<String, ?>> getItems(WebDriver driver,
             WebElement element) {
         Object result = ((JavascriptExecutor) driver).executeScript(
-                "const items = arguments[0]._dataProviderController.rootCache.items;"
-                        + "return items.reduce((obj, item, i) => ({ ...obj, [i]: item }), {});",
+                """
+                        const { items } = arguments[0]._dataProviderController.rootCache;
+                        return items.reduce((obj, item, i) => {
+                            if (item) {
+                                obj[i] = item;
+                            }
+                            return obj;
+                        }, {});
+                        """,
                 element);
 
         return (Map<String, Map<String, ?>>) result;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -315,17 +315,19 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
    * Updates the cache for the given page for grid or tree-grid.
    *
    * @param page index of the page to update
-   * @returns an array of the updated items for the page, or undefined if no items were cached for the page
    */
   const updateGridCache = function (page) {
-    let gridCache = dataProviderController.rootCache;
+    const { rootCache } = dataProviderController;
 
-    // Force update unless there's a callback waiting
-    if (gridCache && !gridCache.pendingRequests[page]) {
-      // Update the items in the grid cache or set an array of undefined items
-      // to remove the page from the grid cache if there are no corresponding items
-      // in the connector cache.
-      gridCache.setPage(page, cache[page] || Array.from({ length: grid.pageSize }));
+    // Force update unless there's a callback waiting.
+    if (cache[page] && rootCache.pendingRequests[page]) {
+      return;
+    }
+
+    for (let i = 0; i < grid.pageSize; i++) {
+      const index = page * grid.pageSize + i;
+      const item = cache[page]?.[i];
+      rootCache.items[index] = item;
     }
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -367,9 +367,9 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       updateGridCache(page);
     }
 
-    itemsUpdated(items);
     grid.$connector.doSelection(items.filter((item) => item.selected));
     grid.$connector.doDeselection(items.filter((item) => !item.selected && selectedKeys[item.key]));
+    itemsUpdated(items);
 
     grid.__updateVisibleRows();
   };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -318,8 +318,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
    * @returns an array of the updated items for the page, or undefined if no items were cached for the page
    */
   const updateGridCache = function (page) {
-    const items = cache[page];
-
     let gridCache = dataProviderController.rootCache;
 
     // Force update unless there's a callback waiting
@@ -327,10 +325,8 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       // Update the items in the grid cache or set an array of undefined items
       // to remove the page from the grid cache if there are no corresponding items
       // in the connector cache.
-      gridCache.setPage(page, items || Array.from({ length: grid.pageSize }));
+      gridCache.setPage(page, cache[page] || Array.from({ length: grid.pageSize }));
     }
-
-    return items;
   };
 
   /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -364,18 +364,14 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     currentUpdateSetRange = [firstPage, firstPage + updatedPageCount - 1];
 
     for (let i = 0; i < updatedPageCount; i++) {
-      let page = firstPage + i;
-      let slice = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
-      cache[page] = slice;
-
-      grid.$connector.doSelection(slice.filter((item) => item.selected));
-      grid.$connector.doDeselection(slice.filter((item) => !item.selected && selectedKeys[item.key]));
-
-      const updatedItems = updateGridCache(page);
-      if (updatedItems) {
-        itemsUpdated(updatedItems);
-      }
+      const page = firstPage + i;
+      cache[page] = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
+      updateGridCache(page);
     }
+
+    itemsUpdated(items);
+    grid.$connector.doSelection(items.filter((item) => item.selected));
+    grid.$connector.doDeselection(items.filter((item) => !item.selected && selectedKeys[item.key]));
 
     grid.__updateVisibleRows();
   };
@@ -476,11 +472,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
         delete cache[page];
         updateGridCache(page);
       }
-    }
-    let cacheToClear = dataProviderController.rootCache;
-    const endIndex = index + updatedPageCount * grid.pageSize;
-    for (let itemIndex = index; itemIndex < endIndex; itemIndex++) {
-      delete cacheToClear.items[itemIndex];
     }
     grid.__updateVisibleRows();
   };


### PR DESCRIPTION
## Description

The PR simplifies gridConnector's `set` and `clear` methods and makes them more reliable by avoiding the `delete` operator. Using `delete` creates "holes" in the array and causes deleted items to be skipped by JS iteration methods like `forEach` and `reduce`, which can be unexpected and hard to debug.

## Type of change

- [x] Refactor
