### PR TITLE
fix: force reset on open when client updates filter after setting it null

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxThrottledProvider.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxThrottledProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.router.Route;
+
+@Route("multi-select-combo-box-throttled-provider")
+public class MultiSelectComboBoxThrottledProvider extends Div {
+
+    public MultiSelectComboBoxThrottledProvider() {
+        setSizeFull();
+        var comboBox = new MultiSelectComboBox<String>();
+        comboBox.setItems(DataProvider.fromFilteringCallbacks(query -> {
+            int offset = query.getOffset();
+            int limit = query.getLimit();
+            int end = Math.min(offset + limit, 1000);
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return IntStream.range(offset, end)
+                    .mapToObj(i -> "Item " + (i + 1));
+        }, query -> 1000));
+        add(comboBox);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxThrottledProviderIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxThrottledProviderIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.combobox.testbench.MultiSelectComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("multi-select-combo-box-throttled-provider")
+public class MultiSelectComboBoxThrottledProviderIT
+        extends AbstractComponentIT {
+    private MultiSelectComboBoxElement comboBox;
+
+    @Before
+    public void init() {
+        open();
+        comboBox = $(MultiSelectComboBoxElement.class).waitForFirst();
+    }
+
+    @Test
+    public void selectItem_blurWhileLoading_reopen_itemsCorrectlyLoaded() {
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+        // Add a filter
+        comboBox.sendKeys("Item");
+        comboBox.waitForLoadingFinished();
+        // Choose the first item
+        comboBox.sendKeys(Keys.DOWN, Keys.ENTER, Keys.TAB);
+        Assert.assertTrue(comboBox.getSelectedTexts().contains("Item 1"));
+
+        comboBox.openPopup();
+        comboBox.waitForLoadingFinished();
+        Assert.assertFalse(comboBox.getOptions().isEmpty());
+    }
+}


### PR DESCRIPTION
## Description

Adds a flag that force resets the communicator when reopened. This addresses the edge cases where an item is selected while a filter is present, and then the overlay is closed while still in loading state.

Fixes #8235

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.