### PR TITLE
chore: fix extra trailing whitespace in Javadoc comments

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Axis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Axis.java
@@ -151,7 +151,7 @@ public abstract class Axis extends AbstractConfigurationObject {
 
     /**
      * The minimum and maximum value of the axis as Instant.
-     * 
+     *
      * @param min
      *            Minimum value as Instant.
      * @param max

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AxisGrid.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AxisGrid.java
@@ -83,7 +83,7 @@ public class AxisGrid extends AbstractConfigurationObject {
 
     /**
      * Add a new column to the grid. See {@link #setColumns(List)}
-     * 
+     *
      * @param column
      *            A column to be added
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Completed.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Completed.java
@@ -41,7 +41,7 @@ public class Completed extends AbstractConfigurationObject {
     /**
      * The amount of the progress indicator, ranging from 0 (not started) to 1
      * (finished). Defaults to 0.
-     * 
+     *
      * @param amount
      */
     public void setAmount(Number amount) {
@@ -58,7 +58,7 @@ public class Completed extends AbstractConfigurationObject {
     /**
      * The fill of the progress indicator. Defaults to a darkened variety of the
      * main color. The value will be ignored if the chart is in Styled mode.
-     * 
+     *
      * @param fill
      */
     public void setFill(Color fill) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -1197,11 +1197,11 @@ public class Configuration extends AbstractConfigurationObject
      * and/or end points. Multiple algorithms are available for calculating how
      * the connecting lines are drawn. In Gantt charts, the connectors are used
      * to draw dependencies between tasks.
-     * 
+     *
      * Values set here serve as the default values for all connectors in the
      * chart. Individual style for a connector can be set on each point
      * dependency (see {@link GanttSeriesItemDependency}).
-     * 
+     *
      * @param connectors
      */
     public void setConnectors(ChartConnectors connectors) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ConnectorStyle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ConnectorStyle.java
@@ -124,7 +124,7 @@ public class ConnectorStyle extends AbstractConfigurationObject {
 
     /**
      * Set the default pathfinder algorithm to use for this chart.
-     * 
+     *
      * @see PathfinderType
      */
     public void setType(PathfinderType type) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ContextButton.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ContextButton.java
@@ -60,7 +60,7 @@ public class ContextButton extends AbstractConfigurationObject {
 
     /**
      * Gets the spacing between the context button and other exporting buttons.
-     * 
+     *
      * @return the button spacing
      */
     public Number getButtonSpacing() {
@@ -69,7 +69,7 @@ public class ContextButton extends AbstractConfigurationObject {
 
     /**
      * Sets the spacing between the context button and other exporting buttons.
-     * 
+     *
      * @param buttonSpacing
      *            the spacing value
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
@@ -610,7 +610,7 @@ public class DataLabels extends AbstractDataLabels {
     /**
      * Aligns data labels relative to points. If center alignment is not
      * possible, it defaults to right. Defaults to "center".
-     * 
+     *
      * @param position
      */
     public void setPosition(HorizontalAlign position) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragDrop.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragDrop.java
@@ -204,7 +204,7 @@ public class DragDrop extends AbstractConfigurationObject {
 
     /**
      * Set the minimum Y value the points can be moved to.
-     * 
+     *
      * @param dragMinY
      */
     public void setDragMinY(Number dragMinY) {
@@ -222,7 +222,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * The X precision value to drag to for this series. Set to 0 to disable. By
      * default this is disabled, except for category axes, where the default is
      * 1. Defaults to 0.
-     * 
+     *
      * @param dragPrecisionX
      */
     public void setDragPrecisionX(Number dragPrecisionX) {
@@ -240,7 +240,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * The Y precision value to drag to for this series. Set to 0 to disable. By
      * default this is disabled, except for category axes, where the default is
      * 1. Defaults to 0.
-     * 
+     *
      * @param dragPrecisionY
      */
     public void setDragPrecisionY(Number dragPrecisionY) {
@@ -258,7 +258,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * The amount of pixels to drag the pointer before it counts as a drag
      * operation. This prevents drag/drop to fire when just clicking or
      * selecting points. Defaults to 2.
-     * 
+     *
      * @param dragSensitivity
      */
     public void setDragSensitivity(Number dragSensitivity) {
@@ -275,7 +275,7 @@ public class DragDrop extends AbstractConfigurationObject {
     /**
      * Group the points by a property. Points with the same property value will
      * be grouped together when moving. Defaults to undefined.
-     * 
+     *
      * @param groupBy
      */
     public void setGroupBy(String groupBy) {
@@ -295,9 +295,9 @@ public class DragDrop extends AbstractConfigurationObject {
     /**
      * Style options for the guide box. The guide box has one state by default,
      * the default state. Guide box is visible only when liveRedraw is false.
-     * 
+     *
      * @see #setLiveRedraw(Boolean)
-     * 
+     *
      * @param guideBox
      */
     public void setGuideBox(GuideBox guideBox) {
@@ -314,7 +314,7 @@ public class DragDrop extends AbstractConfigurationObject {
     /**
      * Update points as they are dragged. If false, a guide box is drawn to
      * illustrate the new point size. Defaults to true.
-     * 
+     *
      * @param liveRedraw
      */
     public void setLiveRedraw(Boolean liveRedraw) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragHandle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragHandle.java
@@ -47,7 +47,7 @@ public class DragHandle extends AbstractConfigurationObject {
 
     /**
      * The fill color of the drag handles. Defaults to #fff.
-     * 
+     *
      * @param color
      */
     public void setColor(Color color) {
@@ -65,7 +65,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * The mouse cursor to use for the drag handles. By default this is
      * intelligently switching between ew-resize and ns-resize depending on the
      * direction the point is being dragged.
-     * 
+     *
      * @param cursor
      */
     public void setCursor(String cursor) {
@@ -131,7 +131,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * Function to define the SVG path to use for the drag handles. Takes the
      * point as argument. Should return an SVG path in array format. The SVG
      * path is automatically positioned on the point.
-     * 
+     *
      * @param _fn_pathFormatter
      */
     public void setPathFormatter(String _fn_pathFormatter) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GanttSeriesItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GanttSeriesItem.java
@@ -147,7 +147,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
 
     /**
      * Dependencies on another tasks (points) in the Gantt chart.
-     * 
+     *
      * @see #addDependency(GanttSeriesItemDependency)
      * @see #addDependency(String)
      */
@@ -157,7 +157,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
 
     /**
      * Adds a dependency on another task.
-     * 
+     *
      * @param dependency
      *            The dependency configuration object, allowing to specify
      *            further connecting options between the points.
@@ -171,7 +171,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
 
     /**
      * Adds a dependency on another task.
-     * 
+     *
      * @param to
      *            The ID of the point (task) that this point depends on in Gantt
      *            charts
@@ -189,7 +189,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
 
     /**
      * The end time of a task.
-     * 
+     *
      * @param end
      */
     public void setEnd(Instant end) {
@@ -206,7 +206,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
     /**
      * Whether this point is a milestone. If so, only the start option is
      * handled, while end is ignored. Defaults to false.
-     * 
+     *
      * @param milestone
      */
     public void setMilestone(Boolean milestone) {
@@ -223,7 +223,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
     /**
      * The ID of the parent point (task) of this point in Gantt charts. Defaults
      * to null
-     * 
+     *
      * @param parent
      */
     public void setParent(String parent) {
@@ -239,7 +239,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
 
     /**
      * The start time of a task.
-     * 
+     *
      * @param start
      */
     public void setStart(Instant start) {
@@ -255,7 +255,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
 
     /**
      * The Y value of a task.
-     * 
+     *
      * @param y
      */
     public void setY(Number y) {
@@ -338,7 +338,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * A reserved subspace to store options and values for customized
      * functionality. Here you can add additional data for your own event
      * callbacks and formatter callbacks.
-     * 
+     *
      * @param custom
      */
     public void setCustom(AbstractConfigurationObject custom) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBox.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBox.java
@@ -32,7 +32,7 @@ public class GuideBox extends AbstractConfigurationObject {
 
     /**
      * Style options for the guide box default state.
-     * 
+     *
      * @param defaultState
      */
     public void setDefaultState(GuideBoxDefaultState defaultState) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBoxDefaultState.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBoxDefaultState.java
@@ -61,7 +61,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
 
     /**
      * Guide box cursor. Defaults to "move".
-     * 
+     *
      * @param cursor
      */
     public void setCursor(String cursor) {
@@ -93,7 +93,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
 
     /**
      * Width of the line around the guide box. Defaults to 1.
-     * 
+     *
      * @param lineWidth
      */
     public void setLineWidth(Number lineWidth) {
@@ -109,7 +109,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
 
     /**
      * Guide box zIndex. Defaults to 900.
-     * 
+     *
      * @param zIndex
      */
     public void setzIndex(Number zIndex) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Link.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Link.java
@@ -29,7 +29,7 @@ public class Link extends AbstractConfigurationObject {
 
     /**
      * Sets the color of the link between nodes.
-     * 
+     *
      * @param color
      *            the color to use for the link
      */
@@ -47,7 +47,7 @@ public class Link extends AbstractConfigurationObject {
 
     /**
      * Sets the line width of the link connecting nodes, in pixels.
-     * 
+     *
      * @param lineWidth
      *            the width of the link line
      */
@@ -66,7 +66,7 @@ public class Link extends AbstractConfigurationObject {
     /**
      * Radius for the rounded corners of the links between nodes. Works for
      * {@link LinkType#DEFAULT} link type.
-     * 
+     *
      * @param radius
      *            the radius for link corners
      */
@@ -84,7 +84,7 @@ public class Link extends AbstractConfigurationObject {
 
     /**
      * Sets the type of link shape.
-     * 
+     *
      * @param type
      *            the link shape type
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTreemap.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTreemap.java
@@ -243,7 +243,7 @@ public class PlotOptionsTreemap extends AbstractPlotOptions {
     /**
      * Options for the breadcrumbs, the navigation at the top leading the way up
      * through the traversed levels.
-     * 
+     *
      * @param breadcrumbs
      */
     public void setBreadcrumbs(Breadcrumbs breadcrumbs) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/SeriesConnectorAnimation.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/SeriesConnectorAnimation.java
@@ -25,7 +25,7 @@ public class SeriesConnectorAnimation extends AbstractConfigurationObject {
 
     /**
      * Defaults to true.
-     * 
+     *
      * @param reversed
      */
     public void setReversed(Boolean reversed) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Time.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Time.java
@@ -95,7 +95,7 @@ public class Time extends AbstractConfigurationObject {
      * when correct Daylight Saving Time transitions are required.
      * <p>
      * Defaults to: true
-     * 
+     *
      * @deprecated This property is deprecated and should not be used in new
      *             code. Use {@link #setTimezone(String)} instead.
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
@@ -1604,7 +1604,7 @@ public class XAxis extends Axis {
      * If there are multiple axes on the same side of the chart, the pixel
      * margin between the axes. Defaults to 0 on vertical axes, 15 on horizontal
      * axes.
-     * 
+     *
      * @param margin
      */
     public void setMargin(Number margin) {
@@ -1621,7 +1621,7 @@ public class XAxis extends Axis {
     /**
      * Maximum range which can be set using the navigator's handles. Opposite of
      * {@link #setMinRange(Number)}
-     * 
+     *
      * @param maxRange
      */
     public void setMaxRange(Number maxRange) {
@@ -1638,7 +1638,7 @@ public class XAxis extends Axis {
     /**
      * Whether to pan axis. If chart.panning is enabled, the option allows to
      * disable panning on an individual axis. Defaults to true.
-     * 
+     *
      * @param panningEnabled
      */
     public void setPanningEnabled(Boolean panningEnabled) {
@@ -1659,7 +1659,7 @@ public class XAxis extends Axis {
      * approximately 5 minor ticks between each major tick. Prior to v6.0.0,
      * ticks were unabled in auto layout by setting minorTickInterval to "auto".
      * Defaults to false.
-     * 
+     *
      * @param minorTicks
      */
     public void setMinorTicks(Boolean minorTicks) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
@@ -1758,7 +1758,7 @@ public class YAxis extends Axis {
     /**
      * Maximum range which can be set using the navigator's handles. Opposite of
      * {@link #setMinRange(Number)}
-     * 
+     *
      * @param maxRange
      */
     public void setMaxRange(Number maxRange) {
@@ -1799,7 +1799,7 @@ public class YAxis extends Axis {
      * height. For example, setting the static scale to 24 results in each Y
      * axis category taking up 24 pixels, and the height of the chart adjusts.
      * Adding or removing items will make the chart resize. Defaults to 50.
-     * 
+     *
      * @param staticScale
      */
     public void setStaticScale(Number staticScale) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Zooming.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Zooming.java
@@ -35,7 +35,7 @@ public class Zooming extends AbstractConfigurationObject {
      * Set a key to hold when dragging to zoom the chart. This is useful to
      * avoid zooming while moving points. Should be set different than
      * {@link ChartModel#getPanKey()}.
-     * 
+     *
      * @param key
      */
     public void setKey(PanKey key) {
@@ -54,7 +54,7 @@ public class Zooming extends AbstractConfigurationObject {
 
     /**
      * Configuration for mouse wheel zoom.
-     * 
+     *
      * @param mouseWheel
      */
     public void setMouseWheel(ZoomingMouseWheel mouseWheel) {
@@ -71,7 +71,7 @@ public class Zooming extends AbstractConfigurationObject {
     /**
      * Equivalent to type, but for pinch gestures. By default, the pinchType is
      * the same as the {@link #getType()} setting.
-     * 
+     *
      * @param pinchType
      */
     public void setPinchType(Dimension pinchType) {
@@ -91,7 +91,7 @@ public class Zooming extends AbstractConfigurationObject {
     /**
      * The button that appears after a selection zoom, allowing the user to
      * reset zoom.
-     * 
+     *
      * @param resetButton
      */
     public void setResetButton(ZoomingResetButton resetButton) {
@@ -112,7 +112,7 @@ public class Zooming extends AbstractConfigurationObject {
      * touch-dragging the chart to read the tooltip. And especially when
      * vertical zooming is enabled, it will make it hard to scroll vertically on
      * the page.
-     * 
+     *
      * @param singleTouch
      */
     public void setSingleTouch(Boolean singleTouch) {
@@ -132,7 +132,7 @@ public class Zooming extends AbstractConfigurationObject {
      * Note: For non-cartesian series, the only supported zooming type is
      * {@link Dimension#XY}, as zooming in a single direction is not applicable
      * due to the radial nature of the coordinate system.
-     * 
+     *
      * @param type
      */
     public void setType(Dimension type) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingMouseWheel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingMouseWheel.java
@@ -36,7 +36,7 @@ public class ZoomingMouseWheel extends AbstractConfigurationObject {
 
     /**
      * Enable zooming with mouse wheel.
-     * 
+     *
      * @param enabled
      */
     public void setEnabled(Boolean enabled) {
@@ -57,7 +57,7 @@ public class ZoomingMouseWheel extends AbstractConfigurationObject {
      * <p>
      * Sensitivity of mouse wheel or trackpad scrolling. 1 is no sensitivity,
      * while with 2, one mouse wheel delta will zoom in 50%.
-     * 
+     *
      * @param sensitivity
      */
     public void setSensitivity(Number sensitivity) {
@@ -77,14 +77,14 @@ public class ZoomingMouseWheel extends AbstractConfigurationObject {
      * here, it will inherit the type from {@link Zooming#getType()}. In
      * {@link Chart#setTimeline(Boolean)} charts, it defaults to
      * {@link Dimension#X}.
-     * 
+     *
      * Note that particularly with mouse wheel in the y direction, the zoom is
      * affected by the default {@link YAxis#getStartOnTick()} and
      * {@link YAxis#getEndOnTick()} settings. In order to respect these
      * settings, the zoom level will adjust after the user has stopped zooming.
      * To prevent this, consider setting {@link YAxis#setStartOnTick(Boolean)}
      * and {@link YAxis#setEndOnTick(Boolean)} to false.
-     * 
+     *
      * @param type
      */
     public void setType(Dimension type) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingResetButton.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingResetButton.java
@@ -37,7 +37,7 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
     /**
      * Defines whether the reset button is visible. When undefined, it is shown
      * automatically if zooming is enabled and hidden if zooming is disabled.
-     * 
+     *
      * @param enabled
      */
     public void setEnabled(Boolean enabled) {
@@ -56,12 +56,12 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
 
     /**
      * The position of the button.
-     * 
+     *
      * <p>
      * Adjusting position values might cause overlap with chart elements. Ensure
      * coordinates do not obstruct other components or data visibility.
      * </p>
-     * 
+     *
      * @param position
      */
     public void setPosition(Position position) {
@@ -96,7 +96,7 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
 
     /**
      * A collection of attributes for the button theme.
-     * 
+     *
      * @param theme
      */
     public void setTheme(ButtonTheme theme) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/DOMTokenList.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/DOMTokenList.java
@@ -57,7 +57,7 @@ public interface DOMTokenList {
     /**
      * Removes the given token from the list if it is present, and adds it if it
      * is not.
-     * 
+     *
      * @param token
      *            The token to toggle.
      * @return {@code true} if the token is now present in the list, and

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -3319,10 +3319,10 @@ public class SheetWidget extends Panel {
     /**
      * Handles horizontal scrolling in the spreadsheet. It calculates the
      * visible columns and updates the column headers accordingly.
-     * 
+     *
      * The method takes the current scroll position and the difference since the
      * last update to determine how many columns to display.
-     * 
+     *
      * @param scrollLeft
      *            the current scroll position from the left
      * @param scrollDiff
@@ -3424,10 +3424,10 @@ public class SheetWidget extends Panel {
     /**
      * Handles vertical scrolling in the spreadsheet. It calculates the visible
      * rows and updates the row headers accordingly.
-     * 
+     *
      * The method takes the current scroll position and the difference since the
      * last update to determine how many rows to display.
-     * 
+     *
      * @param scrollTop
      *            the current scroll position from the top
      * @param scrollDiff

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -2185,7 +2185,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
 
     /**
      * Returns whether the custom editor is shown when the cell gets focus.
-     * 
+     *
      * @return true if the custom editor is shown on focus, false otherwise
      */
     public boolean isShowCustomEditorOnFocus() {
@@ -2194,7 +2194,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
 
     /**
      * Sets whether the custom editor should be shown when the cell gets focus.
-     * 
+     *
      * @param showCustomEditorOnFocus
      *            true to show the custom editor on focus, false to not show it
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1219,7 +1219,7 @@ public class Spreadsheet extends Component
 
     /**
      * Create the default Spreadsheet handler.
-     * 
+     *
      * @return SpreadsheetHandlerImpl
      */
     protected SpreadsheetHandlerImpl createDefaultHandler() {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabElement.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabElement.java
@@ -31,7 +31,7 @@ public class TabElement extends TestBenchElement {
 
     /**
      * Gets the label of the tab.
-     * 
+     *
      * @return the label of the tab
      */
     public String getLabel() {

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
@@ -39,7 +39,7 @@ public abstract class AbstractUploadIT extends AbstractComponentIT {
     /**
      * Creates a temp file with the provided name and extension for testing
      * purposes.
-     * 
+     *
      * @param fileName
      *            the temp file name prefix
      * @param extension


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/flow-components/pull/8410

## Type of change

- Internal change