### PR TITLE
chore: add shaded classifier for flow-build-tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-build-tools</artifactId>
                 <version>${flow.version}</version>
+                <classifier>shaded</classifier>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -14,6 +14,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-build-tools</artifactId>
+            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Apply `shaded` classifier to `flow-build-tools` to use the variant that uses repackaged Apache Commons dependencies. This way an Apache Commons added to an application does not conflict with `flow-build-tools`.