### PR TITLE
fix: preserve value on unparsable input

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -809,13 +809,21 @@ public class DatePicker
             isFallbackParserRunning = false;
         }
 
+        // Case: User enters unparsable input in a field with valid input
+        if (fromClient && newModelValue == null && oldModelValue != null
+                && isInputUnparsable()) {
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
+        }
+
         boolean isModelValueRemainedEmpty = newModelValue == null
                 && oldModelValue == null;
 
         // Cases:
         // - User modifies input but it remains unparsable
         // - User enters unparsable input in empty field
-        // - User clears unparsable input
+        // - User clears unparsable input (that was already empty)
         if (fromClient && isModelValueRemainedEmpty) {
             validate();
             fireValidationStatusChangeEvent();

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -390,13 +390,21 @@ public class TimePicker
             unparsableValue = null;
         }
 
+        // Case: User enters unparsable input in a field with valid input
+        if (fromClient && newModelValue == null && oldModelValue != null
+                && isInputUnparsable()) {
+            validate();
+            fireValidationStatusChangeEvent();
+            return;
+        }
+
         boolean isModelValueRemainedEmpty = newModelValue == null
                 && oldModelValue == null;
 
         // Cases:
         // - User modifies input but it remains unparsable
         // - User enters unparsable input in empty field
-        // - User clears unparsable input
+        // - User clears unparsable input (that was already empty)
         if (fromClient && isModelValueRemainedEmpty) {
             validate();
             fireValidationStatusChangeEvent();


### PR DESCRIPTION
## Description

This PR updates the validation logic for DatePicker and TimePicker so that the value is preserved on setting unparsable input in a field with a valid value. 

Fixes #8209

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.