### PR TITLE
refactor: use hasValidValue() for Slider client-side validation

### DIFF
--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Slider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Slider.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.function.SerializableBiFunction;
 
 /**
  * Slider is an input field that allows the user to select a numeric value
@@ -38,9 +37,6 @@ public class Slider extends SliderBase<Slider, Double> {
     private static final double DEFAULT_MIN = 0.0;
     private static final double DEFAULT_MAX = 100.0;
     private static final double DEFAULT_STEP = 1.0;
-
-    private static final SerializableBiFunction<Slider, Double, Double> IDENTITY = (
-            component, value) -> value;
 
     /**
      * Constructs a {@code Slider} with min 0, max 100, and initial value 0.
@@ -115,7 +111,7 @@ public class Slider extends SliderBase<Slider, Double> {
      *            the initial value
      */
     public Slider(double min, double max, double step, double value) {
-        super(min, max, step, value, Double.class, IDENTITY, IDENTITY);
+        super(min, max, step, value, Double.class, (v) -> v, (v) -> v);
     }
 
     /**

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.KeyNotifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.InputField;
-import com.vaadin.flow.function.SerializableBiFunction;
+import com.vaadin.flow.function.SerializableFunction;
 
 /**
  * Abstract base class for slider components.
@@ -63,8 +63,8 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      */
     <TPresentation> SliderBase(double min, double max, double step,
             TValue value, Class<TPresentation> presentationType,
-            SerializableBiFunction<TComponent, TPresentation, TValue> presentationToModel,
-            SerializableBiFunction<TComponent, TValue, TPresentation> modelToPresentation) {
+            SerializableFunction<TPresentation, TValue> presentationToModel,
+            SerializableFunction<TValue, TPresentation> modelToPresentation) {
         super("value", null, presentationType, presentationToModel,
                 modelToPresentation);
 


### PR DESCRIPTION
## Description
- Replace custom `PARSER` and `FORMATTER` validation logic with the standard Flow API method `hasValidValue()` from `AbstractSinglePropertyField`
- Simplify the converter functions to identity transformations since validation is now handled by `hasValidValue()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8481 
