### PR TITLE
fix: Update ValueSignal import to new package location

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/SignalButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/SignalButtonView.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.component.*;
 import com.vaadin.flow.component.html.*;
 import com.vaadin.flow.router.Route;
 import com.vaadin.signals.Signal;
-import com.vaadin.signals.ValueSignal;
+import com.vaadin.signals.local.ValueSignal;
 
 /**
  * View for {@link Button} demo.

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.*;
 import com.vaadin.signals.BindingActiveException;
 import com.vaadin.signals.Signal;
-import com.vaadin.signals.ValueSignal;
+import com.vaadin.signals.local.ValueSignal;
 import com.vaadin.tests.AbstractSignalsUnitTest;
 
 public class ButtonSignalTest extends AbstractSignalsUnitTest {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasThemeVariantTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasThemeVariantTest.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.signals.BindingActiveException;
-import com.vaadin.signals.ValueSignal;
+import com.vaadin.signals.local.ValueSignal;
 
 public class HasThemeVariantTest extends AbstractSignalsUnitTest {
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/test/java/com/vaadin/flow/component/shared/HasValidationPropertiesBindingTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/test/java/com/vaadin/flow/component/shared/HasValidationPropertiesBindingTest.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.signals.BindingActiveException;
-import com.vaadin.signals.ValueSignal;
+import com.vaadin.signals.local.ValueSignal;
 import com.vaadin.tests.AbstractSignalsUnitTest;
 
 /**


### PR DESCRIPTION
## Description

Update import from `com.vaadin.signals.ValueSignal` to `com.vaadin.signals.local.ValueSignal` following the signals package restructuring in vaadin/flow#23292.

## Type of change

- Bugfix
