### PR TITLE
refactor: use getPrototypeOf(this) to call super methods

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -553,7 +553,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     return this._sorters.filter((sorter) => sorter.direction);
   };
 
-  grid.__applySorters = (...args) => {
+  grid.__applySorters = function (...args) {
     const sorters = grid._mapSorters();
     const sortersChanged = JSON.stringify(grid._previousSorters) !== JSON.stringify(sorters);
 


### PR DESCRIPTION
## Description

`Object.getPrototypeOf(this).methodName.call(this)` should be preferred over `Grid.prototype.methodName.call(this)`. Calling the Grid prototype directly skips overridden methods in subclassed grids, which are common in addons extending existing components.

## Type of change

- [x] Refactor
