### PR TITLE
chore: fix signals unit tests

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/AbstractSignalsUnitTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/AbstractSignalsUnitTest.java
@@ -27,9 +27,11 @@ import com.vaadin.flow.component.UI;
  */
 public class AbstractSignalsUnitTest {
 
+    private static UI mockUI;
+
     @BeforeClass
     public static void setupUI() {
-        var mockUI = new MockUI();
+        mockUI = new MockUI();
         UI.setCurrent(mockUI);
     }
 
@@ -39,5 +41,6 @@ public class AbstractSignalsUnitTest {
             UI.getCurrent().removeAll();
             UI.setCurrent(null);
         }
+        mockUI = null;
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractSignalsUnitTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractSignalsUnitTest.java
@@ -27,9 +27,11 @@ import com.vaadin.flow.component.UI;
  */
 public class AbstractSignalsUnitTest {
 
+    private static UI mockUI;
+
     @BeforeClass
     public static void setupUI() {
-        var mockUI = new MockUI();
+        mockUI = new MockUI();
         UI.setCurrent(mockUI);
     }
 
@@ -39,5 +41,6 @@ public class AbstractSignalsUnitTest {
             UI.getCurrent().removeAll();
             UI.setCurrent(null);
         }
+        mockUI = null;
     }
 }


### PR DESCRIPTION
Fix signals unit tests to hold a reference the to `UI`, otherwise it can be garbage collected during test runs causing `UI.getCurrent` to return `null`.
