### PR TITLE
test: make tests wait for spreadsheet to update on selection change

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.Point;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.logging.LogEntry;
@@ -373,6 +374,18 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
                 findElements(By.className("v-errorindicator")).isEmpty());
     }
 
+    protected void assertAddressFieldValue(String expected) {
+        try {
+            waitUntil(
+                    driver -> Objects.equals(expected, getAddressFieldValue()),
+                    2);
+        } catch (TimeoutException e) {
+            var actual = getAddressFieldValue();
+            Assert.fail("Expected " + expected + " on addressField, actual:"
+                    + actual);
+        }
+    }
+
     protected void assertAddressFieldValue(String expected, String actual) {
         Assert.assertEquals(
                 "Expected " + expected + " on addressField, actual:" + actual,
@@ -380,7 +393,11 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     }
 
     protected void assertSelectedCell(String cell) {
-        assertSelectedCell(cell, isCellSelected(cell));
+        try {
+            waitUntil(driver -> isCellSelected(cell), 2);
+        } catch (TimeoutException e) {
+            Assert.fail("Cell " + cell + " should be the selected cell");
+        }
     }
 
     protected void assertSelectedCell(String cell, boolean selected) {
@@ -389,7 +406,11 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     }
 
     protected void assertNotSelectedCell(String cell) {
-        assertNotSelectedCell(cell, isCellSelected(cell));
+        try {
+            waitUntil(driver -> !isCellSelected(cell), 2);
+        } catch (TimeoutException e) {
+            Assert.fail("Cell " + cell + " should not be selected cell");
+        }
     }
 
     protected void assertNotSelectedCell(String cell, boolean selected) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NavigationIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/NavigationIT.java
@@ -36,37 +36,37 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     public void testClickingOnCellsUpdatesAddressFieldAndUpdatesSelection()
             throws Exception {
         clickCell("A2");
-        assertAddressFieldValue("A2", getAddressFieldValue());
-        assertSelectedCell("A2", isCellSelected("A2"));
+        assertAddressFieldValue("A2");
+        assertSelectedCell("A2");
 
         clickCell("B1");
-        assertAddressFieldValue("B1", getAddressFieldValue());
-        assertSelectedCell("B1", isCellSelected("B1"));
-        assertNotSelectedCell("A2", isCellSelected("A2"));
+        assertAddressFieldValue("B1");
+        assertSelectedCell("B1");
+        assertNotSelectedCell("A2");
 
         clickCell("D7");
-        assertAddressFieldValue("D7", getAddressFieldValue());
-        assertSelectedCell("D7", isCellSelected("D7"));
-        assertNotSelectedCell("B1", isCellSelected("B1"));
+        assertAddressFieldValue("D7");
+        assertSelectedCell("D7");
+        assertNotSelectedCell("B1");
 
         clickCell("Q15");
-        assertAddressFieldValue("Q15", getAddressFieldValue());
-        assertSelectedCell("Q15", isCellSelected("Q15"));
+        assertAddressFieldValue("Q15");
+        assertSelectedCell("Q15");
     }
 
     @Test
     public void testUpdatingAddressFieldMovesSelection() throws Exception {
         setAddressFieldValue("A5");
-        assertSelectedCell("A5", isCellSelected("A5"));
+        assertSelectedCell("A5");
 
         setAddressFieldValue("G10");
-        assertSelectedCell("G10", isCellSelected("G10"));
+        assertSelectedCell("G10");
 
         setAddressFieldValue("D20");
-        assertSelectedCell("D20", isCellSelected("D20"));
+        assertSelectedCell("D20");
 
         setAddressFieldValue("AC2");
-        assertSelectedCell("AC2", isCellSelected("AC2"));
+        assertSelectedCell("AC2");
     }
 
     @Test
@@ -78,7 +78,7 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     @Test
     public void testKeyboardSelection() throws Exception {
         clickCell("H10");
-        assertSelectedCell("H10", isCellSelected("H10"));
+        assertSelectedCell("H10");
         WebElement cell = getCellAt(8, 10);
         new Actions(getDriver()).moveToElement(cell).keyDown(Keys.SHIFT)
                 .sendKeys(Keys.RIGHT).sendKeys(Keys.RIGHT).sendKeys(Keys.DOWN)
@@ -91,18 +91,18 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     public void testAddressFieldUpdatesWhenDragging() throws Exception {
         new Actions(getDriver()).clickAndHold(getCellAt(8, 10))
                 .moveToElement(getCellAt(9, 10)).build().perform();
-        assertAddressFieldValue("1R x 2C", getAddressFieldValue());
+        assertAddressFieldValue("1R x 2C");
         new Actions(getDriver()).moveToElement(getCellAt(10, 10)).build()
                 .perform();
-        assertAddressFieldValue("1R x 3C", getAddressFieldValue());
+        assertAddressFieldValue("1R x 3C");
         new Actions(getDriver()).moveToElement(getCellAt(10, 11)).build()
                 .perform();
-        assertAddressFieldValue("2R x 3C", getAddressFieldValue());
+        assertAddressFieldValue("2R x 3C");
         new Actions(getDriver()).moveToElement(getCellAt(10, 12)).build()
                 .perform();
-        assertAddressFieldValue("3R x 3C", getAddressFieldValue());
+        assertAddressFieldValue("3R x 3C");
         new Actions(getDriver()).release().build().perform();
-        assertAddressFieldValue("H10", getAddressFieldValue());
+        assertAddressFieldValue("H10");
     }
 
     @Test
@@ -112,15 +112,15 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         WebElement cell = getCellAt(8, 10);
         new Actions(getDriver()).moveToElement(cell).keyDown(Keys.SHIFT)
                 .sendKeys(Keys.RIGHT).build().perform();
-        assertAddressFieldValue("1R x 2C", getAddressFieldValue());
+        assertAddressFieldValue("1R x 2C");
         new Actions(getDriver()).sendKeys(Keys.RIGHT).build().perform();
-        assertAddressFieldValue("1R x 3C", getAddressFieldValue());
+        assertAddressFieldValue("1R x 3C");
         new Actions(getDriver()).sendKeys(Keys.DOWN).build().perform();
-        assertAddressFieldValue("2R x 3C", getAddressFieldValue());
+        assertAddressFieldValue("2R x 3C");
         new Actions(getDriver()).sendKeys(Keys.DOWN).build().perform();
-        assertAddressFieldValue("3R x 3C", getAddressFieldValue());
+        assertAddressFieldValue("3R x 3C");
         new Actions(getDriver()).keyUp(Keys.SHIFT).build().perform();
-        assertAddressFieldValue("H10", getAddressFieldValue());
+        assertAddressFieldValue("H10");
     }
 
     @Test
@@ -128,37 +128,37 @@ public class NavigationIT extends AbstractSpreadsheetIT {
             throws Exception {
         assertSelectionRange("G10:J10", false);
         clickCell("H10");
-        assertNotSelectedCell("G10", isCellSelected("G10"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertNotSelectedCell("I10", isCellSelected("I10"));
-        assertNotSelectedCell("J10", isCellSelected("J10"));
+        assertNotSelectedCell("G10");
+        assertSelectedCell("H10");
+        assertNotSelectedCell("I10");
+        assertNotSelectedCell("J10");
         new Actions(getDriver()).moveToElement(getCellAt(8, 10))
                 .keyDown(Keys.SHIFT).sendKeys(Keys.RIGHT).build().perform();
-        assertNotSelectedCell("G10", isCellSelected("G10"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertSelectedCell("I10", isCellSelected("I10"));
-        assertNotSelectedCell("J10", isCellSelected("J10"));
+        assertNotSelectedCell("G10");
+        assertSelectedCell("H10");
+        assertSelectedCell("I10");
+        assertNotSelectedCell("J10");
         new Actions(getDriver()).sendKeys(Keys.RIGHT).build().perform();
-        assertNotSelectedCell("G10", isCellSelected("G10"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertSelectedCell("I10", isCellSelected("I10"));
-        assertSelectedCell("J10", isCellSelected("J10"));
+        assertNotSelectedCell("G10");
+        assertSelectedCell("H10");
+        assertSelectedCell("I10");
+        assertSelectedCell("J10");
         new Actions(getDriver()).sendKeys(Keys.LEFT).build().perform();
-        assertNotSelectedCell("G10", isCellSelected("G10"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertSelectedCell("I10", isCellSelected("I10"));
-        assertNotSelectedCell("J10", isCellSelected("J10"));
+        assertNotSelectedCell("G10");
+        assertSelectedCell("H10");
+        assertSelectedCell("I10");
+        assertNotSelectedCell("J10");
         new Actions(getDriver()).sendKeys(Keys.LEFT).build().perform();
-        assertNotSelectedCell("G10", isCellSelected("G10"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertNotSelectedCell("I10", isCellSelected("I10"));
-        assertNotSelectedCell("J10", isCellSelected("J10"));
+        assertNotSelectedCell("G10");
+        assertSelectedCell("H10");
+        assertNotSelectedCell("I10");
+        assertNotSelectedCell("J10");
         new Actions(getDriver()).sendKeys(Keys.LEFT).keyUp(Keys.SHIFT).build()
                 .perform();
-        assertSelectedCell("G10", isCellSelected("G10"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertNotSelectedCell("I10", isCellSelected("I10"));
-        assertNotSelectedCell("J10", isCellSelected("J10"));
+        assertSelectedCell("G10");
+        assertSelectedCell("H10");
+        assertNotSelectedCell("I10");
+        assertNotSelectedCell("J10");
     }
 
     @Test
@@ -166,37 +166,37 @@ public class NavigationIT extends AbstractSpreadsheetIT {
             throws Exception {
         assertSelectionRange("H9:H12", false);
         clickCell("H10");
-        assertNotSelectedCell("H9", isCellSelected("H9"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertNotSelectedCell("H11", isCellSelected("H11"));
-        assertNotSelectedCell("H12", isCellSelected("H12"));
+        assertNotSelectedCell("H9");
+        assertSelectedCell("H10");
+        assertNotSelectedCell("H11");
+        assertNotSelectedCell("H12");
         new Actions(getDriver()).moveToElement(getCellAt(8, 10))
                 .keyDown(Keys.SHIFT).sendKeys(Keys.DOWN).build().perform();
-        assertNotSelectedCell("H9", isCellSelected("H9"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertSelectedCell("H11", isCellSelected("H11"));
-        assertNotSelectedCell("H12", isCellSelected("H12"));
+        assertNotSelectedCell("H9");
+        assertSelectedCell("H10");
+        assertSelectedCell("H11");
+        assertNotSelectedCell("H12");
         new Actions(getDriver()).sendKeys(Keys.DOWN).build().perform();
-        assertNotSelectedCell("H9", isCellSelected("H9"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertSelectedCell("H11", isCellSelected("H11"));
-        assertSelectedCell("H12", isCellSelected("H12"));
+        assertNotSelectedCell("H9");
+        assertSelectedCell("H10");
+        assertSelectedCell("H11");
+        assertSelectedCell("H12");
         new Actions(getDriver()).sendKeys(Keys.UP).build().perform();
-        assertNotSelectedCell("H9", isCellSelected("H9"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertSelectedCell("H11", isCellSelected("H11"));
-        assertNotSelectedCell("H12", isCellSelected("H12"));
+        assertNotSelectedCell("H9");
+        assertSelectedCell("H10");
+        assertSelectedCell("H11");
+        assertNotSelectedCell("H12");
         new Actions(getDriver()).sendKeys(Keys.UP).build().perform();
-        assertNotSelectedCell("H9", isCellSelected("H9"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertNotSelectedCell("H11", isCellSelected("H11"));
-        assertNotSelectedCell("H12", isCellSelected("H12"));
+        assertNotSelectedCell("H9");
+        assertSelectedCell("H10");
+        assertNotSelectedCell("H11");
+        assertNotSelectedCell("H12");
         new Actions(getDriver()).sendKeys(Keys.UP).keyUp(Keys.SHIFT).build()
                 .perform();
-        assertSelectedCell("H9", isCellSelected("H9"));
-        assertSelectedCell("H10", isCellSelected("H10"));
-        assertNotSelectedCell("H11", isCellSelected("H11"));
-        assertNotSelectedCell("H12", isCellSelected("H12"));
+        assertSelectedCell("H9");
+        assertSelectedCell("H10");
+        assertNotSelectedCell("H11");
+        assertNotSelectedCell("H12");
     }
 
     @Test
@@ -216,32 +216,32 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     public void testKeyboardNavigation() throws Exception {
         clickCell("J10");
         new Actions(getDriver()).sendKeys(Keys.RIGHT).build().perform();
-        assertSelectedCell("K10", isCellSelected("K10"));
+        assertSelectedCell("K10");
 
         new Actions(getDriver()).sendKeys(Keys.DOWN).build().perform();
-        assertSelectedCell("K11", isCellSelected("K11"));
+        assertSelectedCell("K11");
 
         new Actions(getDriver()).sendKeys(Keys.ENTER, Keys.ENTER).build()
                 .perform();
-        assertSelectedCell("K12", isCellSelected("K12"));
+        assertSelectedCell("K12");
 
         new Actions(getDriver()).sendKeys(Keys.LEFT).build().perform();
-        assertSelectedCell("J12", isCellSelected("J12"));
+        assertSelectedCell("J12");
 
         new Actions(getDriver()).sendKeys(Keys.UP).build().perform();
-        assertSelectedCell("J11", isCellSelected("J11"));
+        assertSelectedCell("J11");
 
         new Actions(getDriver()).keyDown(Keys.SHIFT)
                 .sendKeys(Keys.ENTER, Keys.ENTER).keyUp(Keys.SHIFT).build()
                 .perform();
-        assertSelectedCell("J10", isCellSelected("J10"));
+        assertSelectedCell("J10");
 
         new Actions(getDriver()).sendKeys(Keys.TAB).build().perform();
-        assertSelectedCell("K10", isCellSelected("K10"));
+        assertSelectedCell("K10");
 
         new Actions(getDriver()).keyDown(Keys.SHIFT).sendKeys(Keys.TAB)
                 .keyUp(Keys.SHIFT).build().perform();
-        assertSelectedCell("J10", isCellSelected("J10"));
+        assertSelectedCell("J10");
     }
 
     @Test
@@ -278,10 +278,10 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         assertSelectionRange("A1:B2", true);
 
         new Actions(getDriver()).sendKeys(Keys.RIGHT).build().perform();
-        assertNotSelectedCell("A1", isCellSelected("A1"));
-        assertNotSelectedCell("A2", isCellSelected("A2"));
-        assertSelectedCell("B1", isCellSelected("B1"));
-        assertNotSelectedCell("B2", isCellSelected("B2"));
+        assertNotSelectedCell("A1");
+        assertNotSelectedCell("A2");
+        assertSelectedCell("B1");
+        assertNotSelectedCell("B2");
     }
 
     @Test
@@ -291,10 +291,10 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         assertSelectionRange("A1:B2", true);
 
         new Actions(getDriver()).sendKeys(Keys.DOWN).build().perform();
-        assertNotSelectedCell("A1", isCellSelected("A1"));
-        assertSelectedCell("A2", isCellSelected("A2"));
-        assertNotSelectedCell("B1", isCellSelected("B1"));
-        assertNotSelectedCell("B2", isCellSelected("B2"));
+        assertNotSelectedCell("A1");
+        assertSelectedCell("A2");
+        assertNotSelectedCell("B1");
+        assertNotSelectedCell("B2");
     }
 
     @Test
@@ -304,7 +304,7 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         assertSelectionRange("B1:C2", true);
 
         new Actions(getDriver()).sendKeys(Keys.LEFT).build().perform();
-        assertSelectedCell("A1", isCellSelected("A1"));
+        assertSelectedCell("A1");
         assertSelectionRange("B1:C2", false);
     }
 
@@ -315,7 +315,7 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         assertSelectionRange("A2:B3", true);
 
         new Actions(getDriver()).sendKeys(Keys.UP).build().perform();
-        assertSelectedCell("A1", isCellSelected("A1"));
+        assertSelectedCell("A1");
         assertSelectionRange("A2:B3", false);
     }
 
@@ -334,12 +334,12 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         // We need to press the key two times to make it scroll.
         new Actions(getDriver()).sendKeys(Keys.RIGHT).sendKeys(Keys.RIGHT)
                 .build().perform();
-        assertSelectedCell("AB1", isCellSelected("AB1"));
+        assertSelectedCell("AB1");
 
         // We need to press the key two times to make it scroll.
         new Actions(getDriver()).sendKeys(Keys.RIGHT).sendKeys(Keys.RIGHT)
                 .build().perform();
-        assertSelectedCell("AD1", isCellSelected("AD1"));
+        assertSelectedCell("AD1");
     }
 
     @Test
@@ -350,12 +350,12 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         // We need to press the key two times to make it scroll.
         new Actions(getDriver()).sendKeys(Keys.DOWN).sendKeys(Keys.DOWN).build()
                 .perform();
-        assertSelectedCell("A42", isCellSelected("A42"));
+        assertSelectedCell("A42");
 
         // We need to press the key two times to make it scroll.
         new Actions(getDriver()).sendKeys(Keys.DOWN).sendKeys(Keys.DOWN).build()
                 .perform();
-        assertSelectedCell("A44", isCellSelected("A44"));
+        assertSelectedCell("A44");
     }
 
     @Test
@@ -365,22 +365,24 @@ public class NavigationIT extends AbstractSpreadsheetIT {
         setFormulaFieldValue("2");
 
         clickCell("J10");
+        assertSelectedCell("J10");
         new Actions(getDriver()).sendKeys(Keys.ENTER).sendKeys(Keys.ENTER)
                 .build().perform();
-        assertSelectedCell("J11", isCellSelected("J11"));
+
+        assertSelectedCell("J11");
         assertCellValue("2", "J10");
 
         new Actions(getDriver()).keyDown(Keys.SHIFT).sendKeys(Keys.ENTER)
                 .sendKeys(Keys.ENTER).keyUp(Keys.SHIFT).build().perform();
-        assertSelectedCell("J10", isCellSelected("J10"));
+        assertSelectedCell("J10");
 
         new Actions(getDriver()).sendKeys(Keys.TAB).build().perform();
-        assertSelectedCell("K10", isCellSelected("K10"));
+        assertSelectedCell("K10");
         assertCellValue("2", "J10");
 
         new Actions(getDriver()).keyDown(Keys.SHIFT).sendKeys(Keys.TAB)
                 .keyUp(Keys.SHIFT).build().perform();
-        assertSelectedCell("J10", isCellSelected("J10"));
+        assertSelectedCell("J10");
     }
 
     @Test
@@ -405,7 +407,7 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     @Test
     public void testShiftClickShouldSelect() throws Exception {
         clickCell("B2");
-        assertSelectedCell("B2", isCellSelected("B2"));
+        assertSelectedCell("B2");
         // new Actions(getDriver()).keyDown(Keys.SHIFT).build().perform();
         // clickCell("D7");
         // new Actions(getDriver()).keyUp(Keys.SHIFT).build().perform();
@@ -417,7 +419,7 @@ public class NavigationIT extends AbstractSpreadsheetIT {
     @Test
     public void testShiftClickOnColumnHeader() throws Exception {
         clickCell("B2");
-        assertSelectedCell("B2", isCellSelected("B2"));
+        assertSelectedCell("B2");
         // new Actions(getDriver()).keyDown(Keys.SHIFT).build().perform();
         // clickOnColumnHeader("D");
         // new Actions(getDriver()).keyUp(Keys.SHIFT).build().perform();
@@ -429,9 +431,8 @@ public class NavigationIT extends AbstractSpreadsheetIT {
 
     @Test
     public void testShiftClickOnRowHeader() throws Exception {
-
         clickCell("B10");
-        assertSelectedCell("B10", isCellSelected("B10"));
+        assertSelectedCell("B10");
         // new Actions(getDriver()).keyDown(Keys.SHIFT).build().perform();
         // clickOnRowHeader(15);
         // new Actions(getDriver()).keyUp(Keys.SHIFT).build().perform();
@@ -443,22 +444,21 @@ public class NavigationIT extends AbstractSpreadsheetIT {
 
     @Test
     public void testSelectCellsByCtrlClick() throws Exception {
-
         // ("only works on windows due to
         // https://code.google.com/p/selenium/issues/detail?id=4843 (patch
         // pending)")
         clickCell("A2");
         clickCell("A1");
-        assertSelectedCell("A1", isCellSelected("A1"));
+        assertSelectedCell("A1");
         new Actions(getDriver()).keyDown(Keys.CONTROL).build().perform();
         clickCell("B2");
-        assertSelectedCell("A1", isCellSelected("A1"));
-        assertSelectedCell("B2", isCellSelected("B2"));
+        assertSelectedCell("A1");
+        assertSelectedCell("B2");
         clickCell("F12");
         new Actions(getDriver()).keyUp(Keys.CONTROL).build().perform();
-        assertSelectedCell("A1", isCellSelected("A1"));
-        assertSelectedCell("B2", isCellSelected("B2"));
-        assertSelectedCell("F12", isCellSelected("F12"));
+        assertSelectedCell("A1");
+        assertSelectedCell("B2");
+        assertSelectedCell("F12");
     }
 
     private void assertActiveCellInsideSelection(String cellAddress) {


### PR DESCRIPTION
## Description

Spreadsheet selection updates can take some time to be reflected on the state. This can cause flaky tests and stale element references. This PR updates the tests to try the assertion for 2 seconds so that that are more stable in different environments.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Test

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.