### PR TITLE
chore: fix signals unit tests

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/AbstractSignalsUnitTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/AbstractSignalsUnitTest.java
@@ -15,8 +15,8 @@
  */
 package com.vaadin.flow.component.shared;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 
 import com.vaadin.flow.component.UI;
 
@@ -27,16 +27,16 @@ import com.vaadin.flow.component.UI;
  */
 public class AbstractSignalsUnitTest {
 
-    private static UI mockUI;
+    private UI mockUI;
 
-    @BeforeClass
-    public static void setupUI() {
+    @Before
+    public void setupUI() {
         mockUI = new MockUI();
         UI.setCurrent(mockUI);
     }
 
-    @AfterClass
-    public static void teardownUI() {
+    @After
+    public void teardownUI() {
         if (UI.getCurrent() != null) {
             UI.getCurrent().removeAll();
             UI.setCurrent(null);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractSignalsUnitTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractSignalsUnitTest.java
@@ -15,8 +15,8 @@
  */
 package com.vaadin.tests;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 
 import com.vaadin.flow.component.UI;
 
@@ -27,16 +27,16 @@ import com.vaadin.flow.component.UI;
  */
 public class AbstractSignalsUnitTest {
 
-    private static UI mockUI;
+    private UI mockUI;
 
-    @BeforeClass
-    public static void setupUI() {
+    @Before
+    public void setupUI() {
         mockUI = new MockUI();
         UI.setCurrent(mockUI);
     }
 
-    @AfterClass
-    public static void teardownUI() {
+    @After
+    public void teardownUI() {
         if (UI.getCurrent() != null) {
             UI.getCurrent().removeAll();
             UI.setCurrent(null);


### PR DESCRIPTION
Due to the changes from https://github.com/vaadin/flow/pull/23491, JUnit tests now use a `CurrentInstanceCleanerListener` that automatically removes the current UI before a test. Thus setting up a UI in a class setup method does not work anymore.

This fixes the two base signal test classes to use per test setup methods.