### PR TITLE
test: update tests to collect items from all arrayUpdate.set calls

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
@@ -45,10 +45,6 @@ public class TreeGridSetViewportRangeByIndexPathTest {
 
     private Update arrayUpdate = Mockito.mock(Update.class);
 
-    @SuppressWarnings("unchecked")
-    private ArgumentCaptor<List<JsonValue>> updateItemsCaptor = ArgumentCaptor
-            .forClass(List.class);
-
     private TreeGrid<String> treeGrid = new TreeGrid<>() {
         @Override
         protected GridArrayUpdater createDefaultArrayUpdater() {
@@ -201,12 +197,16 @@ public class TreeGridSetViewportRangeByIndexPathTest {
         });
     }
 
+    @SuppressWarnings("unchecked")
     private LinkedList<String> captureViewportRange() {
-        Mockito.verify(arrayUpdate).set(Mockito.anyInt(),
-                updateItemsCaptor.capture());
+        ArgumentCaptor<List<JsonValue>> itemsCaptor = ArgumentCaptor
+                .forClass(List.class);
 
-        return updateItemsCaptor.getValue().stream().map(
-                (jsonObject) -> ((JsonObject) jsonObject).getString("name"))
+        Mockito.verify(arrayUpdate).set(Mockito.anyInt(),
+                itemsCaptor.capture());
+
+        return itemsCaptor.getAllValues().stream().flatMap(List::stream).map(
+                (jsonValue) -> ((JsonObject) jsonValue).getString("name"))
                 .collect(Collectors.toCollection(LinkedList::new));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
@@ -205,8 +205,8 @@ public class TreeGridSetViewportRangeByIndexPathTest {
         Mockito.verify(arrayUpdate).set(Mockito.anyInt(),
                 itemsCaptor.capture());
 
-        return itemsCaptor.getAllValues().stream().flatMap(List::stream).map(
-                (jsonValue) -> ((JsonObject) jsonValue).getString("name"))
+        return itemsCaptor.getAllValues().stream().flatMap(List::stream)
+                .map((jsonValue) -> ((JsonObject) jsonValue).getString("name"))
                 .collect(Collectors.toCollection(LinkedList::new));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
@@ -202,7 +202,7 @@ public class TreeGridSetViewportRangeByIndexPathTest {
         ArgumentCaptor<List<JsonValue>> itemsCaptor = ArgumentCaptor
                 .forClass(List.class);
 
-        Mockito.verify(arrayUpdate).set(Mockito.anyInt(),
+        Mockito.verify(arrayUpdate, Mockito.atLeastOnce()).set(Mockito.anyInt(),
                 itemsCaptor.capture());
 
         return itemsCaptor.getAllValues().stream().flatMap(List::stream)


### PR DESCRIPTION
## Description

HierarchicalDataCommunicator can now make multiple `arrayUpdate.set(int, List)` calls, so the tests need to be updated to collect items from each call.

Follow-up to https://github.com/vaadin/flow/issues/21989

## Type of change

- [x] Internal
