### PR TITLE
feat: add has upload handler api for upload

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -98,6 +98,8 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
      */
     private Receiver receiver;
 
+    private boolean handlerExplicitlyConfigured;
+
     /**
      * Create a new instance of Upload.
      * <p>
@@ -778,6 +780,9 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
             throw new IllegalArgumentException(
                     "The target name cannot be blank");
         }
+        if (!(handler instanceof FailFastUploadHandler)) {
+            handlerExplicitlyConfigured = true;
+        }
         StreamResourceRegistry.ElementStreamResource elementStreamResource = new StreamResourceRegistry.ElementStreamResource(
                 handler, this.getElement()) {
             @Override
@@ -918,6 +923,15 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
                         event.getMimeType(), event.getContentLength());
             }
         }
+    }
+
+    /**
+     * Returns whether an UploadHandler is explicitly configured.
+     * <p>
+     * Intended only for internal use.
+     */
+    boolean isHandlerExplicitlyConfigured() {
+        return handlerExplicitlyConfigured;
     }
 
     /**

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadHelper.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadHelper.java
@@ -38,4 +38,17 @@ public class UploadHelper implements Serializable {
     public static boolean hasUploadHandler(UploadManager uploadManager) {
         return uploadManager.isHandlerExplicitlyConfigured();
     }
+
+    /**
+     * Checks whether the given {@link Upload} has an explicitly configured
+     * {@link UploadHandler UploadHandler}.
+     *
+     * @param upload
+     *            the upload component to check, not {@code null}
+     * @return {@code true} if the upload has an explicitly configured upload
+     *         handler, {@code false} otherwise
+     */
+    public static boolean hasUploadHandler(Upload upload) {
+        return upload.isHandlerExplicitlyConfigured();
+    }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHelperTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/UploadHelperTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadHelper;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.server.Command;
@@ -96,5 +97,28 @@ public class UploadHelperTest {
         });
         manager.setUploadHandler(handler);
         Assert.assertTrue(UploadHelper.hasUploadHandler(manager));
+    }
+
+    @Test
+    public void hasUploadHandler_upload_withDefaultConstructor_returnsFalse() {
+        var upload = new Upload();
+        Assert.assertFalse(UploadHelper.hasUploadHandler(upload));
+    }
+
+    @Test
+    public void hasUploadHandler_upload_withHandlerInConstructor_returnsTrue() {
+        var handler = UploadHandler.inMemory((metadata, data) -> {
+        });
+        var upload = new Upload(handler);
+        Assert.assertTrue(UploadHelper.hasUploadHandler(upload));
+    }
+
+    @Test
+    public void hasUploadHandler_upload_withDefaultConstructor_setHandler_returnsTrue() {
+        var upload = new Upload();
+        var handler = UploadHandler.inMemory((metadata, data) -> {
+        });
+        upload.setUploadHandler(handler);
+        Assert.assertTrue(UploadHelper.hasUploadHandler(upload));
     }
 }


### PR DESCRIPTION
## Description

Adds static `hasUploadHandler` method for `Upload` to the `UploadHelper` class.

Part of https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=156884832

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.