### PR TITLE
docs: remove confusing HTML mentions in Javadocs for Notification

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -152,8 +152,8 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     /**
-     * Creates a Notification with the given String rendered as its text,
-     * that does not close automatically.
+     * Creates a Notification with the given String rendered as its text, that
+     * does not close automatically.
      *
      * @param text
      *            the text of the Notification
@@ -163,8 +163,8 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     /**
-     * Creates a Notification with given String rendered as its text and
-     * given Integer rendered as its duration.
+     * Creates a Notification with given String rendered as its text and given
+     * Integer rendered as its duration.
      * <p>
      * Set to {@code 0} or a negative number to disable the notification
      * auto-closing.

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -152,7 +152,7 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     /**
-     * Creates a Notification with the given String rendered as its HTML text,
+     * Creates a Notification with the given String rendered as its text,
      * that does not close automatically.
      *
      * @param text
@@ -163,7 +163,7 @@ public class Notification extends Component implements HasComponents, HasStyle,
     }
 
     /**
-     * Creates a Notification with given String rendered as its HTML text and
+     * Creates a Notification with given String rendered as its text and
      * given Integer rendered as its duration.
      * <p>
      * Set to {@code 0} or a negative number to disable the notification


### PR DESCRIPTION
"rendered as its HTML text" can give the impression that the string is interpreted as HTML and would thus need to be escaped to avoid XSS. This is not the case – the string is in fact used as plain text.