### PR TITLE
fix: fire opened-change only when opened state changes

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Synchronize;
@@ -78,6 +77,9 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
 
         updateTrigger();
         setRole("dialog");
+
+        getElement().addPropertyChangeListener("opened", event -> fireEvent(
+                new OpenedChangeEvent(this, event.isUserOriginated())));
     }
 
     /**
@@ -177,7 +179,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
      * {@code opened-changed} event is sent when the popover opened state
      * changes.
      */
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent extends ComponentEvent<Popover> {
         private final boolean opened;
 
@@ -200,7 +201,6 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     public void setOpened(boolean opened) {
         if (opened != isOpened()) {
             getElement().setProperty("opened", opened);
-            fireEvent(new OpenedChangeEvent(this, false));
         }
     }
 

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverOpenedChangeListenerTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverOpenedChangeListenerTest.java
@@ -25,6 +25,10 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.server.VaadinSession;
 
 public class PopoverOpenedChangeListenerTest {
@@ -83,6 +87,19 @@ public class PopoverOpenedChangeListenerTest {
 
         clearCapturedData();
         popover.close();
+        Assert.assertNull(event.get());
+        assertListenerCalls(0);
+    }
+
+    @Test
+    public void openedChangeFromClient_noChangeEvent() {
+        Element element = popover.getElement();
+        element.getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(new DomEvent(element, "opened-changed",
+                        JacksonUtils.createObjectNode()));
+
+        // The event should only be fired when the opened state changes, not for
+        // any opened-changed event from the client
         Assert.assertNull(event.get());
         assertListenerCalls(0);
     }


### PR DESCRIPTION
## Description

Popover currently fires an opened changed event whenever it receives an `opened-changed` event from the client. This makes it also fire the event when the web component sets its initial opened value when it is connected to the DOM.

This changes it so that the component only fires the event if the state of the opened property actually changed.

Fixes https://github.com/vaadin/flow-components/issues/8227

## Type of change

- Bugfix
