### PR TITLE
feat: add `ButtonRelativeTo` enum; deprecate `DrillUpButtonRelativeTo`

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ButtonRelativeTo.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ButtonRelativeTo.java
@@ -11,12 +11,11 @@ package com.vaadin.flow.component.charts.model;
 /**
  * What box to align the button to.
  */
-@Deprecated(since = "25.0", forRemoval = true)
-public enum DrillUpButtonRelativeTo implements ChartEnum {
+public enum ButtonRelativeTo implements ChartEnum {
 
     PLOTBOX("plotBox"), SPACINGBOX("spacingBox");
 
-    DrillUpButtonRelativeTo(String box) {
+    ButtonRelativeTo(String box) {
         this.box = box;
     }
 


### PR DESCRIPTION
## Description

The enum values found in `DrillUpButtonRelativeTo` are useful for other types that are not related to the drill-up functionality. And since the drill-up button has been deprecated in Highcharts in favor of breadcrumbs, it makes sense to create a new enum with the same values to be used in places like the [reset zoom](https://api.highcharts.com/highcharts/chart.zooming.resetButton.relativeTo) and [breadcrumbs](https://api.highcharts.com/highcharts/drilldown.breadcrumbs.relativeTo) buttons.

Part of #7923
Part of #7946

## Type of change

- Feature