### PR TITLE
chore: bump FW8 version to 8.29.0 in V24

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
@@ -38,7 +38,7 @@
         <!-- we dont put this dependencies in parent poms because they are only
          used in this module just for the compilation Java to JS -->
         <gwt.version>2.9.0</gwt.version>
-        <framework.version>8.27.7</framework.version>
+        <framework.version>8.29.0</framework.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Description

A fix for iPad device detection has been done in Framework 8, which is needed to make context menus in Spreadsheet work on long press. 

> [!NOTE]
> This version has already been updated in V25 by @dependadot.

Fixes #8155

## Type of change

- Bugfix

