### PR TITLE
feat: add api for getting message input submit button

### DIFF
--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputIT.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputIT.java
@@ -68,7 +68,7 @@ public class MessageInputIT extends AbstractComponentIT {
                 .getPropertyString("placeholder");
         Assert.assertEquals("Viesti", inputPlaceholder);
 
-        String buttonText = messageInput.$("vaadin-button").first().getText();
+        String buttonText = messageInput.getSubmitButton().getText();
         Assert.assertEquals("Lähetä", buttonText);
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageInputElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageInputElement.java
@@ -35,6 +35,15 @@ public class MessageInputElement extends TestBenchElement {
      */
     public void submit(String message) {
         setProperty("value", message);
-        $("vaadin-button").first().click();
+        getSubmitButton().click();
+    }
+
+    /**
+     * Gets the message submit button.
+     *
+     * @return the message submit button
+     */
+    public TestBenchElement getSubmitButton() {
+        return $("vaadin-message-input-button").first();
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageInputElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageInputElement.java
@@ -44,6 +44,6 @@ public class MessageInputElement extends TestBenchElement {
      * @return the message submit button
      */
     public TestBenchElement getSubmitButton() {
-        return $("vaadin-message-input-button").first();
+        return $("*").withAttribute("slot", "button").first();
     }
 }


### PR DESCRIPTION
## Description

Adds `getSubmitButton` to `MessageInputElement`. Follow up from https://github.com/vaadin/web-components/pull/10173 since the `vaadin-button` is replaced with the custom `vaadin-message-input-button`.

Related to [#10170](https://github.com/vaadin/web-components/issues/10170)

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.