### PR TITLE
refactor: update for eager ElementEffect init (CP: 25.1)

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -687,9 +687,10 @@ public class AvatarGroup extends Component
      * binding so that the rendered avatars are updated when the signal's value
      * or any individual item signal changes.
      * <p>
-     * When a signal is bound, the items are kept synchronized with the signal
-     * value while the component is attached. When the component is detached,
-     * signal value changes have no effect.
+     * The items are set immediately with the current signal value when the
+     * binding is created, and are kept synchronized with any subsequent signal
+     * value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to modify items manually through
      * {@link #setItems(Collection)}, {@link #add(AvatarGroupItem...)}, or

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupSignalTest.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/test/java/com/vaadin/flow/component/avatar/tests/AvatarGroupSignalTest.java
@@ -143,14 +143,15 @@ public class AvatarGroupSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindItems_notAttached_bindingInactiveUntilAttach() {
+    public void bindItems_notAttached_initialValueApplied() {
         var item1Signal = new ValueSignal<>(new AvatarGroupItem("Alice"));
         var item2Signal = new ValueSignal<>(new AvatarGroupItem("Bob"));
         var listSignal = new ValueSignal<>(List.of(item1Signal, item2Signal));
 
         avatarGroup.bindItems(listSignal);
 
-        Assert.assertEquals(0, avatarGroup.getItems().size());
+        // Initial value is applied immediately (effect runs on creation)
+        Assert.assertEquals(2, avatarGroup.getItems().size());
 
         ui.add(avatarGroup);
 

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
@@ -116,6 +116,7 @@ public class ButtonSignalTest extends AbstractSignalsUnitTest {
     public void setIcon_textSignalChange_slotRemoved() {
         icon = new Icon();
         button = new Button(textSignal, icon);
+        UI.getCurrent().add(button);
 
         textSignal.set("");
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -434,9 +434,10 @@ public class DatePicker
      * Binds the given signal to the minimum date allowed to be selected for
      * this field.
      * <p>
-     * When a signal is bound, the minimum date is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The minimum date is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum date manually
      * through {@link #setMin(LocalDate)} throws a
@@ -486,9 +487,10 @@ public class DatePicker
      * Binds the given signal to the maximum date allowed to be selected for
      * this field.
      * <p>
-     * When a signal is bound, the maximum date is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The maximum date is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum date manually
      * through {@link #setMax(LocalDate)} throws a
@@ -937,9 +939,10 @@ public class DatePicker
      * Binds the given signal to the visible date when there is no value
      * selected.
      * <p>
-     * When a signal is bound, the initial position is kept synchronized with
-     * the signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The initial position is set immediately with the current signal value
+     * when the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the initial position manually
      * through {@link #setInitialPosition(LocalDate)} throws a

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -891,9 +891,11 @@ public class DateTimePicker
      * Binds the given signal to the minimum date and time allowed to be set for
      * this field.
      * <p>
-     * When a signal is bound, the minimum date and time is kept synchronized
-     * with the signal value while the component is attached. When the component
-     * is detached, signal value changes have no effect.
+     * The minimum date and time is set immediately with the current signal
+     * value when the binding is created, and is kept synchronized with any
+     * subsequent signal value changes while the component is in attached state.
+     * When the component is in detached state, signal value changes have no
+     * effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum date and time
      * manually through {@link #setMin(LocalDateTime)} throws a
@@ -945,9 +947,11 @@ public class DateTimePicker
      * Binds the given signal to the maximum date and time allowed to be set for
      * this field.
      * <p>
-     * When a signal is bound, the maximum date and time is kept synchronized
-     * with the signal value while the component is attached. When the component
-     * is detached, signal value changes have no effect.
+     * The maximum date and time is set immediately with the current signal
+     * value when the binding is created, and is kept synchronized with any
+     * subsequent signal value changes while the component is in attached state.
+     * When the component is in detached state, signal value changes have no
+     * effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum date and time
      * manually through {@link #setMax(LocalDateTime)} throws a

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerSignalTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerSignalTest.java
@@ -50,10 +50,11 @@ public class DateTimePickerSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindMin_elementNotAttached_bindingInactive_untilAttach() {
+    public void bindMin_elementNotAttached_initialValueApplied() {
         dateTimePicker.bindMin(signal);
 
-        Assert.assertNull(dateTimePicker.getMin());
+        // Initial value is applied immediately (effect runs on creation)
+        Assert.assertEquals(signal.peek(), dateTimePicker.getMin());
 
         UI.getCurrent().add(dateTimePicker);
         Assert.assertEquals(signal.peek(), dateTimePicker.getMin());
@@ -90,10 +91,11 @@ public class DateTimePickerSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindMax_elementNotAttached_bindingInactive_untilAttach() {
+    public void bindMax_elementNotAttached_initialValueApplied() {
         dateTimePicker.bindMax(signal);
 
-        Assert.assertNull(dateTimePicker.getMax());
+        // Initial value is applied immediately (effect runs on creation)
+        Assert.assertEquals(signal.peek(), dateTimePicker.getMax());
 
         UI.getCurrent().add(dateTimePicker);
         Assert.assertEquals(signal.peek(), dateTimePicker.getMax());
@@ -125,11 +127,12 @@ public class DateTimePickerSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementNotAttached_bindingInactive_untilAttach() {
+    public void bindReadOnly_elementNotAttached_initialValueApplied() {
         readonlySignal.set(true);
         dateTimePicker.bindReadOnly(readonlySignal);
 
-        Assert.assertFalse(dateTimePicker.isReadOnly());
+        // Initial value is applied immediately (effect runs on creation)
+        Assert.assertTrue(dateTimePicker.isReadOnly());
 
         UI.getCurrent().add(dateTimePicker);
         Assert.assertTrue(dateTimePicker.isReadOnly());

--- a/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsSignalTest.java
+++ b/vaadin-details-flow-parent/vaadin-details-flow/src/test/java/com/vaadin/flow/component/details/DetailsSignalTest.java
@@ -78,14 +78,15 @@ public class DetailsSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindChildren_notAttached_bindingInactiveUntilAttach() {
+    public void bindChildren_notAttached_initialValueApplied() {
         var textSignal1 = new ValueSignal<>("Item 1");
         var textSignal2 = new ValueSignal<>("Item 2");
         var listSignal = new ValueSignal<>(List.of(textSignal1, textSignal2));
 
         details.bindChildren(listSignal, Span::new);
 
-        Assert.assertEquals(0, details.getContent().count());
+        // Initial value is applied immediately (effect runs on creation)
+        Assert.assertEquals(2, details.getContent().count());
 
         UI.getCurrent().add(details);
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClearButton.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasClearButton.java
@@ -55,9 +55,11 @@ public interface HasClearButton extends HasElement {
     /**
      * Binds a given signal to the visibility of the clear button.
      * <p>
-     * When a signal is bound, the clear button visibility is kept synchronized
-     * with the signal value while the element is in the attached state. When
-     * the element is detached, signal value changes have no effect.
+     * The clear button visibility is set immediately with the current signal
+     * value when the binding is created, and is kept synchronized with any
+     * subsequent signal value changes while the element is in attached state.
+     * When the element is in detached state, signal value changes have no
+     * effect.
      * <p>
      * While a signal is bound, any attempt to set the visibility manually
      * through {@link #setClearButtonVisible(boolean)} throws a

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasClearButtonSignalTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/HasClearButtonSignalTest.java
@@ -62,17 +62,19 @@ public class HasClearButtonSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindClearButtonVisible_elementNotAttached_bindingInactive_untilAttach() {
+    public void bindClearButtonVisible_elementNotAttached_initialValueApplied_changesDeferred_untilAttach() {
         TestComponent component = new TestComponent();
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         component.bindClearButtonVisible(signal);
 
-        // While detached, binding should be inactive
-        assertFalse(component.isClearButtonVisible());
-        signal.set(false);
-        assertFalse(component.isClearButtonVisible());
+        // Initial value is applied immediately (effect runs on creation)
+        assertTrue(component.isClearButtonVisible());
 
-        // Attach -> latest value is applied
+        // While detached, subsequent changes are deferred
+        signal.set(false);
+        assertTrue(component.isClearButtonVisible());
+
+        // Attach -> latest deferred value is applied
         UI.getCurrent().add(component);
         assertFalse(component.isClearButtonVisible());
 

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/FontIcon.java
@@ -118,9 +118,10 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     /**
      * Binds the given signal to the character code of the font icon.
      * <p>
-     * When a signal is bound, the character code is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The character code is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the character code manually
      * through {@link #setCharCode(String)} throws a
@@ -166,9 +167,10 @@ public class FontIcon extends AbstractIcon<FontIcon> {
     /**
      * Binds the given signal to the ligature name of the font icon.
      * <p>
-     * When a signal is bound, the ligature name is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The ligature name is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the ligature manually through
      * {@link #setLigature(String)} throws a

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -141,9 +141,10 @@ public class Icon extends AbstractIcon<Icon> {
     /**
      * Binds the given signal to the icon of the component.
      * <p>
-     * When a signal is bound, the icon is kept synchronized with the signal
-     * value while the component is attached. When the component is detached,
-     * signal value changes have no effect.
+     * The icon is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the icon manually through
      * {@link #setIcon(VaadinIcon)} throws a

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/SvgIcon.java
@@ -331,9 +331,10 @@ public class SvgIcon extends AbstractIcon<SvgIcon> {
     /**
      * Binds the given signal to the symbol of the SVG icon.
      * <p>
-     * When a signal is bound, the symbol is kept synchronized with the signal
-     * value while the component is attached. When the component is detached,
-     * signal value changes have no effect.
+     * The symbol is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the symbol manually through
      * {@link #setSymbol(String)} throws a

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBar.java
@@ -122,9 +122,10 @@ public class ProgressBar extends Component
      * binding so that the property is updated when the signal's value is
      * updated.
      * <p>
-     * When a signal is bound, the value is kept synchronized with the signal
-     * value while the component is attached. When the component is detached,
-     * signal value changes have no effect.
+     * The value is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the value manually through
      * {@link #setValue(double)} throws a
@@ -185,9 +186,10 @@ public class ProgressBar extends Component
     /**
      * Binds the given signal to the minimum bound of the progressbar.
      * <p>
-     * When a signal is bound, the minimum bound is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The minimum bound is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum bound manually
      * through {@link #setMin(double)} throws a
@@ -210,9 +212,10 @@ public class ProgressBar extends Component
     /**
      * Binds the given signal to the maximum bound of the progressbar.
      * <p>
-     * When a signal is bound, the maximum bound is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The maximum bound is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum bound manually
      * through {@link #setMax(double)} throws a

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupSignalTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupSignalTest.java
@@ -43,11 +43,12 @@ public class RadioButtonGroupSignalTest extends AbstractSignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementNotAttached_bindingInactive_untilAttach() {
+    public void bindReadOnly_elementNotAttached_initialValueApplied() {
         readonlySignal.set(true);
         group.bindReadOnly(readonlySignal);
 
-        Assert.assertFalse(group.isReadOnly());
+        // Initial value is applied immediately (effect runs on creation)
+        Assert.assertTrue(group.isReadOnly());
 
         UI.getCurrent().add(group);
         Assert.assertTrue(group.isReadOnly());

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -180,9 +180,10 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      * binding so that the property is updated when the signal's value is
      * updated.
      * <p>
-     * When a signal is bound, the minimum value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The minimum value is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum value manually
      * through the setter throws a
@@ -206,9 +207,10 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      * binding so that the property is updated when the signal's value is
      * updated.
      * <p>
-     * When a signal is bound, the maximum value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The maximum value is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum value manually
      * through the setter throws a
@@ -232,9 +234,10 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      * binding so that the property is updated when the signal's value is
      * updated.
      * <p>
-     * When a signal is bound, the step value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The step value is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the step value manually
      * through the setter throws a

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/IntegerField.java
@@ -284,9 +284,10 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
     /**
      * Binds the given signal to the minimum value for this field.
      * <p>
-     * When a signal is bound, the minimum value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The minimum value is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum value manually
      * through {@link #setMin(int)} throws a
@@ -308,9 +309,10 @@ public class IntegerField extends AbstractNumberField<IntegerField, Integer>
     /**
      * Binds the given signal to the maximum value for this field.
      * <p>
-     * When a signal is bound, the maximum value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The maximum value is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum value manually
      * through {@link #setMax(int)} throws a

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/NumberField.java
@@ -289,9 +289,10 @@ public class NumberField extends AbstractNumberField<NumberField, Double>
     /**
      * Binds the given signal to the minimum value for this field.
      * <p>
-     * When a signal is bound, the minimum value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The minimum value is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum value manually
      * through {@link #setMin(double)} throws a
@@ -312,9 +313,10 @@ public class NumberField extends AbstractNumberField<NumberField, Double>
     /**
      * Binds the given signal to the maximum value for this field.
      * <p>
-     * When a signal is bound, the maximum value is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The maximum value is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum value manually
      * through {@link #setMax(double)} throws a

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -819,9 +819,10 @@ public class TimePicker
      * Binds the given signal to the minimum time allowed to be selected for
      * this field.
      * <p>
-     * When a signal is bound, the minimum time is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The minimum time is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the minimum time manually
      * through {@link #setMin(LocalTime)} throws a
@@ -847,9 +848,10 @@ public class TimePicker
      * Binds the given signal to the maximum time allowed to be selected for
      * this field.
      * <p>
-     * When a signal is bound, the maximum time is kept synchronized with the
-     * signal value while the component is attached. When the component is
-     * detached, signal value changes have no effect.
+     * The maximum time is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a signal is bound, any attempt to set the maximum time manually
      * through {@link #setMax(LocalTime)} throws a


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #8902 to branch 25.1.

---

> Update tests and javadoc for changes in ElementEffect in Flow. ElementEffect is run always initially when it's created even when owner component or element is not attached.
> 
> RelatedTo: vaadin/flow#23813

🤖 Generated with [Claude Code](https://claude.com/claude-code)