### PR TITLE
chore: use MockUIRule in notification tests

### DIFF
--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
@@ -19,42 +19,30 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Text;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.tests.MockUIRule;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 
 public class NotificationChildrenTest {
+    @Rule
+    public MockUIRule ui = new MockUIRule();
 
-    private UI ui = new UI();
     private Notification notification;
 
     @Before
     public void setup() {
-        UI.setCurrent(ui);
-
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        Mockito.when(session.hasLock()).thenReturn(true);
-        ui.getInternals().setSession(session);
-
         notification = new Notification();
         ui.add(notification);
-    }
-
-    @After
-    public void tearDown() {
-        UI.setCurrent(null);
     }
 
     @Test

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationHasStyleTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationHasStyleTest.java
@@ -15,37 +15,13 @@
  */
 package com.vaadin.flow.component.notification;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.shared.internal.OverlayClassListProxy;
-import com.vaadin.flow.server.VaadinSession;
 
 public class NotificationHasStyleTest {
-
-    private UI ui = new UI();
-    private Notification notification;
-
-    @Before
-    public void setup() {
-        UI.setCurrent(ui);
-
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        Mockito.when(session.hasLock()).thenReturn(true);
-        ui.getInternals().setSession(session);
-
-        notification = new Notification();
-        ui.add(notification);
-    }
-
-    @After
-    public void tearDown() {
-        UI.setCurrent(null);
-    }
+    private final Notification notification = new Notification();
 
     @Test
     public void addClassName_notificationHasOverlayClass() {

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationSignalTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationSignalTest.java
@@ -15,9 +15,7 @@
  */
 package com.vaadin.flow.component.notification;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
@@ -30,30 +28,9 @@ import com.vaadin.tests.AbstractSignalsUnitTest;
 public class NotificationSignalTest extends AbstractSignalsUnitTest {
 
     private Notification notification;
-    private ValueSignal<String> textSignal;
-    private Signal<String> computedSignal;
-
-    private UI ui;
-
-    @Before
-    public void setup() {
-        ui = new UI();
-        UI.setCurrent(ui);
-        textSignal = new ValueSignal<>("foo");
-        computedSignal = Signal.computed(() -> textSignal.get() + " bar");
-    }
-
-    @After
-    public void tearDown() {
-        if (notification != null) {
-            notification.close();
-            if (notification.isAttached()) {
-                notification.removeFromParent();
-            }
-        }
-        UI.setCurrent(null);
-        ui = null;
-    }
+    private final ValueSignal<String> textSignal = new ValueSignal<>("foo");
+    private final Signal<String> computedSignal = Signal
+            .computed(() -> textSignal.get() + " bar");
 
     @Test
     public void textSignalCtor() {
@@ -240,12 +217,6 @@ public class NotificationSignalTest extends AbstractSignalsUnitTest {
         Assert.assertEquals("foo", getNotificationText());
         textSignal.set("bar");
         Assert.assertEquals("bar", getNotificationText());
-    }
-
-    private void assertTextSignalBindingInactive() {
-        var currentText = getNotificationText();
-        textSignal.set(currentText + " with change");
-        Assert.assertEquals(currentText, getNotificationText());
     }
 
     private String getNotificationText() {

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTest.java
@@ -15,37 +15,24 @@
  */
 package com.vaadin.flow.component.notification.tests;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
+import com.vaadin.tests.MockUIRule;
 
 import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class NotificationTest {
+    @Rule
+    public MockUIRule ui = new MockUIRule();
 
     private Notification notification;
-
-    private UI ui;
-
-    @Before
-    public void setup() {
-        ui = new UI();
-        UI.setCurrent(ui);
-    }
-
-    @After
-    public void tearDown() {
-        UI.setCurrent(null);
-        ui = null;
-    }
 
     @Test
     public void stringAndDurationCtor() {


### PR DESCRIPTION
Updates Notification unit tests to use `MockUIRule` for setting up and cleaning up the current UI.
