### PR TITLE
chore: add SLF4J Simple dependency to Charts IT's pom.xml

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -97,6 +97,10 @@
             <artifactId>vaadin-testbench-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
## Description

Add a missing concrete implementation of an SLF4J library, which prevented errors in the Charts IT module from being logged to the Java console.