### PR TITLE
feat: return SignalBinding from all bind methods

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.NodeOwner;
 import com.vaadin.flow.internal.StateTree;
@@ -699,13 +700,16 @@ public class AvatarGroup extends Component
      *            the type of signal holding individual items
      * @param itemsSignal
      *            the signal to bind the items to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @since 25.1
      */
-    public <S extends Signal<AvatarGroupItem>> void bindItems(
+    public <S extends Signal<AvatarGroupItem>> SignalBinding<Collection<AvatarGroupItem>> bindItems(
             Signal<List<S>> itemsSignal) {
         Objects.requireNonNull(itemsSignal, "Signal cannot be null");
-        itemsSupport.bind(() -> itemsSignal.get().stream().map(Signal::get)
-                .collect(Collectors.toList()));
+        return itemsSupport.bind(() -> itemsSignal.get().stream()
+                .map(Signal::get).collect(Collectors.toList()));
     }
 
     /**

--- a/vaadin-badge-flow-parent/vaadin-badge-flow/src/main/java/com/vaadin/flow/component/badge/Badge.java
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow/src/main/java/com/vaadin/flow/component/badge/Badge.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -229,9 +230,9 @@ public class Badge extends Component
     }
 
     @Override
-    public void bindText(Signal<String> textSignal) {
+    public SignalBinding<String> bindText(Signal<String> textSignal) {
         updateContent(null);
-        textSignalSupport.bind(textSignal);
+        return textSignalSupport.bind(textSignal);
     }
 
     /**
@@ -253,9 +254,12 @@ public class Badge extends Component
      *
      * @param numberSignal
      *            the signal providing the number value
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      */
-    public void bindNumber(Signal<Integer> numberSignal) {
-        getElement().bindProperty("number", numberSignal, null);
+    public SignalBinding<Integer> bindNumber(Signal<Integer> numberSignal) {
+        return getElement().bindProperty("number", numberSignal, null);
     }
 
     /**

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
@@ -260,8 +261,8 @@ public class Button extends Component
     }
 
     @Override
-    public void bindText(Signal<String> textSignal) {
-        textSupport.bind(textSignal);
+    public SignalBinding<String> bindText(Signal<String> textSignal) {
+        return textSupport.bind(textSignal);
     }
 
     /**
@@ -476,16 +477,19 @@ public class Button extends Component
      * not be synchronized back to the signal due to
      * {@link #bindEnabled(Signal)} only supporting one-way bindings.
      *
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @throws IllegalStateException
      *             if disable-on-click is active
      */
     @Override
-    public void bindEnabled(Signal<Boolean> enabledSignal) {
+    public SignalBinding<Boolean> bindEnabled(Signal<Boolean> enabledSignal) {
         if (isDisableOnClick()) {
             throw new IllegalStateException(
                     "Binding the enabled state to a signal is not supported when disable on click is active. ");
         }
-        Focusable.super.bindEnabled(enabledSignal);
+        return Focusable.super.bindEnabled(enabledSignal);
     }
 
     /**

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.*;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.local.ValueSignal;
@@ -185,9 +186,9 @@ public class ButtonSignalTest extends AbstractSignalsUnitTest {
             }
 
             @Override
-            public void bindText(Signal<String> value) {
+            public SignalBinding<String> bindText(Signal<String> value) {
                 mockButton.bindText(value);
-                super.bindText(value);
+                return super.bindText(value);
             }
         }
         ;

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.component.shared.internal.ModalRoot;
 import com.vaadin.flow.component.shared.internal.OverlayAutoAddController;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
@@ -174,8 +175,8 @@ public class ConfirmDialog extends Component
     }
 
     @Override
-    public void bindWidth(Signal<String> widthSignal) {
-        getElement().bindProperty("width", widthSignal, null);
+    public SignalBinding<String> bindWidth(Signal<String> widthSignal) {
+        return getElement().bindProperty("width", widthSignal, null);
     }
 
     @Override
@@ -202,8 +203,8 @@ public class ConfirmDialog extends Component
     }
 
     @Override
-    public void bindHeight(Signal<String> heightSignal) {
-        getElement().bindProperty("height", heightSignal, null);
+    public SignalBinding<String> bindHeight(Signal<String> heightSignal) {
+        return getElement().bindProperty("height", heightSignal, null);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.flow.signals.Signal;
 
@@ -274,16 +275,19 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
      * not be synchronized back to the signal due to
      * {@link #bindEnabled(Signal)} only supporting one-way bindings.
      *
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @throws IllegalStateException
      *             if disable-on-click is active
      */
     @Override
-    public void bindEnabled(Signal<Boolean> enabledSignal) {
+    public SignalBinding<Boolean> bindEnabled(Signal<Boolean> enabledSignal) {
         if (isDisableOnClick()) {
             throw new IllegalStateException(
                     "Binding the enabled state to a signal is not supported when disable on click is active. ");
         }
-        HasComponents.super.bindEnabled(enabledSignal);
+        return HasComponents.super.bindEnabled(enabledSignal);
     }
 
     /**

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
@@ -600,12 +601,15 @@ public class Dashboard extends Component
      *
      * @param visibleSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindVisible(Signal<Boolean> visibleSignal) {
+    public SignalBinding<Boolean> bindVisible(Signal<Boolean> visibleSignal) {
         throw new UnsupportedOperationException(
                 "Dashboard does not support setting visibility");
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardSection.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -199,12 +200,15 @@ public class DashboardSection extends Component implements HasWidgets {
      *
      * @param visibleSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindVisible(Signal<Boolean> visibleSignal) {
+    public SignalBinding<Boolean> bindVisible(Signal<Boolean> visibleSignal) {
         throw new UnsupportedOperationException(
                 "Dashboard section does not support setting visibility");
     }

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/DashboardWidget.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -233,12 +234,15 @@ public class DashboardWidget extends Component {
      *
      * @param visibleSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindVisible(Signal<Boolean> visibleSignal) {
+    public SignalBinding<Boolean> bindVisible(Signal<Boolean> visibleSignal) {
         throw new UnsupportedOperationException(
                 "Dashboard widget does not support setting visibility");
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -62,6 +62,7 @@ import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
@@ -443,13 +444,16 @@ public class DatePicker
      *
      * @param signal
      *            the signal to bind the minimum date to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMin(LocalDate)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMin(Signal<LocalDate> signal) {
-        getElement().bindProperty("min",
+    public SignalBinding<String> bindMin(Signal<LocalDate> signal) {
+        return getElement().bindProperty("min",
                 signal == null ? null : signal.map(FORMATTER::apply), null);
     }
 
@@ -492,14 +496,18 @@ public class DatePicker
      *
      * @param signal
      *            the signal to bind the maximum date to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMax(LocalDate)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMax(Signal<LocalDate> signal) {
+    public SignalBinding<String> bindMax(Signal<LocalDate> signal) {
         Objects.requireNonNull(signal, "Signal cannot be null");
-        getElement().bindProperty("max", signal.map(FORMATTER::apply), null);
+        return getElement().bindProperty("max", signal.map(FORMATTER::apply),
+                null);
     }
 
     /**
@@ -939,13 +947,16 @@ public class DatePicker
      *
      * @param signal
      *            the signal to bind the initial position to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setInitialPosition(LocalDate)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindInitialPosition(Signal<LocalDate> signal) {
-        getElement().bindProperty("initialPosition",
+    public SignalBinding<String> bindInitialPosition(Signal<LocalDate> signal) {
+        return getElement().bindProperty("initialPosition",
                 signal == null ? null : signal.map(FORMATTER::apply), null);
     }
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
@@ -452,8 +453,8 @@ public class DateTimePicker
     }
 
     @Override
-    public void bindReadOnly(Signal<Boolean> readOnlySignal) {
-        readonlySupport.bind(readOnlySignal);
+    public SignalBinding<Boolean> bindReadOnly(Signal<Boolean> readOnlySignal) {
+        return readonlySupport.bind(readOnlySignal);
     }
 
     @Override
@@ -904,13 +905,16 @@ public class DateTimePicker
      * @param signal
      *            the signal to bind the minimum date and time to, not
      *            {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMin(LocalDateTime)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMin(Signal<LocalDateTime> signal) {
-        getElement().bindProperty("min",
+    public SignalBinding<String> bindMin(Signal<LocalDateTime> signal) {
+        return getElement().bindProperty("min",
                 signal == null ? null : signal.map(FORMATTER::apply), null);
     }
 
@@ -955,13 +959,16 @@ public class DateTimePicker
      * @param signal
      *            the signal to bind the maximum date and time to, not
      *            {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMax(LocalDateTime)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMax(Signal<LocalDateTime> signal) {
-        getElement().bindProperty("max",
+    public SignalBinding<String> bindMax(Signal<LocalDateTime> signal) {
+        return getElement().bindProperty("max",
                 signal == null ? null : signal.map(FORMATTER::apply), null);
     }
 

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.dom.ElementDetachEvent;
 import com.vaadin.flow.dom.ElementDetachListener;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
@@ -335,12 +336,15 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * 
      * @param widthSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindWidth(Signal<String> widthSignal) {
+    public SignalBinding<String> bindWidth(Signal<String> widthSignal) {
         throw new UnsupportedOperationException(
                 "One-way binding of the width is not supported as the width may be modified for resizable dialogs.");
     }
@@ -372,12 +376,15 @@ public class Dialog extends Component implements HasComponents, HasSize,
      *
      * @param heightSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindHeight(Signal<String> heightSignal) {
+    public SignalBinding<String> bindHeight(Signal<String> heightSignal) {
         throw new UnsupportedOperationException(
                 "One-way binding of the height is not supported as the height may be modified for resizable dialogs.");
     }
@@ -1040,8 +1047,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     @Override
-    public void bindVisible(Signal<Boolean> visibleSignal) {
-        visibleSupport.bind(visibleSignal);
+    public SignalBinding<Boolean> bindVisible(Signal<Boolean> visibleSignal) {
+        return visibleSupport.bind(visibleSignal);
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClearButton.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClearButton.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.shared;
 import java.util.Objects;
 
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -70,12 +71,16 @@ public interface HasClearButton extends HasElement {
      * @param signal
      *            the signal to bind the clear button visibility to, not
      *            {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setClearButtonVisible(boolean)
      * @since 25.1
      */
-    default void bindClearButtonVisible(Signal<Boolean> signal) {
+    default SignalBinding<Boolean> bindClearButtonVisible(
+            Signal<Boolean> signal) {
         Objects.requireNonNull(signal, "Signal cannot be null");
-        getElement().bindProperty("clearButtonVisible",
+        return getElement().bindProperty("clearButtonVisible",
                 signal.map(
                         visible -> visible == null ? Boolean.FALSE : visible),
                 null);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasThemeVariant.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasThemeVariant.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.shared;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.HasTheme;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -111,10 +112,13 @@ public interface HasThemeVariant<TVariantEnum extends ThemeVariant>
      *            the theme variant to bind, not {@code null} or blank
      * @param signal
      *            the boolean signal to bind to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see HasTheme#bindThemeName(String, Signal)
      */
-    default void bindThemeVariant(TVariantEnum variant,
+    default SignalBinding<Boolean> bindThemeVariant(TVariantEnum variant,
             Signal<Boolean> signal) {
-        bindThemeName(variant.getVariantName(), signal);
+        return bindThemeName(variant.getVariantName(), signal);
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayClassListProxy.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/OverlayClassListProxy.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.dom.ClassList;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -61,8 +62,9 @@ public class OverlayClassListProxy extends AbstractSet<String>
     }
 
     @Override
-    public void bind(String className, Signal<Boolean> signal) {
-        classList.bind(className, signal);
+    public SignalBinding<Boolean> bind(String className,
+            Signal<Boolean> signal) {
+        return classList.bind(className, signal);
     }
 
     private class IteratorProxy implements Serializable, Iterator<String> {

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.icon;
 import java.util.Optional;
 
 import com.vaadin.flow.dom.ElementConstants;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.signals.Signal;
 
@@ -127,13 +128,16 @@ public class FontIcon extends AbstractIcon<FontIcon> {
      *
      * @param signal
      *            the signal to bind the character code to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setCharCode(String)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindCharCode(Signal<String> signal) {
-        getElement().bindProperty("char", signal, null);
+    public SignalBinding<String> bindCharCode(Signal<String> signal) {
+        return getElement().bindProperty("char", signal, null);
     }
 
     /**
@@ -172,13 +176,16 @@ public class FontIcon extends AbstractIcon<FontIcon> {
      *
      * @param signal
      *            the signal to bind the ligature to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setLigature(String)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindLigature(Signal<String> signal) {
-        getElement().bindProperty("ligature", signal, null);
+    public SignalBinding<String> bindLigature(Signal<String> signal) {
+        return getElement().bindProperty("ligature", signal, null);
     }
 
     @Override

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -150,12 +151,15 @@ public class Icon extends AbstractIcon<Icon> {
      *
      * @param signal
      *            the signal to bind the icon to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setIcon(VaadinIcon)
      * @see com.vaadin.flow.dom.Element#bindAttribute(String, Signal)
      * @since 25.1
      */
-    public void bindIcon(Signal<VaadinIcon> signal) {
-        getElement().bindAttribute(ICON_ATTRIBUTE_NAME,
+    public SignalBinding<String> bindIcon(Signal<VaadinIcon> signal) {
+        return getElement().bindAttribute(ICON_ATTRIBUTE_NAME,
                 signal == null ? null
                         : signal.map(icon -> VAADIN_ICON_COLLECTION_NAME + ":"
                                 + normalizeIcon(icon)));

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.icon;
 
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamResource;
@@ -340,13 +341,16 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
      *
      * @param signal
      *            the signal to bind the symbol to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setSymbol(String)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindSymbol(Signal<String> signal) {
-        getElement().bindProperty("symbol", signal, null);
+    public SignalBinding<String> bindSymbol(Signal<String> signal) {
+        return getElement().bindProperty("symbol", signal, null);
     }
 
     @Override

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -57,6 +57,7 @@ import com.vaadin.flow.data.provider.ListDataView;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TextRenderer;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
@@ -266,12 +267,16 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
      *
      * @param requiredSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindRequiredIndicatorVisible(Signal<Boolean> requiredSignal) {
+    public SignalBinding<Boolean> bindRequiredIndicatorVisible(
+            Signal<Boolean> requiredSignal) {
         throw new UnsupportedOperationException(
                 "ListBox does not support showing a required indicator");
     }

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.PropertyChangeListener;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
@@ -233,12 +234,15 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
      *
      * @param enabledSignal
      *            the signal to bind, not <code>null</code>
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @deprecated This method is not supported and will throw an exception when
      *             called.
      */
     @Deprecated
     @Override
-    public void bindEnabled(Signal<Boolean> enabledSignal) {
+    public SignalBinding<Boolean> bindEnabled(Signal<Boolean> enabledSignal) {
         throw new UnsupportedOperationException(
                 "One-way binding of the enabled state is not supported.");
     }

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.signals.Signal;
 
@@ -131,13 +132,16 @@ public class ProgressBar extends Component
      *
      * @param signal
      *            the signal to bind the value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setValue(double)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindValue(Signal<Double> signal) {
-        getElement().bindProperty("value", signal, null);
+    public SignalBinding<Double> bindValue(Signal<Double> signal) {
+        return getElement().bindProperty("value", signal, null);
     }
 
     /**
@@ -191,13 +195,16 @@ public class ProgressBar extends Component
      *
      * @param signal
      *            the signal to bind the minimum bound to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMin(double)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMin(Signal<Double> signal) {
-        getElement().bindProperty("min", signal, null);
+    public SignalBinding<Double> bindMin(Signal<Double> signal) {
+        return getElement().bindProperty("min", signal, null);
     }
 
     /**
@@ -213,13 +220,16 @@ public class ProgressBar extends Component
      *
      * @param signal
      *            the signal to bind the maximum bound to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMax(double)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMax(Signal<Double> signal) {
-        getElement().bindProperty("max", signal, null);
+    public SignalBinding<Double> bindMax(Signal<Double> signal) {
+        return getElement().bindProperty("max", signal, null);
     }
 
     /**

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -64,6 +64,7 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.selection.SingleSelect;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
@@ -533,8 +534,8 @@ public class RadioButtonGroup<T>
     }
 
     @Override
-    public void bindReadOnly(Signal<Boolean> readOnlySignal) {
-        readonlySupport.bind(readOnlySignal);
+    public SignalBinding<Boolean> bindReadOnly(Signal<Boolean> readOnlySignal) {
+        return readonlySupport.bind(readOnlySignal);
     }
 
     /**

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.signals.Signal;
@@ -189,12 +190,15 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *
      * @param signal
      *            the signal to bind the minimum value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMin(Signal<Double> signal) {
-        getElement().bindProperty("min", signal, null);
+    public SignalBinding<Double> bindMin(Signal<Double> signal) {
+        return getElement().bindProperty("min", signal, null);
     }
 
     /**
@@ -212,12 +216,15 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *
      * @param signal
      *            the signal to bind the maximum value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMax(Signal<Double> signal) {
-        getElement().bindProperty("max", signal, null);
+    public SignalBinding<Double> bindMax(Signal<Double> signal) {
+        return getElement().bindProperty("max", signal, null);
     }
 
     /**
@@ -235,12 +242,15 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *
      * @param signal
      *            the signal to bind the step value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindStep(Signal<Double> signal) {
-        getElement().bindProperty("step", signal, null);
+    public SignalBinding<Double> bindStep(Signal<Double> signal) {
+        return getElement().bindProperty("step", signal, null);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
@@ -344,16 +345,26 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
 
     /**
      * Internal helper to bind a signal to the minimum value.
+     *
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      */
-    protected final void bindMinInternal(Signal<Double> signal) {
-        minSupport.bind(signal);
+    protected final SignalBinding<Double> bindMinInternal(
+            Signal<Double> signal) {
+        return minSupport.bind(signal);
     }
 
     /**
      * Internal helper to bind a signal to the maximum value.
+     *
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      */
-    protected final void bindMaxInternal(Signal<Double> signal) {
-        maxSupport.bind(signal);
+    protected final SignalBinding<Double> bindMaxInternal(
+            Signal<Double> signal) {
+        return maxSupport.bind(signal);
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.signals.Signal;
 
@@ -293,11 +294,14 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
      *
      * @param signal
      *            the signal to bind the minimum value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMin(int)
      * @since 25.1
      */
-    public void bindMin(Signal<Integer> signal) {
-        bindMinInternal(
+    public SignalBinding<Double> bindMin(Signal<Integer> signal) {
+        return bindMinInternal(
                 signal == null ? null : signal.map(Integer::doubleValue));
     }
 
@@ -314,11 +318,14 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
      *
      * @param signal
      *            the signal to bind the maximum value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMax(int)
      * @since 25.1
      */
-    public void bindMax(Signal<Integer> signal) {
-        bindMaxInternal(
+    public SignalBinding<Double> bindMax(Signal<Integer> signal) {
+        return bindMaxInternal(
                 signal == null ? null : signal.map(Integer::doubleValue));
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.signals.Signal;
 
@@ -298,11 +299,14 @@ public class NumberField extends AbstractNumberField<NumberField, Double>
      *
      * @param signal
      *            the signal to bind the minimum value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMin(double)
      * @since 25.1
      */
-    public void bindMin(Signal<Double> signal) {
-        bindMinInternal(signal);
+    public SignalBinding<Double> bindMin(Signal<Double> signal) {
+        return bindMinInternal(signal);
     }
 
     /**
@@ -318,11 +322,14 @@ public class NumberField extends AbstractNumberField<NumberField, Double>
      *
      * @param signal
      *            the signal to bind the maximum value to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMax(double)
      * @since 25.1
      */
-    public void bindMax(Signal<Double> signal) {
-        bindMaxInternal(signal);
+    public SignalBinding<Double> bindMax(Signal<Double> signal) {
+        return bindMaxInternal(signal);
     }
 
     /**

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -55,6 +55,7 @@ import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.ValidationStatusChangeEvent;
 import com.vaadin.flow.data.binder.ValidationStatusChangeListener;
 import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.StateTree;
@@ -828,14 +829,18 @@ public class TimePicker
      *
      * @param signal
      *            the signal to bind the minimum time to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMin(LocalTime)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMin(Signal<LocalTime> signal) {
+    public SignalBinding<String> bindMin(Signal<LocalTime> signal) {
         Objects.requireNonNull(signal, "Signal cannot be null");
-        getElement().bindProperty("min", signal.map(FORMATTER::apply), null);
+        return getElement().bindProperty("min", signal.map(FORMATTER::apply),
+                null);
     }
 
     /**
@@ -852,14 +857,18 @@ public class TimePicker
      *
      * @param signal
      *            the signal to bind the maximum time to, not {@code null}
+     * @return a {@link SignalBinding} that can be used to register
+     *         {@link SignalBinding#onChange(com.vaadin.flow.function.SerializableConsumer)
+     *         onChange} callbacks
      * @see #setMax(LocalTime)
      * @see com.vaadin.flow.dom.Element#bindProperty(String, Signal,
      *      SerializableConsumer)
      * @since 25.1
      */
-    public void bindMax(Signal<LocalTime> signal) {
+    public SignalBinding<String> bindMax(Signal<LocalTime> signal) {
         Objects.requireNonNull(signal, "Signal cannot be null");
-        getElement().bindProperty("max", signal.map(FORMATTER::apply), null);
+        return getElement().bindProperty("max", signal.map(FORMATTER::apply),
+                null);
     }
 
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {


### PR DESCRIPTION
Change all component-level bind methods from void to returning SignalBinding<T>, enabling fluent .onChange() callbacks. This includes bind methods that delegate to super, to SignalPropertySupport.bind(), to Element.bindProperty/bindAttribute, and methods that throw UnsupportedOperationException.
