### PR TITLE
test: Remove signal binding test that clears theme bindings

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasThemeVariantTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasThemeVariantTest.java
@@ -141,22 +141,6 @@ public class HasThemeVariantTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindThemeVariant_setThemeVariants_removesBinding() {
-        TestComponent component = new TestComponent();
-        UI.getCurrent().add(component);
-        ValueSignal<Boolean> signal = new ValueSignal<>(true);
-        component.bindThemeVariant(TestComponentVariant.TEST_VARIANT, signal);
-        // setThemeVariants calls getThemeNames().clear() which removes the
-        // binding
-        component.setThemeVariants(); // clears all variants and biding
-
-        Assert.assertTrue(component.getThemeNames().isEmpty());
-        Assert.assertTrue(signal.peek());
-        signal.set(true); // no effect
-        Assert.assertTrue(component.getThemeNames().isEmpty());
-    }
-
-    @Test
     public void bindThemeVariant_editWithActiveBinding_throwBindingActiveException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);


### PR DESCRIPTION
Related-to https://github.com/vaadin/flow/pull/23721 : signal bindings are permanent and bulk operation including `clear()` are not allowed for active binding.