### PR TITLE
fix: Grid column respects custom reversed comparator and improves serialization (#3926)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -445,7 +445,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             return Stream.of(new QuerySortOrder(key, direction));
         };
 
-        private SerializableComparator<T> comparator;
+        private Comparator<T> comparator;
 
         private Registration columnDataGeneratorRegistration;
         private Registration editorDataGeneratorRegistration;
@@ -735,7 +735,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         public Column<T> setComparator(Comparator<T> comparator) {
             Objects.requireNonNull(comparator, "Comparator must not be null");
             setSortable(true);
-            this.comparator = comparator::compare;
+            this.comparator = comparator;
             return this;
         }
 
@@ -782,7 +782,19 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     "No comparator defined for sorted column.");
             setSortable(true);
             boolean reverse = sortDirection != SortDirection.ASCENDING;
-            return reverse ? comparator.reversed()::compare : comparator;
+
+            if (reverse) {
+                Comparator<T> reversed = comparator.reversed();
+                if (reversed instanceof SerializableComparator) {
+                    return (SerializableComparator<T>) reversed;
+                }
+                return reversed::compare;
+            }
+
+            if (comparator instanceof SerializableComparator) {
+                return (SerializableComparator<T>) comparator;
+            }
+            return comparator::compare;
         }
 
         /**


### PR DESCRIPTION
- Store the original Comparator object instead of just method references
- Preserve SerializableComparator instances when provided
- Respect custom reversed() implementations for descending sort

The column now stores the full comparator object, allowing it to:
1. Use custom reversed() implementations when sorting descending
2. Preserve serialization capability when SerializableComparator is provided
3. Only create method references as a fallback for non-serializable comparators

Fixes #3926
