### PR TITLE
feat: add Aura field alignment theme variants

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxVariant.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxVariant.java
@@ -26,6 +26,11 @@ public enum ComboBoxVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxVariant.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxVariant.java
@@ -27,6 +27,11 @@ public enum MultiSelectComboBoxVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePickerVariant.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePickerVariant.java
@@ -26,6 +26,11 @@ public enum DatePickerVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerVariant.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerVariant.java
@@ -27,6 +27,11 @@ public enum DateTimePickerVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/SelectVariant.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/SelectVariant.java
@@ -26,6 +26,11 @@ public enum SelectVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
@@ -25,6 +25,11 @@ public enum TextAreaVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
@@ -26,6 +26,11 @@ public enum TextFieldVariant implements ThemeVariant {
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 
     private final String variant;

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePickerVariant.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePickerVariant.java
@@ -25,6 +25,11 @@ public enum TimePickerVariant implements ThemeVariant {
     LUMO_ALIGN_LEFT("align-left"),
     LUMO_ALIGN_CENTER("align-center"),
     LUMO_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_LEFT("align-left"),
+    AURA_ALIGN_CENTER("align-center"),
+    AURA_ALIGN_RIGHT("align-right"),
+    AURA_ALIGN_START("align-start"),
+    AURA_ALIGN_END("align-end"),
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     AURA_HELPER_ABOVE_FIELD("helper-above-field");
 


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/web-components/pull/10551

Added `align-start`, `align-center`, `align-end`, `align-left` and `align-right` variants.

## Type of change

- Feature