### PR TITLE
chore: fix context menu unit tests (25.0)

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTargetTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTargetTest.java
@@ -45,7 +45,10 @@ public class ContextMenuTargetTest {
         Mockito.when(mockSession.getService()).thenReturn(mockService);
         Mockito.when(mockSession.getConfiguration())
                 .thenReturn(mockConfiguration);
+        Mockito.when(mockService.getDeploymentConfiguration())
+                .thenReturn(mockConfiguration);
         Mockito.when(mockService.getContext()).thenReturn(mockContext);
+        Mockito.when(mockConfiguration.isProductionMode()).thenReturn(false);
 
         ui.getInternals().setSession(mockSession);
     }

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
@@ -34,6 +34,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 public class GridProTest {
 
+    private UI ui;
     GridPro<Person> grid;
     ObjectNode selectedItem;
     ArrayList<Person> items = new ArrayList<>();
@@ -45,7 +46,7 @@ public class GridProTest {
     @Before
     public void setup() {
         VaadinSession session = Mockito.mock(VaadinSession.class);
-        var ui = new UI();
+        ui = new UI();
         ui.getInternals().setSession(session);
 
         UI.setCurrent(ui);


### PR DESCRIPTION
Similar change as https://github.com/vaadin/flow-components/pull/8761 for 25.0. 