### PR TITLE
fix: check if element exists before initializing grid connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DetachReattachPage.java
@@ -138,11 +138,19 @@ public class DetachReattachPage extends Div {
                 });
         btnDetachAndReattach.setId("detach-and-reattach-button");
 
+        NativeButton attachAndDetach = new NativeButton("attach and detach",
+                e -> {
+                    add(grid);
+                    remove(grid);
+                });
+        attachAndDetach.setId("attach-and-detach-button");
+
         add(btnAttach, btnDetach, btnDisallowDeselect, addItemDetailsButton,
                 toggleDetailsVisibleOnClick, resetSortingButton,
                 selectAndDetachButton, selectMultipleItems,
                 setPageSizeAndDetachButton, setSelectionModeAndDetachButton,
                 sortAndDetachButton, btnHideGrid, btnSelectionModeNone,
-                btnSelectionModeMulti, btnDetachAndReattach, btnShowGrid, grid);
+                btnSelectionModeMulti, btnDetachAndReattach, btnShowGrid,
+                attachAndDetach, grid);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
@@ -44,6 +44,14 @@ public class TreeGridDetachAttachPage extends Div {
         toggleAttached.setId("toggle-attached");
         add(toggleAttached);
 
+        NativeButton attachAndDetach = new NativeButton("attach and detach",
+                e -> {
+                    add(grid);
+                    grid.setUniqueKeyDataGenerator("key", null);
+                    remove(grid);
+                });
+        attachAndDetach.setId("attach-and-detach-button");
+
         NativeButton useAutoWidthColumn = new NativeButton(
                 "use auto-width column", e -> {
                     grid.removeAllColumns();
@@ -51,6 +59,6 @@ public class TreeGridDetachAttachPage extends Div {
                             .setAutoWidth(true).setFlexGrow(0);
                 });
         useAutoWidthColumn.setId("use-auto-width-column");
-        add(useAutoWidthColumn);
+        add(useAutoWidthColumn, attachAndDetach);
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DetachReattachIT.java
@@ -220,4 +220,17 @@ public class DetachReattachIT extends AbstractComponentIT {
         sorter = grid.getHeaderCell(0).$("vaadin-grid-sorter").first();
         Assert.assertEquals(direction, sorter.getProperty("direction"));
     }
+
+    @Test
+    public void detach_attachAndDetach_noClientErrors() {
+        open();
+
+        // Detach
+        $("button").id("detach-button").click();
+
+        // Attach and detach in the same round trip
+        $("button").id("attach-and-detach-button").click();
+
+        checkLogsForErrors();
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
@@ -90,4 +90,15 @@ public class TreeGridDetachAttachIT extends AbstractComponentIT {
         Assert.assertEquals(columnOffsetWidth,
                 grid.getCell(0, 0).getPropertyInteger("offsetWidth"));
     }
+
+    @Test
+    public void detach_attachAndDetach_noClientErrors() {
+        // Detach
+        $("button").id("toggle-attached").click();
+
+        // Attach and detach in the same round trip
+        $("button").id("attach-and-detach-button").click();
+
+        checkLogsForErrors();
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1746,8 +1746,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     protected void initConnector() {
         getUI().orElseThrow(() -> new IllegalStateException(
                 "Connector can only be initialized for an attached Grid"))
-                .getPage()
-                .executeJs("window.Vaadin.Flow.gridConnector.initLazy($0)",
+                .getPage().executeJs(
+                        "if ($0) window.Vaadin.Flow.gridConnector.initLazy($0)",
                         getElement());
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -109,8 +109,8 @@ public class TreeGrid<T> extends Grid<T>
     protected void initConnector() {
         getUI().orElseThrow(() -> new IllegalStateException(
                 "Connector can only be initialized for an attached Grid"))
-                .getPage()
-                .executeJs("window.Vaadin.Flow.treeGridConnector.initLazy($0)",
+                .getPage().executeJs(
+                        "if ($0) window.Vaadin.Flow.treeGridConnector.initLazy($0)",
                         getElement());
     }
 


### PR DESCRIPTION
## Description

Fixes the regression from #7734 by checking element existence before initializing the grid connector.

## Type of change

- [x] Bugfix
