### PR TITLE
chore: add flow-build-tools dependency

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -17,6 +17,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-build-tools</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
The `FrontendToolsLocator` class was moved to the `flow-build-tools` module in https://github.com/vaadin/flow/pull/23161.