### PR TITLE
test: add additional test cases for upload handler target name

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHandlerTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHandlerTest.java
@@ -114,6 +114,23 @@ public class UploadHandlerTest {
     }
 
     @Test
+    public void setUploadHandler_withNullTarget_throws() {
+        Assert.assertThrows(NullPointerException.class,
+                () -> upload.setUploadHandler(event -> {
+                }, null));
+    }
+
+    @Test
+    public void setUploadHandler_withBlankTarget_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> upload.setUploadHandler(event -> {
+                }, ""));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> upload.setUploadHandler(event -> {
+                }, "   "));
+    }
+
+    @Test
     public void uploadWithStandardHandler_activeUploadsIsChanged_from0to1_from1to0()
             throws IOException, URISyntaxException {
         // Not uploading initially


### PR DESCRIPTION
## Description

As a follow-up from https://github.com/vaadin/flow-components/pull/8060, adds additional test cases for null or blank target names.

## Type of change

- Test