### PR TITLE
fix: clear filter debouncer on connector reset (CP: 25.0)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -1,0 +1,62 @@
+import { expect, fixtureSync } from '@open-wc/testing';
+import { comboBoxConnector, FlowComboBox, init } from './shared.ts';
+import '@vaadin/combo-box';
+import * as sinon from 'sinon';
+
+describe('combo-box connector', () => {
+  let comboBox: FlowComboBox;
+
+  beforeEach(() => {
+    comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+    init(comboBox);
+  });
+
+  it('should not reinitialize the connector', () => {
+    const connector = comboBox.$connector;
+    comboBoxConnector.initLazy(comboBox);
+    expect(comboBox.$connector).to.equal(connector);
+  });
+
+  describe('filter debouncing', () => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(async () => {
+      clock = sinon.useFakeTimers({
+        toFake: ['setTimeout', 'clearTimeout']
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should debounce filter requests with default timeout', () => {
+      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'a' }, () => {});
+      expect(comboBox.$server.setViewportRange).to.be.not.called;
+      clock.tick(500);
+      expect(comboBox.$server.setViewportRange).to.be.calledOnce;
+
+      comboBox.$server.setViewportRange.resetHistory();
+
+      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'ab' }, () => {});
+      clock.tick(250);
+      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'abc' }, () => {});
+      clock.tick(250);
+      expect(comboBox.$server.setViewportRange).to.be.not.called;
+      clock.tick(250);
+      expect(comboBox.$server.setViewportRange).to.be.calledOnce;
+    });
+
+    it('should cancel filter request when the connector is reset', () => {
+      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'test' }, () => {});
+      expect(comboBox._filterDebouncer).to.exist;
+
+      comboBox.$connector.reset();
+      expect(comboBox._filterDebouncer).to.not.exist;
+
+      clock.tick(600);
+
+      expect(comboBox.$server.setViewportRange).to.not.be.called;
+    });
+  });
+});

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/env-setup.ts
@@ -1,0 +1,3 @@
+window.Vaadin ||= {};
+// @ts-expect-error
+window.Vaadin.Flow = {};

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/shared.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/shared.ts
@@ -1,0 +1,37 @@
+import './env-setup.js';
+import { ComboBox } from '@vaadin/combo-box';
+import '../frontend/generated/jar-resources/comboBoxConnector.js';
+import * as sinon from 'sinon';
+
+export type ComboBoxConnector = {
+  initLazy: (comboBox: ComboBox) => void;
+  reset: () => void;
+};
+
+export type ComboBoxServer = {
+  setViewportRange: sinon.SinonSpy;
+};
+
+export type FlowComboBox = ComboBox & {
+  $connector: ComboBoxConnector;
+  $server: ComboBoxServer;
+  _filterDebouncer: unknown;
+};
+
+type Vaadin = {
+  Flow: {
+    comboBoxConnector: ComboBoxConnector;
+  };
+};
+
+const Vaadin = window.Vaadin as Vaadin;
+
+export const comboBoxConnector = Vaadin.Flow.comboBoxConnector;
+
+export function init(comboBox: FlowComboBox): void {
+  comboBox.$server = {
+    setViewportRange: sinon.spy()
+  };
+
+  comboBoxConnector.initLazy(comboBox);
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
@@ -1,0 +1,11 @@
+import { esbuildPlugin } from "@web/dev-server-esbuild";
+
+export default {
+  plugins: [esbuildPlugin({ ts: true })],
+  testFramework: {
+    config: {
+      ui: 'bdd',
+      timeout: '10000',
+    },
+  },
+};


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #8563 to branch 25.0.

---

> ## Description
> 
> Currently a combo box can get stuck in a loading state if it is closed right after a filter change. The flow is something like:
> - Changing filter runs data provider
>   - Connector schedules debounced request
> - Closing calls `connector.reset`
>   - Calls `comboBox.clearCache`
>   - This set a `_forceNextRequest` flag internally
> - Debouncer fires
>   - Loads data from server, puts it into cache
> - Combo box is opened again
>   - `_forceNextRequest` causes cached data to be ignored
>   - Calls data provider again
>   - Data communicator ignores request as data is already there
>   - Loading state is never resolved
> 
> This fix changes `connector.reset` so that is also cancels any debounced requests, so that the connector will not attempt to load data after a reset and while the component is closed.
> 
> Fixes https://github.com/vaadin/flow-components/issues/8235
> 
> ## Type of change
> 
> - Bugfix