### PR TITLE
fix: add popover to UI as fallback instead of current UI modal

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -745,7 +745,7 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
                                 parentComponent.getElement()
                                         .appendChild(getElement());
                             }
-                        }, () -> ui.addToModalComponent(this));
+                        }, () -> ui.add(this));
 
                 autoAddedToTheUi = true;
             }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -189,6 +189,20 @@ public class PopoverAutoAddTest {
     }
 
     @Test
+    public void openModal_setTargetOutsideOfModal_popoverIsAttachedToUi() {
+        Div modal = new Div();
+        ui.add(modal);
+        ui.setChildComponentModal(modal, true);
+
+        Div target = new Div();
+        Popover popover = new Popover();
+        popover.setTarget(target);
+        ui.add(target);
+
+        Assert.assertEquals(ui, popover.getParent().orElseThrow());
+    }
+
+    @Test
     public void popoverWithTargetInPopover_popoverAttachedToPopover() {
         var firstPopover = new Popover();
         ui.add(firstPopover);


### PR DESCRIPTION
## Description

Currently a popover adds itself to the current UI modal component as a fallback when the target component is not within a modal component itself. As shown in https://github.com/vaadin/flow-components/issues/8286 that can be a problem if the target is outside of that modal, in which case removing the current modal will also remove the popover even though the target is still part of the UI.

This changes it so that the popover adds itself to the UI itself instead, so that it will still exist even if the current UI modal is removed.

Fixes https://github.com/vaadin/flow-components/issues/8286

## Type of change

- Bugfix
