### PR TITLE
feat: add markdown support to Tooltip

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipMarkdownPage.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/TooltipMarkdownPage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.button.tests;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-button/tooltip-markdown")
+public class TooltipMarkdownPage extends Div {
+    public TooltipMarkdownPage() {
+        Button buttonWithTooltip = new Button("Button with tooltip");
+        buttonWithTooltip.setTooltipText("Initial tooltip");
+
+        NativeButton setMarkdownTooltip = new NativeButton(
+                "Set markdown tooltip", e -> {
+                    buttonWithTooltip
+                            .setTooltipMarkdown("**Markdown** _tooltip_");
+                });
+        setMarkdownTooltip.setId("set-markdown-tooltip");
+
+        NativeButton setTextTooltip = new NativeButton("Set text tooltip",
+                e -> {
+                    buttonWithTooltip
+                            .setTooltipText("**Plain text** _tooltip_");
+                });
+        setTextTooltip.setId("set-text-tooltip");
+
+        add(buttonWithTooltip, new Div(setMarkdownTooltip, setTextTooltip));
+    }
+}

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipMarkdownIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipMarkdownIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.button.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-button/tooltip-markdown")
+public class TooltipMarkdownIT extends AbstractComponentIT {
+
+    private TestBenchElement tooltipContent;
+
+    @Before
+    public void init() {
+        open();
+        tooltipContent = $(ButtonElement.class).first().$("vaadin-tooltip")
+                .first().$("div").withAttribute("slot", "overlay").first();
+    }
+
+    @Test
+    public void initialContent_renderedAsText() {
+        Assert.assertEquals("Initial tooltip",
+                tooltipContent.getPropertyString("innerHTML"));
+    }
+
+    @Test
+    public void setMarkdownText_renderedAsMarkdown() {
+        $("button").id("set-markdown-tooltip").click();
+
+        waitForElementPresent(By.tagName("strong"));
+
+        Assert.assertEquals("<p><strong>Markdown</strong> <em>tooltip</em></p>",
+                tooltipContent.getPropertyString("innerHTML").strip());
+    }
+
+    @Test
+    public void switchBackToText_renderedAsText() {
+        $("button").id("set-markdown-tooltip").click();
+
+        waitForElementPresent(By.tagName("strong"));
+
+        $("button").id("set-text-tooltip").click();
+
+        Assert.assertEquals("**Plain text** _tooltip_",
+                tooltipContent.getPropertyString("innerHTML"));
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -37,7 +37,7 @@ import com.vaadin.flow.component.HasElement;
 public interface HasTooltip extends HasElement {
 
     /**
-     * Sets a tooltip text for the component.
+     * Sets a tooltip text for the component as plain text.
      *
      * @param text
      *            The tooltip text
@@ -50,6 +50,23 @@ public interface HasTooltip extends HasElement {
             tooltip = Tooltip.forHasTooltip(this);
         }
         tooltip.setText(text);
+        return tooltip;
+    }
+
+    /**
+     * Sets a tooltip text for the component in Markdown format.
+     *
+     * @param markdown
+     *            The tooltip text in Markdown format
+     *
+     * @return the tooltip handle
+     */
+    default Tooltip setTooltipMarkdown(String markdown) {
+        var tooltip = Tooltip.getForElement(getElement());
+        if (tooltip == null) {
+            tooltip = Tooltip.forHasTooltip(this);
+        }
+        tooltip.setMarkdown(markdown);
         return tooltip;
     }
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -169,13 +169,25 @@ public class Tooltip implements Serializable {
     }
 
     /**
-     * String used as a tooltip content.
+     * Sets the tooltip content as plain text.
      *
      * @param text
      *            the text to set
      */
     public void setText(String text) {
         tooltipElement.setProperty("text", text);
+        tooltipElement.setProperty("markdown", false);
+    }
+
+    /**
+     * Sets the tooltip content in Markdown format.
+     *
+     * @param markdown
+     *            the text to set in Markdown format
+     */
+    public void setMarkdown(String markdown) {
+        tooltipElement.setProperty("text", markdown);
+        tooltipElement.setProperty("markdown", true);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasTooltipTest.java
@@ -96,6 +96,32 @@ public class HasTooltipTest {
         component.setTooltipText("foo");
         Assert.assertEquals("foo",
                 getTooltipElement(component).get().getProperty("text"));
+        Assert.assertFalse(getTooltipElement(component).get()
+                .getProperty("markdown", false));
+    }
+
+    @Test
+    public void setTooltipMarkdown_tooltipHasMarkdown() {
+        component.setTooltipMarkdown("**Markdown** _foo_");
+        Assert.assertEquals("**Markdown** _foo_",
+                getTooltipElement(component).get().getProperty("text"));
+        Assert.assertTrue(getTooltipElement(component).get()
+                .getProperty("markdown", false));
+    }
+
+    @Test
+    public void switchContentTypes() {
+        component.setTooltipText("foo");
+        Assert.assertFalse(getTooltipElement(component).get()
+                .getProperty("markdown", false));
+
+        component.setTooltipMarkdown("**Markdown** _foo_");
+        Assert.assertTrue(getTooltipElement(component).get()
+                .getProperty("markdown", false));
+
+        component.setTooltipText("foo");
+        Assert.assertFalse(getTooltipElement(component).get()
+                .getProperty("markdown", false));
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -95,6 +95,38 @@ public class TooltipTest {
         Assert.assertEquals("foo",
                 getTooltipElement().get().getProperty("text"));
         Assert.assertEquals("foo", tooltip.getText());
+        Assert.assertFalse(
+                getTooltipElement().get().getProperty("markdown", false));
+    }
+
+    @Test
+    public void createTooltip_setMarkdown() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setMarkdown("**Markdown** _foo_");
+        ui.add(component);
+        Assert.assertEquals("**Markdown** _foo_",
+                getTooltipElement().get().getProperty("text"));
+        Assert.assertEquals("**Markdown** _foo_", tooltip.getText());
+        Assert.assertTrue(
+                getTooltipElement().get().getProperty("markdown", false));
+    }
+
+    @Test
+    public void createTooltip_switchContentType() {
+        var tooltip = Tooltip.forComponent(component);
+        ui.add(component);
+
+        tooltip.setText("foo");
+        Assert.assertFalse(
+                getTooltipElement().get().getProperty("markdown", false));
+
+        tooltip.setMarkdown("**Markdown** _foo_");
+        Assert.assertTrue(
+                getTooltipElement().get().getProperty("markdown", false));
+
+        tooltip.setText("foo");
+        Assert.assertFalse(
+                getTooltipElement().get().getProperty("markdown", false));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTooltipPage.java
@@ -56,6 +56,15 @@ public class GridTooltipPage extends Div {
                 });
         setAgeTooltipButton.setId("set-age-tooltip-button");
 
+        var setMarkdownTooltipButton = new NativeButton("Set markdown tooltip",
+                event -> {
+                    grid.setTooltipMarkdownEnabled(true);
+                    grid.setTooltipGenerator(
+                            person -> "**Markdown** _tooltip_ for "
+                                    + person.getFirstName());
+                });
+        setMarkdownTooltipButton.setId("set-markdown-tooltip-button");
+
         var toggleGridButton = new NativeButton("Toggle grid", event -> {
 
             if (grid.getParent().isPresent()) {
@@ -68,7 +77,7 @@ public class GridTooltipPage extends Div {
 
         grid.setId("grid-with-tooltips");
         add(setGridTooltipButton, addColumnButton, setAgeTooltipButton,
-                toggleGridButton, grid);
+                setMarkdownTooltipButton, toggleGridButton, grid);
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTooltipIT.java
@@ -104,6 +104,16 @@ public class GridTooltipIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setMarkdownTooltip() {
+        clickElementWithJs("set-markdown-tooltip-button");
+        flushScrolling(grid);
+        showTooltip(grid.getCell(0, 0));
+        Assert.assertEquals(
+                "<p><strong>Markdown</strong> <em>tooltip</em> for Jack</p>",
+                getActiveTooltipHtmlContent());
+    }
+
+    @Test
     public void newColumnHasGridTooltipGenerator() {
         scrollToElement(grid);
         // set grid tooltip
@@ -125,6 +135,12 @@ public class GridTooltipIT extends AbstractComponentIT {
 
     private String getActiveTooltipText() {
         return findElement(By.tagName("vaadin-tooltip")).getText();
+    }
+
+    private String getActiveTooltipHtmlContent() {
+        return $("vaadin-tooltip").first().$("div")
+                .withAttribute("slot", "overlay").first()
+                .getAttribute("innerHTML").strip();
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4918,6 +4918,33 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 .setAttribute("position", position.getPosition()));
     }
 
+    /**
+     * Returns whether the tooltip content is rendered as Markdown.
+     *
+     * @return {@code true} if the content is rendered as Markdown,
+     *         {@code false} if it is treated as plain text
+     */
+    public boolean isTooltipMarkdownEnabled() {
+        return getTooltipElement().map(
+                tooltipElement -> tooltipElement.getProperty("markdown", false))
+                .orElse(false);
+    }
+
+    /**
+     * Sets whether the tooltip content is rendered as Markdown. By default, the
+     * content is treated as plain text.
+     *
+     * @param markdownEnabled
+     *            {@code true} to render the content as Markdown, {@code false}
+     *            to treat it as plain text
+     */
+    public void setTooltipMarkdownEnabled(boolean markdownEnabled) {
+        addTooltipElementToTooltipSlot();
+
+        getTooltipElement().ifPresent(tooltipElement -> tooltipElement
+                .setProperty("markdown", markdownEnabled));
+    }
+
     private void addTooltipElementToTooltipSlot() {
         if (getTooltipElement().isPresent()) {
             // the grid's tooltip slot has already been filled

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTooltipTest.java
@@ -147,6 +147,42 @@ public class GridTooltipTest {
                 grid.getTooltipPosition());
     }
 
+    @Test
+    public void setTooltipMarkdownEnabled_hasTooltipElement() {
+        grid.setTooltipMarkdownEnabled(true);
+        Assert.assertTrue(getTooltipElement(grid).isPresent());
+    }
+
+    @Test
+    public void setTooltipMarkdownEnabled_hasTooltipWithProperty() {
+        grid.setTooltipMarkdownEnabled(true);
+        Assert.assertTrue(getTooltipElement(grid).orElseThrow()
+                .getProperty("markdown", false));
+
+        grid.setTooltipMarkdownEnabled(false);
+        Assert.assertFalse(getTooltipElement(grid).orElseThrow()
+                .getProperty("markdown", false));
+    }
+
+    @Test
+    public void setTooltipMarkdownEnabled_isTooltipMarkdownEnabled() {
+        grid.setTooltipMarkdownEnabled(true);
+        Assert.assertTrue(grid.isTooltipMarkdownEnabled());
+
+        grid.setTooltipMarkdownEnabled(false);
+        Assert.assertFalse(grid.isTooltipMarkdownEnabled());
+    }
+
+    @Test
+    public void isTooltipMarkdownEnabled_defaultValue() {
+        // without tooltip element
+        Assert.assertFalse(grid.isTooltipMarkdownEnabled());
+
+        // with tooltip element, no property value
+        grid.setTooltipGenerator(item -> item);
+        Assert.assertFalse(grid.isTooltipMarkdownEnabled());
+    }
+
     private Optional<Element> getTooltipElement(Grid<?> grid) {
         return getTooltipElements(grid).findFirst();
     }


### PR DESCRIPTION
## Description

Adds Markdown support to tooltips:
- Adds `Tooltip.setMarkdown(string)` to tooltip handles
- Adds `HasTooltip.setTooltipMarkdown(string)` to components that implement `HasTooltip`
- Adds `Grid.setTooltipMarkdownEnabled(boolean)` to enable Markdown for the Grid tooltip

Part of https://github.com/vaadin/web-components/issues/9771

## Type of change

- Feature
