### PR TITLE
refactor: Use method for setting comparator

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1864,7 +1864,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                         item -> formatValueToSendToTheClient(
                                 applyValueProvider(valueProvider, item))),
                 columnFactory);
-        ((Column<T>) column).comparator = ((a, b) -> compareMaybeComparables(
+        column.setComparator((a, b) -> compareMaybeComparables(
                 applyValueProvider(valueProvider, a),
                 applyValueProvider(valueProvider, b)));
         return column;


### PR DESCRIPTION
There does not seem to be any need to hack the comparator in place
