### PR TITLE
feat: add `setPointStart(Instant)` to `ColumnOptions`; deprecate the `Date` overload

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ColumnOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ColumnOptions.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.flow.component.charts.model;
 
+import java.time.Instant;
 import java.util.Date;
 
 import com.vaadin.flow.component.charts.model.style.Color;
@@ -565,7 +566,13 @@ public abstract class ColumnOptions extends AbstractPlotOptions {
     public abstract void removeZone(Zones zone);
 
     /**
+     * @deprecated Use {@link #setPointStart(Instant)} instead.
+     */
+    @Deprecated(since = "24.9", forRemoval = true)
+    public abstract void setPointStart(Date date);
+
+    /**
      * @see #setPointStart(Number)
      */
-    public abstract void setPointStart(Date date);
+    public abstract void setPointStart(Instant instant);
 }


### PR DESCRIPTION
## Description

All the classes that extend the `ColumnOptions` abstract method already have `setPointStart(Date)` as deprecated, while having the alternative with `Instant` as the parameter. The parent method, however, missed this update, which is being done before we remove the method in V25.

Part of #7988

## Type of change

-  Feature
