### PR TITLE
feat: zoom to fit the provides features in the viewport

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ZoomToFitPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ZoomToFitPage.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.map;
+
+import java.util.List;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-map/zoom-to-fit")
+public class ZoomToFitPage extends Div {
+    public static final MarkerFeature FEATURE_1 = new MarkerFeature(
+            new Coordinate(-40, 0));
+    public static final MarkerFeature FEATURE_2 = new MarkerFeature(
+            new Coordinate(-41, 0));
+    public static final MarkerFeature FEATURE_3 = new MarkerFeature(
+            new Coordinate(-42, 0));
+    public static final MarkerFeature FEATURE_4 = new MarkerFeature(
+            new Coordinate(40, 0));
+    public static final MarkerFeature FEATURE_5 = new MarkerFeature(
+            new Coordinate(41, 0));
+    public static final MarkerFeature FEATURE_6 = new MarkerFeature(
+            new Coordinate(42, 0));
+
+    public ZoomToFitPage() {
+        Map map = new Map();
+
+        map.getFeatureLayer().addFeature(FEATURE_1);
+        map.getFeatureLayer().addFeature(FEATURE_2);
+        map.getFeatureLayer().addFeature(FEATURE_3);
+
+        map.getFeatureLayer().addFeature(FEATURE_4);
+        map.getFeatureLayer().addFeature(FEATURE_5);
+        map.getFeatureLayer().addFeature(FEATURE_6);
+
+        // Initial zoom to fit
+        map.zoomToFit(List.of(FEATURE_1, FEATURE_2, FEATURE_3), 50, 0);
+
+        // Buttons to fit individual sets
+        NativeButton zoomToFirstSet = new NativeButton("Zoom to fit first set",
+                e -> map.zoomToFit(List.of(FEATURE_1, FEATURE_2, FEATURE_3), 50,
+                        0));
+        zoomToFirstSet.setId("zoom-to-first-set");
+
+        NativeButton zoomToSecondSet = new NativeButton(
+                "Zoom to fit second set",
+                e -> map.zoomToFit(List.of(FEATURE_4, FEATURE_5, FEATURE_6), 50,
+                        0));
+        zoomToSecondSet.setId("zoom-to-second-set");
+
+        add(map, zoomToFirstSet, zoomToSecondSet);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ZoomToFitIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ZoomToFitIT.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.components.map;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.map.ZoomToFitPage;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
+import com.vaadin.flow.component.map.testbench.MapElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-map/zoom-to-fit")
+public class ZoomToFitIT extends AbstractComponentIT {
+
+    private MapElement map;
+
+    @Before
+    public void init() {
+        open();
+        map = $(MapElement.class).waitForFirst();
+    }
+
+    @Test
+    public void initialZoomToFit_showsFirstSet() {
+        Assert.assertTrue(isFeatureVisible(map, ZoomToFitPage.FEATURE_1));
+        Assert.assertTrue(isFeatureVisible(map, ZoomToFitPage.FEATURE_2));
+        Assert.assertTrue(isFeatureVisible(map, ZoomToFitPage.FEATURE_3));
+
+        Assert.assertFalse(isFeatureVisible(map, ZoomToFitPage.FEATURE_4));
+        Assert.assertFalse(isFeatureVisible(map, ZoomToFitPage.FEATURE_5));
+        Assert.assertFalse(isFeatureVisible(map, ZoomToFitPage.FEATURE_6));
+    }
+
+    @Test
+    public void zoomToFitSecondSet_showsSecondSet() {
+        clickElementWithJs("zoom-to-second-set");
+
+        Assert.assertFalse(isFeatureVisible(map, ZoomToFitPage.FEATURE_1));
+        Assert.assertFalse(isFeatureVisible(map, ZoomToFitPage.FEATURE_2));
+        Assert.assertFalse(isFeatureVisible(map, ZoomToFitPage.FEATURE_3));
+
+        Assert.assertTrue(isFeatureVisible(map, ZoomToFitPage.FEATURE_4));
+        Assert.assertTrue(isFeatureVisible(map, ZoomToFitPage.FEATURE_5));
+        Assert.assertTrue(isFeatureVisible(map, ZoomToFitPage.FEATURE_6));
+    }
+
+    private boolean isFeatureVisible(MapElement map, MarkerFeature feature) {
+        Coordinate coordinates = feature.getGeometry().getCoordinates();
+        List<Double> extent = map.getMapReference().getView().calculateExtent();
+        return coordinates.getX() >= extent.get(0)
+                && coordinates.getX() <= extent.get(2)
+                && coordinates.getY() >= extent.get(1)
+                && coordinates.getY() <= extent.get(3);
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.map;
 
 import java.beans.PropertyChangeEvent;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -31,10 +32,13 @@ import com.vaadin.flow.component.map.events.MapFeatureDropEvent;
 import com.vaadin.flow.component.map.events.MapViewMoveEndEvent;
 import com.vaadin.flow.component.map.serialization.MapSerializer;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.shared.Registration;
 
+import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.BaseJsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Base class for the map component. Contains all base functionality for the map
@@ -81,6 +85,46 @@ public abstract class MapBase extends Component
      */
     public void setView(View view) {
         configuration.setView(view);
+    }
+
+    /**
+     * Zooms and pans the map to fit the given features in the viewport. Uses a
+     * default padding of 50 pixels and animation duration of 400 milliseconds.
+     *
+     * @param features
+     *            the features to fit in the viewport
+     */
+    public void zoomToFit(List<Feature> features) {
+        zoomToFit(features, 50, 400);
+    }
+
+    /**
+     * Zooms and pans the map to fit the given features in the viewport.
+     *
+     * @param features
+     *            the features to fit in the viewport
+     * @param padding
+     *            padding in pixels to add around the features
+     * @param duration
+     *            animation duration in milliseconds, 0 for no animation
+     */
+    public void zoomToFit(List<Feature> features, int padding, int duration) {
+        ArrayNode featureIds = JacksonUtils.createArrayNode();
+        features.forEach(feature -> featureIds.add(feature.getId()));
+
+        ObjectNode options = JacksonUtils.createObjectNode();
+        options.put("padding", padding);
+        options.put("duration", duration);
+
+        // In order to allow calling this method before the map, or the view
+        // that contains it, is attached to the UI, this needs to be delayed
+        // with beforeClientResponse to ensure that the client-side connector
+        // has been initialized beforehand.
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                        context -> getElement().executeJs(
+                                "this.$connector.zoomToFit($0, $1)", featureIds,
+                                options)));
     }
 
     @Override

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -318,6 +318,10 @@ public class MapElement extends TestBenchElement {
         public void setRotation(float rotation) {
             executor.executeScript(path("setRotation(%s)", rotation));
         }
+
+        public List<Double> calculateExtent() {
+            return (List<Double>) get("calculateExtent()");
+        }
     }
 
     public static class LayerCollectionReference


### PR DESCRIPTION
## Description

Adds a `zoomToFit` method to the `Map` component that allows to fit the provided features within the viewport. The options allow to configure a padding for the viewport and an animtation duration.

Closes https://github.com/vaadin/flow-components/issues/3137

## Type of change

- Feature
