### PR TITLE
fix: use celldata cache for merged cell styles

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -3645,11 +3645,7 @@ public class SheetWidget extends Panel {
         }
         String key = toKey(region.col1, region.row1);
         MergedCell mergedCell = new MergedCell(this, region.col1, region.row1);
-        String cellStyle = "cs0";
-        Cell cell = getCell(region.col1, region.row1);
-        if (cell != null) {
-            cellStyle = cell.getCellStyle();
-        }
+        String cellStyle = getMergedRegionCellStyle(region);
         mergedCell.setValue(getCellValue(region.col1, region.row1), cellStyle,
                 false);
         DivElement element = mergedCell.getElement();
@@ -3676,6 +3672,18 @@ public class SheetWidget extends Panel {
             Widget customWidget = customWidgetMap.get(key);
             addCustomWidgetToCell(mergedCell, customWidget);
         }
+    }
+
+    private String getMergedRegionCellStyle(MergedRegion region) {
+        CellData cellData = getCellData(region.col1, region.row1);
+        if (cellData != null && cellData.cellStyle != null) {
+            return cellData.cellStyle;
+        }
+        Cell cell = getCell(region.col1, region.row1);
+        if (cell != null) {
+            return cell.getCellStyle();
+        }
+        return "cs0";
     }
 
     /**


### PR DESCRIPTION
## Description

When `addMergedRegion()` in `SheetWidget` retrieves the cell style from a recycled `Cell` object, it may get stale styling from the cell's previous position instead of the correct style for the merged cell. 

This PR modifies `addMergedRegion()` to prioritize the `CellData` cache over the `Cell` object when retrieving cell styles.

The timing depends on OS and browser, therefore there is no test in this PR. The behaviour can be manually verified.

Fixes #8317

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.