### PR TITLE
test: update drilldown tests to work with new DOM structure

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractTBTest.java
@@ -8,6 +8,8 @@
  */
 package com.vaadin.flow.component.charts.tests;
 
+import java.util.List;
+
 import com.vaadin.flow.component.charts.examples.AbstractChartExample;
 import com.vaadin.flow.component.charts.testbench.ChartElement;
 import com.vaadin.flow.component.charts.ui.MainView;
@@ -30,6 +32,11 @@ public abstract class AbstractTBTest extends AbstractParallelTest {
     protected TestBenchElement getElementFromShadowRoot(
             TestBenchElement shadowRootOwner, String selector) {
         return shadowRootOwner.$(selector).first();
+    }
+
+    protected List<TestBenchElement> getElementsFromShadowRoot(
+            TestBenchElement shadowRootOwner, String selector) {
+        return shadowRootOwner.$(selector).all();
     }
 
     protected TestBenchElement getElementFromShadowRoot(

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.charts.tests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,11 +50,12 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
         assertLastLogText("DrilldownEvent: Item1_2_2");
         // Set same callback
         findElement(By.id("setSame")).click();
-        getDrillUpButtonByTopItemName(chart, "Item1_2").click();
+        getDrillUpButton(chart, "Item1_2").click();
         assertLastLogText("ChartDrillupEvent");
+        System.out.println("clicking drilldown point before test failure");
         clickDrilldownPoint(chart, 0);
         assertLastLogText("DrilldownEvent: Item1_2_1");
-        getDrillUpButtonByTopItemName(chart, "Item1_2").click();
+        getDrillUpButton(chart, "Item1_2").click();
         assertLastLogText("ChartDrillupEvent");
 
         // Set callback to null
@@ -63,9 +63,9 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
         clickDrilldownPoint(chart, 0);
         // Can't drilldown with null callback
         assertLastLogText("ChartDrillupEvent");
-        getDrillUpButtonByTopItemName(chart, "Item1").click();
+        getDrillUpButton(chart, "Item1").click();
         // At Item1
-        getDrillUpButton(chart, "Back to Top").click();
+        getDrillUpButton(chart, "Top").click();
         // At top level, no more drilldown buttons
         assertLastLogText("ChartDrillupEvent");
 
@@ -90,32 +90,27 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
     }
 
     private void clickDrilldownPoint(ChartElement chart, int index) {
-        getElementFromShadowRoot(chart, ".highcharts-drilldown-point", index)
-                .click();
-    }
-
-    private WebElement getDrillUpButtonByTopItemName(ChartElement chart,
-            String item) {
-        return getDrillUpButton(chart, "Back to " + item + "_drill");
+        var button = getElementFromShadowRoot(chart,
+                ".highcharts-drilldown-point", index);
+        System.out.println("Clicking drilldown point: "
+                + button.getAttribute("aria-label"));
+        button.click();
     }
 
     private WebElement getDrillUpButton(ChartElement chart, String label) {
-        final String selector = String.format("button[aria-label=\"◁ %s\"",
-                label);
-        return getElementFromShadowRoot(chart, selector);
+        var elements = getElementsFromShadowRoot(chart,
+                ".highcharts-button.highcharts-breadcrumbs-button.highcharts-button-normal");
+        for (TestBenchElement drillupButton : elements) {
+            if (drillupButton.getText().contains(label)) {
+                return drillupButton;
+            }
+        }
+        return null;
     }
 
     private void assertLastLogText(String text) {
         final List<String> messages = getLogMessages();
         assertEquals(text, messages.get(messages.size() - 1));
-    }
-
-    private void assertLogText(String text) {
-        final StringBuilder sb = new StringBuilder();
-        getLogMessages().forEach(sb::append);
-        final String messages = sb.toString();
-        assertTrue(String.format("Couldn't find text '%s' from the log.", text),
-                messages.contains(text));
     }
 
     private List<String> getLogMessages() {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownIT.java
@@ -36,7 +36,7 @@ public class ColumnWithLazyMultiLevelDrilldownIT extends AbstractTBTest {
         getFirstDrilldownPoint(chart).click();
         assertLogText("DrilldownEvent: Costa Rica");
 
-        getDrillUpButton(chart).click();
+        getDrillUpButton(chart, "Latin America and Caribbean").click();
         assertLogText("ChartDrillupEvent");
     }
 
@@ -44,8 +44,15 @@ public class ColumnWithLazyMultiLevelDrilldownIT extends AbstractTBTest {
         return getElementFromShadowRoot(chart, ".highcharts-drilldown-point");
     }
 
-    private WebElement getDrillUpButton(ChartElement chart) {
-        return getElementFromShadowRoot(chart, "button");
+    private WebElement getDrillUpButton(ChartElement chart, String label) {
+        var elements = getElementsFromShadowRoot(chart,
+                ".highcharts-button.highcharts-breadcrumbs-button.highcharts-button-normal");
+        for (TestBenchElement drillupButton : elements) {
+            if (drillupButton.getText().contains(label)) {
+                return drillupButton;
+            }
+        }
+        return null;
     }
 
     private void assertLogText(String text) {


### PR DESCRIPTION
## Description

The DOM structure in Highcharts V12 differs in relation to how the drilldown controls are rendered. That will cause test failures in the ITs, so we need to update them.

Part of https://github.com/vaadin/web-components/issues/8825
Depends on https://github.com/vaadin/web-components/pull/10010
