### PR TITLE
Grid: Add support for setting a filtered data provider

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2844,8 +2844,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * GridLazyFilterDataView&lt;Person, PersonFilter&gt; dataView = grid
      *         .setItemsWithFilter(query -&gt; {
      *             PersonFilter filter = query.getFilter().orElse(null);
-     *             return personService.fetch(query.getOffset(), query.getLimit(),
-     *                     filter);
+     *             return personService.fetch(query.getOffset(),
+     *                     query.getLimit(), filter);
      *         });
      *
      * // Set a filter - automatically refreshes the grid
@@ -2874,15 +2874,17 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                                     + "%nor switch to undefined size with%n"
                                     + "dataView.setItemCountUnknown();");
                 });
-        GridLazyFilterDataView<T, F> dataView = setItemsWithFilter(dataProvider);
+        GridLazyFilterDataView<T, F> dataView = setItemsWithFilter(
+                dataProvider);
         dataView.setItemCountUnknown();
         return dataView;
     }
 
     /**
-     * Sets the items of the grid with callbacks for lazily fetching items from a
-     * backend with typed filter support. The returned data view allows setting a
-     * filter that will be passed to both the fetch and count callbacks.
+     * Sets the items of the grid with callbacks for lazily fetching items from
+     * a backend with typed filter support. The returned data view allows
+     * setting a filter that will be passed to both the fetch and count
+     * callbacks.
      * <p>
      * This method creates a data provider that fetches items lazily from a
      * backend. The filter type parameter {@code F} allows you to use custom
@@ -2893,15 +2895,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *
      * <pre>
      * GridLazyFilterDataView&lt;Person, PersonFilter&gt; dataView = grid
-     *         .setItemsWithFilter(
-     *                 query -&gt; {
-     *                     PersonFilter filter = query.getFilter().orElse(null);
-     *                     return personService.fetch(query.getOffset(),
-     *                             query.getLimit(), filter);
-     *                 }, query -&gt; {
-     *                     PersonFilter filter = query.getFilter().orElse(null);
-     *                     return personService.count(filter);
-     *                 });
+     *         .setItemsWithFilter(query -&gt; {
+     *             PersonFilter filter = query.getFilter().orElse(null);
+     *             return personService.fetch(query.getOffset(),
+     *                     query.getLimit(), filter);
+     *         }, query -&gt; {
+     *             PersonFilter filter = query.getFilter().orElse(null);
+     *             return personService.count(filter);
+     *         });
      *
      * // Set a filter - automatically refreshes the grid
      * dataView.setFilter(new PersonFilter("John", 25));
@@ -2922,18 +2923,18 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             CallbackDataProvider.CountCallback<T, F> countCallback) {
         Objects.requireNonNull(fetchCallback, "fetch callback cannot be null");
         Objects.requireNonNull(countCallback, "count callback cannot be null");
-        return setItemsWithFilter(
-                DataProvider.fromFilteringCallbacks(fetchCallback, countCallback));
+        return setItemsWithFilter(DataProvider
+                .fromFilteringCallbacks(fetchCallback, countCallback));
     }
 
     /**
      * Sets the items of the grid from a backend data provider with typed filter
-     * support. The returned data view allows setting a filter that will be passed
-     * to the data provider.
+     * support. The returned data view allows setting a filter that will be
+     * passed to the data provider.
      * <p>
-     * This method wraps the provided data provider to enable programmatic filter
-     * setting. The filter type parameter {@code F} allows you to use custom
-     * filter objects.
+     * This method wraps the provided data provider to enable programmatic
+     * filter setting. The filter type parameter {@code F} allows you to use
+     * custom filter objects.
      * <p>
      * Example:
      *

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/dataview/GridLazyFilterDataView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/dataview/GridLazyFilterDataView.java
@@ -33,8 +33,8 @@ import com.vaadin.flow.data.provider.DataCommunicator;
  *
  * <pre>
  * Grid&lt;Person&gt; grid = new Grid&lt;&gt;();
- * GridLazyFilterDataView&lt;Person, PersonFilter&gt; dataView = grid.setItems(
- *         query -&gt; {
+ * GridLazyFilterDataView&lt;Person, PersonFilter&gt; dataView = grid
+ *         .setItems(query -&gt; {
  *             PersonFilter filter = query.getFilter().orElse(null);
  *             return personService.fetch(query.getOffset(), query.getLimit(),
  *                     filter);
@@ -98,8 +98,8 @@ public class GridLazyFilterDataView<T, F> extends GridLazyDataView<T> {
 
     /**
      * Sets a callback that the Grid uses to get the exact item count in the
-     * backend with access to the typed filter. Use this when it is cheap to
-     * get the exact item count and it is desired that the user sees the "full
+     * backend with access to the typed filter. Use this when it is cheap to get
+     * the exact item count and it is desired that the user sees the "full
      * scrollbar size".
      * <p>
      * The given callback will be queried for the count and will receive the
@@ -107,18 +107,17 @@ public class GridLazyFilterDataView<T, F> extends GridLazyDataView<T> {
      * allows the count callback to access the filter without type casting.
      *
      * @param callback
-     *            the callback to use for determining item count in the
-     *            backend, not {@code null}
+     *            the callback to use for determining item count in the backend,
+     *            not {@code null}
      * @see #setItemCountFromDataProvider()
      * @see #setItemCountUnknown()
      */
     public void setItemCountCallbackWithFilter(
             CallbackDataProvider.CountCallback<T, F> callback) {
-        getDataCommunicator().setCountCallback(
-                query -> callback.count(new com.vaadin.flow.data.provider.Query<>(
-                        query.getOffset(), query.getLimit(),
-                        query.getSortOrders(), query.getInMemorySorting(),
-                        currentFilter)));
+        getDataCommunicator().setCountCallback(query -> callback.count(
+                new com.vaadin.flow.data.provider.Query<>(query.getOffset(),
+                        query.getLimit(), query.getSortOrders(),
+                        query.getInMemorySorting(), currentFilter)));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyFilterDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyFilterDataViewTest.java
@@ -110,9 +110,9 @@ public class GridLazyFilterDataViewTest {
         ui.add(grid);
 
         // Create test data
-        allItems = Arrays.asList(new Person("Alice", 25),
-                new Person("Bob", 30), new Person("Charlie", 35),
-                new Person("David", 40), new Person("Eve", 45));
+        allItems = Arrays.asList(new Person("Alice", 25), new Person("Bob", 30),
+                new Person("Charlie", 35), new Person("David", 40),
+                new Person("Eve", 45));
     }
 
     @Test
@@ -332,8 +332,8 @@ public class GridLazyFilterDataViewTest {
         GridLazyFilterDataView<Person, String> dataView = grid
                 .setItemsWithFilter(query -> {
                     String filter = query.getFilter().orElse(null);
-                    return allItems.stream().filter(
-                            p -> filter == null || p.getName().contains(filter));
+                    return allItems.stream().filter(p -> filter == null
+                            || p.getName().contains(filter));
                 });
 
         dataView.setFilter("Alice");
@@ -371,7 +371,8 @@ public class GridLazyFilterDataViewTest {
 
         if (filter != null) {
             if (filter.getName() != null) {
-                stream = stream.filter(p -> p.getName().equals(filter.getName()));
+                stream = stream
+                        .filter(p -> p.getName().equals(filter.getName()));
             }
             if (filter.getMinAge() != null) {
                 stream = stream.filter(p -> p.getAge() >= filter.getMinAge());
@@ -387,7 +388,8 @@ public class GridLazyFilterDataViewTest {
 
         if (filter != null) {
             if (filter.getName() != null) {
-                stream = stream.filter(p -> p.getName().equals(filter.getName()));
+                stream = stream
+                        .filter(p -> p.getName().equals(filter.getName()));
             }
             if (filter.getMinAge() != null) {
                 stream = stream.filter(p -> p.getAge() >= filter.getMinAge());


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/3842.

This is my outcome from the AI workshop. Claude wrote all the code according to my specifications. This PR:

* Introduces a new set of methods, `setItemsWithFilter` that accept a fetch callback, a fetch/count callback pair, and a backend data provider, respectively, with a non-void filter type.
* Introduces a new `GridLazyFilterDataView` type that makes it possible to set a filter.

This maintains backwards compatibility with the existing methods and types without introducing new generic type parameters.