### PR TITLE
refactor: deprecate resource setter using stream resource

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -3595,7 +3595,11 @@ public class Spreadsheet extends Component
      * com.vaadin.server.Resource)
      *
      * Provides package visibility.
+     *
+     * @deprecated Use #setResource(java.lang.String,
+     * com.vaadin.flow.server.streams.DownloadHandler) instead.
      */
+    @Deprecated(since = "24.9.0", forRemoval = true)
     protected void setResource(String key, StreamResource resource) {
         if (resource == null) {
             resources.remove(key);


### PR DESCRIPTION
## Description

This PR deprecates the Spreadsheet API `setResource` that uses the deprecated `StreamResource` in v24.9.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.