### PR TITLE
chore: add build tools dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>flow-build-tools</artifactId>
+                <version>${flow.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>flow-client</artifactId>
                 <version>${flow.version}</version>
             </dependency>
@@ -148,11 +153,6 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-server</artifactId>
-                <version>${flow.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-build-tools</artifactId>
                 <version>${flow.version}</version>
             </dependency>
             <dependency>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -13,11 +13,11 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-server</artifactId>
+            <artifactId>flow-build-tools</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-build-tools</artifactId>
+            <artifactId>flow-server</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
## Description

https://github.com/vaadin/flow/pull/23161 moved several classes from `flow-server` to `flow-build-tools`. This adds the dependency to Chart SVG generator, as it depends on `FrontendToolsLocator`.

## Type of change

- Internal