### PR TITLE
refactor: deprecate addViewMoveEndEventListener, addClickEventListener

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ChangeUserProjectionPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ChangeUserProjectionPage.java
@@ -26,7 +26,7 @@ public class ChangeUserProjectionPage extends Div {
 
         Div eventData = new Div();
         eventData.setId("event-data");
-        map.addViewMoveEndEventListener(event -> {
+        map.addViewMoveEndListener(event -> {
             String eventText = event.getCenter().getX() + ";"
                     + event.getCenter().getY() + ";";
 

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DefineCustomProjectionPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/DefineCustomProjectionPage.java
@@ -63,7 +63,7 @@ public class DefineCustomProjectionPage extends Div {
 
         Div eventData = new Div();
         eventData.setId("event-data");
-        map.addViewMoveEndEventListener(event -> {
+        map.addViewMoveEndListener(event -> {
             String eventText = event.getCenter().getX() + ";"
                     + event.getCenter().getY() + ";";
 

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapEventsPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/MapEventsPage.java
@@ -46,7 +46,7 @@ public class MapEventsPage extends Div {
 
         NativeButton addMoveEndListener = new NativeButton(
                 "Add move end listener", e -> {
-                    map.addViewMoveEndEventListener(event -> {
+                    map.addViewMoveEndListener(event -> {
                         View mapView = map.getView();
                         String stateText = mapView.getCenter().getX() + ";"
                                 + mapView.getCenter().getY() + ";";
@@ -66,7 +66,7 @@ public class MapEventsPage extends Div {
 
         NativeButton addClickListener = new NativeButton("Add click listener",
                 e -> {
-                    map.addClickEventListener(event -> {
+                    map.addClickListener(event -> {
                         String coordinatesInfo = event.getCoordinate().getX()
                                 + ";" + event.getCoordinate().getY();
                         String pixelPositionInfo = event.getMouseDetails()

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/MapBase.java
@@ -132,7 +132,7 @@ public abstract class MapBase extends Component
         // Register an event listener before all the other listeners of the view
         // move end event to update view state to the latest values received
         // from the client
-        addViewMoveEndEventListener(event -> {
+        addViewMoveEndListener(event -> {
             double rotation = event.getRotation();
             double zoom = event.getZoom();
             Coordinate center = event.getCenter();
@@ -168,9 +168,28 @@ public abstract class MapBase extends Component
      * interaction.
      *
      * @param listener
+     *            the listener to add
+     * @return a registration object for removing the added listener
+     * @deprecated use {@link #addViewMoveEndListener(ComponentEventListener)}
+     *             instead
+     */
+    @Deprecated(since = "25.0", forRemoval = true)
+    public Registration addViewMoveEndEventListener(
+            ComponentEventListener<MapViewMoveEndEvent> listener) {
+        return addViewMoveEndListener(listener);
+    }
+
+    /**
+     * Adds an event listener for changes to the map's viewport. The event will
+     * only be triggered after the user has finished manipulating the viewport,
+     * for example after letting go of the mouse button after a mouse drag
+     * interaction.
+     *
+     * @param listener
+     *            the listener to add
      * @return a registration object for removing the added listener
      */
-    public Registration addViewMoveEndEventListener(
+    public Registration addViewMoveEndListener(
             ComponentEventListener<MapViewMoveEndEvent> listener) {
         return addListener(MapViewMoveEndEvent.class, listener);
     }
@@ -183,9 +202,28 @@ public abstract class MapBase extends Component
      * whether a feature exists at the clicked location.
      *
      * @param listener
+     *            the listener to add
+     * @return a registration object for removing the added listener
+     * @deprecated use {@link #addClickListener(ComponentEventListener)} instead
+     */
+    @Deprecated(since = "25.0", forRemoval = true)
+    public Registration addClickEventListener(
+            ComponentEventListener<MapClickEvent> listener) {
+        return addClickListener(listener);
+    }
+
+    /**
+     * Adds a click listener for the map.
+     * <p>
+     * Note that the listener will also be invoked when clicking on a
+     * {@link Feature}. Use {@link MapClickEvent#getFeatures()} to distinguish
+     * whether a feature exists at the clicked location.
+     *
+     * @param listener
+     *            the listener to add
      * @return a registration object for removing the added listener
      */
-    public Registration addClickEventListener(
+    public Registration addClickListener(
             ComponentEventListener<MapClickEvent> listener) {
         return addListener(MapClickEvent.class, listener);
     }


### PR DESCRIPTION
## Description

Deprecates:
- `addViewMoveEndEventListener` in favor of `addViewMoveEndListener`
- `addClickEventListener` in favor of `addClickListener`

Part of https://github.com/vaadin/flow-components/issues/3667

## Type of change

- Deprecation