### PR TITLE
Provide setThemeVariants for HasThemeVariant interface.

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasThemeVariant.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasThemeVariant.java
@@ -54,4 +54,53 @@ public interface HasThemeVariant<TVariantEnum extends ThemeVariant>
                 .removeAll(Stream.of(variants).map(TVariantEnum::getVariantName)
                         .collect(Collectors.toList()));
     }
+
+    /**
+     * Sets or removes the given theme variant for this component.
+     *
+     * @param variant
+     *            the theme variant to set or remove, not <code>null</code>
+     * @param set
+     *            <code>true</code> to set the theme variant, <code>false</code> to
+     *            remove it
+     */
+    default void setThemeVariant(TVariantEnum variant, boolean set) {
+        if (set) {
+            addThemeVariants(variant);
+        } else {
+            removeThemeVariants(variant);
+        }
+    }
+
+    /**
+     * Sets the theme variants of this component. This method overwrites any
+     * previous set theme variants.
+     *
+     * @param variants
+     *            the theme variants to add, or
+     *            <code>null</code> to remove all class names
+     */
+    default void setThemeVariants(TVariantEnum... variants) {
+        getThemeNames().clear();
+        addThemeVariants(variants);
+    }
+
+
+    /**
+     * Sets or removes the given theme variants for this component.
+     *
+     * @param set
+     *            <code>true</code> to set the theme variant, <code>false</code> to
+     *            remove it
+     * @param variants
+     *            the theme variants to add, or
+     *            <code>null</code> to remove all class names
+     */
+    default void setThemeVariants(boolean set, TVariantEnum... variants) {
+        if (set) {
+            addThemeVariants(variants);
+        } else {
+            removeThemeVariants(variants);
+        }
+    }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasThemeVariantTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasThemeVariantTest.java
@@ -45,8 +45,73 @@ public class HasThemeVariantTest {
                 .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
     }
 
+    @Test
+    public void setThemeVariant_setTrueContainsThemeVariant() {
+        TestComponent component = new TestComponent();
+        component.setThemeVariant(TestComponentVariant.TEST_VARIANT, true);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+    }
+
+    @Test
+    public void setThemeVariant_setFalseDoesNotContainsThemeVariant() {
+        TestComponent component = new TestComponent();
+        component.addThemeVariants(TestComponentVariant.TEST_VARIANT);
+        component.setThemeVariant(TestComponentVariant.TEST_VARIANT, false);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+    }
+
+    @Test
+    public void setThemeVariants_overridesExisting() {
+        TestComponent component = new TestComponent();
+        component.addThemeVariants(TestComponentVariant.TEST_VARIANT);
+        component.setThemeVariants(TestComponentVariant.TEST_VARIANT_2,
+                TestComponentVariant.TEST_VARIANT_3);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT_2.getVariantName()));
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT_3.getVariantName()));
+    }
+
+    @Test
+    public void setThemeVariants_setTrueContainsThemeVariantDoesntOverrideExisting() {
+        TestComponent component = new TestComponent();
+        component.addThemeVariants(TestComponentVariant.TEST_VARIANT_3);
+        component.setThemeVariants(true, TestComponentVariant.TEST_VARIANT, TestComponentVariant.TEST_VARIANT_2);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT_2.getVariantName()));
+    }
+
+    @Test
+    public void setThemeVariants_setFalseContainsThemeVariantDoesntOverrideExisting() {
+        TestComponent component = new TestComponent();
+        component.addThemeVariants(TestComponentVariant.TEST_VARIANT, TestComponentVariant.TEST_VARIANT_2, TestComponentVariant.TEST_VARIANT_3);
+        component.setThemeVariants(false, TestComponentVariant.TEST_VARIANT, TestComponentVariant.TEST_VARIANT_2);
+
+        Set<String> themeNames = component.getThemeNames();
+        Assert.assertFalse(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT.getVariantName()));
+        Assert.assertFalse(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT_2.getVariantName()));
+        Assert.assertTrue(themeNames
+                .contains(TestComponentVariant.TEST_VARIANT_3.getVariantName()));
+    }
+
     private enum TestComponentVariant implements ThemeVariant {
-        TEST_VARIANT("test");
+        TEST_VARIANT("test1"), TEST_VARIANT_2("test2"), TEST_VARIANT_3("test3");
 
         private final String variant;
 


### PR DESCRIPTION
## Description
Introduced 
* `setThemeVariant(TVariantEnum, boolean)`
* `setThemeVariants(TVariantEnum...)`
* `setThemeVariants(boolean, TVariantEnum...)`

**Question 1:**
Not sure about `setThemeVariants(TVariantEnum...)` however. Do we want to override all theme names base on theme variants set? 

**Question 2:**
Should I add tests for each method in each component test, like for the `addThemeVariants` method? 

Fixes # (issue)
#6887

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
