### PR TITLE
refactor: remove commons-io usage

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/CrudI18n.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/CrudI18n.java
@@ -10,12 +10,10 @@ package com.vaadin.flow.component.crud;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.StringUtil;
 
 import tools.jackson.databind.JsonNode;
 
@@ -41,9 +39,8 @@ public class CrudI18n implements Serializable {
 
     static {
         try {
-            String jsonString = IOUtils.toString(
-                    CrudI18n.class.getResource("i18n.json"),
-                    StandardCharsets.UTF_8);
+            String jsonString = StringUtil.toUTF8String(
+                    CrudI18n.class.getResourceAsStream("i18n.json"));
             DEFAULT_I18N = JacksonUtils.readTree(jsonString);
         } catch (IOException e) {
             throw new IllegalStateException(

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginI18n.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/LoginI18n.java
@@ -17,12 +17,10 @@ package com.vaadin.flow.component.login;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.StringUtil;
 
 import tools.jackson.databind.JsonNode;
 
@@ -40,9 +38,8 @@ public class LoginI18n implements Serializable {
 
     static {
         try {
-            String jsonString = IOUtils.toString(
-                    LoginI18n.class.getResource("i18n.json"),
-                    StandardCharsets.UTF_8);
+            String jsonString = StringUtil.toUTF8String(
+                    LoginI18n.class.getResourceAsStream("i18n.json"));
             DEFAULT_I18N = JacksonUtils.readTree(jsonString);
         } catch (IOException e) {
             throw new IllegalStateException(

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/FileBufferView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/FileBufferView.java
@@ -19,13 +19,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Function;
 
-import org.apache.commons.io.IOUtils;
-
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.upload.SucceededEvent;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.receivers.FileBuffer;
 import com.vaadin.flow.component.upload.receivers.MultiFileBuffer;
+import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -71,7 +70,7 @@ public class FileBufferView extends Div {
             try {
                 output.add(event.getFileName());
                 output.add(
-                        IOUtils.toString(streamProvider.apply(event), "UTF-8"));
+                        StringUtil.toUTF8String(streamProvider.apply(event)));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadView.java
@@ -17,14 +17,13 @@ package com.vaadin.flow.component.upload.tests;
 
 import java.io.IOException;
 
-import org.apache.commons.io.IOUtils;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -52,8 +51,8 @@ public class UploadView extends Div {
             try {
                 output.add(event.getFileName());
                 output.add(event.getMIMEType());
-                output.add(IOUtils.toString(
-                        buffer.getInputStream(event.getFileName()), "UTF-8"));
+                output.add(StringUtil.toUTF8String(
+                        buffer.getInputStream(event.getFileName())));
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferTest.java
@@ -19,11 +19,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.upload.receivers.FileBuffer;
+import com.vaadin.flow.internal.StringUtil;
 
 public class FileBufferTest {
 
@@ -35,8 +35,8 @@ public class FileBufferTest {
         try (OutputStream os = fileBuffer.receiveUpload("uploadData", "text")) {
             os.write(dataBytes);
         }
-        final String readData = IOUtils.toString(fileBuffer.getInputStream(),
-                Charset.defaultCharset());
+        final String readData = StringUtil
+                .toUTF8String(fileBuffer.getInputStream());
         Assert.assertEquals(data, readData);
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/MultiFileBufferTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/MultiFileBufferTest.java
@@ -19,11 +19,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.upload.receivers.MultiFileBuffer;
+import com.vaadin.flow.internal.StringUtil;
 
 public class MultiFileBufferTest {
 
@@ -42,9 +42,8 @@ public class MultiFileBufferTest {
             }
         }
         for (TestData data : testData) {
-            final String readData = IOUtils.toString(
-                    fileBuffer.getInputStream(data.filename),
-                    Charset.defaultCharset());
+            final String readData = StringUtil
+                    .toUTF8String(fileBuffer.getInputStream(data.filename));
             Assert.assertEquals(data.data, readData);
         }
     }


### PR DESCRIPTION
## Description

The dependency was removed from Flow in https://github.com/vaadin/flow/pull/22785. Replace it with the helper method introduced in the linked PR.

## Type of change

- Refactor