### PR TITLE
chore: upgrade spring-data-commons to 3.5.5 (24.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <cvdlName/>
         <jakarta.servlet.api.version>5.0.0</jakarta.servlet.api.version>
         <jakarta.web.api.version>10.0.0</jakarta.web.api.version>
-        <spring-data-commons.version>3.5.4</spring-data-commons.version>
+        <spring-data-commons.version>3.5.5</spring-data-commons.version>
 
         <!-- spreadsheet -->
         <poi.version>5.4.1</poi.version>


### PR DESCRIPTION
to align with springboot 3.5.7 release, which should be on 23rd of October