### PR TITLE
refactor!: revert scroll to index changes

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollToIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollToIT.java
@@ -114,7 +114,7 @@ public class TreeGridScrollToIT extends AbstractComponentIT {
     @Test
     public void scrollToIndex30_1_correctFirstVisibleItem() {
         scrollToIndexInput.sendKeys("30-1", Keys.TAB);
-        assertFirstVisibleRowContent("Dad 30/1");
+        assertFirstVisibleRowContent("Granddad 30");
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -956,23 +956,22 @@ public class TreeGrid<T> extends Grid<T>
      * {@link HierarchyFormat#FLATTENED}: the index refers to an item in the
      * entire flattened tree, not only the root level, allowing items at any
      * expanded level to be reached with this method.
+     * <p>
+     * If the index exceeds the valid range, scrolling stops at the last
+     * available item.
      *
      * @param index
      *            zero based index of the item to scroll to
      */
     @Override
     public void scrollToIndex(int index) {
-        var itemCount = getDataCommunicator().getItemCount();
-        if (index >= itemCount || index < -itemCount) {
-            // The index does not correspond to an item
-            return;
-        }
-        doScrollToIndex(index);
+        getUI().ifPresent(
+                ui -> ui.beforeClientResponse(this, ctx -> getElement()
+                        .executeJs("this.scrollToIndex($0);", index)));
     }
 
     /**
-     * Scrolls to a nested item specified by its hierarchical path. Any
-     * collapsed parent of the item is expanded before scrolling.
+     * Scrolls to a nested item specified by its hierarchical path.
      * <p>
      * The hierarchical path is an array of zero-based indexes, where each index
      * refers to a child of the item at the previous index. Scrolling continues
@@ -1005,27 +1004,24 @@ public class TreeGrid<T> extends Grid<T>
                             For HierarchyFormat.FLATTENED, use scrollToIndex(int) with a flat index instead.
                             """);
         }
+
         if (path.length == 0) {
             throw new IllegalArgumentException(
                     "At least one index should be provided.");
         }
-        try {
-            var pathItems = ((TreeGridDataCommunicator<T>) getDataCommunicator())
-                    .getPathItems(path);
-            var ancestors = pathItems.subList(0, pathItems.size() - 1);
-            expand(ancestors);
-        } catch (IllegalArgumentException e) {
-            // The path does not correspond to an item
-            return;
-        }
-        doScrollToIndex(path);
+
+        String joinedIndexes = Arrays.stream(path).mapToObj(String::valueOf)
+                .collect(Collectors.joining(","));
+        getUI().ifPresent(ui -> ui.beforeClientResponse(this,
+                ctx -> getElement().executeJs(
+                        "this.scrollToIndex(" + joinedIndexes + ");")));
     }
 
     @Override
     public void scrollToEnd() {
-        var indexes = new int[10];
-        Arrays.fill(indexes, -1);
-        doScrollToIndex(indexes);
+        getUI().ifPresent(ui -> ui.beforeClientResponse(this,
+                ctx -> getElement().executeJs(
+                        "this.scrollToIndex(...Array(10).fill(-1))")));
     }
 
     /**
@@ -1160,13 +1156,5 @@ public class TreeGrid<T> extends Grid<T>
         } else {
             scrollToIndex(indexPath);
         }
-    }
-
-    private void doScrollToIndex(int... path) {
-        var joinedIndexes = Arrays.stream(path).mapToObj(String::valueOf)
-                .collect(Collectors.joining(","));
-        getUI().ifPresent(ui -> ui.beforeClientResponse(this,
-                ctx -> getElement().executeJs(
-                        "this.scrollToIndex(" + joinedIndexes + ");")));
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGridDataCommunicator.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGridDataCommunicator.java
@@ -97,8 +97,6 @@ class TreeGridDataCommunicator<T> extends HierarchicalDataCommunicator<T> {
      * @param ancestors
      *            the ordered list of the ancestors of the item
      * @return index path for the given item
-     * @throws IllegalArgumentException
-     *             if the item does not exist
      */
     private int[] getIndexPath(T item, List<T> ancestors) {
         var path = new ArrayList<Integer>();
@@ -132,38 +130,6 @@ class TreeGridDataCommunicator<T> extends HierarchicalDataCommunicator<T> {
             ancestors.addFirst(item);
         }
         return ancestors;
-    }
-
-    /**
-     * Gets the ordered list of items for the specified path. Returns empty if
-     * any of the items are not found.
-     *
-     * @param path
-     *            the path to get the items for
-     * @return ordered list of items for the specified path
-     * @throws IllegalArgumentException
-     *             if the path does not correspond to an item
-     */
-    public List<T> getPathItems(int... path) {
-        var dataProvider = (HierarchicalDataProvider<T, Object>) getDataProvider();
-        var pathItems = new ArrayList<T>();
-        T parent = null;
-        for (var index : path) {
-            if (index < 0) {
-                var childrenCount = dataProvider.getChildCount(
-                        buildQuery(parent, 0, Integer.MAX_VALUE));
-                index = childrenCount + index;
-            }
-            var query = buildQuery(parent, index, 1);
-            var childOptional = dataProvider.fetchChildren(query).findFirst();
-            if (childOptional.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "There is no item with the specified path.");
-            }
-            parent = childOptional.get();
-            pathItems.add(parent);
-        }
-        return pathItems;
     }
 
     private List<Integer> getAncestorPath(List<T> ancestors) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ScrollToIndexTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ScrollToIndexTest.java
@@ -15,135 +15,29 @@
  */
 package com.vaadin.flow.component.treegrid;
 
-import java.util.stream.IntStream;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider.HierarchyFormat;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
-import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinSession;
 
 public class ScrollToIndexTest {
-    private TreeGrid<String> treeGrid;
-    private TreeData<String> treeData;
-    private UI ui;
+    private TreeGrid<String> treeGrid = new TreeGrid<>();
+    private TreeData<String> treeData = new TreeData<>();
 
-    @Before
-    public void init() {
-        ui = new UI();
-        UI.setCurrent(ui);
-        var mockSession = Mockito.mock(VaadinSession.class);
-        var mockService = Mockito.mock(VaadinService.class);
-        var mockContext = Mockito.mock(VaadinContext.class);
-        var mockConfiguration = Mockito.mock(DeploymentConfiguration.class);
-        Mockito.when(mockSession.getService()).thenReturn(mockService);
-        Mockito.when(mockSession.getConfiguration())
-                .thenReturn(mockConfiguration);
-        Mockito.when(mockService.getContext()).thenReturn(mockContext);
-        ui.getInternals().setSession(mockSession);
-        treeGrid = new TreeGrid<>();
-        ui.add(treeGrid);
-        treeData = getTreeData();
-    }
-
-    @After
-    public void tearDown() {
-        UI.setCurrent(null);
+    @Test
+    public void nestedHierarchyFormat_scrollToIndexPath_doesNotThrow() {
+        treeGrid.setDataProvider(
+                new TreeDataProvider<>(treeData, HierarchyFormat.NESTED));
+        treeGrid.scrollToIndex(0, 0);
     }
 
     @Test
-    public void flattenedHierarchyFormat_scrollToIndexPath_throwsUnsupportedOperationException() {
+    public void flattenedHierarchyFormat_scrollToIndexPath_throws() {
         treeGrid.setDataProvider(
                 new TreeDataProvider<>(treeData, HierarchyFormat.FLATTENED));
         Assert.assertThrows(UnsupportedOperationException.class,
                 () -> treeGrid.scrollToIndex(0, 0));
-    }
-
-    @Test
-    public void nestedHierarchyFormat_scrollToIndexPathWithCollapsedParent_expandsParent() {
-        treeGrid.setDataProvider(
-                new TreeDataProvider<>(treeData, HierarchyFormat.NESTED));
-        var rootItem = treeData.getRootItems().get(10);
-        var firstChild = treeData.getChildren(rootItem).getFirst();
-        Assert.assertFalse(treeGrid.isExpanded(rootItem));
-        Assert.assertFalse(treeGrid.isExpanded(firstChild));
-        treeGrid.scrollToIndex(10, 0);
-        Assert.assertTrue(treeGrid.isExpanded(rootItem));
-        Assert.assertFalse(treeGrid.isExpanded(firstChild));
-    }
-
-    @Test
-    public void flattenedHierarchyFormat_scrollToIndexNotPresent_notScrolled() {
-        treeGrid.setDataProvider(
-                new TreeDataProvider<>(treeData, HierarchyFormat.FLATTENED));
-        assertScrollToIndexCalled(false, 1000);
-        assertScrollToIndexCalled(false, -1000);
-    }
-
-    @Test
-    public void flattenedHierarchyFormat_scrollToIndex_scrolled() {
-        treeGrid.setDataProvider(
-                new TreeDataProvider<>(treeData, HierarchyFormat.FLATTENED));
-        assertScrollToIndexCalled(true, 10);
-        assertScrollToIndexCalled(true, -10);
-    }
-
-    @Test
-    public void nestedHierarchyFormat_scrollToPathNotPresent_notScrolled() {
-        treeGrid.setDataProvider(
-                new TreeDataProvider<>(treeData, HierarchyFormat.NESTED));
-        assertScrollToPathCalled(false, 1000);
-        assertScrollToPathCalled(false, -1000);
-        assertScrollToPathCalled(false, 10, 5, 5);
-        assertScrollToPathCalled(false, -10, -5, -5);
-    }
-
-    @Test
-    public void nestedHierarchyFormat_scrollToPath_scrolled() {
-        treeGrid.setDataProvider(
-                new TreeDataProvider<>(treeData, HierarchyFormat.NESTED));
-        assertScrollToPathCalled(true, 10, 5);
-        assertScrollToPathCalled(true, -10, -5);
-    }
-
-    private void assertScrollToIndexCalled(boolean called, int index) {
-        treeGrid.scrollToIndex(index);
-        Assert.assertEquals(called, isScrollToIndexCalled());
-    }
-
-    private void assertScrollToPathCalled(boolean called, int... path) {
-        treeGrid.scrollToIndex(path);
-        Assert.assertEquals(called, isScrollToIndexCalled());
-    }
-
-    private boolean isScrollToIndexCalled() {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
-        var invocations = ui.getInternals().dumpPendingJavaScriptInvocations();
-        return invocations.stream().anyMatch(invocation -> invocation
-                .getInvocation().getExpression().contains("scrollToIndex"));
-    }
-
-    private static TreeData<String> getTreeData() {
-        var rootItemCount = 50;
-        var childItemCountPerRootItem = 10;
-        var treeData = new TreeData<String>();
-        var rootItems = IntStream.range(0, rootItemCount)
-                .mapToObj(i -> "Item " + i).toList();
-        treeData.addRootItems(rootItems);
-        rootItems.forEach(rootItem -> treeData.addItems(rootItem,
-                IntStream.range(0, childItemCountPerRootItem)
-                        .mapToObj(i -> rootItem + "-" + i)));
-        return treeData;
     }
 }


### PR DESCRIPTION
## Description

This PR reverts the `scrollToIndex` changes in https://github.com/vaadin/flow-components/pull/8109

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.