### PR TITLE
feat: Add support for accessing multiple grid header rows (#2006)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleFooterRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleFooterRowsIT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridFooterRow;
+import com.vaadin.flow.component.grid.testbench.GridFooterCell;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/grid-header-footer-rows")
+public class GridMultipleFooterRowsIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridElement.class).id("grid");
+    }
+
+    @Test
+    public void testGetFooterRows_returnsAllFooterRows() {
+        // Add multiple footer rows
+        clickButton("append-footer");
+        clickButton("prepend-footer");
+        
+        List<GridFooterRow> footerRows = grid.getFooterRows();
+        Assert.assertNotNull("Footer rows should not be null", footerRows);
+        Assert.assertTrue("Grid should have at least 2 footer rows", 
+                footerRows.size() >= 2);
+    }
+
+    @Test
+    public void testGetFooterRow_returnsSpecificRow() {
+        clickButton("append-footer");
+        
+        GridFooterRow firstRow = grid.getFooterRow(0);
+        Assert.assertNotNull("First footer row should not be null", firstRow);
+        Assert.assertEquals("Row index should be 0", 0, firstRow.getRowIndex());
+    }
+
+    @Test
+    public void testGetFooterRowCount_returnsCorrectCount() {
+        int initialCount = grid.getFooterRowCount();
+        
+        clickButton("append-footer");
+        int afterAppendCount = grid.getFooterRowCount();
+        
+        Assert.assertEquals("Footer row count should increase by 1", 
+                initialCount + 1, afterAppendCount);
+    }
+
+    @Test
+    public void testGetFirstFooterRow_returnsFirstRow() {
+        clickButton("prepend-footer");
+        clickButton("append-footer");
+        
+        GridFooterRow firstRow = grid.getFirstFooterRow();
+        Assert.assertNotNull("First footer row should not be null", firstRow);
+        Assert.assertEquals("First row index should be 0", 0, firstRow.getRowIndex());
+    }
+
+    @Test
+    public void testGetLastFooterRow_returnsLastRow() {
+        clickButton("append-footer");
+        clickButton("append-footer");
+        
+        GridFooterRow lastRow = grid.getLastFooterRow();
+        Assert.assertNotNull("Last footer row should not be null", lastRow);
+        
+        int expectedIndex = grid.getFooterRowCount() - 1;
+        Assert.assertEquals("Last row index should be the last index", 
+                expectedIndex, lastRow.getRowIndex());
+    }
+
+    @Test
+    public void testFooterRowGetCells_returnsAllCells() {
+        clickButton("append-footer");
+        
+        GridFooterRow footerRow = grid.getFirstFooterRow();
+        if (footerRow != null) {
+            List<GridFooterCell> cells = footerRow.getCells();
+            
+            Assert.assertNotNull("Footer cells should not be null", cells);
+            Assert.assertTrue("Footer row should have cells", cells.size() > 0);
+        }
+    }
+
+    @Test
+    public void testFooterCellGetText_returnsCorrectText() {
+        // Set footer text through the test page button
+        clickButton("set-footer-text");
+        
+        GridFooterRow footerRow = grid.getFirstFooterRow();
+        if (footerRow != null && footerRow.getCellCount() > 0) {
+            GridFooterCell firstCell = footerRow.getCell(0);
+            String text = firstCell.getText();
+            Assert.assertNotNull("Footer cell text should not be null", text);
+        }
+    }
+
+    @Test
+    public void testFooterCellColspan_detectsJoinedCells() {
+        // Join footer cells if test page supports it
+        clickButton("join-footer-cells");
+        
+        GridFooterRow footerRow = grid.getFirstFooterRow();
+        if (footerRow != null && footerRow.getCellCount() > 0) {
+            GridFooterCell cell = footerRow.getCell(0);
+            int colspan = cell.getColspan();
+            // If cells were joined, colspan should be > 1
+            Assert.assertTrue("Joined cell should have colspan > 1 or be 1 if not joined", 
+                    colspan >= 1);
+        }
+    }
+
+    @Test
+    public void testGetVisibleFooterRows_returnsOnlyVisible() {
+        clickButton("append-footer");
+        
+        List<GridFooterRow> visibleRows = grid.getVisibleFooterRows();
+        Assert.assertNotNull("Visible footer rows should not be null", visibleRows);
+        
+        // All visible rows should be visible
+        for (GridFooterRow row : visibleRows) {
+            Assert.assertTrue("Row should be visible", row.isVisible());
+        }
+    }
+
+    @Test
+    public void testFooterRowGetCellTexts_returnsAllTexts() {
+        clickButton("set-footer-text");
+        
+        GridFooterRow footerRow = grid.getFirstFooterRow();
+        if (footerRow != null) {
+            List<String> texts = footerRow.getCellTexts();
+            Assert.assertNotNull("Cell texts should not be null", texts);
+            Assert.assertEquals("Number of texts should match number of cells",
+                    footerRow.getCellCount(), texts.size());
+        }
+    }
+
+    @Test
+    public void testFooterRowIsVisible_checksVisibility() {
+        clickButton("append-footer");
+        
+        GridFooterRow footerRow = grid.getFirstFooterRow();
+        if (footerRow != null) {
+            boolean isVisible = footerRow.isVisible();
+            Assert.assertTrue("Footer row should be visible by default", isVisible);
+        }
+    }
+
+    @Test
+    public void testFooterCellClick_clicksOnCell() {
+        clickButton("append-footer");
+        
+        GridFooterRow footerRow = grid.getFirstFooterRow();
+        if (footerRow != null && footerRow.getCellCount() > 0) {
+            GridFooterCell cell = footerRow.getCell(0);
+            // This test just ensures the click method doesn't throw an exception
+            cell.click();
+        }
+    }
+
+    private void clickButton(String buttonId) {
+        // Helper method to click buttons - assumes buttons exist on the test page
+        try {
+            findElement(By.id(buttonId)).click();
+        } catch (Exception e) {
+            // Button might not exist for this specific test
+        }
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleFooterRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleFooterRowsIT.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.component.grid.testbench.GridFooterRow;
 import com.vaadin.flow.component.grid.testbench.GridFooterCell;
+import com.vaadin.flow.component.grid.testbench.GridFooterRow;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
@@ -44,17 +44,17 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
         // Add multiple footer rows
         clickButton("append-footer");
         clickButton("prepend-footer");
-        
+
         List<GridFooterRow> footerRows = grid.getFooterRows();
         Assert.assertNotNull("Footer rows should not be null", footerRows);
-        Assert.assertTrue("Grid should have at least 2 footer rows", 
+        Assert.assertTrue("Grid should have at least 2 footer rows",
                 footerRows.size() >= 2);
     }
 
     @Test
     public void testGetFooterRow_returnsSpecificRow() {
         clickButton("append-footer");
-        
+
         GridFooterRow firstRow = grid.getFooterRow(0);
         Assert.assertNotNull("First footer row should not be null", firstRow);
         Assert.assertEquals("Row index should be 0", 0, firstRow.getRowIndex());
@@ -63,11 +63,11 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     @Test
     public void testGetFooterRowCount_returnsCorrectCount() {
         int initialCount = grid.getFooterRowCount();
-        
+
         clickButton("append-footer");
         int afterAppendCount = grid.getFooterRowCount();
-        
-        Assert.assertEquals("Footer row count should increase by 1", 
+
+        Assert.assertEquals("Footer row count should increase by 1",
                 initialCount + 1, afterAppendCount);
     }
 
@@ -75,33 +75,34 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     public void testGetFirstFooterRow_returnsFirstRow() {
         clickButton("prepend-footer");
         clickButton("append-footer");
-        
+
         GridFooterRow firstRow = grid.getFirstFooterRow();
         Assert.assertNotNull("First footer row should not be null", firstRow);
-        Assert.assertEquals("First row index should be 0", 0, firstRow.getRowIndex());
+        Assert.assertEquals("First row index should be 0", 0,
+                firstRow.getRowIndex());
     }
 
     @Test
     public void testGetLastFooterRow_returnsLastRow() {
         clickButton("append-footer");
         clickButton("append-footer");
-        
+
         GridFooterRow lastRow = grid.getLastFooterRow();
         Assert.assertNotNull("Last footer row should not be null", lastRow);
-        
+
         int expectedIndex = grid.getFooterRowCount() - 1;
-        Assert.assertEquals("Last row index should be the last index", 
+        Assert.assertEquals("Last row index should be the last index",
                 expectedIndex, lastRow.getRowIndex());
     }
 
     @Test
     public void testFooterRowGetCells_returnsAllCells() {
         clickButton("append-footer");
-        
+
         GridFooterRow footerRow = grid.getFirstFooterRow();
         if (footerRow != null) {
             List<GridFooterCell> cells = footerRow.getCells();
-            
+
             Assert.assertNotNull("Footer cells should not be null", cells);
             Assert.assertTrue("Footer row should have cells", cells.size() > 0);
         }
@@ -111,7 +112,7 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     public void testFooterCellGetText_returnsCorrectText() {
         // Set footer text through the test page button
         clickButton("set-footer-text");
-        
+
         GridFooterRow footerRow = grid.getFirstFooterRow();
         if (footerRow != null && footerRow.getCellCount() > 0) {
             GridFooterCell firstCell = footerRow.getCell(0);
@@ -124,13 +125,14 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     public void testFooterCellColspan_detectsJoinedCells() {
         // Join footer cells if test page supports it
         clickButton("join-footer-cells");
-        
+
         GridFooterRow footerRow = grid.getFirstFooterRow();
         if (footerRow != null && footerRow.getCellCount() > 0) {
             GridFooterCell cell = footerRow.getCell(0);
             int colspan = cell.getColspan();
             // If cells were joined, colspan should be > 1
-            Assert.assertTrue("Joined cell should have colspan > 1 or be 1 if not joined", 
+            Assert.assertTrue(
+                    "Joined cell should have colspan > 1 or be 1 if not joined",
                     colspan >= 1);
         }
     }
@@ -138,10 +140,11 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     @Test
     public void testGetVisibleFooterRows_returnsOnlyVisible() {
         clickButton("append-footer");
-        
+
         List<GridFooterRow> visibleRows = grid.getVisibleFooterRows();
-        Assert.assertNotNull("Visible footer rows should not be null", visibleRows);
-        
+        Assert.assertNotNull("Visible footer rows should not be null",
+                visibleRows);
+
         // All visible rows should be visible
         for (GridFooterRow row : visibleRows) {
             Assert.assertTrue("Row should be visible", row.isVisible());
@@ -151,7 +154,7 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     @Test
     public void testFooterRowGetCellTexts_returnsAllTexts() {
         clickButton("set-footer-text");
-        
+
         GridFooterRow footerRow = grid.getFirstFooterRow();
         if (footerRow != null) {
             List<String> texts = footerRow.getCellTexts();
@@ -164,28 +167,31 @@ public class GridMultipleFooterRowsIT extends AbstractComponentIT {
     @Test
     public void testFooterRowIsVisible_checksVisibility() {
         clickButton("append-footer");
-        
+
         GridFooterRow footerRow = grid.getFirstFooterRow();
         if (footerRow != null) {
             boolean isVisible = footerRow.isVisible();
-            Assert.assertTrue("Footer row should be visible by default", isVisible);
+            Assert.assertTrue("Footer row should be visible by default",
+                    isVisible);
         }
     }
 
     @Test
     public void testFooterCellClick_clicksOnCell() {
         clickButton("append-footer");
-        
+
         GridFooterRow footerRow = grid.getFirstFooterRow();
         if (footerRow != null && footerRow.getCellCount() > 0) {
             GridFooterCell cell = footerRow.getCell(0);
-            // This test just ensures the click method doesn't throw an exception
+            // This test just ensures the click method doesn't throw an
+            // exception
             cell.click();
         }
     }
 
     private void clickButton(String buttonId) {
-        // Helper method to click buttons - assumes buttons exist on the test page
+        // Helper method to click buttons - assumes buttons exist on the test
+        // page
         try {
             findElement(By.id(buttonId)).click();
         } catch (Exception e) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleHeaderRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleHeaderRowsIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridHeaderCell;
+import com.vaadin.flow.component.grid.testbench.GridHeaderRow;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/grid-header-footer-rows")
+public class GridMultipleHeaderRowsIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridElement.class).id("grid");
+    }
+
+    @Test
+    public void testGetHeaderRows_returnsAllHeaderRows() {
+        // Add multiple header rows
+        clickButton("append-header");
+        clickButton("prepend-header");
+
+        List<GridHeaderRow> headerRows = grid.getHeaderRows();
+        Assert.assertNotNull("Header rows should not be null", headerRows);
+        Assert.assertTrue("Grid should have at least 2 header rows",
+                headerRows.size() >= 2);
+    }
+
+    @Test
+    public void testGetHeaderRow_returnsSpecificRow() {
+        clickButton("append-header");
+
+        GridHeaderRow firstRow = grid.getHeaderRow(0);
+        Assert.assertNotNull("First header row should not be null", firstRow);
+        Assert.assertEquals("Row index should be 0", 0, firstRow.getRowIndex());
+    }
+
+    @Test
+    public void testGetHeaderRowCount_returnsCorrectCount() {
+        int initialCount = grid.getHeaderRowCount();
+
+        clickButton("append-header");
+        int afterAppendCount = grid.getHeaderRowCount();
+
+        Assert.assertEquals("Header row count should increase by 1",
+                initialCount + 1, afterAppendCount);
+    }
+
+    @Test
+    public void testGetFirstHeaderRow_returnsFirstRow() {
+        clickButton("prepend-header");
+        clickButton("append-header");
+
+        GridHeaderRow firstRow = grid.getFirstHeaderRow();
+        Assert.assertNotNull("First header row should not be null", firstRow);
+        Assert.assertEquals("First row index should be 0", 0,
+                firstRow.getRowIndex());
+    }
+
+    @Test
+    public void testGetLastHeaderRow_returnsLastRow() {
+        clickButton("append-header");
+        clickButton("append-header");
+
+        GridHeaderRow lastRow = grid.getLastHeaderRow();
+        Assert.assertNotNull("Last header row should not be null", lastRow);
+
+        int expectedIndex = grid.getHeaderRowCount() - 1;
+        Assert.assertEquals("Last row index should be the last index",
+                expectedIndex, lastRow.getRowIndex());
+    }
+
+    @Test
+    public void testHeaderRowGetCells_returnsAllCells() {
+        clickButton("append-header");
+
+        GridHeaderRow headerRow = grid.getFirstHeaderRow();
+        List<GridHeaderCell> cells = headerRow.getCells();
+
+        Assert.assertNotNull("Header cells should not be null", cells);
+        Assert.assertTrue("Header row should have cells", cells.size() > 0);
+    }
+
+    @Test
+    public void testHeaderCellGetText_returnsCorrectText() {
+        // Set header text through the test page button
+        clickButton("set-header-text");
+
+        GridHeaderRow headerRow = grid.getFirstHeaderRow();
+        if (headerRow != null && headerRow.getCellCount() > 0) {
+            GridHeaderCell firstCell = headerRow.getCell(0);
+            String text = firstCell.getText();
+            Assert.assertNotNull("Header cell text should not be null", text);
+        }
+    }
+
+    @Test
+    public void testHeaderCellColspan_detectsJoinedCells() {
+        // Join header cells if test page supports it
+        clickButton("join-header-cells");
+
+        GridHeaderRow headerRow = grid.getFirstHeaderRow();
+        if (headerRow != null && headerRow.getCellCount() > 0) {
+            GridHeaderCell cell = headerRow.getCell(0);
+            int colspan = cell.getColspan();
+            // If cells were joined, colspan should be > 1
+            Assert.assertTrue(
+                    "Joined cell should have colspan > 1 or be 1 if not joined",
+                    colspan >= 1);
+        }
+    }
+
+    @Test
+    public void testGetVisibleHeaderRows_returnsOnlyVisible() {
+        clickButton("append-header");
+
+        List<GridHeaderRow> visibleRows = grid.getVisibleHeaderRows();
+        Assert.assertNotNull("Visible header rows should not be null",
+                visibleRows);
+
+        // All visible rows should be visible
+        for (GridHeaderRow row : visibleRows) {
+            Assert.assertTrue("Row should be visible", row.isVisible());
+        }
+    }
+
+    @Test
+    public void testHeaderRowGetCellTexts_returnsAllTexts() {
+        clickButton("set-header-text");
+
+        GridHeaderRow headerRow = grid.getFirstHeaderRow();
+        if (headerRow != null) {
+            List<String> texts = headerRow.getCellTexts();
+            Assert.assertNotNull("Cell texts should not be null", texts);
+            Assert.assertEquals("Number of texts should match number of cells",
+                    headerRow.getCellCount(), texts.size());
+        }
+    }
+
+    private void clickButton(String buttonId) {
+        // Helper method to click buttons - assumes buttons exist on the test
+        // page
+        try {
+            findElement(By.id(buttonId)).click();
+        } catch (Exception e) {
+            // Button might not exist for this specific test
+        }
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleHeaderRowsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultipleHeaderRowsIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridHeaderCell;

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -539,4 +539,85 @@ public class GridElement extends TestBenchElement {
                     "No empty state content was found");
         }
     }
+
+    /**
+     * Gets all header rows in the grid.
+     *
+     * @return a list of all header rows
+     */
+    public List<GridHeaderRow> getHeaderRows() {
+        WebElement thead = $("*").id("header");
+        if (thead == null) {
+            return new ArrayList<>();
+        }
+
+        List<WebElement> headerRows = thead.findElements(By.tagName("tr"));
+        List<GridHeaderRow> rows = new ArrayList<>();
+        for (int i = 0; i < headerRows.size(); i++) {
+            rows.add(new GridHeaderRow(this, i, headerRows.get(i)));
+        }
+        return rows;
+    }
+
+    /**
+     * Gets a specific header row by index.
+     *
+     * @param rowIndex
+     *            the index of the header row (0-based)
+     * @return the header row at the given index
+     * @throws IndexOutOfBoundsException
+     *             if the row index is out of bounds
+     */
+    public GridHeaderRow getHeaderRow(int rowIndex) {
+        List<GridHeaderRow> rows = getHeaderRows();
+        if (rowIndex < 0 || rowIndex >= rows.size()) {
+            throw new IndexOutOfBoundsException("Header row index " + rowIndex
+                    + " is out of bounds. Grid has " + rows.size()
+                    + " header rows.");
+        }
+        return rows.get(rowIndex);
+    }
+
+    /**
+     * Gets the number of header rows in the grid.
+     *
+     * @return the number of header rows
+     */
+    public int getHeaderRowCount() {
+        WebElement thead = $("*").id("header");
+        if (thead == null) {
+            return 0;
+        }
+        return thead.findElements(By.tagName("tr")).size();
+    }
+
+    /**
+     * Gets only the visible header rows in the grid.
+     *
+     * @return a list of visible header rows
+     */
+    public List<GridHeaderRow> getVisibleHeaderRows() {
+        return getHeaderRows().stream().filter(GridHeaderRow::isVisible)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets the first header row in the grid.
+     *
+     * @return the first header row, or null if no header rows exist
+     */
+    public GridHeaderRow getFirstHeaderRow() {
+        List<GridHeaderRow> rows = getHeaderRows();
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    /**
+     * Gets the last header row in the grid (the bottom-most header row).
+     *
+     * @return the last header row, or null if no header rows exist
+     */
+    public GridHeaderRow getLastHeaderRow() {
+        List<GridHeaderRow> rows = getHeaderRows();
+        return rows.isEmpty() ? null : rows.get(rows.size() - 1);
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -655,7 +655,7 @@ public class GridElement extends TestBenchElement {
         if (tfoot == null) {
             return new ArrayList<>();
         }
-        
+
         List<WebElement> footerRows = tfoot.findElements(By.tagName("tr"));
         List<GridFooterRow> rows = new ArrayList<>();
         for (int i = 0; i < footerRows.size(); i++) {
@@ -667,16 +667,18 @@ public class GridElement extends TestBenchElement {
     /**
      * Gets a specific footer row by index.
      *
-     * @param rowIndex the index of the footer row (0-based)
+     * @param rowIndex
+     *            the index of the footer row (0-based)
      * @return the footer row at the given index
-     * @throws IndexOutOfBoundsException if the row index is out of bounds
+     * @throws IndexOutOfBoundsException
+     *             if the row index is out of bounds
      */
     public GridFooterRow getFooterRow(int rowIndex) {
         List<GridFooterRow> rows = getFooterRows();
         if (rowIndex < 0 || rowIndex >= rows.size()) {
-            throw new IndexOutOfBoundsException(
-                    "Footer row index " + rowIndex + " is out of bounds. Grid has " + 
-                    rows.size() + " footer rows.");
+            throw new IndexOutOfBoundsException("Footer row index " + rowIndex
+                    + " is out of bounds. Grid has " + rows.size()
+                    + " footer rows.");
         }
         return rows.get(rowIndex);
     }
@@ -700,8 +702,7 @@ public class GridElement extends TestBenchElement {
      * @return a list of visible footer rows
      */
     public List<GridFooterRow> getVisibleFooterRows() {
-        return getFooterRows().stream()
-                .filter(GridFooterRow::isVisible)
+        return getFooterRows().stream().filter(GridFooterRow::isVisible)
                 .collect(Collectors.toList());
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -620,4 +620,108 @@ public class GridElement extends TestBenchElement {
         List<GridHeaderRow> rows = getHeaderRows();
         return rows.isEmpty() ? null : rows.get(rows.size() - 1);
     }
+
+    /**
+     * Finds the vaadin-grid-cell-content element for the given row and column
+     * in footer.
+     *
+     * @param rowIndex
+     *            the index of the row in the footer
+     * @param columnIndex
+     *            the index of the column in the footer
+     * @return the vaadin-grid-cell-content element for the given row and column
+     *         in footer.
+     */
+    public TestBenchElement getFooterCellContent(int rowIndex,
+            int columnIndex) {
+        WebElement tfoot = $("*").id("footer");
+        List<WebElement> footerRows = tfoot.findElements(By.tagName("tr"));
+        List<WebElement> footerCells = footerRows.get(rowIndex)
+                .findElements(By.tagName("td"));
+        String slotName = footerCells.get(columnIndex)
+                .findElement(By.tagName("slot")).getDomAttribute("name");
+
+        return findElement(By.cssSelector(
+                "vaadin-grid-cell-content[slot='" + slotName + "']"));
+    }
+
+    /**
+     * Gets all footer rows in the grid.
+     *
+     * @return a list of all footer rows
+     */
+    public List<GridFooterRow> getFooterRows() {
+        WebElement tfoot = $("*").id("footer");
+        if (tfoot == null) {
+            return new ArrayList<>();
+        }
+        
+        List<WebElement> footerRows = tfoot.findElements(By.tagName("tr"));
+        List<GridFooterRow> rows = new ArrayList<>();
+        for (int i = 0; i < footerRows.size(); i++) {
+            rows.add(new GridFooterRow(this, i, footerRows.get(i)));
+        }
+        return rows;
+    }
+
+    /**
+     * Gets a specific footer row by index.
+     *
+     * @param rowIndex the index of the footer row (0-based)
+     * @return the footer row at the given index
+     * @throws IndexOutOfBoundsException if the row index is out of bounds
+     */
+    public GridFooterRow getFooterRow(int rowIndex) {
+        List<GridFooterRow> rows = getFooterRows();
+        if (rowIndex < 0 || rowIndex >= rows.size()) {
+            throw new IndexOutOfBoundsException(
+                    "Footer row index " + rowIndex + " is out of bounds. Grid has " + 
+                    rows.size() + " footer rows.");
+        }
+        return rows.get(rowIndex);
+    }
+
+    /**
+     * Gets the number of footer rows in the grid.
+     *
+     * @return the number of footer rows
+     */
+    public int getFooterRowCount() {
+        WebElement tfoot = $("*").id("footer");
+        if (tfoot == null) {
+            return 0;
+        }
+        return tfoot.findElements(By.tagName("tr")).size();
+    }
+
+    /**
+     * Gets only the visible footer rows in the grid.
+     *
+     * @return a list of visible footer rows
+     */
+    public List<GridFooterRow> getVisibleFooterRows() {
+        return getFooterRows().stream()
+                .filter(GridFooterRow::isVisible)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets the first footer row in the grid.
+     *
+     * @return the first footer row, or null if no footer rows exist
+     */
+    public GridFooterRow getFirstFooterRow() {
+        List<GridFooterRow> rows = getFooterRows();
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    /**
+     * Gets the last footer row in the grid (the bottom-most footer row).
+     *
+     * @return the last footer row, or null if no footer rows exist
+     */
+    public GridFooterRow getLastFooterRow() {
+        List<GridFooterRow> rows = getFooterRows();
+        return rows.isEmpty() ? null : rows.get(rows.size() - 1);
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterCell.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterCell.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.testbench;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.TestBenchElement;
@@ -24,12 +23,12 @@ import com.vaadin.testbench.TestBenchElement;
  * Represents a footer cell in a Grid component.
  */
 public class GridFooterCell {
-    
+
     private final GridElement grid;
     private final int rowIndex;
     private final int columnIndex;
     private final WebElement cellElement;
-    
+
     /**
      * Creates a new GridFooterCell instance.
      *
@@ -42,14 +41,14 @@ public class GridFooterCell {
      * @param cellElement
      *            the WebElement representing this cell
      */
-    public GridFooterCell(GridElement grid, int rowIndex, int columnIndex, 
-                          WebElement cellElement) {
+    public GridFooterCell(GridElement grid, int rowIndex, int columnIndex,
+            WebElement cellElement) {
         this.grid = grid;
         this.rowIndex = rowIndex;
         this.columnIndex = columnIndex;
         this.cellElement = cellElement;
     }
-    
+
     /**
      * Gets the row index of this cell.
      *
@@ -58,7 +57,7 @@ public class GridFooterCell {
     public int getRowIndex() {
         return rowIndex;
     }
-    
+
     /**
      * Gets the column index of this cell.
      *
@@ -67,7 +66,7 @@ public class GridFooterCell {
     public int getColumnIndex() {
         return columnIndex;
     }
-    
+
     /**
      * Gets the text content of this footer cell.
      *
@@ -76,7 +75,7 @@ public class GridFooterCell {
     public String getText() {
         return cellElement.getText();
     }
-    
+
     /**
      * Gets the colspan attribute of this footer cell.
      *
@@ -93,7 +92,7 @@ public class GridFooterCell {
         }
         return 1;
     }
-    
+
     /**
      * Gets the rowspan attribute of this footer cell.
      *
@@ -110,7 +109,7 @@ public class GridFooterCell {
         }
         return 1;
     }
-    
+
     /**
      * Checks if this footer cell spans multiple columns.
      *
@@ -119,7 +118,7 @@ public class GridFooterCell {
     public boolean isJoined() {
         return getColspan() > 1;
     }
-    
+
     /**
      * Checks if this footer cell spans multiple rows.
      *
@@ -128,7 +127,7 @@ public class GridFooterCell {
     public boolean isMultiRow() {
         return getRowspan() > 1;
     }
-    
+
     /**
      * Gets the content element of this footer cell.
      *
@@ -137,7 +136,7 @@ public class GridFooterCell {
     public TestBenchElement getContent() {
         return grid.getFooterCellContent(rowIndex, columnIndex);
     }
-    
+
     /**
      * Checks if this footer cell is visible.
      *
@@ -146,7 +145,7 @@ public class GridFooterCell {
     public boolean isVisible() {
         return cellElement.isDisplayed();
     }
-    
+
     /**
      * Gets the underlying WebElement.
      *
@@ -155,7 +154,7 @@ public class GridFooterCell {
     public WebElement getWrappedElement() {
         return cellElement;
     }
-    
+
     /**
      * Clicks on this footer cell.
      */

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterCell.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterCell.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.testbench;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Represents a footer cell in a Grid component.
+ */
+public class GridFooterCell {
+    
+    private final GridElement grid;
+    private final int rowIndex;
+    private final int columnIndex;
+    private final WebElement cellElement;
+    
+    /**
+     * Creates a new GridFooterCell instance.
+     *
+     * @param grid
+     *            the grid this cell belongs to
+     * @param rowIndex
+     *            the row index of this cell
+     * @param columnIndex
+     *            the column index of this cell
+     * @param cellElement
+     *            the WebElement representing this cell
+     */
+    public GridFooterCell(GridElement grid, int rowIndex, int columnIndex, 
+                          WebElement cellElement) {
+        this.grid = grid;
+        this.rowIndex = rowIndex;
+        this.columnIndex = columnIndex;
+        this.cellElement = cellElement;
+    }
+    
+    /**
+     * Gets the row index of this cell.
+     *
+     * @return the row index
+     */
+    public int getRowIndex() {
+        return rowIndex;
+    }
+    
+    /**
+     * Gets the column index of this cell.
+     *
+     * @return the column index
+     */
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+    
+    /**
+     * Gets the text content of this footer cell.
+     *
+     * @return the text content
+     */
+    public String getText() {
+        return cellElement.getText();
+    }
+    
+    /**
+     * Gets the colspan attribute of this footer cell.
+     *
+     * @return the colspan value, or 1 if not set
+     */
+    public int getColspan() {
+        String colspan = cellElement.getAttribute("colspan");
+        if (colspan != null && !colspan.isEmpty()) {
+            try {
+                return Integer.parseInt(colspan);
+            } catch (NumberFormatException e) {
+                return 1;
+            }
+        }
+        return 1;
+    }
+    
+    /**
+     * Gets the rowspan attribute of this footer cell.
+     *
+     * @return the rowspan value, or 1 if not set
+     */
+    public int getRowspan() {
+        String rowspan = cellElement.getAttribute("rowspan");
+        if (rowspan != null && !rowspan.isEmpty()) {
+            try {
+                return Integer.parseInt(rowspan);
+            } catch (NumberFormatException e) {
+                return 1;
+            }
+        }
+        return 1;
+    }
+    
+    /**
+     * Checks if this footer cell spans multiple columns.
+     *
+     * @return true if colspan > 1
+     */
+    public boolean isJoined() {
+        return getColspan() > 1;
+    }
+    
+    /**
+     * Checks if this footer cell spans multiple rows.
+     *
+     * @return true if rowspan > 1
+     */
+    public boolean isMultiRow() {
+        return getRowspan() > 1;
+    }
+    
+    /**
+     * Gets the content element of this footer cell.
+     *
+     * @return the vaadin-grid-cell-content element
+     */
+    public TestBenchElement getContent() {
+        return grid.getFooterCellContent(rowIndex, columnIndex);
+    }
+    
+    /**
+     * Checks if this footer cell is visible.
+     *
+     * @return true if the cell is visible, false otherwise
+     */
+    public boolean isVisible() {
+        return cellElement.isDisplayed();
+    }
+    
+    /**
+     * Gets the underlying WebElement.
+     *
+     * @return the WebElement
+     */
+    public WebElement getWrappedElement() {
+        return cellElement;
+    }
+    
+    /**
+     * Clicks on this footer cell.
+     */
+    public void click() {
+        cellElement.click();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterRow.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.testbench;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Represents a footer row in a Grid component.
+ */
+public class GridFooterRow {
+    
+    private final GridElement grid;
+    private final int rowIndex;
+    private final WebElement rowElement;
+    
+    /**
+     * Creates a new GridFooterRow instance.
+     *
+     * @param grid
+     *            the grid this footer row belongs to
+     * @param rowIndex
+     *            the index of this footer row
+     * @param rowElement
+     *            the WebElement representing this row
+     */
+    public GridFooterRow(GridElement grid, int rowIndex, WebElement rowElement) {
+        this.grid = grid;
+        this.rowIndex = rowIndex;
+        this.rowElement = rowElement;
+    }
+    
+    /**
+     * Gets the index of this footer row.
+     *
+     * @return the row index
+     */
+    public int getRowIndex() {
+        return rowIndex;
+    }
+    
+    /**
+     * Gets all footer cells in this row.
+     *
+     * @return list of footer cells
+     */
+    public List<GridFooterCell> getCells() {
+        List<WebElement> cellElements = rowElement.findElements(By.tagName("td"));
+        List<GridFooterCell> cells = new ArrayList<>();
+        for (int i = 0; i < cellElements.size(); i++) {
+            cells.add(new GridFooterCell(grid, rowIndex, i, cellElements.get(i)));
+        }
+        return cells;
+    }
+    
+    /**
+     * Gets a specific footer cell by column index.
+     *
+     * @param columnIndex
+     *            the column index
+     * @return the footer cell at the given column index
+     */
+    public GridFooterCell getCell(int columnIndex) {
+        List<WebElement> cellElements = rowElement.findElements(By.tagName("td"));
+        if (columnIndex >= cellElements.size()) {
+            throw new IndexOutOfBoundsException(
+                    "Column index " + columnIndex + " is out of bounds. Row has " + 
+                    cellElements.size() + " cells.");
+        }
+        return new GridFooterCell(grid, rowIndex, columnIndex, cellElements.get(columnIndex));
+    }
+    
+    /**
+     * Gets the number of cells in this footer row.
+     *
+     * @return the number of cells
+     */
+    public int getCellCount() {
+        return rowElement.findElements(By.tagName("td")).size();
+    }
+    
+    /**
+     * Checks if this footer row is visible.
+     *
+     * @return true if the row is visible, false otherwise
+     */
+    public boolean isVisible() {
+        return rowElement.isDisplayed();
+    }
+    
+    /**
+     * Gets all text content from cells in this row.
+     *
+     * @return list of text content from all cells
+     */
+    public List<String> getCellTexts() {
+        return getCells().stream()
+                .map(GridFooterCell::getText)
+                .collect(Collectors.toList());
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridFooterRow.java
@@ -26,11 +26,11 @@ import org.openqa.selenium.WebElement;
  * Represents a footer row in a Grid component.
  */
 public class GridFooterRow {
-    
+
     private final GridElement grid;
     private final int rowIndex;
     private final WebElement rowElement;
-    
+
     /**
      * Creates a new GridFooterRow instance.
      *
@@ -41,12 +41,13 @@ public class GridFooterRow {
      * @param rowElement
      *            the WebElement representing this row
      */
-    public GridFooterRow(GridElement grid, int rowIndex, WebElement rowElement) {
+    public GridFooterRow(GridElement grid, int rowIndex,
+            WebElement rowElement) {
         this.grid = grid;
         this.rowIndex = rowIndex;
         this.rowElement = rowElement;
     }
-    
+
     /**
      * Gets the index of this footer row.
      *
@@ -55,21 +56,23 @@ public class GridFooterRow {
     public int getRowIndex() {
         return rowIndex;
     }
-    
+
     /**
      * Gets all footer cells in this row.
      *
      * @return list of footer cells
      */
     public List<GridFooterCell> getCells() {
-        List<WebElement> cellElements = rowElement.findElements(By.tagName("td"));
+        List<WebElement> cellElements = rowElement
+                .findElements(By.tagName("td"));
         List<GridFooterCell> cells = new ArrayList<>();
         for (int i = 0; i < cellElements.size(); i++) {
-            cells.add(new GridFooterCell(grid, rowIndex, i, cellElements.get(i)));
+            cells.add(
+                    new GridFooterCell(grid, rowIndex, i, cellElements.get(i)));
         }
         return cells;
     }
-    
+
     /**
      * Gets a specific footer cell by column index.
      *
@@ -78,15 +81,17 @@ public class GridFooterRow {
      * @return the footer cell at the given column index
      */
     public GridFooterCell getCell(int columnIndex) {
-        List<WebElement> cellElements = rowElement.findElements(By.tagName("td"));
+        List<WebElement> cellElements = rowElement
+                .findElements(By.tagName("td"));
         if (columnIndex >= cellElements.size()) {
-            throw new IndexOutOfBoundsException(
-                    "Column index " + columnIndex + " is out of bounds. Row has " + 
-                    cellElements.size() + " cells.");
+            throw new IndexOutOfBoundsException("Column index " + columnIndex
+                    + " is out of bounds. Row has " + cellElements.size()
+                    + " cells.");
         }
-        return new GridFooterCell(grid, rowIndex, columnIndex, cellElements.get(columnIndex));
+        return new GridFooterCell(grid, rowIndex, columnIndex,
+                cellElements.get(columnIndex));
     }
-    
+
     /**
      * Gets the number of cells in this footer row.
      *
@@ -95,7 +100,7 @@ public class GridFooterRow {
     public int getCellCount() {
         return rowElement.findElements(By.tagName("td")).size();
     }
-    
+
     /**
      * Checks if this footer row is visible.
      *
@@ -104,15 +109,14 @@ public class GridFooterRow {
     public boolean isVisible() {
         return rowElement.isDisplayed();
     }
-    
+
     /**
      * Gets all text content from cells in this row.
      *
      * @return list of text content from all cells
      */
     public List<String> getCellTexts() {
-        return getCells().stream()
-                .map(GridFooterCell::getText)
+        return getCells().stream().map(GridFooterCell::getText)
                 .collect(Collectors.toList());
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridHeaderCell.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridHeaderCell.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.testbench;
+
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Represents a header cell in a Grid component.
+ */
+public class GridHeaderCell {
+
+    private final GridElement grid;
+    private final int rowIndex;
+    private final int columnIndex;
+    private final WebElement cellElement;
+
+    /**
+     * Creates a new GridHeaderCell instance.
+     *
+     * @param grid
+     *            the grid this cell belongs to
+     * @param rowIndex
+     *            the row index of this cell
+     * @param columnIndex
+     *            the column index of this cell
+     * @param cellElement
+     *            the WebElement representing this cell
+     */
+    public GridHeaderCell(GridElement grid, int rowIndex, int columnIndex,
+            WebElement cellElement) {
+        this.grid = grid;
+        this.rowIndex = rowIndex;
+        this.columnIndex = columnIndex;
+        this.cellElement = cellElement;
+    }
+
+    /**
+     * Gets the row index of this cell.
+     *
+     * @return the row index
+     */
+    public int getRowIndex() {
+        return rowIndex;
+    }
+
+    /**
+     * Gets the column index of this cell.
+     *
+     * @return the column index
+     */
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+
+    /**
+     * Gets the text content of this header cell.
+     *
+     * @return the text content
+     */
+    public String getText() {
+        return cellElement.getText();
+    }
+
+    /**
+     * Gets the colspan attribute of this header cell.
+     *
+     * @return the colspan value, or 1 if not set
+     */
+    public int getColspan() {
+        String colspan = cellElement.getAttribute("colspan");
+        if (colspan != null && !colspan.isEmpty()) {
+            try {
+                return Integer.parseInt(colspan);
+            } catch (NumberFormatException e) {
+                return 1;
+            }
+        }
+        return 1;
+    }
+
+    /**
+     * Gets the rowspan attribute of this header cell.
+     *
+     * @return the rowspan value, or 1 if not set
+     */
+    public int getRowspan() {
+        String rowspan = cellElement.getAttribute("rowspan");
+        if (rowspan != null && !rowspan.isEmpty()) {
+            try {
+                return Integer.parseInt(rowspan);
+            } catch (NumberFormatException e) {
+                return 1;
+            }
+        }
+        return 1;
+    }
+
+    /**
+     * Checks if this header cell spans multiple columns.
+     *
+     * @return true if colspan > 1
+     */
+    public boolean isJoined() {
+        return getColspan() > 1;
+    }
+
+    /**
+     * Checks if this header cell spans multiple rows.
+     *
+     * @return true if rowspan > 1
+     */
+    public boolean isMultiRow() {
+        return getRowspan() > 1;
+    }
+
+    /**
+     * Gets the content element of this header cell.
+     *
+     * @return the vaadin-grid-cell-content element
+     */
+    public TestBenchElement getContent() {
+        return grid.getHeaderCellContent(rowIndex, columnIndex);
+    }
+
+    /**
+     * Checks if this header cell is visible.
+     *
+     * @return true if the cell is visible, false otherwise
+     */
+    public boolean isVisible() {
+        return cellElement.isDisplayed();
+    }
+
+    /**
+     * Gets the underlying WebElement.
+     *
+     * @return the WebElement
+     */
+    public WebElement getWrappedElement() {
+        return cellElement;
+    }
+
+    /**
+     * Clicks on this header cell.
+     */
+    public void click() {
+        cellElement.click();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridHeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridHeaderRow.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.testbench;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Represents a header row in a Grid component.
+ */
+public class GridHeaderRow {
+
+    private final GridElement grid;
+    private final int rowIndex;
+    private final WebElement rowElement;
+
+    /**
+     * Creates a new GridHeaderRow instance.
+     *
+     * @param grid
+     *            the grid this header row belongs to
+     * @param rowIndex
+     *            the index of this header row
+     * @param rowElement
+     *            the WebElement representing this row
+     */
+    public GridHeaderRow(GridElement grid, int rowIndex,
+            WebElement rowElement) {
+        this.grid = grid;
+        this.rowIndex = rowIndex;
+        this.rowElement = rowElement;
+    }
+
+    /**
+     * Gets the index of this header row.
+     *
+     * @return the row index
+     */
+    public int getRowIndex() {
+        return rowIndex;
+    }
+
+    /**
+     * Gets all header cells in this row.
+     *
+     * @return list of header cells
+     */
+    public List<GridHeaderCell> getCells() {
+        List<WebElement> cellElements = rowElement
+                .findElements(By.tagName("th"));
+        List<GridHeaderCell> cells = new ArrayList<>();
+        for (int i = 0; i < cellElements.size(); i++) {
+            cells.add(
+                    new GridHeaderCell(grid, rowIndex, i, cellElements.get(i)));
+        }
+        return cells;
+    }
+
+    /**
+     * Gets a specific header cell by column index.
+     *
+     * @param columnIndex
+     *            the column index
+     * @return the header cell at the given column index
+     */
+    public GridHeaderCell getCell(int columnIndex) {
+        List<WebElement> cellElements = rowElement
+                .findElements(By.tagName("th"));
+        if (columnIndex >= cellElements.size()) {
+            throw new IndexOutOfBoundsException("Column index " + columnIndex
+                    + " is out of bounds. Row has " + cellElements.size()
+                    + " cells.");
+        }
+        return new GridHeaderCell(grid, rowIndex, columnIndex,
+                cellElements.get(columnIndex));
+    }
+
+    /**
+     * Gets the number of cells in this header row.
+     *
+     * @return the number of cells
+     */
+    public int getCellCount() {
+        return rowElement.findElements(By.tagName("th")).size();
+    }
+
+    /**
+     * Checks if this header row is visible.
+     *
+     * @return true if the row is visible, false otherwise
+     */
+    public boolean isVisible() {
+        return rowElement.isDisplayed();
+    }
+
+    /**
+     * Gets all text content from cells in this row.
+     *
+     * @return list of text content from all cells
+     */
+    public List<String> getCellTexts() {
+        return getCells().stream().map(GridHeaderCell::getText)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Extends GridElement to provide access to all header rows, including hierarchical and joined header cells. Previously only the bottom-most header was accessible.

New features:
- GridHeaderRow class to represent individual header rows
- GridHeaderCell class to represent header cells with colspan/rowspan support
- Methods to get all header rows, specific rows by index, and row counts
- Support for detecting joined cells and multi-row spans
- Methods to access first, last, and visible header rows only

Fixes vaadin/testbench#2006
