### PR TITLE
refactor: move MockUI to root package

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -38,8 +38,8 @@ import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.MockUI;
 import com.vaadin.tests.dataprovider.DataProviderListenersTest;
-import com.vaadin.tests.dataprovider.MockUI;
 
 /**
  * Suite of basic tests that apply to both, ComboBox and MultiSelectComboBox

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 public class MultiSelectComboBoxFilteringTest {
     private MockUI ui;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -35,7 +35,7 @@ import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 import tools.jackson.databind.JsonNode;
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -30,8 +30,8 @@ import com.vaadin.flow.component.combobox.ComboBoxBase;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.tests.MockUI;
 import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
-import com.vaadin.tests.dataprovider.MockUI;
 
 public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractSignalsUnitTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractSignalsUnitTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Base class for testing components with full-stack signals. Since signal
+ * bindings are only active when components are attached, this class sets up a
+ * mock UI instance for attaching components under test.
+ */
+public class AbstractSignalsUnitTest {
+
+    @BeforeClass
+    public static void setupUI() {
+        var mockUI = new MockUI();
+        UI.setCurrent(mockUI);
+    }
+
+    @AfterClass
+    public static void teardownUI() {
+        if (UI.getCurrent() != null) {
+            UI.getCurrent().removeAll();
+            UI.setCurrent(null);
+        }
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUI.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUI.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.tests.dataprovider;
+package com.vaadin.tests;
 
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractListDataViewListenerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractListDataViewListenerTest.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.function.SerializablePredicate;
+import com.vaadin.tests.MockUI;
 
 // Originally from com.vaadin.flow.data.provider.AbstractListDataViewListenerTest
 // If this breaks, check there for updates

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelSelectedItemsTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.selection.MultiSelect;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 public class AbstractGridMultiSelectionModelSelectedItemsTest {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.provider.*;
 import com.vaadin.flow.data.selection.SelectionListener;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 public class AbstractGridMultiSelectionModelTest {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
     private TreeGrid<String> treeGrid;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -27,8 +27,8 @@ import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.tests.MockUI;
 import com.vaadin.tests.dataprovider.DataProviderListenersTest;
-import com.vaadin.tests.dataprovider.MockUI;
 
 public class GridTest {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/TreeGridTest.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 public class TreeGridTest {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyDataViewTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridLazyDataViewTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 public class GridLazyDataViewTest {
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/TreeGridSetViewportRangeByIndexPathTest.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.GridArrayUpdater;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
-import com.vaadin.tests.dataprovider.MockUI;
+import com.vaadin.tests.MockUI;
 
 import tools.jackson.databind.JsonNode;
 

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -29,8 +29,8 @@ import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.component.shared.HasTooltip;
+import com.vaadin.tests.MockUI;
 import com.vaadin.tests.dataprovider.DataProviderListenersTest;
-import com.vaadin.tests.dataprovider.MockUI;
 
 public class ListBoxUnitTest {
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -46,8 +46,8 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.tests.MockUI;
 import com.vaadin.tests.dataprovider.DataProviderListenersTest;
-import com.vaadin.tests.dataprovider.MockUI;
 
 public class RadioButtonGroupTest {
 


### PR DESCRIPTION
MockUI would be really useful for unit-testing component features integrating with Vaadin full-stack signals, as Flow deactivates the signal bindings when the components aren't attached to an UI.

In addition, this adds `AbstractSignalsUnitTest`.