### PR TITLE
refactor!: remove no longer existing button Aura accent variant

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/ButtonVariant.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/ButtonVariant.java
@@ -33,7 +33,6 @@ public enum ButtonVariant implements ThemeVariant {
     LUMO_ICON("icon"),
     AURA_PRIMARY("primary"),
     AURA_TERTIARY("tertiary"),
-    AURA_ACCENT("accent"),
     AURA_DANGER("danger");
 
     private final String variant;


### PR DESCRIPTION
## Description

Usage of `:where(:not([theme~='accent']))` has been removed from Button CSS, see following PRs:

- https://github.com/vaadin/web-components/pull/10522
- https://github.com/vaadin/web-components/pull/10532

Removed `AURA_ACCENT` variant from `ButtonVariant` enum as no longer needed.

## Type of change

- Refactor