### PR TITLE
chore: dedupe dependencies when using local web components (#7743) (CP: 24.9)

### DIFF
--- a/shared/web-components-vite-plugin.ts
+++ b/shared/web-components-vite-plugin.ts
@@ -22,11 +22,21 @@ export function useLocalWebComponents(webComponentsRepoPath: string): PluginOpti
           watch: {
             ignored: [`!${nodeModulesPath}/**`]
           }
+        },
+        // The following dependencies are imported both in the external web-components, and in Flow application sources.
+        // Vite always resolves dependencies from where they are imported, so these dependencies would then be bundled
+        // twice. To avoid that, use dedupe. Dedupe only works for non-optimized dependencies, so they also need to be
+        // excluded from optimization / pre-bundling.
+        optimizeDeps: {
+          exclude: ['@polymer/polymer', 'lit', 'lit-html', 'ol']
+        },
+        resolve: {
+          dedupe: ['@polymer/polymer', 'lit', 'lit-html', 'ol'],
         }
       };
     },
-    resolveId(id) {
-      if (/^(@polymer|@vaadin)/.test(id)) {
+    resolveId(id: string) {
+      if (id.startsWith('@vaadin')) {
         return this.resolve(path.join(nodeModulesPath, id));
       }
     }


### PR DESCRIPTION
## Description

Manual cherry-pick of https://github.com/vaadin/flow-components/pull/7743 to `24.9` branch with the addition of `@polymer/polymer` needed for V24.

## Type of change

- Cherry-pick