### PR TITLE
refactor: align exception type with grid

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -1143,7 +1143,7 @@ public class TreeGrid<T> extends Grid<T>
      *
      * @param item
      *            the item to scroll to
-     * @throws IllegalArgumentException
+     * @throws NoSuchElementException
      *             if the item does not belong to the tree
      */
     @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGridDataCommunicator.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGridDataCommunicator.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.treegrid;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
@@ -107,7 +108,7 @@ class TreeGridDataCommunicator<T> extends HierarchicalDataCommunicator<T> {
         var itemIndex = getItemIndex(item,
                 path.isEmpty() ? null : ancestors.get(ancestors.size() - 1));
         if (itemIndex == -1) {
-            throw new IllegalArgumentException("Item does not exist.");
+            throw new NoSuchElementException("Item does not exist.");
         }
         path.add(itemIndex);
         return path.stream().mapToInt(i -> i).toArray();
@@ -138,7 +139,7 @@ class TreeGridDataCommunicator<T> extends HierarchicalDataCommunicator<T> {
             var ancestorIndex = getItemIndex(ancestors.get(i),
                     i == 0 ? null : ancestors.get(i - 1));
             if (ancestorIndex == -1) {
-                throw new IllegalArgumentException("Item does not exist.");
+                throw new NoSuchElementException("Item does not exist.");
             }
             ancestorPath.add(ancestorIndex);
         }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ScrollToItemTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ScrollToItemTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.treegrid;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -140,7 +141,7 @@ public class ScrollToItemTest {
     public void treeDataProvider_flattenedHierarchyFormat_scrollToMissingItem_doesNotScroll() {
         treeGrid.setDataProvider(new TreeDataProvider<>(treeData,
                 HierarchicalDataProvider.HierarchyFormat.FLATTENED));
-        Assert.assertThrows(IllegalArgumentException.class,
+        Assert.assertThrows(NoSuchElementException.class,
                 this::scrollToMissingItem);
         assertNotScrolled();
     }
@@ -149,7 +150,7 @@ public class ScrollToItemTest {
     public void treeDataProvider_nestedHierarchyFormat_scrollToMissingItem_doesNotScroll() {
         treeGrid.setDataProvider(new TreeDataProvider<>(treeData,
                 HierarchicalDataProvider.HierarchyFormat.NESTED));
-        Assert.assertThrows(IllegalArgumentException.class,
+        Assert.assertThrows(NoSuchElementException.class,
                 this::scrollToMissingItem);
         assertNotScrolled();
     }


### PR DESCRIPTION
## Description

This PR makes `TreeGrid#scrollToItem` throw `NoSuchElementException` instead of `IllegalArgumentException` in order to align with `Grid#scrollToItem`.

Follow-up to https://github.com/vaadin/flow-components/pull/8070

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.