### PR TITLE
fix: add missing flow-component-renderer.js import to Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -62,6 +62,7 @@ import elemental.json.JsonArray;
 @NpmPackage(value = "@vaadin/popover", version = "24.9.4")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("@vaadin/popover/src/vaadin-popover.js")
+@JsModule("./flow-component-renderer.js")
 @JsModule("./vaadin-popover/popover.ts")
 public class Popover extends Component implements HasAriaLabel, HasComponents,
         HasThemeVariant<PopoverVariant> {


### PR DESCRIPTION
## Description

Fixes #8210

While `Popover` in 24.9 expects `FlowComponentHost` to be defined, it doesn't import it unlike e.g. `Dialog`.

Note, this fix is not needed on `main` as in V25, we replaced its usage with light DOM content in https://github.com/vaadin/flow-components/pull/7791.

## Type of change

- Bugfix