### PR TITLE
refactor!: remove validation for ProgressBar.setValue

### DIFF
--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
@@ -85,6 +85,11 @@ public class ProgressBar extends Component
             throw new IllegalArgumentException(String.format(
                     "min ('%s') must be less than max ('%s')", min, max));
         }
+        if (min > value || value > max) {
+            throw new IllegalArgumentException(String.format(
+                    "value must be between min ('%s') and max ('%s')", min,
+                    max));
+        }
         setMin(min);
         setMax(max);
         setValue(value);
@@ -97,13 +102,6 @@ public class ProgressBar extends Component
      *            the double value to set
      */
     public void setValue(double value) {
-        double min = getMin();
-        double max = getMax();
-        if (min > value || value > max) {
-            throw new IllegalArgumentException(String.format(
-                    "value must be between min ('%s') and max ('%s')", min,
-                    max));
-        }
         getElement().setProperty("value", value);
     }
 

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarTest.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarTest.java
@@ -172,30 +172,4 @@ public class ProgressBarTest {
         Assert.assertEquals("updated value is wrong", max,
                 progressBar.getValue(), 0.0);
     }
-
-    @Test
-    public void setValueShouldThrowIfValueLessThanMin() {
-        double min = 10.0;
-        double max = 100.0;
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(String.format(
-                "value must be between min ('%s') and max ('%s')", min, max));
-
-        ProgressBar progressBar = new ProgressBar(min, max);
-        progressBar.setValue(9);
-    }
-
-    @Test
-    public void setValueShouldThrowIfValueGreaterThanMax() {
-        double min = 10.0;
-        double max = 100.0;
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(String.format(
-                "value must be between min ('%s') and max ('%s')", min, max));
-
-        ProgressBar progressBar = new ProgressBar(min, max);
-        progressBar.setValue(101);
-    }
 }


### PR DESCRIPTION
## Description

Removes validation in `ProgressBar.setValue` so that it doesn't throw an exception if the value is outside of the min/max constraints. This made it unnecessarily difficult to reconfigure the progress bar's value and constraints, provided little value and was not working consistently between the three setters.

It keeps the validation for the constructor that receives all three values at once, as in that case you should be able to provide a valid configuration.

Closes https://github.com/vaadin/flow-components/issues/8394

## Type of change

- Refactoring / behavior change