### PR TITLE
fix: make TreeGrid scroll methods work when called before attach (CP: 24.10)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -1164,15 +1164,16 @@ public class TreeGrid<T> extends Grid<T>
         getDataCommunicator().setViewportRange(firstRootIndex, pageSize);
         String joinedIndexes = Arrays.stream(indexes).mapToObj(String::valueOf)
                 .collect(Collectors.joining(","));
-        getUI().ifPresent(ui -> ui.beforeClientResponse(this,
-                ctx -> getElement().executeJs(
-                        "this.scrollToIndex(" + joinedIndexes + ");")));
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                        ctx -> getElement().executeJs(
+                                "this.scrollToIndex(" + joinedIndexes + ");")));
     }
 
     @Override
     public void scrollToEnd() {
-        getUI().ifPresent(ui -> ui.beforeClientResponse(this,
-                ctx -> getElement().executeJs(
+        getElement().getNode().runWhenAttached(ui -> ui
+                .beforeClientResponse(this, ctx -> getElement().executeJs(
                         "this.scrollToIndex(...Array(10).fill(Infinity))")));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ScrollToIndexTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ScrollToIndexTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.server.VaadinSession;
+
+public class ScrollToIndexTest {
+
+    private UI ui;
+    private TreeGrid<String> treeGrid;
+
+    @Before
+    public void setup() {
+        ui = new UI();
+        ui.getInternals().setSession(Mockito.mock(VaadinSession.class));
+        treeGrid = new TreeGrid<>();
+    }
+
+    @Test
+    public void scrollToIndex_afterAttach_schedulesJsExecution() {
+        ui.add(treeGrid);
+
+        treeGrid.scrollToIndex(5);
+
+        assertPendingScrollToIndexInvocation();
+    }
+
+    @Test
+    public void scrollToIndex_beforeAttach_thenAttach_schedulesJsExecution() {
+        treeGrid.scrollToIndex(5);
+
+        ui.add(treeGrid);
+
+        assertPendingScrollToIndexInvocation();
+    }
+
+    @Test
+    public void scrollToIndexPath_afterAttach_schedulesJsExecution() {
+        ui.add(treeGrid);
+
+        treeGrid.scrollToIndex(1, 2);
+
+        assertPendingScrollToIndexPathInvocation();
+    }
+
+    @Test
+    public void scrollToIndexPath_beforeAttach_thenAttach_schedulesJsExecution() {
+        treeGrid.scrollToIndex(1, 2);
+
+        ui.add(treeGrid);
+
+        assertPendingScrollToIndexPathInvocation();
+    }
+
+    @Test
+    public void scrollToEnd_afterAttach_schedulesJsExecution() {
+        ui.add(treeGrid);
+
+        treeGrid.scrollToEnd();
+
+        assertPendingScrollToEndInvocation();
+    }
+
+    @Test
+    public void scrollToEnd_beforeAttach_thenAttach_schedulesJsExecution() {
+        treeGrid.scrollToEnd();
+
+        ui.add(treeGrid);
+
+        assertPendingScrollToEndInvocation();
+    }
+
+    private void assertPendingScrollToIndexInvocation() {
+        List<PendingJavaScriptInvocation> pendingInvocations = getPendingJavaScriptInvocations();
+
+        long scrollToIndexCount = pendingInvocations.stream().filter(inv -> inv
+                .getInvocation().getExpression().contains("scrollToIndex"))
+                .count();
+
+        Assert.assertEquals(
+                "Expected one scrollToIndex JS invocation to be scheduled", 1,
+                scrollToIndexCount);
+    }
+
+    private void assertPendingScrollToIndexPathInvocation() {
+        List<PendingJavaScriptInvocation> pendingInvocations = getPendingJavaScriptInvocations();
+
+        long scrollToIndexCount = pendingInvocations.stream().filter(inv -> inv
+                .getInvocation().getExpression().contains("scrollToIndex(1,2)"))
+                .count();
+
+        Assert.assertEquals(
+                "Expected one scrollToIndex path JS invocation to be scheduled",
+                1, scrollToIndexCount);
+    }
+
+    private void assertPendingScrollToEndInvocation() {
+        List<PendingJavaScriptInvocation> pendingInvocations = getPendingJavaScriptInvocations();
+
+        long scrollToEndCount = pendingInvocations.stream()
+                .filter(inv -> inv.getInvocation().getExpression()
+                        .contains("Array(10).fill(Infinity)"))
+                .count();
+
+        Assert.assertEquals(
+                "Expected one scrollToEnd JS invocation to be scheduled", 1,
+                scrollToEndCount);
+    }
+
+    private List<PendingJavaScriptInvocation> getPendingJavaScriptInvocations() {
+        fakeClientResponse();
+        return ui.getInternals().dumpPendingJavaScriptInvocations();
+    }
+
+    private void fakeClientResponse() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/vaadin/flow-components/pull/8653