### PR TITLE
feat: add signal bind methods to flow components

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
@@ -55,6 +55,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.signals.WritableSignal;
 
 /**
  * App Layout is a component for building common application layouts.
@@ -143,6 +144,24 @@ public class AppLayout extends Component implements RouterLayout, HasStyle {
      */
     public void setDrawerOpened(boolean drawerOpened) {
         getElement().setProperty("drawerOpened", drawerOpened);
+    }
+
+    /**
+     * Binds the drawer opened state to the given writable signal. The binding
+     * is two-way: signal changes push to the DOM property, and client-side
+     * property changes push back to the signal.
+     * <p>
+     * While a signal is bound, any attempt to set the drawer opened state
+     * manually throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindDrawerOpened(WritableSignal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("drawerOpened",
+                signal.map(v -> v == null ? Boolean.TRUE : v), signal::set);
     }
 
     /**

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutSignalTest.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutSignalTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.applayout;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class AppLayoutSignalTest extends AbstractSignalsUnitTest {
+
+    private AppLayout appLayout;
+    private ValueSignal<Boolean> signal;
+
+    @Before
+    public void setup() {
+        appLayout = new AppLayout();
+        signal = new ValueSignal<>(true);
+    }
+
+    @After
+    public void tearDown() {
+        if (appLayout != null && appLayout.isAttached()) {
+            appLayout.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindDrawerOpened_signalBound_propertySync() {
+        appLayout.bindDrawerOpened(signal);
+        UI.getCurrent().add(appLayout);
+
+        Assert.assertTrue(appLayout.isDrawerOpened());
+
+        signal.set(false);
+        Assert.assertFalse(appLayout.isDrawerOpened());
+
+        signal.set(true);
+        Assert.assertTrue(appLayout.isDrawerOpened());
+    }
+
+    @Test
+    public void bindDrawerOpened_notAttached_noEffect() {
+        appLayout.bindDrawerOpened(signal);
+
+        boolean initial = appLayout.getElement().getProperty("drawerOpened",
+                true);
+        signal.set(false);
+        Assert.assertEquals(initial,
+                appLayout.getElement().getProperty("drawerOpened", true));
+    }
+
+    @Test
+    public void bindDrawerOpened_detachAndReattach() {
+        appLayout.bindDrawerOpened(signal);
+        UI.getCurrent().add(appLayout);
+
+        signal.set(false);
+        Assert.assertFalse(appLayout.isDrawerOpened());
+
+        appLayout.removeFromParent();
+        signal.set(true);
+        Assert.assertFalse(appLayout.isDrawerOpened());
+
+        UI.getCurrent().add(appLayout);
+        Assert.assertTrue(appLayout.isDrawerOpened());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindDrawerOpened_setWhileBound_throws() {
+        appLayout.bindDrawerOpened(signal);
+        UI.getCurrent().add(appLayout);
+
+        appLayout.setDrawerOpened(false);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindDrawerOpened_doubleBind_throws() {
+        appLayout.bindDrawerOpened(signal);
+        appLayout.bindDrawerOpened(new ValueSignal<>(false));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindDrawerOpened_nullSignal_throwsNPE() {
+        appLayout.bindDrawerOpened(null);
+    }
+
+    @Test
+    public void bindDrawerOpened_nullDefault_defaultsToTrue() {
+        ValueSignal<Boolean> nullSignal = new ValueSignal<>(null);
+        appLayout.bindDrawerOpened(nullSignal);
+        UI.getCurrent().add(appLayout);
+
+        Assert.assertTrue(appLayout.isDrawerOpened());
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.dom.PropertyChangeListener;
+import com.vaadin.flow.signals.WritableSignal;
 
 /**
  * Checkbox is an input field representing a binary choice.
@@ -348,6 +349,24 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
      */
     public void setIndeterminate(boolean indeterminate) {
         getElement().setProperty("indeterminate", indeterminate);
+    }
+
+    /**
+     * Binds the indeterminate state to the given writable signal. The binding
+     * is two-way: signal changes push to the DOM property, and client-side
+     * property changes push back to the signal.
+     * <p>
+     * While a signal is bound, any attempt to set the indeterminate state
+     * manually throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindIndeterminate(WritableSignal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("indeterminate",
+                signal.map(v -> v == null ? Boolean.FALSE : v), signal::set);
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -73,6 +73,7 @@ import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.signals.Signal;
 
 import tools.jackson.databind.node.ArrayNode;
 
@@ -695,6 +696,31 @@ public class CheckboxGroup<T>
      */
     public void setRequired(boolean required) {
         setRequiredIndicatorVisible(required);
+    }
+
+    /**
+     * Binds the given signal to the required state of this checkbox group.
+     * <p>
+     * When a signal is bound, the required state is kept synchronized with the
+     * signal value while the component is attached. When the component is
+     * detached, signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the required state manually
+     * through {@link #setRequired(boolean)} or
+     * {@link #setRequiredIndicatorVisible(boolean)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     * <p>
+     * Signal's value {@code null} is treated as {@code false}.
+     *
+     * @param signal
+     *            the signal to bind the required state to, not {@code null}
+     * @see #setRequired(boolean)
+     * @since 25.1
+     */
+    public void bindRequired(Signal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("required",
+                signal.map(v -> v == null ? Boolean.FALSE : v), null);
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupSignalTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupSignalTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class CheckboxGroupSignalTest extends AbstractSignalsUnitTest {
+
+    private CheckboxGroup<String> checkboxGroup;
+    private ValueSignal<Boolean> requiredSignal;
+
+    @Before
+    public void setup() {
+        checkboxGroup = new CheckboxGroup<>();
+        requiredSignal = new ValueSignal<>(false);
+    }
+
+    @After
+    public void tearDown() {
+        if (checkboxGroup != null && checkboxGroup.isAttached()) {
+            checkboxGroup.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindRequired_signalBound_requiredSynchronizedWhenAttached() {
+        checkboxGroup.bindRequired(requiredSignal);
+        UI.getCurrent().add(checkboxGroup);
+
+        Assert.assertFalse(
+                checkboxGroup.getElement().getProperty("required", false));
+
+        requiredSignal.set(true);
+        Assert.assertTrue(
+                checkboxGroup.getElement().getProperty("required", false));
+
+        requiredSignal.set(false);
+        Assert.assertFalse(
+                checkboxGroup.getElement().getProperty("required", false));
+    }
+
+    @Test
+    public void bindRequired_signalBound_noEffectWhenDetached() {
+        checkboxGroup.bindRequired(requiredSignal);
+        // Not attached to UI
+
+        boolean initial = checkboxGroup.getElement().getProperty("required",
+                false);
+        requiredSignal.set(true);
+        Assert.assertEquals(initial,
+                checkboxGroup.getElement().getProperty("required", false));
+    }
+
+    @Test
+    public void bindRequired_signalBound_detachAndReattach() {
+        checkboxGroup.bindRequired(requiredSignal);
+        UI.getCurrent().add(checkboxGroup);
+        Assert.assertFalse(
+                checkboxGroup.getElement().getProperty("required", false));
+
+        // Detach
+        checkboxGroup.removeFromParent();
+        requiredSignal.set(true);
+        Assert.assertFalse(
+                checkboxGroup.getElement().getProperty("required", false));
+
+        // Reattach
+        UI.getCurrent().add(checkboxGroup);
+        Assert.assertTrue(
+                checkboxGroup.getElement().getProperty("required", false));
+
+        requiredSignal.set(false);
+        Assert.assertFalse(
+                checkboxGroup.getElement().getProperty("required", false));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindRequired_nullSignal_throwsNPE() {
+        checkboxGroup.bindRequired(null);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindRequired_setRequiredWhileBound_throwsException() {
+        checkboxGroup.bindRequired(requiredSignal);
+        UI.getCurrent().add(checkboxGroup);
+
+        checkboxGroup.setRequired(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindRequired_bindAgainWhileBound_throwsException() {
+        checkboxGroup.bindRequired(requiredSignal);
+        UI.getCurrent().add(checkboxGroup);
+
+        checkboxGroup.bindRequired(new ValueSignal<>(true));
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxIndeterminateSignalTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxIndeterminateSignalTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class CheckboxIndeterminateSignalTest extends AbstractSignalsUnitTest {
+
+    private Checkbox checkbox;
+    private ValueSignal<Boolean> signal;
+
+    @Before
+    public void setup() {
+        checkbox = new Checkbox();
+        signal = new ValueSignal<>(false);
+    }
+
+    @After
+    public void tearDown() {
+        if (checkbox != null && checkbox.isAttached()) {
+            checkbox.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindIndeterminate_signalBound_propertySync() {
+        checkbox.bindIndeterminate(signal);
+        UI.getCurrent().add(checkbox);
+
+        Assert.assertFalse(checkbox.isIndeterminate());
+
+        signal.set(true);
+        Assert.assertTrue(checkbox.isIndeterminate());
+
+        signal.set(false);
+        Assert.assertFalse(checkbox.isIndeterminate());
+    }
+
+    @Test
+    public void bindIndeterminate_notAttached_noEffect() {
+        checkbox.bindIndeterminate(signal);
+
+        boolean initial = checkbox.isIndeterminate();
+        signal.set(true);
+        Assert.assertEquals(initial, checkbox.isIndeterminate());
+    }
+
+    @Test
+    public void bindIndeterminate_detachAndReattach() {
+        checkbox.bindIndeterminate(signal);
+        UI.getCurrent().add(checkbox);
+
+        signal.set(true);
+        Assert.assertTrue(checkbox.isIndeterminate());
+
+        checkbox.removeFromParent();
+        signal.set(false);
+        Assert.assertTrue(checkbox.isIndeterminate());
+
+        UI.getCurrent().add(checkbox);
+        Assert.assertFalse(checkbox.isIndeterminate());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindIndeterminate_setWhileBound_throws() {
+        checkbox.bindIndeterminate(signal);
+        UI.getCurrent().add(checkbox);
+
+        checkbox.setIndeterminate(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindIndeterminate_doubleBind_throws() {
+        checkbox.bindIndeterminate(signal);
+        checkbox.bindIndeterminate(new ValueSignal<>(true));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindIndeterminate_nullSignal_throwsNPE() {
+        checkbox.bindIndeterminate(null);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -76,6 +76,7 @@ import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
 
 /**
@@ -433,6 +434,31 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      */
     public void setRequired(boolean required) {
         setRequiredIndicatorVisible(required);
+    }
+
+    /**
+     * Binds the given signal to the required state of this combo box.
+     * <p>
+     * When a signal is bound, the required state is kept synchronized with the
+     * signal value while the component is attached. When the component is
+     * detached, signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the required state manually
+     * through {@link #setRequired(boolean)} or
+     * {@link #setRequiredIndicatorVisible(boolean)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     * <p>
+     * Signal's value {@code null} is treated as {@code false}.
+     *
+     * @param signal
+     *            the signal to bind the required state to, not {@code null}
+     * @see #setRequired(boolean)
+     * @since 25.1
+     */
+    public void bindRequired(Signal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("required",
+                signal.map(v -> v == null ? Boolean.FALSE : v), null);
     }
 
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxSignalTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxSignalTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class ComboBoxSignalTest extends AbstractSignalsUnitTest {
+
+    private ComboBox<String> comboBox;
+    private ValueSignal<Boolean> requiredSignal;
+
+    @Before
+    public void setup() {
+        comboBox = new ComboBox<>();
+        requiredSignal = new ValueSignal<>(false);
+    }
+
+    @After
+    public void tearDown() {
+        if (comboBox != null && comboBox.isAttached()) {
+            comboBox.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindRequired_signalBound_requiredSynchronizedWhenAttached() {
+        comboBox.bindRequired(requiredSignal);
+        UI.getCurrent().add(comboBox);
+
+        Assert.assertFalse(
+                comboBox.getElement().getProperty("required", false));
+
+        requiredSignal.set(true);
+        Assert.assertTrue(comboBox.getElement().getProperty("required", false));
+
+        requiredSignal.set(false);
+        Assert.assertFalse(
+                comboBox.getElement().getProperty("required", false));
+    }
+
+    @Test
+    public void bindRequired_signalBound_noEffectWhenDetached() {
+        comboBox.bindRequired(requiredSignal);
+        // Not attached to UI
+
+        boolean initial = comboBox.getElement().getProperty("required", false);
+        requiredSignal.set(true);
+        Assert.assertEquals(initial,
+                comboBox.getElement().getProperty("required", false));
+    }
+
+    @Test
+    public void bindRequired_signalBound_detachAndReattach() {
+        comboBox.bindRequired(requiredSignal);
+        UI.getCurrent().add(comboBox);
+        Assert.assertFalse(
+                comboBox.getElement().getProperty("required", false));
+
+        // Detach
+        comboBox.removeFromParent();
+        requiredSignal.set(true);
+        Assert.assertFalse(
+                comboBox.getElement().getProperty("required", false));
+
+        // Reattach
+        UI.getCurrent().add(comboBox);
+        Assert.assertTrue(comboBox.getElement().getProperty("required", false));
+
+        requiredSignal.set(false);
+        Assert.assertFalse(
+                comboBox.getElement().getProperty("required", false));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindRequired_nullSignal_throwsNPE() {
+        comboBox.bindRequired(null);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindRequired_setRequiredWhileBound_throwsException() {
+        comboBox.bindRequired(requiredSignal);
+        UI.getCurrent().add(comboBox);
+
+        comboBox.setRequired(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindRequired_bindAgainWhileBound_throwsException() {
+        comboBox.bindRequired(requiredSignal);
+        UI.getCurrent().add(comboBox);
+
+        comboBox.bindRequired(new ValueSignal<>(true));
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -35,6 +35,12 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-renderer-flow</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.contextmenu;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -26,8 +27,10 @@ import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
+import com.vaadin.flow.signals.WritableSignal;
 
 /**
  * Base class for item component used inside {@link ContextMenu}s.
@@ -54,6 +57,9 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
 
     private boolean checkable = false;
 
+    private SignalPropertySupport<Boolean> checkedSupport;
+    private WritableSignal<Boolean> boundCheckedSignal;
+
     private Set<String> themeNames = new LinkedHashSet<>();
 
     private final DisableOnClickController<MenuItemBase<C, I, S>> disableOnClickController = new DisableOnClickController<>(
@@ -69,7 +75,11 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         this.contextMenu = contextMenu;
         getElement().addEventListener("click", e -> {
             if (checkable) {
-                setChecked(!isChecked());
+                if (boundCheckedSignal != null) {
+                    boundCheckedSignal.set(!isChecked());
+                } else {
+                    setChecked(!isChecked());
+                }
             }
         });
 
@@ -166,11 +176,38 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
                             + "Use setCheckable() to make the item checkable first.");
         }
 
-        getElement().setProperty("_checked", checked);
+        getCheckedSupport().set(checked);
+    }
 
-        executeJsWhenAttached(
-                "window.Vaadin.Flow.contextMenuConnector.setChecked($0, $1)",
-                getElement(), checked);
+    /**
+     * Binds the checked state to the given writable signal. The binding is
+     * two-way: signal changes push to the DOM property, and client-side click
+     * events push back to the signal.
+     * <p>
+     * While a signal is bound, any attempt to set the checked state manually
+     * throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindChecked(WritableSignal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        boundCheckedSignal = signal;
+        getCheckedSupport()
+                .bind(signal.map(v -> v == null ? Boolean.FALSE : v));
+    }
+
+    private SignalPropertySupport<Boolean> getCheckedSupport() {
+        if (checkedSupport == null) {
+            checkedSupport = SignalPropertySupport.create(this, checked -> {
+                getElement().setProperty("_checked", checked);
+                executeJsWhenAttached(
+                        "window.Vaadin.Flow.contextMenuConnector.setChecked($0, $1)",
+                        getElement(), checked);
+            });
+        }
+        return checkedSupport;
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemSignalTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemSignalTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class MenuItemSignalTest extends AbstractSignalsUnitTest {
+
+    private ContextMenu contextMenu;
+    private MenuItem item;
+    private ValueSignal<Boolean> signal;
+
+    @Before
+    public void setup() {
+        // ContextMenu's MenuItemsArrayGenerator triggers chunk loading on
+        // attach, which requires a DeploymentConfiguration on the session.
+        VaadinSession session = VaadinSession.getCurrent();
+        if (session != null && session.getConfiguration() == null) {
+            DeploymentConfiguration config = Mockito
+                    .mock(DeploymentConfiguration.class);
+            Mockito.when(session.getService().getDeploymentConfiguration())
+                    .thenReturn(config);
+        }
+        contextMenu = new ContextMenu();
+        item = contextMenu.addItem("");
+        item.setCheckable(true);
+        signal = new ValueSignal<>(false);
+    }
+
+    @After
+    public void tearDown() {
+        if (contextMenu != null && contextMenu.isAttached()) {
+            contextMenu.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindChecked_signalBound_propertySync() {
+        item.bindChecked(signal);
+        UI.getCurrent().add(contextMenu);
+        flushBeforeClientResponse();
+
+        Assert.assertFalse(item.isChecked());
+
+        signal.set(true);
+        Assert.assertTrue(item.isChecked());
+
+        signal.set(false);
+        Assert.assertFalse(item.isChecked());
+    }
+
+    @Test
+    public void bindChecked_notAttached_noEffect() {
+        item.bindChecked(signal);
+
+        boolean initial = item.isChecked();
+        signal.set(true);
+        Assert.assertEquals(initial, item.isChecked());
+    }
+
+    @Test
+    public void bindChecked_detachAndReattach() {
+        item.bindChecked(signal);
+        UI.getCurrent().add(contextMenu);
+        flushBeforeClientResponse();
+
+        signal.set(true);
+        Assert.assertTrue(item.isChecked());
+
+        contextMenu.removeFromParent();
+        signal.set(false);
+        Assert.assertTrue(item.isChecked());
+
+        UI.getCurrent().add(contextMenu);
+        flushBeforeClientResponse();
+        Assert.assertFalse(item.isChecked());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindChecked_setWhileBound_throws() {
+        item.bindChecked(signal);
+        UI.getCurrent().add(contextMenu);
+
+        item.setChecked(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindChecked_doubleBind_throws() {
+        item.bindChecked(signal);
+        item.bindChecked(new ValueSignal<>(true));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindChecked_nullSignal_throwsNPE() {
+        item.bindChecked(null);
+    }
+
+    private void flushBeforeClientResponse() {
+        UI.getCurrent().getInternals().getStateTree()
+                .runExecutionsBeforeClientResponse();
+    }
+}

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasTheme;
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -35,6 +36,7 @@ import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.signals.WritableSignal;
 
 import tools.jackson.databind.node.ObjectNode;
 
@@ -68,6 +70,8 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
     private E gridActiveItem;
     private boolean toolbarVisible = true;
     private boolean saveBtnDisabledOverridden;
+
+    private SignalPropertySupport<Boolean> dirtySupport;
 
     final private Button saveButton;
 
@@ -314,7 +318,32 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
      * @see #getSaveButton()
      */
     public void setDirty(boolean dirty) {
-        getElement().executeJs("this.__isDirty = $0", dirty);
+        getDirtySupport().set(dirty);
+    }
+
+    /**
+     * Binds the dirty state to the given writable signal. Signal changes push
+     * the dirty state to the client.
+     * <p>
+     * While a signal is bound, any attempt to set the dirty state manually
+     * throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindDirty(WritableSignal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getDirtySupport().bind(signal.map(v -> v == null ? Boolean.FALSE : v));
+    }
+
+    private SignalPropertySupport<Boolean> getDirtySupport() {
+        if (dirtySupport == null) {
+            dirtySupport = SignalPropertySupport.create(this,
+                    dirty -> getElement().executeJs("this.__isDirty = $0",
+                            dirty));
+        }
+        return dirtySupport;
     }
 
     /**

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudSignalTest.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/test/java/com/vaadin/flow/component/crud/CrudSignalTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.crud;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.provider.DataCommunicator;
+import com.vaadin.flow.data.provider.DataKeyMapper;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class CrudSignalTest extends AbstractSignalsUnitTest {
+
+    private Crud<Thing> crud;
+    private ValueSignal<Boolean> signal;
+
+    @Before
+    public void setup() {
+        Grid<Thing> grid = Mockito.spy(new Grid<>());
+        Mockito.when(grid.getDataProvider())
+                .thenReturn(Mockito.mock(DataProvider.class));
+        DataCommunicator<Thing> communicator = Mockito
+                .mock(DataCommunicator.class);
+        Mockito.when(grid.getDataCommunicator()).thenReturn(communicator);
+        DataKeyMapper<Thing> keyMapper = Mockito.mock(DataKeyMapper.class);
+        Mockito.when(communicator.getKeyMapper()).thenReturn(keyMapper);
+
+        crud = new Crud<>(Thing.class, grid, new ThingEditor());
+        signal = new ValueSignal<>(false);
+    }
+
+    @After
+    public void tearDown() {
+        if (crud != null && crud.isAttached()) {
+            crud.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindDirty_signalBound_propertySync() {
+        crud.bindDirty(signal);
+        UI.getCurrent().add(crud);
+
+        signal.set(true);
+        // The dirty state is pushed via executeJs, so we verify the signal
+        // value reflects correctly
+        Assert.assertTrue(signal.peek());
+
+        signal.set(false);
+        Assert.assertFalse(signal.peek());
+    }
+
+    @Test
+    public void bindDirty_notAttached_noEffect() {
+        crud.bindDirty(signal);
+
+        // Signal changes should not throw when not attached
+        signal.set(true);
+        Assert.assertTrue(signal.peek());
+    }
+
+    @Test
+    public void bindDirty_detachAndReattach() {
+        crud.bindDirty(signal);
+        UI.getCurrent().add(crud);
+
+        signal.set(true);
+        Assert.assertTrue(signal.peek());
+
+        crud.removeFromParent();
+        signal.set(false);
+
+        UI.getCurrent().add(crud);
+        Assert.assertFalse(signal.peek());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindDirty_setWhileBound_throws() {
+        crud.bindDirty(signal);
+        UI.getCurrent().add(crud);
+
+        crud.setDirty(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindDirty_doubleBind_throws() {
+        crud.bindDirty(signal);
+        crud.bindDirty(new ValueSignal<>(true));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindDirty_nullSignal_throwsNPE() {
+        crud.bindDirty(null);
+    }
+
+    public static class Thing {
+        String name;
+    }
+
+    private static class ThingEditor implements CrudEditor<Thing> {
+        private Thing item;
+
+        @Override
+        public void setItem(Thing item, boolean validate) {
+            this.item = item;
+        }
+
+        @Override
+        public Thing getItem() {
+            return item;
+        }
+
+        @Override
+        public void clear() {
+        }
+
+        @Override
+        public boolean validate() {
+            return false;
+        }
+
+        @Override
+        public void writeItemChanges() {
+        }
+
+        @Override
+        public Component getView() {
+            return new Div();
+        }
+    }
+}

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/main/java/com/vaadin/flow/component/details/Details.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.WritableSignal;
 
 /**
  * Details is an expandable panel for showing and hiding content from the user
@@ -439,6 +440,24 @@ public class Details extends Component implements HasComponents, HasSize,
      */
     public void setOpened(boolean opened) {
         doSetOpened(opened);
+    }
+
+    /**
+     * Binds the opened state to the given writable signal. The binding is
+     * two-way: signal changes push to the DOM property, and client-side
+     * property changes push back to the signal.
+     * <p>
+     * While a signal is bound, any attempt to set the opened state manually
+     * throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindOpened(WritableSignal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("opened",
+                signal.map(v -> v == null ? Boolean.FALSE : v), signal::set);
     }
 
     public static class OpenedChangeEvent extends ComponentEvent<Details> {

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsOpenedSignalTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsOpenedSignalTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.details;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class DetailsOpenedSignalTest extends AbstractSignalsUnitTest {
+
+    private Details details;
+    private ValueSignal<Boolean> signal;
+
+    @Before
+    public void setup() {
+        details = new Details();
+        signal = new ValueSignal<>(false);
+    }
+
+    @After
+    public void tearDown() {
+        if (details != null && details.isAttached()) {
+            details.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindOpened_signalBound_propertySync() {
+        details.bindOpened(signal);
+        UI.getCurrent().add(details);
+
+        Assert.assertFalse(details.isOpened());
+
+        signal.set(true);
+        Assert.assertTrue(details.isOpened());
+
+        signal.set(false);
+        Assert.assertFalse(details.isOpened());
+    }
+
+    @Test
+    public void bindOpened_notAttached_noEffect() {
+        details.bindOpened(signal);
+
+        boolean initial = details.isOpened();
+        signal.set(true);
+        Assert.assertEquals(initial, details.isOpened());
+    }
+
+    @Test
+    public void bindOpened_detachAndReattach() {
+        details.bindOpened(signal);
+        UI.getCurrent().add(details);
+
+        signal.set(true);
+        Assert.assertTrue(details.isOpened());
+
+        details.removeFromParent();
+        signal.set(false);
+        Assert.assertTrue(details.isOpened());
+
+        UI.getCurrent().add(details);
+        Assert.assertFalse(details.isOpened());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindOpened_setWhileBound_throws() {
+        details.bindOpened(signal);
+        UI.getCurrent().add(details);
+
+        details.setOpened(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindOpened_doubleBind_throws() {
+        details.bindOpened(signal);
+        details.bindOpened(new ValueSignal<>(true));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindOpened_nullSignal_throwsNPE() {
+        details.bindOpened(null);
+    }
+}

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-renderer-flow</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.shared;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * Mixin interface for components that have special handling for tooltips on the
@@ -68,6 +69,26 @@ public interface HasTooltip extends HasElement {
         }
         tooltip.setMarkdown(markdown);
         return tooltip;
+    }
+
+    /**
+     * Binds the given signal to the tooltip text of this component.
+     * <p>
+     * When a signal is bound, the tooltip text is kept synchronized with the
+     * signal value while the component is attached. When the component is
+     * detached, signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the tooltip text manually
+     * through {@link #setTooltipText(String)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the signal to bind the tooltip text to, not {@code null}
+     * @see #setTooltipText(String)
+     * @since 25.1
+     */
+    default void bindTooltipText(Signal<String> signal) {
+        getTooltip().bindText(signal);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * A handle that can be used to configure and control tooltips.
@@ -188,6 +189,27 @@ public class Tooltip implements Serializable {
     public void setMarkdown(String markdown) {
         tooltipElement.setProperty("text", markdown);
         tooltipElement.setProperty("markdown", true);
+    }
+
+    /**
+     * Binds the given signal to the tooltip text.
+     * <p>
+     * When a signal is bound, the tooltip text is kept synchronized with the
+     * signal value while the tooltip's target component is attached. When
+     * detached, signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the text manually through
+     * {@link #setText(String)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the signal to bind the text to, not {@code null}
+     * @see #setText(String)
+     * @since 25.1
+     */
+    public void bindText(Signal<String> signal) {
+        tooltipElement.setProperty("markdown", false);
+        tooltipElement.bindProperty("text", signal, null);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipSignalTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipSignalTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+
+/**
+ * Tests for {@link HasTooltip#bindTooltipText(com.vaadin.flow.signals.Signal)}
+ * and {@link Tooltip#bindText(com.vaadin.flow.signals.Signal)}.
+ */
+public class TooltipSignalTest extends AbstractSignalsUnitTest {
+
+    @Tag("test-component")
+    public static class TestComponent extends Component implements HasTooltip {
+    }
+
+    private TestComponent component;
+
+    @Before
+    public void setup() {
+        component = new TestComponent();
+    }
+
+    @After
+    public void tearDown() {
+        if (component != null && component.isAttached()) {
+            component.removeFromParent();
+        }
+    }
+
+    // ===== HasTooltip.bindTooltipText TESTS =====
+
+    @Test
+    public void bindTooltipText_signalBound_tooltipTextSynchronized() {
+        UI.getCurrent().add(component);
+
+        ValueSignal<String> signal = new ValueSignal<>("");
+        component.bindTooltipText(signal);
+
+        signal.set("Tooltip text");
+        Tooltip tooltip = component.getTooltip();
+        Assert.assertNotNull(tooltip);
+        Assert.assertEquals("Tooltip text", tooltip.getText());
+    }
+
+    @Test
+    public void bindTooltipText_signalBound_noEffectWhenDetached() {
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        component.bindTooltipText(signal);
+        // Not attached to UI
+
+        Tooltip tooltip = component.getTooltip();
+        String initial = tooltip.getText();
+        signal.set("updated");
+        Assert.assertEquals(initial, tooltip.getText());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindTooltipText_setTooltipTextWhileBound_throwsException() {
+        UI.getCurrent().add(component);
+
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        component.bindTooltipText(signal);
+
+        component.setTooltipText("manual");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindTooltipText_bindAgainWhileBound_throwsException() {
+        UI.getCurrent().add(component);
+
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        component.bindTooltipText(signal);
+
+        component.bindTooltipText(new ValueSignal<>("other"));
+    }
+
+    // ===== Tooltip.bindText TESTS =====
+
+    @Test
+    public void tooltipBindText_signalBound_textSynchronized() {
+        UI.getCurrent().add(component);
+
+        Tooltip tooltip = component.getTooltip();
+        ValueSignal<String> signal = new ValueSignal<>("tooltip text");
+        tooltip.bindText(signal);
+
+        Assert.assertEquals("tooltip text", tooltip.getText());
+
+        signal.set("updated tooltip");
+        Assert.assertEquals("updated tooltip", tooltip.getText());
+    }
+
+    @Test
+    public void tooltipBindText_signalBound_noEffectWhenDetached() {
+        Tooltip tooltip = component.getTooltip();
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        tooltip.bindText(signal);
+        // Not attached to UI
+
+        String initial = tooltip.getText();
+        signal.set("updated");
+        Assert.assertEquals(initial, tooltip.getText());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void tooltipBindText_setTextWhileBound_throwsException() {
+        UI.getCurrent().add(component);
+
+        Tooltip tooltip = component.getTooltip();
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        tooltip.bindText(signal);
+
+        tooltip.setText("manual");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void tooltipBindText_bindAgainWhileBound_throwsException() {
+        UI.getCurrent().add(component);
+
+        Tooltip tooltip = component.getTooltip();
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        tooltip.bindText(signal);
+
+        tooltip.bindText(new ValueSignal<>("other"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void tooltipBindText_nullSignal_throwsNPE() {
+        UI.getCurrent().add(component);
+
+        Tooltip tooltip = component.getTooltip();
+        tooltip.bindText(null);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -131,6 +132,7 @@ import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
 
 import tools.jackson.databind.JsonNode;
@@ -892,13 +894,45 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * @return this column, for method chaining
          */
         public Column<T> setHeader(String labelText) {
-            HeaderRow defaultHeaderRow = getGrid().getDefaultHeaderRow();
-            if (defaultHeaderRow == null) {
-                defaultHeaderRow = getGrid().addFirstHeaderRow();
-            }
-            defaultHeaderRow.getCell(this).setText(labelText);
-            grid.updateClientSideSorterIndicators();
+            getHeaderTextSupport().set(labelText);
             return this;
+        }
+
+        /**
+         * Binds the given signal to the header text of this column.
+         * <p>
+         * When a signal is bound, the header text is kept synchronized with the
+         * signal value while the column is attached. When detached, signal
+         * value changes have no effect.
+         * <p>
+         * While a signal is bound, any attempt to set the header text manually
+         * through {@link #setHeader(String)} throws a
+         * {@link com.vaadin.flow.signals.BindingActiveException}.
+         *
+         * @param signal
+         *            the signal to bind the header text to, not {@code null}
+         * @see #setHeader(String)
+         * @since 25.1
+         */
+        public void bindHeader(Signal<String> signal) {
+            getHeaderTextSupport().bind(signal);
+        }
+
+        private SignalPropertySupport<String> headerTextSupport;
+
+        private SignalPropertySupport<String> getHeaderTextSupport() {
+            if (headerTextSupport == null) {
+                headerTextSupport = SignalPropertySupport.create(this, text -> {
+                    HeaderRow defaultHeaderRow = getGrid()
+                            .getDefaultHeaderRow();
+                    if (defaultHeaderRow == null) {
+                        defaultHeaderRow = getGrid().addFirstHeaderRow();
+                    }
+                    defaultHeaderRow.getCell(Column.this).setText(text);
+                    grid.updateClientSideSorterIndicators();
+                });
+            }
+            return headerTextSupport;
         }
 
         /**
@@ -914,9 +948,39 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * @return this column, for method chaining
          */
         public Column<T> setFooter(String labelText) {
-            getGrid().getColumnLayers().get(0).asFooterRow().getCell(this)
-                    .setText(labelText);
+            getFooterTextSupport().set(labelText);
             return this;
+        }
+
+        /**
+         * Binds the given signal to the footer text of this column.
+         * <p>
+         * When a signal is bound, the footer text is kept synchronized with the
+         * signal value while the column is attached. When detached, signal
+         * value changes have no effect.
+         * <p>
+         * While a signal is bound, any attempt to set the footer text manually
+         * through {@link #setFooter(String)} throws a
+         * {@link com.vaadin.flow.signals.BindingActiveException}.
+         *
+         * @param signal
+         *            the signal to bind the footer text to, not {@code null}
+         * @see #setFooter(String)
+         * @since 25.1
+         */
+        public void bindFooter(Signal<String> signal) {
+            getFooterTextSupport().bind(signal);
+        }
+
+        private SignalPropertySupport<String> footerTextSupport;
+
+        private SignalPropertySupport<String> getFooterTextSupport() {
+            if (footerTextSupport == null) {
+                footerTextSupport = SignalPropertySupport.create(this,
+                        text -> getGrid().getColumnLayers().get(0).asFooterRow()
+                                .getCell(Column.this).setText(text));
+            }
+            return footerTextSupport;
         }
 
         /**
@@ -2221,9 +2285,46 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the properties to create columns for
      */
     public void setColumns(String... propertyNames) {
-        checkForBeanGrid();
-        getColumns().forEach(this::removeColumn);
-        Stream.of(propertyNames).forEach(this::addColumn);
+        getColumnsSupport().set(Arrays.asList(propertyNames));
+    }
+
+    /**
+     * Binds the given signal to the displayed columns of this grid.
+     * <p>
+     * When the signal value changes, all existing columns are removed and new
+     * columns are created for the given bean property names.
+     * <p>
+     * <strong>Note:</strong> This method can only be used for a Grid created
+     * from a bean type with {@link #Grid(Class)}.
+     * <p>
+     * While a signal is bound, any attempt to set the columns manually through
+     * {@link #setColumns(String...)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the signal providing the list of property names to create
+     *            columns for, not {@code null}
+     * @see #setColumns(String...)
+     * @since 25.1
+     */
+    public void bindColumns(Signal<List<String>> signal) {
+        getColumnsSupport().bind(signal);
+    }
+
+    private SignalPropertySupport<List<String>> columnsSupport;
+
+    private SignalPropertySupport<List<String>> getColumnsSupport() {
+        if (columnsSupport == null) {
+            columnsSupport = SignalPropertySupport.create(this,
+                    propertyNames -> {
+                        checkForBeanGrid();
+                        getColumns().forEach(this::removeColumn);
+                        if (propertyNames != null) {
+                            propertyNames.forEach(this::addColumn);
+                        }
+                    });
+        }
+        return columnsSupport;
     }
 
     /**
@@ -5287,9 +5388,40 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            clear the empty state content
      */
     public void setEmptyStateText(String emptyStateText) {
-        this.emptyStateComponent = null;
-        this.emptyStateText = emptyStateText;
-        updateEmptyStateContent();
+        getEmptyStateTextSupport().set(emptyStateText);
+    }
+
+    /**
+     * Binds the given signal to the empty state text of this grid.
+     * <p>
+     * When a signal is bound, the empty state text is kept synchronized with
+     * the signal value while the grid is attached. When detached, signal value
+     * changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the empty state text manually
+     * through {@link #setEmptyStateText(String)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the signal to bind the empty state text to, not {@code null}
+     * @see #setEmptyStateText(String)
+     * @since 25.1
+     */
+    public void bindEmptyStateText(Signal<String> signal) {
+        getEmptyStateTextSupport().bind(signal);
+    }
+
+    private SignalPropertySupport<String> emptyStateTextSupport;
+
+    private SignalPropertySupport<String> getEmptyStateTextSupport() {
+        if (emptyStateTextSupport == null) {
+            emptyStateTextSupport = SignalPropertySupport.create(this, text -> {
+                this.emptyStateComponent = null;
+                this.emptyStateText = text;
+                updateEmptyStateContent();
+            });
+        }
+        return emptyStateTextSupport;
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSignalTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSignalTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class GridSignalTest extends AbstractSignalsUnitTest {
+
+    private Grid<String> grid;
+    private Grid.Column<String> column;
+
+    @Before
+    public void setup() {
+        grid = new Grid<>();
+        column = grid.addColumn(s -> s);
+    }
+
+    @After
+    public void tearDown() {
+        if (grid != null && grid.isAttached()) {
+            grid.removeFromParent();
+        }
+    }
+
+    // ===== COLUMN BIND HEADER TESTS =====
+
+    @Test
+    public void bindHeader_signalBound_headerSynchronizedWhenAttached() {
+        var headerSignal = new ValueSignal<>("Header");
+        column.bindHeader(headerSignal);
+        UI.getCurrent().add(grid);
+
+        // Verify header text is set by checking the default header row
+        var headerRow = grid.getDefaultHeaderRow();
+        Assert.assertNotNull(headerRow);
+        Assert.assertEquals("Header", headerRow.getCell(column).getText());
+
+        headerSignal.set("Updated Header");
+        Assert.assertEquals("Updated Header",
+                headerRow.getCell(column).getText());
+    }
+
+    @Test
+    public void bindHeader_signalBound_noEffectWhenDetached() {
+        var headerSignal = new ValueSignal<>("Header");
+        column.bindHeader(headerSignal);
+        UI.getCurrent().add(grid);
+        Assert.assertEquals("Header",
+                grid.getDefaultHeaderRow().getCell(column).getText());
+
+        // Detach
+        grid.removeFromParent();
+        headerSignal.set("Updated");
+        Assert.assertEquals("Header",
+                grid.getDefaultHeaderRow().getCell(column).getText());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindHeader_setHeaderWhileBound_throwsException() {
+        var headerSignal = new ValueSignal<>("Header");
+        column.bindHeader(headerSignal);
+        UI.getCurrent().add(grid);
+
+        column.setHeader("manual");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindHeader_bindAgainWhileBound_throwsException() {
+        var headerSignal = new ValueSignal<>("Header");
+        column.bindHeader(headerSignal);
+        UI.getCurrent().add(grid);
+
+        column.bindHeader(new ValueSignal<>("Other"));
+    }
+
+    // ===== COLUMN BIND FOOTER TESTS =====
+
+    @Test
+    public void bindFooter_signalBound_footerSynchronizedWhenAttached() {
+        var footerSignal = new ValueSignal<>("Footer");
+        column.bindFooter(footerSignal);
+        UI.getCurrent().add(grid);
+
+        // Verify footer text is set
+        var footerRows = grid.getFooterRows();
+        Assert.assertFalse(footerRows.isEmpty());
+        Assert.assertEquals("Footer",
+                footerRows.get(0).getCell(column).getText());
+
+        footerSignal.set("Updated Footer");
+        Assert.assertEquals("Updated Footer",
+                footerRows.get(0).getCell(column).getText());
+    }
+
+    @Test
+    public void bindFooter_signalBound_noEffectWhenDetached() {
+        var footerSignal = new ValueSignal<>("Footer");
+        column.bindFooter(footerSignal);
+        UI.getCurrent().add(grid);
+        Assert.assertEquals("Footer",
+                grid.getFooterRows().get(0).getCell(column).getText());
+
+        // Detach
+        grid.removeFromParent();
+        footerSignal.set("Updated");
+        Assert.assertEquals("Footer",
+                grid.getFooterRows().get(0).getCell(column).getText());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindFooter_setFooterWhileBound_throwsException() {
+        var footerSignal = new ValueSignal<>("Footer");
+        column.bindFooter(footerSignal);
+        UI.getCurrent().add(grid);
+
+        column.setFooter("manual");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindFooter_bindAgainWhileBound_throwsException() {
+        var footerSignal = new ValueSignal<>("Footer");
+        column.bindFooter(footerSignal);
+        UI.getCurrent().add(grid);
+
+        column.bindFooter(new ValueSignal<>("Other"));
+    }
+
+    // ===== GRID BIND EMPTY STATE TEXT TESTS =====
+
+    @Test
+    public void bindEmptyStateText_signalBound_textSynchronizedWhenAttached() {
+        var emptyStateSignal = new ValueSignal<>("No data");
+        grid.bindEmptyStateText(emptyStateSignal);
+        UI.getCurrent().add(grid);
+
+        Assert.assertEquals("No data", grid.getEmptyStateText());
+
+        emptyStateSignal.set("No items found");
+        Assert.assertEquals("No items found", grid.getEmptyStateText());
+    }
+
+    @Test
+    public void bindEmptyStateText_signalBound_noEffectWhenDetached() {
+        var emptyStateSignal = new ValueSignal<>("No data");
+        grid.bindEmptyStateText(emptyStateSignal);
+        // Not attached to UI
+
+        String initial = grid.getEmptyStateText();
+        emptyStateSignal.set("Updated");
+        Assert.assertEquals(initial, grid.getEmptyStateText());
+    }
+
+    @Test
+    public void bindEmptyStateText_signalBound_detachAndReattach() {
+        var emptyStateSignal = new ValueSignal<>("No data");
+        grid.bindEmptyStateText(emptyStateSignal);
+        UI.getCurrent().add(grid);
+        Assert.assertEquals("No data", grid.getEmptyStateText());
+
+        // Detach
+        grid.removeFromParent();
+        emptyStateSignal.set("Updated");
+        Assert.assertEquals("No data", grid.getEmptyStateText());
+
+        // Reattach
+        UI.getCurrent().add(grid);
+        Assert.assertEquals("Updated", grid.getEmptyStateText());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindEmptyStateText_setEmptyStateTextWhileBound_throwsException() {
+        var emptyStateSignal = new ValueSignal<>("No data");
+        grid.bindEmptyStateText(emptyStateSignal);
+        UI.getCurrent().add(grid);
+
+        grid.setEmptyStateText("manual");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindEmptyStateText_bindAgainWhileBound_throwsException() {
+        var emptyStateSignal = new ValueSignal<>("No data");
+        grid.bindEmptyStateText(emptyStateSignal);
+        UI.getCurrent().add(grid);
+
+        grid.bindEmptyStateText(new ValueSignal<>("Other"));
+    }
+
+    // ===== GRID BIND COLUMNS TESTS =====
+
+    @Test
+    public void bindColumns_signalBound_columnsSynchronizedWhenAttached() {
+        var beanGrid = new Grid<>(Person.class);
+        var columnsSignal = new ValueSignal<>(List.of("name"));
+        beanGrid.bindColumns(columnsSignal);
+        UI.getCurrent().add(beanGrid);
+
+        Assert.assertEquals(1, beanGrid.getColumns().size());
+
+        columnsSignal.set(List.of("name", "born"));
+        Assert.assertEquals(2, beanGrid.getColumns().size());
+    }
+
+    @Test
+    public void bindColumns_signalBound_noEffectWhenDetached() {
+        var beanGrid = new Grid<>(Person.class);
+        var columnsSignal = new ValueSignal<>(List.of("name"));
+        beanGrid.bindColumns(columnsSignal);
+        UI.getCurrent().add(beanGrid);
+        Assert.assertEquals(1, beanGrid.getColumns().size());
+
+        beanGrid.removeFromParent();
+        columnsSignal.set(List.of("name", "born"));
+        Assert.assertEquals(1, beanGrid.getColumns().size());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindColumns_setColumnsWhileBound_throwsException() {
+        var beanGrid = new Grid<>(Person.class);
+        var columnsSignal = new ValueSignal<>(List.of("name"));
+        beanGrid.bindColumns(columnsSignal);
+        UI.getCurrent().add(beanGrid);
+
+        beanGrid.setColumns("name", "born");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindColumns_bindAgainWhileBound_throwsException() {
+        var beanGrid = new Grid<>(Person.class);
+        var columnsSignal = new ValueSignal<>(List.of("name"));
+        beanGrid.bindColumns(columnsSignal);
+        UI.getCurrent().add(beanGrid);
+
+        beanGrid.bindColumns(new ValueSignal<>(List.of("born")));
+    }
+}

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapSignalTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapSignalTest.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.map.configuration.Coordinate;
+import com.vaadin.flow.component.map.events.MapViewMoveEndEvent;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+import tools.jackson.databind.node.ArrayNode;
+
+public class MapSignalTest extends AbstractSignalsUnitTest {
+
+    private Map map;
+
+    @Before
+    public void setup() {
+        map = new Map();
+    }
+
+    @After
+    public void tearDown() {
+        if (map != null && map.isAttached()) {
+            map.removeFromParent();
+        }
+    }
+
+    // ===== BIND ZOOM TESTS =====
+
+    @Test
+    public void bindZoom_signalBound_zoomSynchronizedWhenAttached() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        UI.getCurrent().add(map);
+
+        Assert.assertEquals(5.0, map.getView().getZoom(), 0.001);
+
+        zoomSignal.set(10.0);
+        Assert.assertEquals(10.0, map.getView().getZoom(), 0.001);
+
+        zoomSignal.set(3.5);
+        Assert.assertEquals(3.5, map.getView().getZoom(), 0.001);
+    }
+
+    @Test
+    public void bindZoom_signalBound_noEffectWhenDetached() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        // Not attached to UI
+
+        double initial = map.getView().getZoom();
+        zoomSignal.set(10.0);
+        Assert.assertEquals(initial, map.getView().getZoom(), 0.001);
+    }
+
+    @Test
+    public void bindZoom_signalBound_detachAndReattach() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        UI.getCurrent().add(map);
+        Assert.assertEquals(5.0, map.getView().getZoom(), 0.001);
+
+        // Detach
+        map.removeFromParent();
+        zoomSignal.set(10.0);
+        Assert.assertEquals(5.0, map.getView().getZoom(), 0.001);
+
+        // Reattach
+        UI.getCurrent().add(map);
+        Assert.assertEquals(10.0, map.getView().getZoom(), 0.001);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindZoom_setZoomWhileBound_throwsException() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        UI.getCurrent().add(map);
+
+        map.setZoom(10.0);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindZoom_bindAgainWhileBound_throwsException() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        UI.getCurrent().add(map);
+
+        map.bindZoom(new ValueSignal<>(10.0));
+    }
+
+    // ===== BIND CENTER TESTS =====
+
+    @Test
+    public void bindCenter_signalBound_centerSynchronizedWhenAttached() {
+        var centerSignal = new ValueSignal<>(new Coordinate(10.0, 20.0));
+        map.bindCenter(centerSignal);
+        UI.getCurrent().add(map);
+
+        Assert.assertEquals(10.0, map.getView().getCenter().getX(), 0.001);
+        Assert.assertEquals(20.0, map.getView().getCenter().getY(), 0.001);
+
+        centerSignal.set(new Coordinate(30.0, 40.0));
+        Assert.assertEquals(30.0, map.getView().getCenter().getX(), 0.001);
+        Assert.assertEquals(40.0, map.getView().getCenter().getY(), 0.001);
+    }
+
+    @Test
+    public void bindCenter_signalBound_noEffectWhenDetached() {
+        var centerSignal = new ValueSignal<>(new Coordinate(10.0, 20.0));
+        map.bindCenter(centerSignal);
+        // Not attached to UI
+
+        Coordinate initial = map.getView().getCenter();
+        centerSignal.set(new Coordinate(30.0, 40.0));
+        Assert.assertEquals(initial.getX(), map.getView().getCenter().getX(),
+                0.001);
+        Assert.assertEquals(initial.getY(), map.getView().getCenter().getY(),
+                0.001);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindCenter_setCenterWhileBound_throwsException() {
+        var centerSignal = new ValueSignal<>(new Coordinate(10.0, 20.0));
+        map.bindCenter(centerSignal);
+        UI.getCurrent().add(map);
+
+        map.setCenter(new Coordinate(30.0, 40.0));
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindCenter_bindAgainWhileBound_throwsException() {
+        var centerSignal = new ValueSignal<>(new Coordinate(10.0, 20.0));
+        map.bindCenter(centerSignal);
+        UI.getCurrent().add(map);
+
+        map.bindCenter(new ValueSignal<>(new Coordinate(30.0, 40.0)));
+    }
+
+    // ===== TWO-WAY BINDING TESTS =====
+
+    @Test
+    public void bindZoom_userZoom_signalUpdated() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        UI.getCurrent().add(map);
+
+        fireMoveEndEvent(map, true, 10.0, 0, 0);
+
+        Assert.assertEquals(10.0, zoomSignal.get(), 0.001);
+    }
+
+    @Test
+    public void bindCenter_userPan_signalUpdated() {
+        var centerSignal = new ValueSignal<>(new Coordinate(10.0, 20.0));
+        map.bindCenter(centerSignal);
+        UI.getCurrent().add(map);
+
+        fireMoveEndEvent(map, true, 0, 30.0, 40.0);
+
+        Assert.assertEquals(30.0, centerSignal.get().getX(), 0.001);
+        Assert.assertEquals(40.0, centerSignal.get().getY(), 0.001);
+    }
+
+    @Test
+    public void bindZoom_serverSideChange_signalNotUpdated() {
+        var zoomSignal = new ValueSignal<>(5.0);
+        map.bindZoom(zoomSignal);
+        UI.getCurrent().add(map);
+
+        fireMoveEndEvent(map, false, 10.0, 0, 0);
+
+        Assert.assertEquals(5.0, zoomSignal.get(), 0.001);
+    }
+
+    @Test
+    public void bindCenter_serverSideChange_signalNotUpdated() {
+        var centerSignal = new ValueSignal<>(new Coordinate(10.0, 20.0));
+        map.bindCenter(centerSignal);
+        UI.getCurrent().add(map);
+
+        fireMoveEndEvent(map, false, 0, 30.0, 40.0);
+
+        Assert.assertEquals(10.0, centerSignal.get().getX(), 0.001);
+        Assert.assertEquals(20.0, centerSignal.get().getY(), 0.001);
+    }
+
+    @Test
+    public void noSignalBound_moveEndEvent_noError() {
+        UI.getCurrent().add(map);
+        fireMoveEndEvent(map, true, 5.0, 10.0, 20.0);
+        // No exception expected
+    }
+
+    private void fireMoveEndEvent(Map map, boolean fromClient, double zoom,
+            double centerX, double centerY) {
+        ArrayNode coordinates = JacksonUtils.createArrayNode();
+        coordinates.add(centerX);
+        coordinates.add(centerY);
+        ArrayNode extent = JacksonUtils.createArrayNode();
+        extent.add(0);
+        extent.add(0);
+        extent.add(0);
+        extent.add(0);
+
+        ComponentUtil.fireEvent(map, new MapViewMoveEndEvent(map, fromClient, 0,
+                zoom, coordinates, extent));
+    }
+}

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow/src/main/java/com/vaadin/flow/component/markdown/Markdown.java
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow/src/main/java/com/vaadin/flow/component/markdown/Markdown.java
@@ -20,9 +20,11 @@ import java.util.Objects;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * Markdown is a component for rendering Markdown content. It takes Markdown
@@ -37,6 +39,9 @@ public class Markdown extends Component implements HasSize {
 
     private String serverContent;
     private String clientContent;
+
+    private final SignalPropertySupport<String> contentSupport = SignalPropertySupport
+            .create(this, this::applyContent);
 
     /**
      * Default constructor. Creates an empty Markdown.
@@ -56,14 +61,48 @@ public class Markdown extends Component implements HasSize {
     }
 
     /**
+     * Creates a Markdown with content bound to the given signal.
+     * <p>
+     * The content is kept synchronized with the signal value while the
+     * component is attached. When the component is detached, signal value
+     * changes have no effect.
+     *
+     * @param contentSignal
+     *            the signal providing the markdown content
+     * @see #bindContent(Signal)
+     */
+    public Markdown(Signal<String> contentSignal) {
+        bindContent(contentSignal);
+    }
+
+    /**
      * Sets the markdown content.
      *
      * @param content
      *            the markdown content
      */
     public void setContent(String content) {
-        serverContent = content;
-        scheduleContentUpdate();
+        contentSupport.set(content);
+    }
+
+    /**
+     * Binds the given signal to the markdown content of this component.
+     * <p>
+     * When a signal is bound, the content is kept synchronized with the signal
+     * value while the component is attached. When the component is detached,
+     * signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the content manually through
+     * {@link #setContent(String)} or {@link #appendContent(String)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the signal to bind the content to, not {@code null}
+     * @see #setContent(String)
+     * @since 25.1
+     */
+    public void bindContent(Signal<String> signal) {
+        contentSupport.bind(signal);
     }
 
     /**
@@ -95,6 +134,11 @@ public class Markdown extends Component implements HasSize {
             clientContent = null;
             scheduleContentUpdate();
         }
+    }
+
+    private void applyContent(String content) {
+        serverContent = content;
+        scheduleContentUpdate();
     }
 
     private void scheduleContentUpdate() {

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow/src/test/java/com/vaadin/flow/component/markdown/tests/MarkdownSignalTest.java
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow/src/test/java/com/vaadin/flow/component/markdown/tests/MarkdownSignalTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.markdown.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.markdown.Markdown;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class MarkdownSignalTest extends AbstractSignalsUnitTest {
+
+    private Markdown markdown;
+    private ValueSignal<String> contentSignal;
+
+    @Before
+    public void setup() {
+        markdown = new Markdown();
+        contentSignal = new ValueSignal<>("");
+    }
+
+    @After
+    public void tearDown() {
+        if (markdown != null && markdown.isAttached()) {
+            markdown.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindContent_signalBound_contentSynchronizedWhenAttached() {
+        markdown.bindContent(contentSignal);
+        UI.getCurrent().add(markdown);
+
+        Assert.assertEquals("", markdown.getContent());
+
+        contentSignal.set("# Hello");
+        Assert.assertEquals("# Hello", markdown.getContent());
+
+        contentSignal.set("## World");
+        Assert.assertEquals("## World", markdown.getContent());
+    }
+
+    @Test
+    public void bindContent_signalBound_noEffectWhenDetached() {
+        markdown.bindContent(contentSignal);
+        // Not attached to UI
+
+        String initial = markdown.getContent();
+        contentSignal.set("# Hello");
+        Assert.assertEquals(initial, markdown.getContent());
+    }
+
+    @Test
+    public void bindContent_signalBound_detachAndReattach() {
+        markdown.bindContent(contentSignal);
+        UI.getCurrent().add(markdown);
+        Assert.assertEquals("", markdown.getContent());
+
+        // Detach
+        markdown.removeFromParent();
+        contentSignal.set("# Hello");
+        Assert.assertEquals("", markdown.getContent());
+
+        // Reattach
+        UI.getCurrent().add(markdown);
+        Assert.assertEquals("# Hello", markdown.getContent());
+
+        contentSignal.set("## World");
+        Assert.assertEquals("## World", markdown.getContent());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindContent_setContentWhileBound_throwsException() {
+        markdown.bindContent(contentSignal);
+        UI.getCurrent().add(markdown);
+
+        markdown.setContent("manual");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindContent_appendContentWhileBound_throwsException() {
+        markdown.bindContent(contentSignal);
+        UI.getCurrent().add(markdown);
+
+        markdown.appendContent(" appended");
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindContent_bindAgainWhileBound_throwsException() {
+        markdown.bindContent(contentSignal);
+        UI.getCurrent().add(markdown);
+
+        ValueSignal<String> anotherSignal = new ValueSignal<>("other");
+        markdown.bindContent(anotherSignal);
+    }
+
+    // ===== SIGNAL CONSTRUCTOR TESTS =====
+
+    @Test
+    public void signalConstructor_contentSynchronizedWhenAttached() {
+        contentSignal.set("# Signal Content");
+        markdown = new Markdown(contentSignal);
+        UI.getCurrent().add(markdown);
+
+        Assert.assertEquals("# Signal Content", markdown.getContent());
+
+        contentSignal.set("## Updated");
+        Assert.assertEquals("## Updated", markdown.getContent());
+    }
+
+    @Test
+    public void signalConstructor_noEffectWhenDetached() {
+        contentSignal.set("# Initial");
+        markdown = new Markdown(contentSignal);
+        // Not attached to UI
+
+        String initial = markdown.getContent();
+        contentSignal.set("## Updated");
+        Assert.assertEquals(initial, markdown.getContent());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void signalConstructor_setContentWhileBound_throwsException() {
+        markdown = new Markdown(contentSignal);
+        UI.getCurrent().add(markdown);
+
+        markdown.setContent("manual");
+    }
+}

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.progressbar;
 
+import java.util.Objects;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
@@ -244,5 +246,34 @@ public class ProgressBar extends Component
      */
     public boolean isIndeterminate() {
         return getElement().getProperty("indeterminate", false);
+    }
+
+    /**
+     * Binds the given signal to the indeterminate state of the progressbar as a
+     * one-way binding so that the property is updated when the signal's value
+     * is updated.
+     * <p>
+     * When a signal is bound, the indeterminate state is kept synchronized with
+     * the signal value while the component is attached. When the component is
+     * detached, signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the indeterminate state
+     * manually through {@link #setIndeterminate(boolean)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     * <p>
+     * Signal's value {@code null} is treated as {@code false}.
+     *
+     * @param signal
+     *            the signal to bind the indeterminate state to, not
+     *            {@code null}
+     * @see #setIndeterminate(boolean)
+     * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
+     *      SerializableConsumer)
+     * @since 25.1
+     */
+    public void bindIndeterminate(Signal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("indeterminate",
+                signal.map(v -> v == null ? Boolean.FALSE : v), null);
     }
 }

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarSignalTest.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/test/java/com/vaadin/flow/component/progressbar/tests/ProgressBarSignalTest.java
@@ -32,6 +32,7 @@ public class ProgressBarSignalTest extends AbstractSignalsUnitTest {
     private ValueSignal<Double> minSignal;
     private ValueSignal<Double> maxSignal;
     private ValueSignal<Double> valueSignal;
+    private ValueSignal<Boolean> indeterminateSignal;
 
     @Before
     public void setup() {
@@ -39,6 +40,7 @@ public class ProgressBarSignalTest extends AbstractSignalsUnitTest {
         minSignal = new ValueSignal<>(0.0);
         maxSignal = new ValueSignal<>(100.0);
         valueSignal = new ValueSignal<>(50.0);
+        indeterminateSignal = new ValueSignal<>(false);
     }
 
     @After
@@ -232,5 +234,67 @@ public class ProgressBarSignalTest extends AbstractSignalsUnitTest {
 
         ValueSignal<Double> anotherSignal = new ValueSignal<>(80.0);
         progressBar.bindValue(anotherSignal);
+    }
+
+    // ===== INDETERMINATE BINDING TESTS =====
+
+    @Test
+    public void bindIndeterminate_signalBound_indeterminateSynchronizedWhenAttached() {
+        progressBar.bindIndeterminate(indeterminateSignal);
+        UI.getCurrent().add(progressBar);
+
+        Assert.assertFalse(progressBar.isIndeterminate());
+
+        indeterminateSignal.set(true);
+        Assert.assertTrue(progressBar.isIndeterminate());
+
+        indeterminateSignal.set(false);
+        Assert.assertFalse(progressBar.isIndeterminate());
+    }
+
+    @Test
+    public void bindIndeterminate_signalBound_noEffectWhenDetached() {
+        progressBar.bindIndeterminate(indeterminateSignal);
+        // Not attached to UI
+
+        boolean initial = progressBar.isIndeterminate();
+        indeterminateSignal.set(true);
+        Assert.assertEquals(initial, progressBar.isIndeterminate());
+    }
+
+    @Test
+    public void bindIndeterminate_signalBound_detachAndReattach() {
+        progressBar.bindIndeterminate(indeterminateSignal);
+        UI.getCurrent().add(progressBar);
+        Assert.assertFalse(progressBar.isIndeterminate());
+
+        // Detach
+        progressBar.removeFromParent();
+        indeterminateSignal.set(true);
+        Assert.assertFalse(progressBar.isIndeterminate());
+
+        // Reattach
+        UI.getCurrent().add(progressBar);
+        Assert.assertTrue(progressBar.isIndeterminate());
+
+        indeterminateSignal.set(false);
+        Assert.assertFalse(progressBar.isIndeterminate());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindIndeterminate_setIndeterminateWhileBound_throwsException() {
+        progressBar.bindIndeterminate(indeterminateSignal);
+        UI.getCurrent().add(progressBar);
+
+        progressBar.setIndeterminate(true);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindIndeterminate_bindAgainWhileBound_throwsException() {
+        progressBar.bindIndeterminate(indeterminateSignal);
+        UI.getCurrent().add(progressBar);
+
+        ValueSignal<Boolean> anotherSignal = new ValueSignal<>(true);
+        progressBar.bindIndeterminate(anotherSignal);
     }
 }

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNav.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.signals.WritableSignal;
 
 /**
  * A side navigation menu with support for hierarchical and flat menus.
@@ -150,6 +151,25 @@ public class SideNav extends Component implements HasSideNavItems, HasSize,
      */
     public void setExpanded(boolean expanded) {
         getElement().setProperty("collapsed", !expanded);
+    }
+
+    /**
+     * Binds the expanded state to the given writable signal. The binding is
+     * two-way: signal changes push to the DOM property (inverted as
+     * "collapsed"), and client-side property changes push back to the signal.
+     * <p>
+     * While a signal is bound, any attempt to set the expanded state manually
+     * throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindExpanded(WritableSignal<Boolean> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("collapsed",
+                signal.map(v -> v == null ? Boolean.TRUE : !v),
+                collapsed -> signal.set(!collapsed));
     }
 
     /**

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavSignalTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavSignalTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.sidenav.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.sidenav.SideNav;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class SideNavSignalTest extends AbstractSignalsUnitTest {
+
+    private SideNav sideNav;
+    private ValueSignal<Boolean> signal;
+
+    @Before
+    public void setup() {
+        sideNav = new SideNav();
+        signal = new ValueSignal<>(true);
+    }
+
+    @After
+    public void tearDown() {
+        if (sideNav != null && sideNav.isAttached()) {
+            sideNav.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindExpanded_signalBound_propertySync() {
+        sideNav.bindExpanded(signal);
+        UI.getCurrent().add(sideNav);
+
+        Assert.assertTrue(sideNav.isExpanded());
+
+        signal.set(false);
+        Assert.assertFalse(sideNav.isExpanded());
+
+        signal.set(true);
+        Assert.assertTrue(sideNav.isExpanded());
+    }
+
+    @Test
+    public void bindExpanded_inverted_collapsedProperty() {
+        sideNav.bindExpanded(signal);
+        UI.getCurrent().add(sideNav);
+
+        // expanded=true should mean collapsed=false
+        signal.set(true);
+        Assert.assertFalse(
+                sideNav.getElement().getProperty("collapsed", false));
+
+        // expanded=false should mean collapsed=true
+        signal.set(false);
+        Assert.assertTrue(sideNav.getElement().getProperty("collapsed", false));
+    }
+
+    @Test
+    public void bindExpanded_notAttached_noEffect() {
+        sideNav.bindExpanded(signal);
+
+        boolean initial = sideNav.isExpanded();
+        signal.set(false);
+        Assert.assertEquals(initial, sideNav.isExpanded());
+    }
+
+    @Test
+    public void bindExpanded_detachAndReattach() {
+        sideNav.bindExpanded(signal);
+        UI.getCurrent().add(sideNav);
+
+        signal.set(false);
+        Assert.assertFalse(sideNav.isExpanded());
+
+        sideNav.removeFromParent();
+        signal.set(true);
+        Assert.assertFalse(sideNav.isExpanded());
+
+        UI.getCurrent().add(sideNav);
+        Assert.assertTrue(sideNav.isExpanded());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindExpanded_setWhileBound_throws() {
+        sideNav.bindExpanded(signal);
+        UI.getCurrent().add(sideNav);
+
+        sideNav.setExpanded(false);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindExpanded_doubleBind_throws() {
+        sideNav.bindExpanded(signal);
+        sideNav.bindExpanded(new ValueSignal<>(false));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindExpanded_nullSignal_throwsNPE() {
+        sideNav.bindExpanded(null);
+    }
+
+    @Test
+    public void bindExpanded_nullDefault_defaultsToExpanded() {
+        ValueSignal<Boolean> nullSignal = new ValueSignal<>(null);
+        sideNav.bindExpanded(nullSignal);
+        UI.getCurrent().add(sideNav);
+
+        // null maps to collapsed=true (i.e. not expanded)
+        // because signal.map(v -> v == null ? Boolean.TRUE : !v) returns TRUE
+        // for null
+        // and collapsed=true means not expanded
+        Assert.assertFalse(sideNav.isExpanded());
+    }
+}

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutSignalTest.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutSignalTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.splitlayout.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class SplitLayoutSignalTest extends AbstractSignalsUnitTest {
+
+    private SplitLayout splitLayout;
+    private ValueSignal<Double> signal;
+
+    @Before
+    public void setup() {
+        splitLayout = new SplitLayout();
+        signal = new ValueSignal<>(50.0);
+    }
+
+    @After
+    public void tearDown() {
+        if (splitLayout != null && splitLayout.isAttached()) {
+            splitLayout.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindSplitterPosition_signalBound_propertySync() {
+        splitLayout.bindSplitterPosition(signal);
+        UI.getCurrent().add(splitLayout);
+
+        Assert.assertEquals(50.0, splitLayout.getSplitterPosition(), 0.01);
+
+        signal.set(75.0);
+        Assert.assertEquals(75.0, splitLayout.getSplitterPosition(), 0.01);
+
+        signal.set(25.0);
+        Assert.assertEquals(25.0, splitLayout.getSplitterPosition(), 0.01);
+    }
+
+    @Test
+    public void bindSplitterPosition_notAttached_noEffect() {
+        splitLayout.bindSplitterPosition(signal);
+
+        Double initial = splitLayout.getSplitterPosition();
+        signal.set(75.0);
+        Assert.assertEquals(initial, splitLayout.getSplitterPosition());
+    }
+
+    @Test
+    public void bindSplitterPosition_detachAndReattach() {
+        splitLayout.bindSplitterPosition(signal);
+        UI.getCurrent().add(splitLayout);
+
+        signal.set(75.0);
+        Assert.assertEquals(75.0, splitLayout.getSplitterPosition(), 0.01);
+
+        splitLayout.removeFromParent();
+        signal.set(30.0);
+        Assert.assertEquals(75.0, splitLayout.getSplitterPosition(), 0.01);
+
+        UI.getCurrent().add(splitLayout);
+        Assert.assertEquals(30.0, splitLayout.getSplitterPosition(), 0.01);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindSplitterPosition_setWhileBound_throws() {
+        splitLayout.bindSplitterPosition(signal);
+        UI.getCurrent().add(splitLayout);
+
+        splitLayout.setSplitterPosition(80.0);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindSplitterPosition_doubleBind_throws() {
+        splitLayout.bindSplitterPosition(signal);
+        splitLayout.bindSplitterPosition(new ValueSignal<>(30.0));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindSplitterPosition_nullSignal_throwsNPE() {
+        splitLayout.bindSplitterPosition(null);
+    }
+}

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.signals.WritableSignal;
 
 /**
  * Tabs are used to organize and group content into sections that the user can
@@ -552,6 +553,24 @@ public class Tabs extends Component
      */
     public void setSelectedIndex(int selectedIndex) {
         getElement().setProperty(SELECTED, selectedIndex);
+    }
+
+    /**
+     * Binds the selected index to the given writable signal. The binding is
+     * two-way: signal changes push to the DOM property, and client-side
+     * property changes push back to the signal.
+     * <p>
+     * While a signal is bound, any attempt to set the selected index manually
+     * throws {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the writable signal to bind, not {@code null}
+     * @since 25.1
+     */
+    public void bindSelectedIndex(WritableSignal<Integer> signal) {
+        Objects.requireNonNull(signal, "Signal cannot be null");
+        getElement().bindProperty("selected",
+                signal.map(v -> v == null ? 0 : v), signal::set);
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsSignalTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsSignalTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.tabs.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.Tabs;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class TabsSignalTest extends AbstractSignalsUnitTest {
+
+    private Tabs tabs;
+    private ValueSignal<Integer> signal;
+
+    @Before
+    public void setup() {
+        tabs = new Tabs(false, new Tab("Tab 1"), new Tab("Tab 2"),
+                new Tab("Tab 3"));
+        signal = new ValueSignal<>(0);
+    }
+
+    @After
+    public void tearDown() {
+        if (tabs != null && tabs.isAttached()) {
+            tabs.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindSelectedIndex_signalBound_propertySync() {
+        tabs.bindSelectedIndex(signal);
+        UI.getCurrent().add(tabs);
+
+        Assert.assertEquals(0, tabs.getSelectedIndex());
+
+        signal.set(1);
+        Assert.assertEquals(1, tabs.getSelectedIndex());
+
+        signal.set(2);
+        Assert.assertEquals(2, tabs.getSelectedIndex());
+    }
+
+    @Test
+    public void bindSelectedIndex_notAttached_noEffect() {
+        tabs.bindSelectedIndex(signal);
+
+        int initial = tabs.getSelectedIndex();
+        signal.set(2);
+        Assert.assertEquals(initial, tabs.getSelectedIndex());
+    }
+
+    @Test
+    public void bindSelectedIndex_detachAndReattach() {
+        tabs.bindSelectedIndex(signal);
+        UI.getCurrent().add(tabs);
+
+        signal.set(1);
+        Assert.assertEquals(1, tabs.getSelectedIndex());
+
+        tabs.removeFromParent();
+        signal.set(2);
+        Assert.assertEquals(1, tabs.getSelectedIndex());
+
+        UI.getCurrent().add(tabs);
+        Assert.assertEquals(2, tabs.getSelectedIndex());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindSelectedIndex_setWhileBound_throws() {
+        tabs.bindSelectedIndex(signal);
+        UI.getCurrent().add(tabs);
+
+        tabs.setSelectedIndex(1);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindSelectedIndex_doubleBind_throws() {
+        tabs.bindSelectedIndex(signal);
+        tabs.bindSelectedIndex(new ValueSignal<>(1));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void bindSelectedIndex_nullSignal_throwsNPE() {
+        tabs.bindSelectedIndex(null);
+    }
+}

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -39,6 +40,7 @@ import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * BigDecimalField is an input field for handling decimal numbers with high
@@ -415,11 +417,41 @@ public class BigDecimalField extends TextFieldBase<BigDecimalField, BigDecimal>
      *            the locale to set, not {@code null}
      */
     public void setLocale(Locale locale) {
-        Objects.requireNonNull(locale, "Locale to set can't be null.");
-        this.locale = locale;
+        getLocaleSupport().set(locale);
+    }
 
-        setDecimalSeparator(
-                new DecimalFormatSymbols(locale).getDecimalSeparator());
+    /**
+     * Binds the given signal to the locale of this field.
+     * <p>
+     * When a signal is bound, the locale is kept synchronized with the signal
+     * value while the component is attached. When the component is detached,
+     * signal value changes have no effect.
+     * <p>
+     * While a signal is bound, any attempt to set the locale manually through
+     * {@link #setLocale(Locale)} throws a
+     * {@link com.vaadin.flow.signals.BindingActiveException}.
+     *
+     * @param signal
+     *            the signal to bind the locale to, not {@code null}
+     * @see #setLocale(Locale)
+     * @since 25.1
+     */
+    public void bindLocale(Signal<Locale> signal) {
+        getLocaleSupport().bind(signal);
+    }
+
+    private SignalPropertySupport<Locale> localeSupport;
+
+    private SignalPropertySupport<Locale> getLocaleSupport() {
+        if (localeSupport == null) {
+            localeSupport = SignalPropertySupport.create(this, loc -> {
+                Objects.requireNonNull(loc, "Locale to set can't be null.");
+                this.locale = loc;
+                setDecimalSeparator(
+                        new DecimalFormatSymbols(loc).getDecimalSeparator());
+            });
+        }
+        return localeSupport;
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldSignalTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldSignalTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield.tests;
+
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsUnitTest;
+
+public class BigDecimalFieldSignalTest extends AbstractSignalsUnitTest {
+
+    private BigDecimalField bigDecimalField;
+    private ValueSignal<Locale> localeSignal;
+
+    @Before
+    public void setup() {
+        bigDecimalField = new BigDecimalField();
+        localeSignal = new ValueSignal<>(Locale.US);
+    }
+
+    @After
+    public void tearDown() {
+        if (bigDecimalField != null && bigDecimalField.isAttached()) {
+            bigDecimalField.removeFromParent();
+        }
+    }
+
+    @Test
+    public void bindLocale_signalBound_localeSynchronizedWhenAttached() {
+        bigDecimalField.bindLocale(localeSignal);
+        UI.getCurrent().add(bigDecimalField);
+
+        Assert.assertEquals(Locale.US, bigDecimalField.getLocale());
+
+        localeSignal.set(Locale.GERMANY);
+        Assert.assertEquals(Locale.GERMANY, bigDecimalField.getLocale());
+
+        localeSignal.set(Locale.FRANCE);
+        Assert.assertEquals(Locale.FRANCE, bigDecimalField.getLocale());
+    }
+
+    @Test
+    public void bindLocale_signalBound_noEffectWhenDetached() {
+        bigDecimalField.bindLocale(localeSignal);
+        // Not attached to UI
+
+        Locale initial = bigDecimalField.getLocale();
+        localeSignal.set(Locale.GERMANY);
+        Assert.assertEquals(initial, bigDecimalField.getLocale());
+    }
+
+    @Test
+    public void bindLocale_signalBound_detachAndReattach() {
+        bigDecimalField.bindLocale(localeSignal);
+        UI.getCurrent().add(bigDecimalField);
+        Assert.assertEquals(Locale.US, bigDecimalField.getLocale());
+
+        // Detach
+        bigDecimalField.removeFromParent();
+        localeSignal.set(Locale.GERMANY);
+        Assert.assertEquals(Locale.US, bigDecimalField.getLocale());
+
+        // Reattach
+        UI.getCurrent().add(bigDecimalField);
+        Assert.assertEquals(Locale.GERMANY, bigDecimalField.getLocale());
+
+        localeSignal.set(Locale.FRANCE);
+        Assert.assertEquals(Locale.FRANCE, bigDecimalField.getLocale());
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindLocale_setLocaleWhileBound_throwsException() {
+        bigDecimalField.bindLocale(localeSignal);
+        UI.getCurrent().add(bigDecimalField);
+
+        bigDecimalField.setLocale(Locale.GERMANY);
+    }
+
+    @Test(expected = BindingActiveException.class)
+    public void bindLocale_bindAgainWhileBound_throwsException() {
+        bigDecimalField.bindLocale(localeSignal);
+        UI.getCurrent().add(bigDecimalField);
+
+        bigDecimalField.bindLocale(new ValueSignal<>(Locale.GERMANY));
+    }
+}


### PR DESCRIPTION
Add bindX(Signal/WritableSignal) methods across multiple components for signal bindings that keep component state synchronized with signal values while attached.

One-way bindings (Signal → component):
- CheckboxGroup.bindRequired
- ComboBoxBase.bindRequired
- ProgressBar.bindIndeterminate
- BigDecimalField.bindLocale
- Details.bindOpened (WritableSignal, two-way)
- Markdown.bindContent + Markdown(Signal<String>) constructor
- Grid.bindColumns, Column.bindHeader/bindFooter, bindEmptyStateText
- Tooltip.bindText

Two-way bindings (WritableSignal ↔ component):
- AppLayout.bindDrawerOpened
- Checkbox.bindIndeterminate
- Crud.bindDirty
- MenuItemBase.bindChecked
- SideNav.bindExpanded
- SplitLayout.bindSplitterPosition
- Tabs.bindSelectedIndex
- Map.bindCenter, Map.bindZoom (via moveend event write-back)

Includes unit tests for all bind methods.
