### PR TITLE
fix: fix path to property in events

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
@@ -40,7 +40,7 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
             @EventData("event.detail.originalEvent.browserEvent.ctrlKey") boolean ctrlKey,
             @EventData("event.detail.originalEvent.browserEvent.metaKey") boolean metaKey,
             @EventData("event.detail.originalEvent.browserEvent.shiftKey") boolean shiftKey,
-            @EventData("event.detail.originalEvent.button") int button,
+            @EventData("event.detail.originalEvent.browserEvent.button") int button,
             @EventData("event.detail.point.series.index") int seriesIndex,
             @EventData("event.detail.point.category") String category,
             @EventData("event.detail.point.index") int pointIndex,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/SeriesLegendItemClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/SeriesLegendItemClickEvent.java
@@ -37,7 +37,7 @@ public class SeriesLegendItemClickEvent extends ComponentEvent<Chart>
             @EventData("event.detail.originalEvent.browserEvent.ctrlKey") boolean ctrlKey,
             @EventData("event.detail.originalEvent.browserEvent.metaKey") boolean metaKey,
             @EventData("event.detail.originalEvent.browserEvent.shiftKey") boolean shiftKey,
-            @EventData("event.detail.originalEvent.button") int button,
+            @EventData("event.detail.originalEvent.browserEvent.button") int button,
             @EventData("event.detail.series.index") int seriesIndex) {
         super(source, fromClient);
         this.seriesIndex = seriesIndex;


### PR DESCRIPTION
## Description

The `button` property points to the wrong path in which it is located in the `originalEvent` object sent by the client. It seems that it didn't fail before, but lately, that has caused some IT failures, as the mapping from `null` to `int` now causes an exception that prevents the Java event objects from being instantiated.