### PR TITLE
chore: rename aura theme module

### DIFF
--- a/flow-components-bom/pom.xml
+++ b/flow-components-bom/pom.xml
@@ -34,7 +34,7 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-aura-theme-flow</artifactId>
+                <artifactId>vaadin-aura-theme</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow/pom.xml
@@ -6,7 +6,7 @@
         <artifactId>vaadin-aura-theme-flow-parent</artifactId>
         <version>25.0-SNAPSHOT</version>
     </parent>
-    <artifactId>vaadin-aura-theme-flow</artifactId>
+    <artifactId>vaadin-aura-theme</artifactId>
     <packaging>jar</packaging>
     <name>Vaadin Aura Theme</name>
     <description>Vaadin Aura Theme</description>


### PR DESCRIPTION
## Description

Rename `vaadin-aura-theme-flow` to `vaadin-aura-theme` to align with `vaadin-lumo-theme`.

## Type of change

- Chore