### PR TITLE
refactor: remove unnecessary text node binding

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -61,18 +61,14 @@ public class Button extends Component
         HasEnabled, HasPrefix, HasSize, HasStyle, HasSuffix, HasText,
         HasThemeVariant<ButtonVariant>, HasTooltip {
 
+    private final Text textNode = new Text("");
     private Component iconComponent;
     private boolean iconAfterText;
     private final DisableOnClickController<Button> disableOnClickController = new DisableOnClickController<>(
             this);
 
-    // Explicit text node is used to manage the text content and text signal
-    // bindings of the button separatly from its icon. All `HasText` methods
-    // delegate to this node.
-    private final Text textNode = new Text("");
-
     private final SignalPropertySupport<String> textSupport = SignalPropertySupport
-            .<String> create(this, this::textChangeHandler);
+            .create(this, this::textChangeHandler);
 
     /**
      * Default constructor. Creates an empty button.
@@ -254,8 +250,7 @@ public class Button extends Component
      */
     @Override
     public void setText(String text) {
-        textNode.setText(text);
-        textChangeHandler(text);
+        textSupport.set(text);
     }
 
     @Override
@@ -265,7 +260,6 @@ public class Button extends Component
 
     @Override
     public void bindText(Signal<String> textSignal) {
-        textNode.bindText(textSignal);
         textSupport.bind(textSignal);
     }
 
@@ -632,6 +626,8 @@ public class Button extends Component
      *            the text inside the button
      */
     private void textChangeHandler(String text) {
+        textNode.setText(text);
+
         var hasText = text != null && !text.isEmpty();
         var textNodeAttached = textNode.getParent().isPresent();
         if (hasText && !textNodeAttached) {


### PR DESCRIPTION
Removes a separate binding for the Button's text node in favor of updating the text node from the text signal support. Also make the setter use the text signal support to automatically apply the same side effects.