### PR TITLE
refactor: replace elemental with jackson in more components

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -34,11 +34,9 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
-
-import elemental.json.Json;
-import elemental.json.JsonArray;
 
 /**
  * Popover is a component for creating overlays that are positioned next to
@@ -646,18 +644,17 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     private void updateTrigger() {
-        JsonArray trigger = Json.createArray();
-
+        var trigger = JacksonUtils.createArrayNode();
         if (isOpenOnClick()) {
-            trigger.set(trigger.length(), "click");
+            trigger.add("click");
         }
 
         if (isOpenOnHover()) {
-            trigger.set(trigger.length(), "hover");
+            trigger.add("hover");
         }
 
         if (isOpenOnFocus()) {
-            trigger.set(trigger.length(), "focus");
+            trigger.add("focus");
         }
 
         getElement().setPropertyJson("trigger", trigger);

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -28,11 +28,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.server.VaadinService;
-
-import elemental.json.JsonArray;
 
 /**
  * @author Vaadin Ltd.
@@ -173,41 +172,41 @@ public class PopoverTest {
 
     @Test
     public void getTriggerProperty_defaultValue_click() {
-        JsonArray jsonArray = (JsonArray) popover.getElement()
+        var jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(1, jsonArray.length());
-        Assert.assertEquals("click", jsonArray.get(0).asString());
+        Assert.assertEquals(1, jsonArray.size());
+        Assert.assertEquals("click", jsonArray.get(0).asText());
     }
 
     @Test
     public void setOpenOnClick_triggerPropertyUpdated() {
         popover.setOpenOnClick(false);
 
-        JsonArray jsonArray = (JsonArray) popover.getElement()
+        var jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(0, jsonArray.length());
+        Assert.assertEquals(0, jsonArray.size());
     }
 
     @Test
     public void setOpenOnFocus_triggerPropertyUpdated() {
         popover.setOpenOnFocus(true);
 
-        JsonArray jsonArray = (JsonArray) popover.getElement()
+        var jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(2, jsonArray.length());
-        Assert.assertEquals("click", jsonArray.get(0).asString());
-        Assert.assertEquals("focus", jsonArray.get(1).asString());
+        Assert.assertEquals(2, jsonArray.size());
+        Assert.assertEquals("click", jsonArray.get(0).asText());
+        Assert.assertEquals("focus", jsonArray.get(1).asText());
     }
 
     @Test
     public void setOpenOnHover_triggerPropertyUpdated() {
         popover.setOpenOnHover(true);
 
-        JsonArray jsonArray = (JsonArray) popover.getElement()
+        var jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(2, jsonArray.length());
-        Assert.assertEquals("click", jsonArray.get(0).asString());
-        Assert.assertEquals("hover", jsonArray.get(1).asString());
+        Assert.assertEquals(2, jsonArray.size());
+        Assert.assertEquals("click", jsonArray.get(0).asText());
+        Assert.assertEquals("hover", jsonArray.get(1).asText());
     }
 
     @Test

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import org.jsoup.nodes.Document;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.AttachEvent;
@@ -38,11 +39,9 @@ import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.dom.PropertyChangeListener;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JacksonSerializer;
 import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.shared.Registration;
-
-import elemental.json.JsonArray;
 
 /**
  * Rich Text Editor is an input field for entering rich text. It allows you to
@@ -338,8 +337,8 @@ public class RichTextEditor
      * @return an unmodifiable list of colors options
      */
     public List<String> getColorOptions() {
-        List options = JsonSerializer.toObjects(String.class,
-                (JsonArray) getElement().getPropertyRaw("colorOptions"));
+        var options = JacksonSerializer.toObjects(String.class,
+                (ArrayNode) getElement().getPropertyRaw("colorOptions"));
         return Collections.unmodifiableList(options);
     }
 
@@ -354,7 +353,7 @@ public class RichTextEditor
     public void setColorOptions(List<String> colorOptions) {
         Objects.requireNonNull(colorOptions, "Color options must not be null");
         getElement().setPropertyJson("colorOptions",
-                JsonSerializer.toJson(colorOptions));
+                JacksonSerializer.toJson(colorOptions));
     }
 
     static String sanitize(String html) {

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
@@ -27,8 +28,6 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
-
-import elemental.json.JsonArray;
 
 /**
  * Tests for the {@link RichTextEditor}.
@@ -246,9 +245,9 @@ public class RichTextEditorTest {
         RichTextEditor rte = new RichTextEditor();
         rte.setColorOptions(
                 List.of("#000000", "#0066cc", "#008a00", "#e60000"));
-        JsonArray jsonArray = (JsonArray) rte.getElement()
+        var jsonArray = (ArrayNode) rte.getElement()
                 .getPropertyRaw("colorOptions");
-        Assert.assertEquals(4, jsonArray.length());
+        Assert.assertEquals(4, jsonArray.size());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR replaces the elemental usages with Jackson in Popover and RichTextEditor.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.