### PR TITLE
refactor: update upload manager connector to fix TS warnings

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/resources/META-INF/resources/frontend/vaadin-upload-manager-connector.ts
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/resources/META-INF/resources/frontend/vaadin-upload-manager-connector.ts
@@ -1,5 +1,4 @@
-// @ts-expect-error
-import { UploadManager } from '@vaadin/upload/vaadin-upload-manager.js';
+import { UploadManager, type UploadFormat } from '@vaadin/upload/vaadin-upload-manager.js';
 
 /**
  * Connector element for UploadManager. This element is added as a virtual child
@@ -50,7 +49,7 @@ class UploadManagerConnector extends HTMLElement {
     this.manager.noAuto = value;
   }
 
-  set uploadFormat(value: string) {
+  set uploadFormat(value: UploadFormat) {
     this.manager.uploadFormat = value;
   }
 


### PR DESCRIPTION
## Description

I'm getting following TS compilation errors in the docs project, this PR should fix them:

```
  ERROR(TypeScript)  Unused '@ts-expect-error' directive.
  FILE  /Users/serhii/vaadin/docs/frontend/generated/jar-resources/vaadin-upload-manager-connector.ts:1:1

   > 1 | // @ts-expect-error
       | ^^^^^^^^^^^^^^^^^^^
     2 | import { UploadManager } from '@vaadin/upload/vaadin-upload-manager.js';
     3 |
     4 | /**

  ERROR(TypeScript)  Type 'string' is not assignable to type 'UploadFormat'.
  FILE  /Users/serhii/vaadin/docs/frontend/generated/jar-resources/vaadin-upload-manager-connector.ts:54:5

     52 |
     53 |   set uploadFormat(value: string) {
   > 54 |     this.manager.uploadFormat = value;
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^

```

## Type of change

- Refactor