### PR TITLE
chore: update for Jakarta EE 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
         <osgi.bundle.license>http://www.apache.org/licenses/LICENSE-2.0</osgi.bundle.license>
         <osgi.export.package>default</osgi.export.package>
         <cvdlName/>
-        <jakarta.servlet.api.version>5.0.0</jakarta.servlet.api.version>
-        <jakarta.web.api.version>10.0.0</jakarta.web.api.version>
+        <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
+        <jakarta.web.api.version>11.0.0</jakarta.web.api.version>
         <spring-data-commons.version>4.0.0-M5</spring-data-commons.version>
 
         <!-- spreadsheet -->


### PR DESCRIPTION
bump jakarta.jakartaee-web-api from 10.0.0 to 11.0.0. bump jakarta.servlet-api from 5.0.0 to 6.1.0.

Fixes: #7634
