### PR TITLE
feat: make Upload target name configurable

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -100,6 +100,12 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     private Receiver receiver;
 
     /**
+     * Represents the name of the target location or identifier where files
+     * or data are to be uploaded. Default value is set to "upload".
+     */
+    private String uploadTargetName = "upload";
+
+    /**
      * Create a new instance of Upload.
      * <p>
      * The upload handler must be set through
@@ -194,6 +200,19 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     public Upload(UploadHandler handler) {
         this();
         setUploadHandler(handler);
+    }
+
+    /**
+     * Create a new instance of Upload with the given upload handler and target name.
+     *
+     * @param handler
+     *            upload handler that handles the upload, not {@code null}
+     * @param targetName
+     *            the endpoint name (single path segment) to publish the upload under, not blank
+     */
+    public Upload(UploadHandler handler, String targetName) {
+        this();
+        setUploadHandler(handler, targetName);
     }
 
     /**
@@ -731,7 +750,7 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
                 handler, this.getElement()) {
             @Override
             public String getName() {
-                return "upload";
+                return uploadTargetName;
             }
         };
         runBeforeClientResponse(ui -> getElement().setAttribute("target",
@@ -742,6 +761,23 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
             addListener(UploadCompleteEvent.class, event -> endUpload());
         }
         receiver = null;
+    }
+
+    /**
+     * Set the upload handler to be used for this upload component.
+     * <p>
+     * The given handler defines how uploaded file content is handled on the
+     * server and invoked per each single file to be uploaded. Note! This method
+     * overrides the receiver set by {@link #setReceiver(Receiver)}.
+     *
+     * @param handler
+     *            upload handler to use for file receptions, not {@code null}
+     * @param targetName
+     *            endpoint name (single path segment), not blank
+     */
+    public void setUploadHandler(UploadHandler handler, String targetName) {
+        setUploadTargetName(targetName);
+        setUploadHandler(handler);
     }
 
     private boolean isMultiFileReceiver(Receiver receiver) {
@@ -820,6 +856,24 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
      */
     public void clearFileList() {
         getElement().setPropertyJson("files", JacksonUtils.createArrayNode());
+    }
+
+    /**
+     * Retrieves the name of the upload target.
+     *
+     * @return the name of the upload target as a String.
+     */
+    public String getUploadTargetName() {
+        return uploadTargetName;
+    }
+
+    /**
+     * Sets the name of the upload target.
+     *
+     * @param uploadTargetName the name to set for the upload target
+     */
+    public void setUploadTargetName(String uploadTargetName) {
+        this.uploadTargetName = uploadTargetName;
     }
 
     private static class DefaultStreamVariable implements StreamVariable {

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -202,8 +202,9 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
      * @param handler
      *            upload handler that handles the upload, not {@code null}
      * @param targetName
-     *            the endpoint name (single path segment) to publish the upload
-     *            under, not blank
+     *            the endpoint name (single path segment), used as the last path
+     *            segment of the dynamically generated upload URL; must not be
+     *            blank
      */
     public Upload(UploadHandler handler, String targetName) {
         this();

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -100,8 +100,8 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     private Receiver receiver;
 
     /**
-     * Represents the name of the target location or identifier where files
-     * or data are to be uploaded. Default value is set to "upload".
+     * Represents the name of the target location or identifier where files or
+     * data are to be uploaded. Default value is set to "upload".
      */
     private String uploadTargetName = "upload";
 
@@ -203,12 +203,14 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     }
 
     /**
-     * Create a new instance of Upload with the given upload handler and target name.
+     * Create a new instance of Upload with the given upload handler and target
+     * name.
      *
      * @param handler
      *            upload handler that handles the upload, not {@code null}
      * @param targetName
-     *            the endpoint name (single path segment) to publish the upload under, not blank
+     *            the endpoint name (single path segment) to publish the upload
+     *            under, not blank
      */
     public Upload(UploadHandler handler, String targetName) {
         this();
@@ -870,7 +872,8 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle {
     /**
      * Sets the name of the upload target.
      *
-     * @param uploadTargetName the name to set for the upload target
+     * @param uploadTargetName
+     *            the name to set for the upload target
      */
     public void setUploadTargetName(String uploadTargetName) {
         this.uploadTargetName = uploadTargetName;

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHandlerTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHandlerTest.java
@@ -101,6 +101,18 @@ public class UploadHandlerTest {
     }
 
     @Test
+    public void setUploadHandler_withCustomTarget_generatedUrlEndsWithCustomName() {
+        String targetName = "custom-target";
+        upload.setUploadHandler(event -> {
+        }, targetName);
+        fakeClientCommunication();
+
+        String targetUploadUrl = upload.getElement().getAttribute("target");
+        Assert.assertTrue("Upload url should end with custom target name 'custom-target'",
+                targetUploadUrl.endsWith(targetName));
+    }
+
+    @Test
     public void uploadWithStandardHandler_activeUploadsIsChanged_from0to1_from1to0()
             throws IOException, URISyntaxException {
         // Not uploading initially

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHandlerTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHandlerTest.java
@@ -108,7 +108,8 @@ public class UploadHandlerTest {
         fakeClientCommunication();
 
         String targetUploadUrl = upload.getElement().getAttribute("target");
-        Assert.assertTrue("Upload url should end with custom target name 'custom-target'",
+        Assert.assertTrue(
+                "Upload url should end with custom target name 'custom-target'",
                 targetUploadUrl.endsWith(targetName));
     }
 


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description
This change makes the server-side upload endpoint name of the Upload component configurable instead of hardcoded to "upload".

Motivation and context:
- Some applications need distinct endpoint names per Upload instance (e.g., custom routing, reverse proxies, or security rules bound to specific path segments).
- The static endpoint name limited integration flexibility.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
