### PR TITLE
refactor: only apply icon slot if there is text content

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.flow.component.button;
 
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.ClickEvent;
@@ -182,10 +177,11 @@ public class Button extends Component
      */
     @Override
     public void setText(String text) {
-        removeAll(getNonTextNodes());
+        removeAllTextContent();
         if (text != null && !text.isEmpty()) {
             getElement().appendChild(Element.createText(text));
         }
+        updateIconSlot();
         updateThemeAttribute();
     }
 
@@ -238,6 +234,9 @@ public class Button extends Component
      * <p>
      * At the element-level, this method determines whether to set
      * {@code slot="prefix"} or {@code slot="suffix"} attribute to the icon.
+     * <p>
+     * When there is no text content in the button, the icon will not have any
+     * slot attribute regardless of this setting.
      *
      * @param iconAfterText
      *            whether the icon should be positioned after the text content
@@ -245,9 +244,7 @@ public class Button extends Component
      */
     public void setIconAfterText(boolean iconAfterText) {
         this.iconAfterText = iconAfterText;
-        if (iconComponent != null) {
-            updateIconSlot();
-        }
+        updateIconSlot();
     }
 
     /**
@@ -453,8 +450,17 @@ public class Button extends Component
     }
 
     private void updateIconSlot() {
-        iconComponent.getElement().setAttribute("slot",
-                iconAfterText ? "suffix" : "prefix");
+        if (iconComponent == null) {
+            return;
+        }
+        boolean hasText = getElement().getChildren()
+                .anyMatch(Element::isTextNode);
+        if (hasText) {
+            iconComponent.getElement().setAttribute("slot",
+                    iconAfterText ? "suffix" : "prefix");
+        } else {
+            iconComponent.getElement().removeAttribute("slot");
+        }
     }
 
     /**
@@ -477,26 +483,18 @@ public class Button extends Component
         }
     }
 
-    /**
-     * Removes all contents from this component except elements in
-     * {@code exclusion} array. This includes child components, text content as
-     * well as child elements that have been added directly to this component
-     * using the {@link Element} API.
-     */
-    private void removeAll(Element... exclusion) {
-        Set<Element> toExclude = Stream.of(exclusion)
-                .collect(Collectors.toSet());
-        Predicate<Element> filter = toExclude::contains;
-        getElement().getChildren().filter(filter.negate())
-                .forEach(child -> child.removeAttribute("slot"));
-        getElement().removeAllChildren();
-        getElement().appendChild(exclusion);
-    }
+    private void removeAllTextContent() {
+        // Determine all components to keep
+        Element[] elementsToKeep = getElement().getChildren()
+                .filter(child -> !child.isTextNode()).toArray(Element[]::new);
 
-    private Element[] getNonTextNodes() {
-        return getElement().getChildren()
-                .filter(element -> !element.isTextNode())
-                .toArray(Element[]::new);
+        // Remove all children. This results in the client-side content being
+        // cleared, which is needed to also remove content added through a
+        // template.
+        getElement().removeAllChildren();
+
+        // Re-add the components to keep
+        getElement().appendChild(elementsToKeep);
     }
 
     private void updateThemeAttribute() {

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -134,6 +134,45 @@ public class ButtonTest {
     }
 
     @Test
+    public void setIconWithoutText_noSlot() {
+        icon = new Icon();
+        button = new Button();
+
+        button.setIcon(icon);
+        Assert.assertFalse(icon.getElement().hasAttribute("slot"));
+
+        // Changing icon position should have no effect
+        button.setIconAfterText(true);
+        Assert.assertFalse(icon.getElement().hasAttribute("slot"));
+
+        button.setIconAfterText(false);
+        Assert.assertFalse(icon.getElement().hasAttribute("slot"));
+    }
+
+    @Test
+    public void setIcon_setText_slotUpdated() {
+        icon = new Icon();
+        button = new Button();
+
+        button.setIcon(icon);
+        button.setText(TEST_STRING);
+
+        Assert.assertEquals("prefix", icon.getElement().getAttribute("slot"));
+    }
+
+    @Test
+    public void setIcon_setAndRemoveText_slotRemoved() {
+        icon = new Icon();
+        button = new Button();
+
+        button.setIcon(icon);
+        button.setText(TEST_STRING);
+        button.setText(null);
+
+        Assert.assertFalse(icon.getElement().hasAttribute("slot"));
+    }
+
+    @Test
     public void setEnabled() {
         button = new Button();
         button.setEnabled(true);


### PR DESCRIPTION
## Description

Apply the `prefix` / `suffix` slot to a `Button` icon only if there is also text content. This ensures that icon-only buttons render properly with the Aura theme.

Closes https://github.com/vaadin/web-components/issues/10589

## Type of change

- Refactoring