### PR TITLE
refactor: simplify accessing features from cluster click event

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ClusterPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ClusterPage.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.configuration.Feature;
 import com.vaadin.flow.component.map.configuration.feature.MarkerFeature;
 import com.vaadin.flow.component.map.configuration.layer.FeatureLayer;
 import com.vaadin.flow.component.map.configuration.style.Icon;
@@ -46,10 +47,14 @@ public class ClusterPage extends Div {
         eventLog.getElement().getStyle().set("white-space", "pre");
 
         map.addClusterClickListener(event -> {
-            String features = event.getFeatures().stream()
-                    .map(info -> info.getFeature().getId()).sorted()
-                    .collect(Collectors.joining(", "));
-            eventLog.add(new Div("cluster-click: " + features));
+            String featureIds = event.getFeatures().stream().map(Feature::getId)
+                    .sorted().collect(Collectors.joining(", "));
+            String layerId = event.getLayer().getId();
+            String sourceId = event.getVectorSource().getId();
+            String eventText = String.format(
+                    "cluster-click: features=[%s], layer=%s, source=%s",
+                    featureIds, layerId, sourceId);
+            eventLog.add(new Div(eventText));
         });
 
         map.addFeatureClickListener(event -> {
@@ -66,6 +71,8 @@ public class ClusterPage extends Div {
         layer.setClusteringEnabled(true);
         layer.setClusterDistance(50);
         layer.setClusterMinDistance(50);
+
+        layer.getSource().setId("cluster-source");
 
         // Cluster feature in some region
         MarkerFeature marker = new MarkerFeature(new Coordinate(0, 0));

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/ClusterDemo.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/demo/ClusterDemo.java
@@ -35,6 +35,10 @@ public class ClusterDemo extends Div {
             layer.addFeature(marker);
         }
 
+        map.addClusterClickListener(event -> {
+            map.zoomToFit(event.getFeatures());
+        });
+
         add(map);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ClusterIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ClusterIT.java
@@ -181,7 +181,9 @@ public class ClusterIT extends AbstractComponentIT {
         // Click events are delayed by around 250ms, wait for event
         waitSeconds(1);
 
-        Assert.assertEquals("cluster-click: m1, m2, m3", eventLog.getText());
+        Assert.assertEquals(
+                "cluster-click: features=[m1, m2, m3], layer=feature-layer, source=cluster-source",
+                eventLog.getText());
     }
 
     @Test


### PR DESCRIPTION
## Description

Currently the cluster click event returns a list of `FeatureEventDetails`, which requires you to map those into actual feature instances. However, since the features can only ever come from the same layer and source, we can just provide a list of features and have the layer and source as separate fields on the event itself.

## Type of change

- Refactor