### PR TITLE
feat: add setRole / getRole methods to Badge

### DIFF
--- a/vaadin-badge-flow-parent/vaadin-badge-flow/src/main/java/com/vaadin/flow/component/badge/Badge.java
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow/src/main/java/com/vaadin/flow/component/badge/Badge.java
@@ -323,6 +323,29 @@ public class Badge extends Component
         return SlotUtils.getChildInSlot(this, ICON_SLOT);
     }
 
+    /**
+     * Sets the ARIA role attribute on the badge.
+     *
+     * @param role
+     *            the ARIA role, or {@code null} to clear
+     */
+    public void setRole(String role) {
+        if (role == null) {
+            getElement().removeAttribute("role");
+        } else {
+            getElement().setAttribute("role", role);
+        }
+    }
+
+    /**
+     * Gets the ARIA role attribute of the badge.
+     *
+     * @return the ARIA role, or {@code null} if not set
+     */
+    public String getRole() {
+        return getElement().getAttribute("role");
+    }
+
     private void updateText(String text) {
         textNode.setText(text);
 

--- a/vaadin-badge-flow-parent/vaadin-badge-flow/src/test/java/com/vaadin/flow/component/badge/tests/BadgeTest.java
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow/src/test/java/com/vaadin/flow/component/badge/tests/BadgeTest.java
@@ -143,6 +143,18 @@ public class BadgeTest {
     }
 
     @Test
+    public void setRole_getRole() {
+        var badge = new Badge();
+        Assert.assertNull(badge.getRole());
+
+        badge.setRole("status");
+        Assert.assertEquals("status", badge.getRole());
+
+        badge.setRole(null);
+        Assert.assertNull(badge.getRole());
+    }
+
+    @Test
     public void setIcon_getIcon() {
         var badge = new Badge();
         var icon0 = new Span();


### PR DESCRIPTION
Adds `setRole(String)` and `getRole()` methods to the Badge component for setting the ARIA role attribute.

Part of https://github.com/vaadin/platform/issues/8530