### PR TITLE
refactor: change ai name to assistant name in orchestrator

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -64,7 +64,7 @@ import com.vaadin.flow.server.streams.UploadHandler;
  *         .withFileReceiver(upload) // optional
  *         .withTools(toolObj) // optional, for @Tool annotations
  *         .withUserName(userName) // optional
- *         .withAIName(aiName) // optional
+ *         .withAssistantName(assistantName) // optional
  *         .build();
  * </pre>
  * <p>
@@ -103,7 +103,7 @@ public class AIOrchestrator {
     private final List<AIAttachment> pendingAttachments = new CopyOnWriteArrayList<>();
     private Object[] tools = new Object[0];
     private String userName;
-    private String aiName;
+    private String assistantName;
 
     private final AtomicBoolean isProcessing = new AtomicBoolean(false);
     private final AtomicBoolean featureFlagChecked = new AtomicBoolean(false);
@@ -181,7 +181,7 @@ public class AIOrchestrator {
         if (messageList == null) {
             return null;
         }
-        var assistantMessage = messageList.createMessage("", aiName,
+        var assistantMessage = messageList.createMessage("", assistantName,
                 Collections.emptyList());
         messageList.addMessage(assistantMessage);
         return assistantMessage;
@@ -319,7 +319,7 @@ public class AIOrchestrator {
         private AIFileReceiver fileReceiver;
         private Object[] tools = new Object[0];
         private String userName;
-        private String aiName;
+        private String assistantName;
 
         private Builder(LLMProvider provider, String systemPrompt) {
             Objects.requireNonNull(provider, "Provider cannot be null");
@@ -441,13 +441,14 @@ public class AIOrchestrator {
          * not set, defaults to "Assistant".
          * </p>
          *
-         * @param aiName
+         * @param assistantName
          *            the display name for AI messages, not {@code null}
          * @return this builder
          */
-        public Builder withAIName(String aiName) {
-            Objects.requireNonNull(aiName, "AI name cannot be null");
-            this.aiName = aiName;
+        public Builder withAssistantName(String assistantName) {
+            Objects.requireNonNull(assistantName,
+                    "Assistant name cannot be null");
+            this.assistantName = assistantName;
             return this;
         }
 
@@ -463,7 +464,8 @@ public class AIOrchestrator {
             orchestrator.fileReceiver = fileReceiver;
             orchestrator.tools = tools == null ? new Object[0] : tools;
             orchestrator.userName = userName == null ? "You" : userName;
-            orchestrator.aiName = aiName == null ? "Assistant" : aiName;
+            orchestrator.assistantName = assistantName == null ? "Assistant"
+                    : assistantName;
             if (input != null) {
                 input.addSubmitListener(
                         e -> orchestrator.doPrompt(e.getValue()));
@@ -472,12 +474,12 @@ public class AIOrchestrator {
                 orchestrator.configureFileReceiver();
             }
             LOGGER.debug("Built AIOrchestrator with messageList={}, input={}, "
-                    + "fileReceiver={}, tools={}, userName={}, aiName={}",
+                    + "fileReceiver={}, tools={}, userName={}, assistantName={}",
                     orchestrator.messageList != null,
                     orchestrator.input != null,
                     orchestrator.fileReceiver != null,
                     orchestrator.tools.length, orchestrator.userName,
-                    orchestrator.aiName);
+                    orchestrator.assistantName);
 
             return orchestrator;
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -862,7 +862,7 @@ public class AIOrchestratorTest {
     }
 
     @Test
-    public void builder_withCustomAiName_usesCustomAiName() {
+    public void builder_withCustomAssistantName_usesCustomAssistantName() {
         mockUi();
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.createMessage(Mockito.anyString(),
@@ -873,7 +873,8 @@ public class AIOrchestratorTest {
                 .thenReturn(Flux.just("Response"));
 
         var orchestrator = AIOrchestrator.builder(mockProvider)
-                .withMessageList(mockMessageList).withAIName("Claude").build();
+                .withMessageList(mockMessageList).withAssistantName("Claude")
+                .build();
         orchestrator.prompt("Hello");
 
         Mockito.verify(mockMessageList).createMessage("", "Claude",
@@ -881,7 +882,7 @@ public class AIOrchestratorTest {
     }
 
     @Test
-    public void builder_withCustomUserNameAndAiName_usesBothCustomNames() {
+    public void builder_withCustomUserNameAndAssistantName_usesBothCustomNames() {
         mockUi();
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.createMessage(Mockito.anyString(),
@@ -896,7 +897,7 @@ public class AIOrchestratorTest {
 
         var orchestrator = AIOrchestrator.builder(mockProvider)
                 .withMessageList(mockMessageList).withUserName("Alice")
-                .withAIName("Bot").build();
+                .withAssistantName("Bot").build();
         orchestrator.prompt("Hello");
 
         var inOrder = Mockito.inOrder(mockMessageList);
@@ -923,7 +924,7 @@ public class AIOrchestratorTest {
     }
 
     @Test
-    public void builder_withNullAiName_throws() {
+    public void builder_withNullAssistantName_throws() {
         mockUi();
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.createMessage(Mockito.anyString(),
@@ -935,7 +936,7 @@ public class AIOrchestratorTest {
         var builder = AIOrchestrator.builder(mockProvider)
                 .withMessageList(mockMessageList);
         Assert.assertThrows(NullPointerException.class,
-                () -> builder.withAIName(null));
+                () -> builder.withAssistantName(null));
     }
 
     private AIOrchestrator getSimpleOrchestrator() {


### PR DESCRIPTION
## Description

Changes `AIName` to `AssistantName` in `AIOrchestrator`.

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=156883852

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.