### PR TITLE
refactor: allow granular viewport updates with $connector.set

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-page-size.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-page-size.test.ts
@@ -1,0 +1,48 @@
+import { expect, fixtureSync, nextFrame } from '@open-wc/testing';
+import {
+  init,
+  getBodyRowCount,
+  getBodyCellText,
+  setRootItems,
+} from './shared.js';
+import type { FlowGrid } from './shared.js';
+
+describe('grid connector', () => {
+  let grid: FlowGrid;
+
+  beforeEach(() => {
+    grid = fixtureSync(`
+      <vaadin-grid height="400px">
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+      <style>
+        vaadin-grid::part(cell) {
+          min-height: 36px;
+        }
+      </style>
+    `);
+
+    init(grid);
+  });
+
+  describe('small page size', () => {
+    beforeEach(async () => {
+      grid.pageSize = 5;
+      grid.$connector.reset();
+      await nextFrame();
+      setRootItems(
+        grid.$connector,
+        Array.from({ length: 15 }, (_, i) => ({ key: `${i}`, name: `Item ${i}` }))
+      );
+      await nextFrame();
+    });
+
+    it('should render correct rows', () => {
+      expect(getBodyRowCount(grid)).to.equal(15);
+
+      for (let i = 0; i < 15; i++) {
+        expect(getBodyCellText(grid, i, 0)).to.equal(`Item ${i}`);
+      }
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -63,7 +63,7 @@ describe('grid connector', () => {
       expect(getBodyCellText(grid, 2, 0)).to.equal('baz refreshed');
     });
 
-    it.only('should not re-render unchanged items', async () => {
+    it('should not re-render unchanged items', async () => {
       const rendererSpy = sinon.spy();
       grid.querySelector('vaadin-grid-column')!.renderer = rendererSpy;
       rendererSpy.resetHistory();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -51,7 +51,6 @@ describe('grid connector', () => {
         { key: '2', name: 'baz' }
       ]);
       await nextFrame();
-      await aTimeout(0);
     });
 
     it('should re-render changed items', async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -9,6 +9,7 @@ import {
   GRID_CONNECTOR_ROOT_REQUEST_DELAY
 } from './shared.js';
 import type { FlowGrid } from './shared.js';
+import sinon from 'sinon';
 
 describe('grid connector', () => {
   let grid: FlowGrid;
@@ -40,6 +41,41 @@ describe('grid connector', () => {
 
     expect(getBodyRowCount(grid)).to.equal(1);
     expect(getBodyCellText(grid, 0, 0)).to.equal('foo');
+  });
+
+  describe('multiple set calls', () => {
+    beforeEach(async () => {
+      setRootItems(grid.$connector, [
+        { key: '0', name: 'foo' },
+        { key: '1', name: 'bar' },
+        { key: '2', name: 'baz' }
+      ]);
+      await nextFrame();
+      await aTimeout(0);
+    });
+
+    it('should re-render changed items', async () => {
+      grid.$connector.set(1, [{ key: '1', name: 'bar refreshed' }]);
+      grid.$connector.set(2, [{ key: '2', name: 'baz refreshed' }]);
+      await nextFrame();
+      expect(getBodyCellText(grid, 0, 0)).to.equal('foo');
+      expect(getBodyCellText(grid, 1, 0)).to.equal('bar refreshed');
+      expect(getBodyCellText(grid, 2, 0)).to.equal('baz refreshed');
+    });
+
+    it.only('should not re-render unchanged items', async () => {
+      const rendererSpy = sinon.spy();
+      grid.querySelector('vaadin-grid-column')!.renderer = rendererSpy;
+      rendererSpy.resetHistory();
+
+      grid.$connector.set(1, [{ key: '1', name: 'bar refreshed' }]);
+      await nextFrame();
+
+      rendererSpy.args.forEach(([_root, _column, model]) => {
+        expect(model.item.name).to.not.equal('foo');
+        expect(model.item.name).to.not.equal('baz');
+      });
+    });
   });
 
   it('should cancel debounced requests if all data has already been received', async () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -350,9 +350,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   grid.$connector.set = function (startIndex, items) {
     items.forEach((item, i) => {
-      if (!item) {
-        return;
-      }
 
       const index = startIndex + i;
       const page = Math.floor(index / grid.pageSize);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -350,7 +350,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   grid.$connector.set = function (startIndex, items) {
     items.forEach((item, i) => {
-
       const index = startIndex + i;
       const page = Math.floor(index / grid.pageSize);
       cache[page] ??= [];

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -349,24 +349,27 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   };
 
   grid.$connector.set = function (startIndex, items) {
+    items.forEach((item, i) => {
+      if (!item) {
+        return;
+      }
+
+      const index = startIndex + i;
+      const page = Math.floor(index / grid.pageSize);
+      cache[page] ??= [];
+      cache[page][index % grid.pageSize] = item;
+    });
+
     const firstPage = Math.floor(startIndex / grid.pageSize);
     const updatedPageCount = Math.ceil(items.length / grid.pageSize);
-
     for (let i = 0; i < updatedPageCount; i++) {
-      const page = firstPage + i;
-      for (let j = 0; j < grid.pageSize; j++) {
-        const item = items[i * grid.pageSize + j];
-        if (item) {
-          cache[page] ??= [];
-          cache[page][j] = item;
-        }
-      }
-      updateGridCache(page);
+      updateGridCache(firstPage + i);
     }
 
     grid.$connector.doSelection(items.filter((item) => item.selected));
     grid.$connector.doDeselection(items.filter((item) => !item.selected && selectedKeys[item.key]));
     itemsUpdated(items);
+
     grid.__updateVisibleRows(startIndex, startIndex + (items.length - 1));
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -348,16 +348,19 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
   };
 
-  grid.$connector.set = function (index, items) {
-    if (index % grid.pageSize != 0) {
-      throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + grid.pageSize;
-    }
-    const firstPage = index / grid.pageSize;
+  grid.$connector.set = function (startIndex, items) {
+    const firstPage = startIndex / grid.pageSize;
     const updatedPageCount = Math.ceil(items.length / grid.pageSize);
 
     for (let i = 0; i < updatedPageCount; i++) {
       const page = firstPage + i;
-      cache[page] = items.slice(i * grid.pageSize, (i + 1) * grid.pageSize);
+      for (let j = 0; j < grid.pageSize; j++) {
+        const item = items[page * grid.pageSize + j];
+        if (item) {
+          cache[page] ??= [];
+          cache[page][j] = item;
+        }
+      }
       updateGridCache(page);
     }
 
@@ -365,7 +368,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     grid.$connector.doDeselection(items.filter((item) => !item.selected && selectedKeys[item.key]));
     itemsUpdated(items);
 
-    grid.__updateVisibleRows();
+    grid.__updateVisibleRows(startIndex, startIndex + (items.length - 1));
   };
 
   const itemToCacheLocation = function (item) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -349,13 +349,13 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   };
 
   grid.$connector.set = function (startIndex, items) {
-    const firstPage = startIndex / grid.pageSize;
+    const firstPage = Math.floor(startIndex / grid.pageSize);
     const updatedPageCount = Math.ceil(items.length / grid.pageSize);
 
     for (let i = 0; i < updatedPageCount; i++) {
       const page = firstPage + i;
       for (let j = 0; j < grid.pageSize; j++) {
-        const item = items[page * grid.pageSize + j];
+        const item = items[i * grid.pageSize + j];
         if (item) {
           cache[page] ??= [];
           cache[page][j] = item;
@@ -367,7 +367,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     grid.$connector.doSelection(items.filter((item) => item.selected));
     grid.$connector.doDeselection(items.filter((item) => !item.selected && selectedKeys[item.key]));
     itemsUpdated(items);
-
     grid.__updateVisibleRows(startIndex, startIndex + (items.length - 1));
   };
 


### PR DESCRIPTION
## Description

The PR refactors `$connector.set` so that it can accept item arrays of any size, without mandating them to be aligned with the page size. This makes it possible to use this method for granular viewport updates, e.g. when refreshing items:

```js
$connector.set(0, [{ key: '0', state: 'refreshed' }])
$connector.set(5, [{ key: '5', state: 'refreshed' }])
```

Depends on 
- https://github.com/vaadin/flow-components/pull/7896

Part of https://github.com/vaadin/flow/issues/21989

Should be merged before https://github.com/vaadin/flow/pull/22085

## Type of change

- [x] Refactor
