### PR TITLE
feat: add missing line width setter for inactive state

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Inactive.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Inactive.java
@@ -51,7 +51,7 @@ public class Inactive extends AbstractConfigurationObject {
 
     /**
      * Enable separate styles for the hovered series to visualize that the user
-     * hovers either the series itself or the legend. .
+     * hovers either the series itself or the legend.
      * <p>
      * Defaults to: true
      */
@@ -64,6 +64,15 @@ public class Inactive extends AbstractConfigurationObject {
      */
     public Number getLineWidth() {
         return lineWidth;
+    }
+
+    /**
+     * Pixel width of the graph line.
+     * <p>
+     * Defaults to: 2
+     */
+    public void setLineWidth(Number lineWidth) {
+        this.lineWidth = lineWidth;
     }
 
     /**

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/ConfigurationJSONSerializationTest.java
@@ -138,13 +138,14 @@ public class ConfigurationJSONSerializationTest {
         States states = options.getStates();
         Inactive inactive = states.getInactive();
         inactive.setOpacity(1.0);
+        inactive.setLineWidth(2.0);
         inactive.setBorderColor(new SolidColor("#000000"));
         inactive.setColor(new SolidColor("#808080"));
         inactive.setAnimation(false);
         conf.setPlotOptions(options);
 
         assertEquals(
-                "{\"chart\":{\"styledMode\":false},\"exporting\":{\"enabled\":false},\"plotOptions\":{\"pie\":{\"states\":{\"inactive\":{\"animation\":false,\"borderColor\":\"#000000\",\"color\":\"#808080\",\"opacity\":1.0}}}},\"series\":[]}",
+                "{\"chart\":{\"styledMode\":false},\"exporting\":{\"enabled\":false},\"plotOptions\":{\"pie\":{\"states\":{\"inactive\":{\"animation\":false,\"borderColor\":\"#000000\",\"color\":\"#808080\",\"lineWidth\":2.0,\"opacity\":1.0}}}},\"series\":[]}",
                 toJSON(conf));
     }
 


### PR DESCRIPTION
## Description

The `Inactive` state in charts has a getter for `lineWidth`, but is missing the setter for it. This PR adds the setter and updates the serialization test to use the setter.

No related issue.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.