### PR TITLE
refactor: add withMarkdown fluent API

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -211,6 +211,17 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * String used as a tooltip content in Markdown format.
+     *
+     * @param markdown
+     *            the text to set in Markdown format
+     */
+    public Tooltip withMarkdown(String markdown) {
+        setMarkdown(markdown);
+        return this;
+    }
+
+    /**
      * The delay in milliseconds before the tooltip is opened on keyboard focus,
      * when not in manual mode.
      *

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -214,6 +214,8 @@ public class TooltipTest {
 
         Assert.assertEquals("foo",
                 getTooltipElement().get().getProperty("text"));
+        Assert.assertFalse(
+                getTooltipElement().get().getProperty("markdown", false));
         Assert.assertEquals(200,
                 getTooltipElement().get().getProperty("focusDelay", 0));
         Assert.assertEquals(1000,
@@ -224,6 +226,21 @@ public class TooltipTest {
                 getTooltipElement().get().getProperty("position"));
         Assert.assertEquals(true,
                 getTooltipElement().get().getProperty("manual", false));
+    }
+
+    @Test
+    public void createTooltip_fluentAPI_withMarkdown() {
+        ui.add(component);
+
+        var tooltip = Tooltip.forComponent(component)
+                .withMarkdown("**Bold** _italic_");
+
+        Assert.assertNotNull(tooltip);
+
+        Assert.assertEquals("**Bold** _italic_",
+                getTooltipElement().get().getProperty("text"));
+        Assert.assertTrue(
+                getTooltipElement().get().getProperty("markdown", false));
     }
 
     private Optional<Element> getTooltipElement() {


### PR DESCRIPTION
## Description

Adds a missing fluent API for setting Markdown text on a Tooltip instance.

Part of https://github.com/vaadin/web-components/issues/9771

## Type of change

- Refactor