### PR TITLE
chore: fix npm install for WTR tests

### DIFF
--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -53,7 +53,7 @@ function runTests() {
       });
 
       // Install dependencies required to run the web-test-runner tests
-      execSync(`npm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon @vaadin/testing-helpers --save-dev`, {
+      execSync(`npm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon @vaadin/testing-helpers --save-dev --legacy-peer-deps`, {
         cwd: itFolder,
         stdio: 'inherit'
       });


### PR DESCRIPTION
## Description

`@web/test-runner` has a transitive dependency for `b4a`:
```
wtr-install-test@ /Users/sascha/dev/sandbox/wtr-install-test
└─┬ @web/test-runner@0.20.2
  └─┬ @web/test-runner-chrome@0.18.1
    └─┬ puppeteer-core@24.20.0
      └─┬ @puppeteer/browsers@2.10.9
        └─┬ tar-fs@3.1.0
          └─┬ tar-stream@3.1.7
            ├── b4a@1.7.0
```

`b4a` itself has a peer dependency on `react-native-b4a`, however something seems to be wrong either with that package itself (doesn't show up on npmjs.com), or with how the peer dependency is set up. At least in a Flow project NPM seems to be tripped up by having `"react": "$react"` in `overrides`:
```
904 http fetch GET 200 https://registry.npmjs.org/react-native-b4a 60ms (cache revalidated)
905 silly packumentCache full:https://registry.npmjs.org/react-native-b4a set size:4552 disposed:false
906 verbose stack Error: Unable to resolve reference $react
```

Adding `--legacy-peer-deps` to the install command seems to fix it because it then doesn't try to install / resolve peer dependencies.
