### PR TITLE
fix: make sure no sub cells have z-index

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
@@ -9,7 +9,6 @@
 package com.vaadin.addon.spreadsheet.client;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
@@ -20,8 +19,6 @@ import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Overflow;
 
 public class Cell {
-
-    final Logger debugConsole = Logger.getLogger("spreadsheet Cell");
 
     public static final String CELL_COMMENT_TRIANGLE_CLASSNAME = "cell-comment-triangle";
     public static final String CELL_INVALID_FORMULA_CLASSNAME = "cell-invalidformula-triangle";
@@ -96,10 +93,7 @@ public class Cell {
             element.setInnerText("");
             element.getStyle().clearZIndex();
         } else {
-            if ((sheetWidget.isMergedCell(SheetWidget.toKey(col, row))
-                    || sheetWidget.actionHandler.getMergedRegion(col,
-                            row) != null)
-                    && !(this instanceof MergedCell)) {
+            if (isSubCell()) {
                 element.getStyle().clearZIndex();
             } else {
                 element.getStyle().setZIndex(ZINDEXVALUE);
@@ -174,8 +168,8 @@ public class Cell {
         } else {
             overflowing = false;
         }
-        if (sheetWidget.isMergedCell(SheetWidget.toKey(col, row))
-                && !(this instanceof MergedCell)) {
+
+        if (isSubCell()) {
             element.getStyle().setOverflow(Overflow.HIDDEN);
         } else {
             if (overflowPx > 0) {
@@ -188,6 +182,13 @@ public class Cell {
             }
         }
         overflowDirty = false;
+    }
+
+    private boolean isSubCell() {
+        if (this instanceof MergedCell) {
+            return false;
+        }
+        return sheetWidget.actionHandler.getMergedRegion(col, row) != null;
     }
 
     int measureOverflow() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -578,6 +578,15 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
             public void execute() {
                 // remove old, add new
                 clearMergedRegions();
+
+                // copy list for later
+                if (mergedRegions == null) {
+                    SpreadsheetWidget.this.mergedRegions = null;
+                } else {
+                    SpreadsheetWidget.this.mergedRegions = new ArrayList<>(
+                            mergedRegions);
+                }
+
                 if (mergedRegions != null) {
                     int i = 0;
                     while (i < mergedRegions.size()) {
@@ -594,14 +603,6 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
                         i++;
                     }
                     sheetWidget.checkMergedRegionPositions();
-                }
-
-                // copy list for later
-                if (mergedRegions == null) {
-                    SpreadsheetWidget.this.mergedRegions = null;
-                } else {
-                    SpreadsheetWidget.this.mergedRegions = new ArrayList<MergedRegion>(
-                            mergedRegions);
                 }
             }
         });

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/MergeIT.java
@@ -89,11 +89,13 @@ public class MergeIT extends AbstractSpreadsheetIT {
     @Test
     public void mergeCellsWithText_subCellsShouldNotHaveZIndex() {
         setCellValue("A1", "A1 text");
-        selectRegion("A1", "B1");
+        selectRegion("A1", "B2");
         loadTestFixture(TestFixtures.MergeCells);
 
         Assert.assertFalse(hasZIndex(".cell.row1.col1:not(.merged-cell)"));
         Assert.assertFalse(hasZIndex(".cell.row1.col2:not(.merged-cell)"));
+        Assert.assertFalse(hasZIndex(".cell.row2.col1:not(.merged-cell)"));
+        Assert.assertFalse(hasZIndex(".cell.row2.col2:not(.merged-cell)"));
         Assert.assertTrue(hasZIndex(".cell.row1.col1.merged-cell"));
     }
 


### PR DESCRIPTION
## Description

A follow-up to https://github.com/vaadin/flow-components/pull/7239.

There are cases where the previous fix does not clear the `z-index` for all subcells. This PR updates the check where we determine whether a cell is a subcell. The check now uses the more stable merged region cache from the `SpreadsheetWidget`. Also, it changes the location where the merged region cache is updated so that all the subcells are included.

Fixes #8367 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.