### PR TITLE
feat: add MasterDetailLayoutVariant enum with Aura variant

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.RouterLayout;
@@ -51,8 +52,8 @@ import com.vaadin.flow.shared.Registration;
 @Tag("vaadin-master-detail-layout")
 @NpmPackage(value = "@vaadin/master-detail-layout", version = "25.0.1")
 @JsModule("@vaadin/master-detail-layout/src/vaadin-master-detail-layout.js")
-public class MasterDetailLayout extends Component
-        implements HasSize, RouterLayout {
+public class MasterDetailLayout extends Component implements HasSize,
+        HasThemeVariant<MasterDetailLayoutVariant>, RouterLayout {
 
     public static final String MASTER_SLOT = "";
 

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutVariant.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutVariant.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.masterdetaillayout;
+
+import com.vaadin.flow.component.shared.ThemeVariant;
+
+/**
+ * Set of theme variants applicable for {@code vaadin-master-detail-layout}
+ * component.
+ */
+public enum MasterDetailLayoutVariant implements ThemeVariant {
+    AURA_INSET_DRAWER("inset-drawer");
+
+    private final String variant;
+
+    MasterDetailLayoutVariant(String variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the variant name.
+     *
+     * @return variant name
+     */
+    public String getVariantName() {
+        return variant;
+    }
+}

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutVariantTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutVariantTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.masterdetaillayout.tests;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.masterdetaillayout.MasterDetailLayout;
+import com.vaadin.flow.component.masterdetaillayout.MasterDetailLayoutVariant;
+import com.vaadin.tests.ThemeVariantTestHelper;
+
+public class MasterDetailLayoutVariantTest {
+
+    @Test
+    public void addThemeVariant_themeNamesContainsThemeVariant() {
+        ThemeVariantTestHelper.addThemeVariant_themeNamesContainsThemeVariant(
+                new MasterDetailLayout(),
+                MasterDetailLayoutVariant.AURA_INSET_DRAWER);
+    }
+
+    @Test
+    public void addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant() {
+        ThemeVariantTestHelper
+                .addThemeVariant_removeThemeVariant_themeNamesDoesNotContainThemeVariant(
+                        new MasterDetailLayout(),
+                        MasterDetailLayoutVariant.AURA_INSET_DRAWER);
+    }
+}


### PR DESCRIPTION
## Description

Added `MasterDetailLayoutVariant` enum for `inset-drawer` Aura [variant](https://github.com/vaadin/web-components/blob/109aa71ee63bca13cdb5ee5e209afff142c6a96d/packages/aura/src/components/master-detail-layout.css#L22).
Note: as MDL is still behind a feature flag, we can backport this to `25.0` even though it's marked as `feat:`

## Type of change

- Feature