### PR TITLE
fix: allow data fetch for inert grid (CP: 23.7)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/InertTreeGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/InertTreeGridPage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.flow.dom.ElementUtil;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/inert-tree-grid")
+public class InertTreeGridPage extends Div {
+
+    public InertTreeGridPage() {
+        var grid = new TreeGrid<String>();
+        ElementUtil.setInert(grid.getElement(), true);
+
+        grid.addHierarchyColumn(String::toString).setHeader("Item");
+        add(grid);
+
+        var data = new TreeGridStringDataBuilder().addLevel("Parent", 100)
+                .addLevel("Child", 100).build();
+
+        grid.setDataProvider(new TreeDataProvider<>(data));
+
+        var expandFirst = new NativeButton("Expand first item",
+                e -> grid.expand(data.getRootItems().get(0)));
+        expandFirst.setId("expand-first");
+
+        var setAllRowsVisible = new NativeButton("Set all rows visible",
+                e -> grid.setAllRowsVisible(true));
+        setAllRowsVisible.setId("set-all-rows-visible");
+
+        add(expandFirst, setAllRowsVisible, grid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/InertTreeGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/InertTreeGridPage.java
@@ -1,17 +1,10 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
  */
 package com.vaadin.flow.component.treegrid.it;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridStringDataBuilder.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridStringDataBuilder.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+
+public class TreeGridStringDataBuilder {
+
+    private final TreeData<String> data = new TreeData<>();
+
+    private final Map<String, String> parentPathMap = new HashMap<>();
+
+    private Map<String, Integer> nameToCountMap = new LinkedHashMap<>();
+
+    public TreeGridStringDataBuilder addLevel(String name, int numberOfItems) {
+        nameToCountMap.put(name, numberOfItems);
+        return this;
+    }
+
+    public TreeData<String> build() {
+        List<String> itemsForLevel = null;
+        for (Map.Entry<String, Integer> nameToCountMap : nameToCountMap
+                .entrySet()) {
+            itemsForLevel = addItemsForLevel(nameToCountMap.getKey(),
+                    nameToCountMap.getValue(), itemsForLevel);
+        }
+        return data;
+    }
+
+    private List<String> addItemsForLevel(String name, int numberOfItems,
+            List<String> parentItems) {
+        if (parentItems == null) {
+            return addItemsToParent(name, numberOfItems, null);
+        }
+        return parentItems.stream()
+                .map(parent -> addItemsToParent(name, numberOfItems, parent))
+                .flatMap(List::stream).collect(Collectors.toList());
+    }
+
+    private List<String> addItemsToParent(String name, int numberOfItems,
+            String parent) {
+        return IntStream.range(0, numberOfItems)
+                .mapToObj(index -> createItem(name, parent, index))
+                .collect(Collectors.toList());
+    }
+
+    private String createItem(String name, String parent, int index) {
+        String thisPath = Optional.ofNullable(parentPathMap.get(parent))
+                .map(path -> path + "/" + index).orElse("" + index);
+        String item = (name + " " + thisPath).trim();
+        parentPathMap.put(item, thisPath);
+        data.addItem(parent, item);
+        return item;
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/InertTreeGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/InertTreeGridIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.tests.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-grid/inert-tree-grid")
+public class InertTreeGridIT extends AbstractComponentIT {
+
+    private TreeGridElement treeGrid;
+    private WebElement expandFirstItemButton;
+    private WebElement setAllRowsVisibleButton;
+
+    @Before
+    public void init() {
+        open();
+        treeGrid = $(TreeGridElement.class).first();
+        expandFirstItemButton = $("button").id("expand-first");
+        setAllRowsVisibleButton = $("button").id("set-all-rows-visible");
+    }
+
+    @Test
+    public void setAllRowsVisible_lastParentRowHasData() {
+        setAllRowsVisibleButton.click();
+
+        var cell = treeGrid.getCell(99, 0);
+        Assert.assertEquals("Parent 99", cell.getText());
+    }
+
+    @Test
+    public void expandFirst_setAllRowsVisible_lastChildRowHasData() {
+        expandFirstItemButton.click();
+        setAllRowsVisibleButton.click();
+
+        var cell = treeGrid.getCell(100, 0);
+        Assert.assertEquals("Child 0/99", cell.getText());
+    }
+
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/InertTreeGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/InertTreeGridIT.java
@@ -1,17 +1,10 @@
-/*
+/**
  * Copyright 2000-2024 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Vaadin Commercial License and Service Terms.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
  */
 package com.vaadin.flow.component.treegrid.it;
 
@@ -21,8 +14,8 @@ import org.junit.Test;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
-import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-grid/inert-tree-grid")
 public class InertTreeGridIT extends AbstractComponentIT {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -61,6 +61,7 @@ import com.vaadin.flow.component.grid.dnd.GridDropMode;
 import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.grid.editor.EditorImpl;
 import com.vaadin.flow.component.grid.editor.EditorRenderer;
+import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.data.binder.BeanPropertySet;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.PropertyDefinition;
@@ -3333,11 +3334,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         return item;
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void confirmUpdate(int id) {
         getDataCommunicator().confirmUpdate(id);
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setRequestedRange(int start, int length) {
         if (length > 500 && length / getPageSize() > 10 && isAllRowsVisible()) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.grid.GridArrayUpdater.UpdateQueueData;
 import com.vaadin.flow.component.grid.dataview.GridDataView;
 import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
+import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.data.binder.PropertyDefinition;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -710,6 +711,7 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setParentRequestedRange(int start, int length,
             String parentKey) {
@@ -719,6 +721,7 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void setParentRequestedRanges(JsonArray array) {
         for (int index = 0; index < array.length(); index++) {
@@ -741,6 +744,7 @@ public class TreeGrid<T> extends Grid<T>
         }
     }
 
+    @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
     private void confirmParentUpdate(int id, String parentKey) {
         getDataCommunicator().confirmUpdate(id, parentKey);


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #6465 to branch 23.7.

---

> ## Description
> 
> Fixes https://github.com/vaadin/flow-components/issues/6428
> 
> The issue occurs because the dialog's server-side modality by default blocks calls to `@ClientCallable` methods for components outside of it. As the grid outside the dialog encounters rows without data, it tries to make a data request but the call gets blocked and the rows will remain empty.
> 
> This PR fixes the issue by allowing an inert Grid to fetch data for rows.
> 
> Note: We can't rely on the Grid's item preloading logic to fix this (as mentioned [here](https://github.com/vaadin/flow-components/issues/6428#issuecomment-2219610825)) since it's merely a performance optimization and wouldn't help in cases where unloaded rows are revealed due to other reasons, for example, if the grid's height gets increased programmatically or by browser window resize...
> 
> ## Type of change
> 
> Bugfix