### PR TITLE
feat: add new unprefixed variants to TabSheetVariant

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheetVariant.java
@@ -23,15 +23,26 @@ import com.vaadin.flow.component.shared.ThemeVariant;
 public enum TabSheetVariant implements ThemeVariant {
     LUMO_TABS_CENTERED("centered"),
     LUMO_TABS_SMALL("small"),
+    TABS_SMALL("small"),
     LUMO_TABS_MINIMAL("minimal"),
     LUMO_TABS_HIDE_SCROLL_BUTTONS("hide-scroll-buttons"),
     LUMO_TABS_EQUAL_WIDTH_TABS("equal-width-tabs"),
     LUMO_BORDERED("bordered"),
     LUMO_NO_PADDING("no-padding"),
     LUMO_TABS_SHOW_SCROLL_BUTTONS("show-scroll-buttons"),
+    /**
+     * @deprecated Use {@link #TABS_HIDE_SCROLL_BUTTONS} instead.
+     */
+    @Deprecated
     AURA_TABS_HIDE_SCROLL_BUTTONS("hide-scroll-buttons"),
+    TABS_HIDE_SCROLL_BUTTONS("hide-scroll-buttons"),
     AURA_TABS_SHOW_SCROLL_BUTTONS("show-scroll-buttons"),
+    /**
+     * @deprecated Use {@link #NO_PADDING} instead.
+     */
+    @Deprecated
     AURA_NO_PADDING("no-padding"),
+    NO_PADDING("no-padding"),
     AURA_NO_BORDER("no-border"),
     AURA_TABS_FILLED("filled");
 


### PR DESCRIPTION
## Description

- The `no-padding` variant is supported by Lumo and Aura (base styles), let's add an unprefixed version.
- The `hide-scroll-buttons` has unprefixed `HIDE_SCROLL_BUTTONS` in `TabsVariant` - let's align it.
- The unprefixed `small` variant was added to `TabsVariant` but not `TabSheetVariant` - let's add it too.

## Type of change

- Feature