### PR TITLE
refactor: remove theme-specific prefixes from UploadFileListVariant

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIOrchestratorPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIOrchestratorPage.java
@@ -66,7 +66,7 @@ public class AIOrchestratorPage extends UploadDropZone {
         var uploadButton = new UploadButton(uploadManager);
         uploadButton.setIcon(VaadinIcon.UPLOAD.create());
         var fileList = new UploadFileList(uploadManager);
-        fileList.addThemeVariants(UploadFileListVariant.AURA_THUMBNAILS);
+        fileList.addThemeVariants(UploadFileListVariant.THUMBNAILS);
 
         var messageInput = new MessageInput();
         messageInput.setId("message-input");

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadFileListVariant.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadFileListVariant.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * component.
  */
 public enum UploadFileListVariant implements ThemeVariant {
-    LUMO_THUMBNAILS("thumbnails"), AURA_THUMBNAILS("thumbnails");
+    THUMBNAILS("thumbnails");
 
     private final String variant;
 

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadFileListTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadFileListTest.java
@@ -325,7 +325,7 @@ public class UploadFileListTest {
     public void addThemeVariant_variantIsAdded() {
         UploadFileList fileList = new UploadFileList();
 
-        fileList.addThemeVariants(UploadFileListVariant.LUMO_THUMBNAILS);
+        fileList.addThemeVariants(UploadFileListVariant.THUMBNAILS);
 
         Assert.assertTrue(fileList.getThemeNames().contains("thumbnails"));
     }
@@ -333,9 +333,9 @@ public class UploadFileListTest {
     @Test
     public void removeThemeVariant_variantIsRemoved() {
         UploadFileList fileList = new UploadFileList();
-        fileList.addThemeVariants(UploadFileListVariant.LUMO_THUMBNAILS);
+        fileList.addThemeVariants(UploadFileListVariant.THUMBNAILS);
 
-        fileList.removeThemeVariants(UploadFileListVariant.LUMO_THUMBNAILS);
+        fileList.removeThemeVariants(UploadFileListVariant.THUMBNAILS);
 
         Assert.assertFalse(fileList.getThemeNames().contains("thumbnails"));
     }


### PR DESCRIPTION
## Description

- Merged `LUMO_THUMBNAILS` and `AURA_THUMBNAILS` into a single `THUMBNAILS` variant in `UploadFileListVariant`.

## Type of change

Refactor