### PR TITLE
feat: add missing Select constructors for label

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -198,6 +198,53 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     }
 
     /**
+     * Creates a select with the defined label.
+     *
+     * @param label
+     *            the label describing the select
+     * @see #setLabel(String)
+     */
+    public Select(String label) {
+        this();
+        setLabel(label);
+    }
+
+    /**
+     * Creates a select with the defined label and populated with the items in
+     * the collection.
+     *
+     * @param label
+     *            the label describing the select
+     * @param items
+     *            the items to be shown in the list of the select
+     * @see #setLabel(String)
+     * @see #setItems(Collection)
+     */
+    public Select(String label, Collection<T> items) {
+        this();
+        setLabel(label);
+        setItems(items);
+    }
+
+    /**
+     * Creates a select with the defined label and populated with the items in
+     * the array.
+     *
+     * @param label
+     *            the label describing the select
+     * @param items
+     *            the items to be shown in the list of the select
+     * @see #setLabel(String)
+     * @see #setItems(Object...)
+     */
+    @SafeVarargs
+    public Select(String label, T... items) {
+        this();
+        setLabel(label);
+        setItems(items);
+    }
+
+    /**
      * Constructs a select with the initial value change listener.
      *
      * @param listener

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -148,7 +148,7 @@ public class SelectTest {
         Assert.assertEquals("Invalid number of items", 0,
                 getListBox().getChildren().count());
 
-        select = new Select<>("label", null, "foo", "bar", "baz");
+        select = new Select<>("label", "foo", "bar", "baz");
 
         Assert.assertEquals("Invalid number of items", 3,
                 getListBox().getChildren().count());


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5371

Aligned `Select` constructors with `ComboBox`.

Originally, there used to be a constructor that accepted items as varargs, then we removed it in https://github.com/vaadin/flow-components/pull/4400 landed in 24.0 so now we can actually introduce the constructor that only takes label, as described in https://github.com/vaadin/flow-components/issues/1275#issuecomment-1080314589.

## Type of change

- Feature