### PR TITLE
fix: restore popover behavior in dialogs

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dialog-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-flow-components-base</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.internal.JacksonUtils;
@@ -733,7 +734,21 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
             if (getElement().getNode().getParent() == null) {
                 // Remove the popover from its current state tree
                 getElement().removeFromTree(false);
-                ui.addToModalComponent(this);
+
+                // Check if target is inside a Dialog component
+                Dialog dialog = target.findAncestor(Dialog.class);
+                if (dialog != null) {
+                    // In modal contexts, append to target's parent to ensure
+                    // proper DOM structure
+                    // and maintain backward compatibility for existing
+                    // applications
+                    target.getElement().getParent().appendChild(getElement());
+                } else {
+                    // In non-modal contexts, use UI modal container to enable
+                    // proper cleanup
+                    // when components are removed via removeAll()
+                    ui.addToModalComponent(this);
+                }
                 autoAddedToTheUi = true;
             }
             getElement().executeJs("this.target = $0", target.getElement());

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverModalContextTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverModalContextTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.popover;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * Test to verify that popovers work correctly in modal contexts (like dialogs)
+ * by using the appropriate attachment strategy.
+ */
+public class PopoverModalContextTest {
+
+    private UI ui;
+    private VaadinSession session;
+
+    @Before
+    public void setUp() {
+        ui = new UI();
+        session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui.getInternals().setSession(session);
+        VaadinSession.setCurrent(session);
+        Mockito.when(session.getErrorHandler()).thenReturn(event -> {
+            throw new RuntimeException(event.getThrowable());
+        });
+        UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+        VaadinSession.setCurrent(null);
+    }
+
+    @Test
+    public void popoverInModalDialog_usesLegacyAttachmentBehavior() {
+        // Create a dialog component with a target element
+        Dialog dialog = new Dialog();
+        Div target = new Div();
+        target.setText("Target in dialog");
+        dialog.add(target);
+
+        // Create popover targeting the div
+        Popover popover = new Popover();
+        popover.add(new Span("Popover content"));
+        popover.setTarget(target);
+
+        // Add dialog to UI to trigger attachment
+        ui.add(dialog);
+
+        // Verify popover is attached to the UI tree
+        Assert.assertTrue("Popover should be attached to UI tree",
+                popover.getElement().getNode().getParent() != null);
+
+        // In modal context, popover should be appended to target's parent for
+        // proper DOM structure
+        Assert.assertEquals("Popover should be child of dialog",
+                dialog.getElement(), popover.getElement().getParent());
+    }
+
+    @Test
+    public void popoverInNonModalContext_usesModalComponentAttachment() {
+        // Create a regular container (non-modal context)
+        Div container = new Div();
+        Div target = new Div();
+        target.setText("Target in regular container");
+        container.add(target);
+
+        // Create popover targeting the div
+        Popover popover = new Popover();
+        popover.add(new Span("Popover content"));
+        popover.setTarget(target);
+
+        // Add container to UI to trigger attachment
+        ui.add(container);
+
+        // Verify popover is attached to UI tree
+        Assert.assertTrue("Popover should be attached to UI tree",
+                popover.getElement().getNode().getParent() != null);
+
+        // In non-modal context, popover uses UI modal container instead of
+        // target's parent
+        Assert.assertNotEquals("Popover should not be child of container",
+                container.getElement(), popover.getElement().getParent());
+    }
+
+}


### PR DESCRIPTION
Before V24.7.9, popovers targeting elements inside dialogs were automatically appended to the dialog's DOM structure. The fix in commit 21939d7 changed this behavior to use UI.addToModalComponent() for all contexts, which broke existing applications that relied on the popover being part of the dialog's component tree.

This change introduces smart detection: when a popover target is inside a Dialog, it uses the legacy attachment behavior (append to target's parent) to maintain backward compatibility. For non-modal contexts, it continues using UI.addToModalComponent() to preserve the cleanup fix for removeAll() operations.

Fixes regression introduced in V24.7.9 and addresses issue #8031.
