### PR TITLE
fix: move reverse variant to AvatarGroupVariant

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroupVariant.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroupVariant.java
@@ -24,7 +24,9 @@ public enum AvatarGroupVariant implements ThemeVariant {
     LUMO_XLARGE("xlarge"),
     LUMO_LARGE("large"),
     LUMO_SMALL("small"),
-    LUMO_XSMALL("xsmall");
+    LUMO_XSMALL("xsmall"),
+    LUMO_REVERSE("reverse"),
+    AURA_REVERSE("reverse");
 
     private final String variant;
 

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarVariant.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarVariant.java
@@ -24,9 +24,7 @@ public enum AvatarVariant implements ThemeVariant {
     LUMO_XLARGE("xlarge"),
     LUMO_LARGE("large"),
     LUMO_SMALL("small"),
-    LUMO_XSMALL("xsmall"),
-    LUMO_REVERSE("reverse"),
-    AURA_REVERSE("reverse");
+    LUMO_XSMALL("xsmall");
 
     private final String variant;
 


### PR DESCRIPTION
## Description

The `reverse` variant should be used with `AvatarGroup`.

## Type of change

- Bugfix
