### PR TITLE
chore: convert checkbox unit tests to JUnit 6

### DIFF
--- a/.claude/skills/migrate-junit6/SKILL.md
+++ b/.claude/skills/migrate-junit6/SKILL.md
@@ -123,6 +123,8 @@ JUnit 6 does **not** process JUnit 4 `@Rule` annotations from parent classes. Te
 |---|---|
 | `AbstractSignalsUnitTest` | `AbstractSignalsJUnit6Test` |
 | `AbstractBasicValidationTest` | `AbstractBasicValidationJUnit6Test` |
+| `AbstractComponentDataViewTest` | `AbstractComponentDataViewJUnit6Test` |
+| `AbstractListDataViewListenerTest` | `AbstractListDataViewListenerJUnit6Test` |
 
 ## After editing
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataViewTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataViewTest.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -38,19 +38,19 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
-import com.vaadin.tests.dataprovider.AbstractComponentDataViewTest;
+import com.vaadin.tests.dataprovider.AbstractComponentDataViewJUnit6Test;
 
-public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
+class CheckboxGroupDataViewTest extends AbstractComponentDataViewJUnit6Test {
 
     @Test
-    public void getItem_dataViewWithItems_returnsCorrectItem() {
-        Assert.assertEquals(items.get(0), dataView.getItem(0));
-        Assert.assertEquals(items.get(1), dataView.getItem(1));
-        Assert.assertEquals(items.get(2), dataView.getItem(2));
+    void getItem_dataViewWithItems_returnsCorrectItem() {
+        Assertions.assertEquals(items.get(0), dataView.getItem(0));
+        Assertions.assertEquals(items.get(1), dataView.getItem(1));
+        Assertions.assertEquals(items.get(2), dataView.getItem(2));
     }
 
     @Test
-    public void setIdentifierProvider_customIdentity_itemRefreshed() {
+    void setIdentifierProvider_customIdentity_itemRefreshed() {
         Item first = new Item(1L, "first");
         Item second = new Item(2L, "middle");
 
@@ -68,12 +68,12 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
 
         dataProvider.refreshItem(new Item(1L));
 
-        Assert.assertTrue(containsLabel(component, "changed-1"));
-        Assert.assertFalse(containsLabel(component, "changed-2"));
+        Assertions.assertTrue(containsLabel(component, "changed-1"));
+        Assertions.assertFalse(containsLabel(component, "changed-2"));
     }
 
     @Test
-    public void setIdentifierProvider_customDataProviderIdentity_itemRefreshed() {
+    void setIdentifierProvider_customDataProviderIdentity_itemRefreshed() {
         Item first = new Item(1L, "first");
         Item second = new Item(2L, "middle");
 
@@ -90,12 +90,12 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
 
         customIdentityItemDataProvider.refreshItem(new Item(1L));
 
-        Assert.assertTrue(containsLabel(component, "changed-1"));
-        Assert.assertFalse(containsLabel(component, "changed-2"));
+        Assertions.assertTrue(containsLabel(component, "changed-1"));
+        Assertions.assertFalse(containsLabel(component, "changed-2"));
     }
 
     @Test
-    public void setIdentifierProvider_defaultIdentity_itemRefreshed() {
+    void setIdentifierProvider_defaultIdentity_itemRefreshed() {
         Item first = new Item(1L, "first");
         Item second = new Item(2L, "middle");
 
@@ -110,12 +110,12 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
 
         dataProvider.refreshItem(new Item(1L, "changed-1"));
 
-        Assert.assertTrue(containsLabel(component, "changed-1"));
-        Assert.assertFalse(containsLabel(component, "changed-2"));
+        Assertions.assertTrue(containsLabel(component, "changed-1"));
+        Assertions.assertFalse(containsLabel(component, "changed-2"));
     }
 
     @Test
-    public void setInMemoryDataProvider_convertsToGenericDataProvider() {
+    void setInMemoryDataProvider_convertsToGenericDataProvider() {
         CheckboxGroup<String> checkboxGroup = Mockito
                 .spy(new CheckboxGroup<>());
 
@@ -126,7 +126,7 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
             @Override
             public int size(
                     Query<String, SerializablePredicate<String>> query) {
-                Assert.assertTrue(query.getFilter().isPresent());
+                Assertions.assertTrue(query.getFilter().isPresent());
                 return (int) Stream.of("foo").filter(query.getFilter().get())
                         .count();
             }
@@ -134,7 +134,7 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
             @Override
             public Stream<String> fetch(
                     Query<String, SerializablePredicate<String>> query) {
-                Assert.assertTrue(query.getFilter().isPresent());
+                Assertions.assertTrue(query.getFilter().isPresent());
                 return Stream.of("foo").filter(query.getFilter().get());
             }
 
@@ -184,15 +184,15 @@ public class CheckboxGroupDataViewTest extends AbstractComponentDataViewTest {
         Mockito.verify(checkboxGroup).setItems(Mockito.any(DataProvider.class));
 
         // Verify the predicate filter always returns true and passes the item
-        Assert.assertEquals("foo", dataView.getItem(0));
+        Assertions.assertEquals("foo", dataView.getItem(0));
 
         // Now set the predicate and verify it goes to query parameter
         inMemoryDataProvider.setFilter(item -> item.equals("bar"));
-        Assert.assertEquals(0, dataView.getItems().count());
+        Assertions.assertEquals(0, dataView.getItems().count());
     }
 
     @Override
-    protected HasDataView<String, Void, ? extends DataView<String>> getComponent() {
+    protected HasDataView<String, ?, ? extends DataView<String>> getComponent() {
         return new CheckboxGroup<>();
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataViewTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataViewTest.java
@@ -18,10 +18,10 @@ package com.vaadin.flow.component.checkbox.dataview;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
-import com.vaadin.tests.dataprovider.AbstractListDataViewListenerTest;
+import com.vaadin.tests.dataprovider.AbstractListDataViewListenerJUnit6Test;
 
-public class CheckboxGroupListDataViewTest
-        extends AbstractListDataViewListenerTest {
+class CheckboxGroupListDataViewTest
+        extends AbstractListDataViewListenerJUnit6Test {
 
     /*
      * ListDataView implementation is tested in AbstractListDataViewTest. No

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -26,10 +26,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
@@ -52,68 +51,67 @@ import com.vaadin.flow.data.selection.MultiSelectionEvent;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
 import tools.jackson.databind.node.ArrayNode;
 
-public class CheckboxGroupTest {
-    @Rule
-    public final MockUIRule ui = new MockUIRule();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+class CheckboxGroupTest {
+    @RegisterExtension
+    final MockUIExtension ui = new MockUIExtension();
 
     @Test
-    public void hasEmptySetAsDefaultValue() {
+    void hasEmptySetAsDefaultValue() {
         Set<Object> value = new CheckboxGroup<>().getValue();
-        Assert.assertNotNull(value);
-        Assert.assertTrue(value.isEmpty());
+        Assertions.assertNotNull(value);
+        Assertions.assertTrue(value.isEmpty());
     }
 
     @Test
-    public void setValueNull_throws() {
-        thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Use the clear-method");
-        new CheckboxGroup<>().setValue(null);
+    void setValueNull_throws() {
+        NullPointerException exception = Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new CheckboxGroup<>().setValue(null));
+        Assertions.assertTrue(
+                exception.getMessage().contains("Use the clear-method"));
     }
 
     @Test
-    public void setReadOnlyCheckboxGroup_groupIsReadOnly() {
+    void setReadOnlyCheckboxGroup_groupIsReadOnly() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setItems("foo", "bar");
         group.setReadOnly(true);
-        Assert.assertTrue(group.isReadOnly());
+        Assertions.assertTrue(group.isReadOnly());
 
-        Assert.assertEquals(Boolean.TRUE.toString(),
+        Assertions.assertEquals(Boolean.TRUE.toString(),
                 group.getElement().getProperty("readonly"));
     }
 
     @Test
-    public void setReadOnlyDisabledCheckboxGroup_groupIsDisabledAndReadonly() {
+    void setReadOnlyDisabledCheckboxGroup_groupIsDisabledAndReadonly() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setEnabled(false);
         group.setReadOnly(true);
 
-        Assert.assertTrue(group.isReadOnly());
-        Assert.assertFalse(group.isEnabled());
-        Assert.assertEquals(Boolean.TRUE.toString(),
+        Assertions.assertTrue(group.isReadOnly());
+        Assertions.assertFalse(group.isEnabled());
+        Assertions.assertEquals(Boolean.TRUE.toString(),
                 group.getElement().getProperty("disabled"));
     }
 
     @Test
-    public void unsetReadOnlyDisabledCheckboxGroup_groupIsDisabledAndNotReadonly() {
+    void unsetReadOnlyDisabledCheckboxGroup_groupIsDisabledAndNotReadonly() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setEnabled(false);
         group.setReadOnly(false);
 
-        Assert.assertFalse(group.isReadOnly());
-        Assert.assertFalse(group.isEnabled());
-        Assert.assertEquals(Boolean.TRUE.toString(),
+        Assertions.assertFalse(group.isReadOnly());
+        Assertions.assertFalse(group.isEnabled());
+        Assertions.assertEquals(Boolean.TRUE.toString(),
                 group.getElement().getProperty("disabled"));
     }
 
     @Test
-    public void unsetReadOnlyEnabledCheckboxGroup_groupIsEnabled() {
+    void unsetReadOnlyEnabledCheckboxGroup_groupIsEnabled() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setEnabled(false);
         group.setReadOnly(true);
@@ -121,13 +119,13 @@ public class CheckboxGroupTest {
 
         group.setReadOnly(false);
 
-        Assert.assertTrue(group.isEnabled());
-        Assert.assertEquals(Boolean.FALSE.toString(),
+        Assertions.assertTrue(group.isEnabled());
+        Assertions.assertEquals(Boolean.FALSE.toString(),
                 group.getElement().getProperty("disabled"));
     }
 
     @Test
-    public void selectDisabledItem_noRedundantEvent() {
+    void selectDisabledItem_noRedundantEvent() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setItems("enabled", "disabled");
         group.setItemEnabledProvider("enabled"::equals);
@@ -145,25 +143,27 @@ public class CheckboxGroupTest {
         array.add(disabledKey);
 
         group.getElement().setPropertyJson("value", array);
-        Assert.assertTrue("Group value should be empty",
-                group.getValue().isEmpty());
-        Assert.assertTrue(events.isEmpty());
+        Assertions.assertTrue(group.getValue().isEmpty(),
+                "Group value should be empty");
+        Assertions.assertTrue(events.isEmpty());
 
         array = JacksonUtils.createArrayNode();
         array.add(enabledKey);
 
         group.getElement().setPropertyJson("value", array);
-        Assert.assertEquals(Collections.singleton("enabled"), group.getValue());
-        Assert.assertEquals(1, events.size());
+        Assertions.assertEquals(Collections.singleton("enabled"),
+                group.getValue());
+        Assertions.assertEquals(1, events.size());
 
         ValueChangeEvent<Set<String>> event = events.get(0);
-        Assert.assertTrue("Event old value should be empty",
-                event.getOldValue().isEmpty());
-        Assert.assertEquals(Collections.singleton("enabled"), event.getValue());
+        Assertions.assertTrue(event.getOldValue().isEmpty(),
+                "Event old value should be empty");
+        Assertions.assertEquals(Collections.singleton("enabled"),
+                event.getValue());
     }
 
     @Test
-    public void changeItems_selectionIsReset() {
+    void changeItems_selectionIsReset() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("Foo", "Bar");
 
@@ -173,21 +173,21 @@ public class CheckboxGroupTest {
 
         checkboxGroup.setValue(Collections.singleton("Foo"));
 
-        Assert.assertEquals(Collections.singleton("Foo"), capture.get());
+        Assertions.assertEquals(Collections.singleton("Foo"), capture.get());
 
-        Assert.assertEquals(Collections.singleton("Foo"),
+        Assertions.assertEquals(Collections.singleton("Foo"),
                 checkboxGroup.getValue());
 
         checkboxGroup.setItems("Foo", "Baz");
 
-        Assert.assertTrue("Checkbox group value should be empty",
-                checkboxGroup.getValue().isEmpty());
-        Assert.assertTrue("Captured value should be empty",
-                capture.get().isEmpty());
+        Assertions.assertTrue(checkboxGroup.getValue().isEmpty(),
+                "Checkbox group value should be empty");
+        Assertions.assertTrue(capture.get().isEmpty(),
+                "Captured value should be empty");
     }
 
     @Test
-    public void deselectAll_selectionIsReset() {
+    void deselectAll_selectionIsReset() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("Foo", "Bar");
 
@@ -197,21 +197,21 @@ public class CheckboxGroupTest {
 
         checkboxGroup.setValue(Collections.singleton("Foo"));
 
-        Assert.assertEquals(Collections.singleton("Foo"), capture.get());
+        Assertions.assertEquals(Collections.singleton("Foo"), capture.get());
 
-        Assert.assertEquals(Collections.singleton("Foo"),
+        Assertions.assertEquals(Collections.singleton("Foo"),
                 checkboxGroup.getValue());
 
         checkboxGroup.deselectAll();
 
-        Assert.assertTrue("Checkbox group value should be empty",
-                checkboxGroup.getValue().isEmpty());
-        Assert.assertTrue("Captured value should be empty",
-                capture.get().isEmpty());
+        Assertions.assertTrue(checkboxGroup.getValue().isEmpty(),
+                "Checkbox group value should be empty");
+        Assertions.assertTrue(capture.get().isEmpty(),
+                "Captured value should be empty");
     }
 
     @Test
-    public void updateSelection_checkboxesUpdated() {
+    void updateSelection_checkboxesUpdated() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("Foo", "Bar");
 
@@ -219,16 +219,16 @@ public class CheckboxGroupTest {
                 .map(Checkbox.class::cast).collect(Collectors.toList());
 
         checkboxGroup.select("Foo");
-        Assert.assertTrue(checkboxes.get(0).getValue());
-        Assert.assertFalse(checkboxes.get(1).getValue());
+        Assertions.assertTrue(checkboxes.get(0).getValue());
+        Assertions.assertFalse(checkboxes.get(1).getValue());
 
         checkboxGroup.deselectAll();
-        Assert.assertFalse(checkboxes.get(0).getValue());
-        Assert.assertFalse(checkboxes.get(1).getValue());
+        Assertions.assertFalse(checkboxes.get(0).getValue());
+        Assertions.assertFalse(checkboxes.get(1).getValue());
     }
 
     @Test
-    public void singleDataRefreshEvent() {
+    void singleDataRefreshEvent() {
         Wrapper item1 = new Wrapper(1, "foo");
         Wrapper item2 = new Wrapper(2, "bar");
 
@@ -249,7 +249,7 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void singleDataRefreshEvent_overrideDataProviderGetId() {
+    void singleDataRefreshEvent_overrideDataProviderGetId() {
         Wrapper item1 = new Wrapper(1, "foo");
         Wrapper item2 = new Wrapper(2, "bar");
 
@@ -270,7 +270,7 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void allDataRefreshEvent() {
+    void allDataRefreshEvent() {
         Wrapper item1 = new Wrapper(1, "foo");
         Wrapper item2 = new Wrapper(2, "bar");
 
@@ -291,79 +291,79 @@ public class CheckboxGroupTest {
     }
 
     @Test
-    public void selectItem_setItemLabelGenerator_selectionIsRetained() {
+    void selectItem_setItemLabelGenerator_selectionIsRetained() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");
 
         checkboxGroup.setValue(Set.of("foo"));
-        Assert.assertEquals(Set.of("foo"), checkboxGroup.getValue());
+        Assertions.assertEquals(Set.of("foo"), checkboxGroup.getValue());
 
         checkboxGroup.setItemLabelGenerator(item -> item + " (Updated)");
 
-        Assert.assertEquals(Set.of("foo"), checkboxGroup.getValue());
+        Assertions.assertEquals(Set.of("foo"), checkboxGroup.getValue());
     }
 
     @Test
-    public void setItemLabelGenerator_labelIsUpdated() {
+    void setItemLabelGenerator_labelIsUpdated() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");
 
         Checkbox cb = (Checkbox) checkboxGroup.getChildren().findFirst().get();
-        Assert.assertEquals("foo", cb.getLabel());
+        Assertions.assertEquals("foo", cb.getLabel());
 
         checkboxGroup.setItemLabelGenerator(item -> item + " (Updated)");
 
-        Assert.assertEquals("foo (Updated)", cb.getLabel());
+        Assertions.assertEquals("foo (Updated)", cb.getLabel());
     }
 
     @Test
-    public void setItemLabelGenerator_removesItemRenderer() {
+    void setItemLabelGenerator_removesItemRenderer() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");
         checkboxGroup.setRenderer(new TextRenderer<>());
 
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 checkboxGroup.getItemRenderer() instanceof TextRenderer);
 
         checkboxGroup.setItemLabelGenerator(item -> item);
 
-        Assert.assertNull(checkboxGroup.getItemRenderer());
+        Assertions.assertNull(checkboxGroup.getItemRenderer());
     }
 
     @Test
-    public void addSelectionListener_selectionEventIsFired() {
+    void addSelectionListener_selectionEventIsFired() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");
 
         AtomicReference<MultiSelectionEvent<CheckboxGroup<String>, String>> eventCapture = new AtomicReference<>();
         checkboxGroup.addSelectionListener(event -> {
-            Assert.assertNull(eventCapture.get());
+            Assertions.assertNull(eventCapture.get());
             eventCapture.set(event);
         });
 
         checkboxGroup.setValue(Collections.singleton("bar"));
 
-        Assert.assertNotNull(eventCapture.get());
-        Assert.assertEquals(Collections.emptySet(),
+        Assertions.assertNotNull(eventCapture.get());
+        Assertions.assertEquals(Collections.emptySet(),
                 eventCapture.get().getOldValue());
-        Assert.assertEquals(Collections.singleton("bar"),
+        Assertions.assertEquals(Collections.singleton("bar"),
                 eventCapture.get().getValue());
 
         eventCapture.set(null);
 
         checkboxGroup.select("foo", "bar");
-        Assert.assertNotNull(eventCapture.get());
-        Assert.assertEquals(Collections.singleton("bar"),
+        Assertions.assertNotNull(eventCapture.get());
+        Assertions.assertEquals(Collections.singleton("bar"),
                 eventCapture.get().getOldSelection());
-        Assert.assertEquals(2, eventCapture.get().getValue().size());
+        Assertions.assertEquals(2, eventCapture.get().getValue().size());
 
         Set<String> newSelection = eventCapture.get().getValue();
-        Assert.assertTrue(newSelection.contains("foo"));
-        Assert.assertTrue(newSelection.contains("bar"));
+        Assertions.assertTrue(newSelection.contains("foo"));
+        Assertions.assertTrue(newSelection.contains("bar"));
     }
 
     @Test // https://github.com/vaadin/vaadin-checkbox-flow/issues/81
-    public void disableParent_detachParent_notThrowing() {
+    void disableParent_detachParent_notThrowing() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setItems("foo", "bar");
 
@@ -377,7 +377,7 @@ public class CheckboxGroupTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
+    void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
         Element element = new Element("vaadin-checkbox-group");
         ArrayNode array = JacksonUtils.createArrayNode();
         array.add("foo");
@@ -393,18 +393,12 @@ public class CheckboxGroupTest {
         CheckboxGroup field = Component.from(element, CheckboxGroup.class);
         ArrayNode propertyValue = (ArrayNode) field.getElement()
                 .getPropertyRaw("value");
-        Assert.assertEquals(1, propertyValue.size());
-        Assert.assertEquals("foo", propertyValue.get(0).asString());
+        Assertions.assertEquals(1, propertyValue.size());
+        Assertions.assertEquals("foo", propertyValue.get(0).asString());
     }
 
     @Test
-    public void dataViewForFaultyDataProvider_throwsException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage(
-                "CheckboxGroupListDataView only supports 'ListDataProvider' "
-                        + "or it's subclasses, but was given a "
-                        + "'AbstractBackEndDataProvider'");
-
+    void dataViewForFaultyDataProvider_throwsException() {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         final CheckboxGroupListDataView<String> listDataView = checkboxGroup
                 .setItems(Arrays.asList("one", "two"));
@@ -414,11 +408,17 @@ public class CheckboxGroupTest {
 
         checkboxGroup.setItems(dataProvider);
 
-        checkboxGroup.getListDataView();
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> checkboxGroup.getListDataView());
+        Assertions.assertTrue(exception.getMessage().contains(
+                "CheckboxGroupListDataView only supports 'ListDataProvider' "
+                        + "or it's subclasses, but was given a "
+                        + "'AbstractBackEndDataProvider'"));
     }
 
     @Test
-    public void setIdentifierProvider_setItemsWithIdentifierOnly_shouldSelectCorrectItem() {
+    void setIdentifierProvider_setItemsWithIdentifierOnly_shouldSelectCorrectItem() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -434,13 +434,13 @@ public class CheckboxGroupTest {
 
         checkboxGroup.setValue(Collections.singleton(new CustomItem(1L)));
 
-        Assert.assertNotNull(
+        Assertions.assertNotNull(
                 checkboxGroup.getSelectedItems().stream().findFirst().get());
-        Assert.assertEquals("First", checkboxGroup.getSelectedItems().stream()
-                .map(CustomItem::getName).findFirst().get());
+        Assertions.assertEquals("First", checkboxGroup.getSelectedItems()
+                .stream().map(CustomItem::getName).findFirst().get());
         long[] selectedIds = checkboxGroup.getSelectedItems().stream()
                 .mapToLong(CustomItem::getId).toArray();
-        Assert.assertArrayEquals(new long[] { 1L }, selectedIds);
+        Assertions.assertArrayEquals(new long[] { 1L }, selectedIds);
 
         // Make the names similar to the name of not selected one to mess
         // with the <equals> implementation in CustomItem:
@@ -455,11 +455,11 @@ public class CheckboxGroupTest {
 
         selectedIds = checkboxGroup.getSelectedItems().stream()
                 .mapToLong(CustomItem::getId).toArray();
-        Assert.assertArrayEquals(new long[] { 2L }, selectedIds);
+        Assertions.assertArrayEquals(new long[] { 2L }, selectedIds);
     }
 
     @Test
-    public void setIdentifierProvider_setItemWithIdAndWrongName_shouldSelectCorrectItemBasedOnIdNotEquals() {
+    void setIdentifierProvider_setItemWithIdAndWrongName_shouldSelectCorrectItemBasedOnIdNotEquals() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -475,13 +475,13 @@ public class CheckboxGroupTest {
 
         checkboxGroup.setValue(Collections.singleton(new CustomItem(1L)));
 
-        Assert.assertNotNull(
+        Assertions.assertNotNull(
                 checkboxGroup.getSelectedItems().stream().findFirst().get());
-        Assert.assertEquals("First", checkboxGroup.getSelectedItems().stream()
-                .map(CustomItem::getName).findFirst().get());
+        Assertions.assertEquals("First", checkboxGroup.getSelectedItems()
+                .stream().map(CustomItem::getName).findFirst().get());
         long[] selectedIds = checkboxGroup.getSelectedItems().stream()
                 .mapToLong(CustomItem::getId).toArray();
-        Assert.assertArrayEquals(new long[] { 1L }, selectedIds);
+        Assertions.assertArrayEquals(new long[] { 1L }, selectedIds);
 
         // Make the names similar to the name of not selected one to mess
         // with the <equals> implementation in CustomItem:
@@ -497,11 +497,11 @@ public class CheckboxGroupTest {
 
         selectedIds = checkboxGroup.getSelectedItems().stream()
                 .mapToLong(CustomItem::getId).toArray();
-        Assert.assertArrayEquals(new long[] { 3L }, selectedIds);
+        Assertions.assertArrayEquals(new long[] { 3L }, selectedIds);
     }
 
     @Test
-    public void withoutSettingIdentifierProvider_setItemWithNullId_shouldSelectCorrectItemBasedOnEquals() {
+    void withoutSettingIdentifierProvider_setItemWithNullId_shouldSelectCorrectItemBasedOnEquals() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -515,16 +515,16 @@ public class CheckboxGroupTest {
         checkboxGroup.setValue(
                 Collections.singleton(new CustomItem(null, "Second")));
 
-        Assert.assertNotNull(checkboxGroup.getValue());
+        Assertions.assertNotNull(checkboxGroup.getValue());
 
         long[] selectedIds = checkboxGroup.getSelectedItems().stream()
                 .mapToLong(CustomItem::getId).toArray();
 
-        Assert.assertArrayEquals(new long[] { 2L }, selectedIds);
+        Assertions.assertArrayEquals(new long[] { 2L }, selectedIds);
     }
 
     @Test
-    public void setIdentifierProviderOnId_setItemWithNullId_shouldFailToSelectExistingItemById() {
+    void setIdentifierProviderOnId_setItemWithNullId_shouldFailToSelectExistingItemById() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -540,12 +540,12 @@ public class CheckboxGroupTest {
 
         checkboxGroup
                 .setValue(Collections.singleton(new CustomItem(null, "First")));
-        Assert.assertNull(checkboxGroup.getSelectedItems().stream().findFirst()
-                .get().getId());
+        Assertions.assertNull(checkboxGroup.getSelectedItems().stream()
+                .findFirst().get().getId());
     }
 
     @Test
-    public void setItems_createsLabelValueEventAndItems() {
+    void setItems_createsLabelValueEventAndItems() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -554,17 +554,18 @@ public class CheckboxGroupTest {
         CheckboxGroup<CustomItem> checkboxGroup = new CheckboxGroup<>("label",
                 capture::set, first, second, third);
 
-        Assert.assertEquals("Invalid number of items", 3,
-                checkboxGroup.getChildren().count());
+        Assertions.assertEquals(3, checkboxGroup.getChildren().count(),
+                "Invalid number of items");
 
-        Assert.assertEquals("Invalid label for checkbox group ", "label",
-                checkboxGroup.getElement().getProperty("label"));
+        Assertions.assertEquals("label",
+                checkboxGroup.getElement().getProperty("label"),
+                "Invalid label for checkbox group ");
     }
 
     @Test
-    public void implementsHasTooltip() {
+    void implementsHasTooltip() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
-        Assert.assertTrue(group instanceof HasTooltip);
+        Assertions.assertTrue(group instanceof HasTooltip);
     }
 
     private CheckboxGroup<Wrapper> getRefreshEventCheckboxGroup(
@@ -589,58 +590,59 @@ public class CheckboxGroupTest {
             String firstLabel, String secondLabel) {
         List<Component> components = checkboxGroup.getChildren()
                 .collect(Collectors.toList());
-        Assert.assertEquals(2, components.size());
-        Assert.assertEquals(firstLabel,
+        Assertions.assertEquals(2, components.size());
+        Assertions.assertEquals(firstLabel,
                 ((Checkbox) components.get(0)).getLabel());
-        Assert.assertEquals(secondLabel,
+        Assertions.assertEquals(secondLabel,
                 ((Checkbox) components.get(1)).getLabel());
     }
 
     @Test
-    public void implementHasAriaLabel() {
-        Assert.assertTrue(
+    void implementHasAriaLabel() {
+        Assertions.assertTrue(
                 HasAriaLabel.class.isAssignableFrom(CheckboxGroup.class));
     }
 
     @Test
-    public void setAriaLabel() {
+    void setAriaLabel() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setAriaLabel("aria-label");
 
-        Assert.assertTrue(group.getAriaLabel().isPresent());
-        Assert.assertEquals("aria-label", group.getAriaLabel().get());
+        Assertions.assertTrue(group.getAriaLabel().isPresent());
+        Assertions.assertEquals("aria-label", group.getAriaLabel().get());
 
         group.setAriaLabel(null);
-        Assert.assertTrue(group.getAriaLabel().isEmpty());
+        Assertions.assertTrue(group.getAriaLabel().isEmpty());
     }
 
     @Test
-    public void setAriaLabelledBy() {
+    void setAriaLabelledBy() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.setAriaLabelledBy("aria-labelledby");
 
-        Assert.assertTrue(group.getAriaLabelledBy().isPresent());
-        Assert.assertEquals("aria-labelledby", group.getAriaLabelledBy().get());
+        Assertions.assertTrue(group.getAriaLabelledBy().isPresent());
+        Assertions.assertEquals("aria-labelledby",
+                group.getAriaLabelledBy().get());
 
         group.setAriaLabelledBy(null);
-        Assert.assertTrue(group.getAriaLabelledBy().isEmpty());
+        Assertions.assertTrue(group.getAriaLabelledBy().isEmpty());
     }
 
     @Test
-    public void implementsInputField() {
+    void implementsInputField() {
         CheckboxGroup<String> field = new CheckboxGroup<String>();
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 field instanceof InputField<AbstractField.ComponentValueChangeEvent<CheckboxGroup<String>, Set<String>>, Set<String>>);
     }
 
     @Test
-    public void implementsHasThemeVariant() {
-        Assert.assertTrue(
+    void implementsHasThemeVariant() {
+        Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(CheckboxGroup.class));
     }
 
     @Test
-    public void discardSelectionOnDataChange_noExtraChangeEventsFired() {
+    void discardSelectionOnDataChange_noExtraChangeEventsFired() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         List<HasValue.ValueChangeEvent<Set<String>>> events = new ArrayList<>();
         group.addValueChangeListener(events::add);
@@ -653,17 +655,17 @@ public class CheckboxGroupTest {
 
         String selectedItem = items.get(0);
         group.select(selectedItem);
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertEquals(1, events.size());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertEquals(1, events.size());
         events.clear();
 
         group.getDataProvider().refreshAll();
-        Assert.assertTrue(group.getSelectedItems().isEmpty());
-        Assert.assertEquals(1, events.size());
+        Assertions.assertTrue(group.getSelectedItems().isEmpty());
+        Assertions.assertEquals(1, events.size());
     }
 
     @Test
-    public void preserveExistingSelectionOnDataChange_noExtraChangeEventsFired() {
+    void preserveExistingSelectionOnDataChange_noExtraChangeEventsFired() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         List<HasValue.ValueChangeEvent<Set<String>>> events = new ArrayList<>();
         group.addValueChangeListener(events::add);
@@ -677,27 +679,27 @@ public class CheckboxGroupTest {
 
         String selectedItem = items.get(0);
         group.select(selectedItem);
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertEquals(1, events.size());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertEquals(1, events.size());
         events.clear();
 
         group.getDataProvider().refreshAll();
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertTrue(events.isEmpty());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertTrue(events.isEmpty());
 
         items.remove(items.get(1));
         group.getDataProvider().refreshAll();
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertTrue(events.isEmpty());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertTrue(events.isEmpty());
 
         items.remove(selectedItem);
         group.getDataProvider().refreshAll();
-        Assert.assertTrue(group.getSelectedItems().isEmpty());
-        Assert.assertEquals(1, events.size());
+        Assertions.assertTrue(group.getSelectedItems().isEmpty());
+        Assertions.assertEquals(1, events.size());
     }
 
     @Test
-    public void preserveAllSelectionOnDataChange_noExtraChangeEventsFired() {
+    void preserveAllSelectionOnDataChange_noExtraChangeEventsFired() {
         CheckboxGroup<String> group = new CheckboxGroup<>();
         List<HasValue.ValueChangeEvent<Set<String>>> events = new ArrayList<>();
         group.addValueChangeListener(events::add);
@@ -711,27 +713,27 @@ public class CheckboxGroupTest {
 
         String selectedItem = items.get(0);
         group.select(selectedItem);
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertEquals(1, events.size());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertEquals(1, events.size());
         events.clear();
 
         group.getDataProvider().refreshAll();
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertTrue(events.isEmpty());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertTrue(events.isEmpty());
 
         items.remove(items.get(1));
         group.getDataProvider().refreshAll();
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertTrue(events.isEmpty());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertTrue(events.isEmpty());
 
         items.remove(selectedItem);
         group.getDataProvider().refreshAll();
-        Assert.assertEquals(Set.of(selectedItem), group.getValue());
-        Assert.assertTrue(events.isEmpty());
+        Assertions.assertEquals(Set.of(selectedItem), group.getValue());
+        Assertions.assertTrue(events.isEmpty());
     }
 
     @Test
-    public void refreshItem_selectFromClient_valueContainsUpdatedItem() {
+    void refreshItem_selectFromClient_valueContainsUpdatedItem() {
         CheckboxGroup<CustomItem> group = new CheckboxGroup<>();
         CheckboxGroupListDataView<CustomItem> dataView = group.setItems(
                 new CustomItem(1L, "foo"), new CustomItem(2L, "bar"),
@@ -751,9 +753,9 @@ public class CheckboxGroupTest {
         selection.add(itemKey);
         group.getElement().setPropertyJson("value", selection);
 
-        Assert.assertEquals("updated",
+        Assertions.assertEquals("updated",
                 selectedItems.get().stream().findFirst().orElseThrow().name);
-        Assert.assertEquals("updated",
+        Assertions.assertEquals("updated",
                 group.getValue().stream().findFirst().orElseThrow().name);
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxSerializableTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxSerializableTest.java
@@ -17,5 +17,5 @@ package com.vaadin.flow.component.checkbox.tests;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-public class CheckboxSerializableTest extends ClassesSerializableTest {
+class CheckboxSerializableTest extends ClassesSerializableTest {
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.checkbox.tests;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
@@ -30,71 +30,71 @@ import com.vaadin.flow.component.shared.HasValidationProperties;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
-public class CheckboxUnitTest {
-    @Rule
-    public final MockUIRule ui = new MockUIRule();
+class CheckboxUnitTest {
+    @RegisterExtension
+    final MockUIExtension ui = new MockUIExtension();
 
     @Test
-    public void initialValue() {
+    void initialValue() {
         Checkbox checkbox = new Checkbox();
-        Assert.assertFalse(checkbox.getValue());
+        Assertions.assertFalse(checkbox.getValue());
 
         checkbox = new Checkbox(true);
-        Assert.assertTrue(checkbox.getValue());
+        Assertions.assertTrue(checkbox.getValue());
 
         checkbox = new Checkbox(false);
-        Assert.assertFalse(checkbox.getValue());
+        Assertions.assertFalse(checkbox.getValue());
     }
 
     @Test
-    public void testIndeterminate() {
+    void testIndeterminate() {
         Checkbox checkbox = new Checkbox();
-        Assert.assertFalse(checkbox.isIndeterminate());
+        Assertions.assertFalse(checkbox.isIndeterminate());
 
         checkbox = new Checkbox(true);
-        Assert.assertFalse(checkbox.isIndeterminate());
+        Assertions.assertFalse(checkbox.isIndeterminate());
 
         checkbox.setIndeterminate(true);
-        Assert.assertTrue(checkbox.getValue());
-        Assert.assertTrue(checkbox.isIndeterminate());
+        Assertions.assertTrue(checkbox.getValue());
+        Assertions.assertTrue(checkbox.isIndeterminate());
 
         checkbox.setValue(true);
-        Assert.assertTrue(checkbox.getValue());
-        Assert.assertTrue(checkbox.isIndeterminate());
+        Assertions.assertTrue(checkbox.getValue());
+        Assertions.assertTrue(checkbox.isIndeterminate());
 
         checkbox.setValue(false);
-        Assert.assertFalse(checkbox.getValue());
-        Assert.assertTrue(checkbox.isIndeterminate());
+        Assertions.assertFalse(checkbox.getValue());
+        Assertions.assertTrue(checkbox.isIndeterminate());
 
         checkbox.setIndeterminate(false);
-        Assert.assertFalse(checkbox.getValue());
-        Assert.assertFalse(checkbox.isIndeterminate());
+        Assertions.assertFalse(checkbox.getValue());
+        Assertions.assertFalse(checkbox.isIndeterminate());
     }
 
     @Test
-    public void labelAndInitialValueCtor() {
+    void labelAndInitialValueCtor() {
         Checkbox checkbox = new Checkbox("foo", true);
-        Assert.assertTrue(checkbox.getValue());
-        Assert.assertEquals("foo", checkbox.getLabel());
+        Assertions.assertTrue(checkbox.getValue());
+        Assertions.assertEquals("foo", checkbox.getLabel());
 
         checkbox = new Checkbox("foo", false);
-        Assert.assertFalse(checkbox.getValue());
-        Assert.assertEquals("foo", checkbox.getLabel());
+        Assertions.assertFalse(checkbox.getValue());
+        Assertions.assertEquals("foo", checkbox.getLabel());
     }
 
     @Test
-    public void setEnable() {
+    void setEnable() {
         Checkbox checkbox = new Checkbox("foo", true);
         checkbox.setEnabled(true);
-        Assert.assertTrue(checkbox.isEnabled());
+        Assertions.assertTrue(checkbox.isEnabled());
         checkbox.setEnabled(false);
-        Assert.assertFalse(checkbox.isEnabled());
+        Assertions.assertFalse(checkbox.isEnabled());
     }
 
     @Test
-    public void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
+    void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
         Element element = new Element("vaadin-checkbox");
         element.setProperty("checked", true);
 
@@ -106,63 +106,63 @@ public class CheckboxUnitTest {
         Mockito.when(instantiator.createComponent(Checkbox.class))
                 .thenAnswer(invocation -> new Checkbox());
         Checkbox field = Component.from(element, Checkbox.class);
-        Assert.assertEquals(Boolean.TRUE,
+        Assertions.assertEquals(Boolean.TRUE,
                 field.getElement().getPropertyRaw("checked"));
     }
 
     @Test
-    public void implementsHasTooltip() {
+    void implementsHasTooltip() {
         Checkbox checkbox = new Checkbox();
-        Assert.assertTrue(checkbox instanceof HasTooltip);
+        Assertions.assertTrue(checkbox instanceof HasTooltip);
     }
 
     @Test
-    public void implementHasAriaLabel() {
+    void implementHasAriaLabel() {
         Checkbox checkbox = new Checkbox();
-        Assert.assertTrue(checkbox instanceof HasAriaLabel);
+        Assertions.assertTrue(checkbox instanceof HasAriaLabel);
     }
 
     @Test
-    public void setAriaLabel() {
+    void setAriaLabel() {
         Checkbox checkbox = new Checkbox();
         checkbox.setAriaLabel("aria-label");
 
-        Assert.assertTrue(checkbox.getAriaLabel().isPresent());
-        Assert.assertEquals("aria-label", checkbox.getAriaLabel().get());
+        Assertions.assertTrue(checkbox.getAriaLabel().isPresent());
+        Assertions.assertEquals("aria-label", checkbox.getAriaLabel().get());
 
         checkbox.setAriaLabel(null);
-        Assert.assertTrue(checkbox.getAriaLabel().isEmpty());
+        Assertions.assertTrue(checkbox.getAriaLabel().isEmpty());
     }
 
     @Test
-    public void setAriaLabelledBy() {
+    void setAriaLabelledBy() {
         Checkbox checkbox = new Checkbox();
         checkbox.setAriaLabelledBy("aria-labelledby");
 
-        Assert.assertTrue(checkbox.getAriaLabelledBy().isPresent());
-        Assert.assertEquals("aria-labelledby",
+        Assertions.assertTrue(checkbox.getAriaLabelledBy().isPresent());
+        Assertions.assertEquals("aria-labelledby",
                 checkbox.getAriaLabelledBy().get());
 
         checkbox.setAriaLabelledBy(null);
-        Assert.assertTrue(checkbox.getAriaLabelledBy().isEmpty());
+        Assertions.assertTrue(checkbox.getAriaLabelledBy().isEmpty());
     }
 
     @Test
-    public void implementsInputField() {
+    void implementsInputField() {
         Checkbox field = new Checkbox();
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 field instanceof InputField<AbstractField.ComponentValueChangeEvent<Checkbox, Boolean>, Boolean>);
     }
 
     @Test
-    public void implementsHasValidationProperties() {
+    void implementsHasValidationProperties() {
         Checkbox field = new Checkbox();
-        Assert.assertTrue(field instanceof HasValidationProperties);
+        Assertions.assertTrue(field instanceof HasValidationProperties);
     }
 
     @Test
-    public void implementsHasThemeVariant() {
-        Assert.assertTrue(
+    void implementsHasThemeVariant() {
+        Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(Checkbox.class));
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/HasLabelTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/HasLabelTest.java
@@ -15,25 +15,25 @@
  */
 package com.vaadin.flow.component.checkbox.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 
-public class HasLabelTest {
+class HasLabelTest {
 
     @Test
-    public void checkbox() {
+    void checkbox() {
         Checkbox c = new Checkbox();
-        Assert.assertTrue(c instanceof HasLabel);
+        Assertions.assertTrue(c instanceof HasLabel);
     }
 
     @Test
-    public void checkboxGroup() {
+    void checkboxGroup() {
         CheckboxGroup<String> c = new CheckboxGroup<>();
-        Assert.assertTrue(c instanceof HasLabel);
+        Assertions.assertTrue(c instanceof HasLabel);
     }
 
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBasicValidationTest.java
@@ -15,46 +15,47 @@
  */
 package com.vaadin.flow.component.checkbox.tests.validation;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
-import com.vaadin.tests.validation.AbstractBasicValidationTest;
+import com.vaadin.tests.validation.AbstractBasicValidationJUnit6Test;
 
-public class CheckboxBasicValidationTest
-        extends AbstractBasicValidationTest<Checkbox, Boolean> {
+class CheckboxBasicValidationTest
+        extends AbstractBasicValidationJUnit6Test<Checkbox, Boolean> {
     @Test
-    public void required_validate_emptyErrorMessageDisplayed() {
+    void required_validate_emptyErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setValue(true);
         testField.setValue(false);
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new Checkbox.CheckboxI18n()
                 .setRequiredErrorMessage("Field is required"));
         testField.setValue(true);
         testField.setValue(false);
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
     }
 
     @Test
-    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+    void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new Checkbox.CheckboxI18n()
                 .setRequiredErrorMessage("Field is required"));
         testField.setErrorMessage("Custom error message");
         testField.setValue(true);
         testField.setValue(false);
-        Assert.assertEquals("Custom error message",
+        Assertions.assertEquals("Custom error message",
                 testField.getErrorMessage());
     }
 
     @Test
-    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new Checkbox.CheckboxI18n()
                 .setRequiredErrorMessage("Field is required"));
@@ -64,7 +65,8 @@ public class CheckboxBasicValidationTest
         testField.setErrorMessage("");
         testField.setValue(true);
         testField.setValue(false);
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBinderValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxBinderValidationTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.checkbox.tests.validation;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -29,7 +29,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.BindingValidationStatus;
 import com.vaadin.flow.data.binder.BindingValidationStatusHandler;
 
-public class CheckboxBinderValidationTest {
+class CheckboxBinderValidationTest {
     private static final String BINDER_FAIL_MESSAGE = "BINDER_FAIL_MESSAGE";
     private static final String BINDER_REQUIRED_MESSAGE = "REQUIRED";
 
@@ -53,53 +53,53 @@ public class CheckboxBinderValidationTest {
         }
     }
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         MockitoAnnotations.openMocks(this);
         field = new Checkbox();
     }
 
     @Test
-    public void elementWithBinderValidation_invalidValue_binderValidationFails() {
+    void elementWithBinderValidation_invalidValue_binderValidationFails() {
         var binder = attachBinderToField();
 
         field.setValue(true);
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
 
-        Assert.assertTrue(statusCaptor.getValue().isError());
-        Assert.assertEquals(BINDER_FAIL_MESSAGE,
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_FAIL_MESSAGE,
                 statusCaptor.getValue().getMessage().orElse(""));
     }
 
     @Test
-    public void setRequiredOnBinder_validate_binderValidationFails() {
+    void setRequiredOnBinder_validate_binderValidationFails() {
         var binder = attachBinderToField(true);
         binder.validate();
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertTrue(statusCaptor.getValue().isError());
-        Assert.assertEquals(BINDER_REQUIRED_MESSAGE,
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_REQUIRED_MESSAGE,
                 statusCaptor.getValue().getMessage().orElse(""));
     }
 
     @Test
-    public void setRequiredOnComponent_validate_binderValidationPasses() {
+    void setRequiredOnComponent_validate_binderValidationPasses() {
         var binder = attachBinderToField();
         field.setRequiredIndicatorVisible(true);
         binder.validate();
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertFalse(statusCaptor.getValue().isError());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
     }
 
     @Test
-    public void setRequiredOnBinder_setValidValue_binderValidationPasses() {
+    void setRequiredOnBinder_setValidValue_binderValidationPasses() {
         attachBinderToField(true);
 
         field.setValue(true);
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertFalse(statusCaptor.getValue().isError());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
     }
 
     private Binder<Bean> attachBinderToField() {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBasicValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBasicValidationTest.java
@@ -17,46 +17,47 @@ package com.vaadin.flow.component.checkbox.tests.validation;
 
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
-import com.vaadin.tests.validation.AbstractBasicValidationTest;
+import com.vaadin.tests.validation.AbstractBasicValidationJUnit6Test;
 
-public class CheckboxGroupBasicValidationTest extends
-        AbstractBasicValidationTest<CheckboxGroup<String>, Set<String>> {
+class CheckboxGroupBasicValidationTest extends
+        AbstractBasicValidationJUnit6Test<CheckboxGroup<String>, Set<String>> {
     @Test
-    public void required_validate_emptyErrorMessageDisplayed() {
+    void required_validate_emptyErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setValue(Set.of("foo"));
         testField.setValue(Set.of());
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new CheckboxGroup.CheckboxGroupI18n()
                 .setRequiredErrorMessage("Field is required"));
         testField.setValue(Set.of("foo"));
         testField.setValue(Set.of());
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
     }
 
     @Test
-    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+    void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new CheckboxGroup.CheckboxGroupI18n()
                 .setRequiredErrorMessage("Field is required"));
         testField.setErrorMessage("Custom error message");
         testField.setValue(Set.of("foo"));
         testField.setValue(Set.of());
-        Assert.assertEquals("Custom error message",
+        Assertions.assertEquals("Custom error message",
                 testField.getErrorMessage());
     }
 
     @Test
-    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new CheckboxGroup.CheckboxGroupI18n()
                 .setRequiredErrorMessage("Field is required"));
@@ -66,7 +67,8 @@ public class CheckboxGroupBasicValidationTest extends
         testField.setErrorMessage("");
         testField.setValue(Set.of("foo"));
         testField.setValue(Set.of());
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
     }
 
     @Override

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBinderValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/CheckboxGroupBinderValidationTest.java
@@ -19,9 +19,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -33,7 +33,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.BindingValidationStatus;
 import com.vaadin.flow.data.binder.BindingValidationStatusHandler;
 
-public class CheckboxGroupBinderValidationTest {
+class CheckboxGroupBinderValidationTest {
     private static final String BINDER_FAIL_MESSAGE = "BINDER_FAIL_MESSAGE";
     private static final String BINDER_REQUIRED_MESSAGE = "REQUIRED";
 
@@ -57,55 +57,55 @@ public class CheckboxGroupBinderValidationTest {
         }
     }
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         MockitoAnnotations.openMocks(this);
         field = new CheckboxGroup<>();
         field.setItems(Arrays.asList("foo", "bar", "baz"));
     }
 
     @Test
-    public void elementWithBinderValidation_invalidValue_binderValidationFails() {
+    void elementWithBinderValidation_invalidValue_binderValidationFails() {
         attachBinderToField();
 
         field.setValue(Collections.singleton("bar"));
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
 
-        Assert.assertTrue(statusCaptor.getValue().isError());
-        Assert.assertEquals(BINDER_FAIL_MESSAGE,
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_FAIL_MESSAGE,
                 statusCaptor.getValue().getMessage().orElse(""));
     }
 
     @Test
-    public void setRequiredOnBinder_validate_binderValidationFails() {
+    void setRequiredOnBinder_validate_binderValidationFails() {
         var binder = attachBinderToField(true);
         binder.validate();
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertTrue(statusCaptor.getValue().isError());
-        Assert.assertEquals(BINDER_REQUIRED_MESSAGE,
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_REQUIRED_MESSAGE,
                 statusCaptor.getValue().getMessage().orElse(""));
     }
 
     @Test
-    public void setRequiredOnComponent_validate_binderValidationPasses() {
+    void setRequiredOnComponent_validate_binderValidationPasses() {
         var binder = attachBinderToField();
         field.setRequiredIndicatorVisible(true);
         binder.validate();
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertFalse(statusCaptor.getValue().isError());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
 
     }
 
     @Test
-    public void setValidValue_binderValidationPasses() {
+    void setValidValue_binderValidationPasses() {
         attachBinderToField();
 
         field.setValue(Collections.singleton("foo"));
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertFalse(statusCaptor.getValue().isError());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
     }
 
     private Binder<Bean> attachBinderToField() {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractComponentDataViewJUnit6Test.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractComponentDataViewJUnit6Test.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dataprovider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.data.provider.AbstractDataView;
+import com.vaadin.flow.data.provider.DataView;
+import com.vaadin.flow.data.provider.HasDataView;
+import com.vaadin.flow.data.provider.InMemoryDataProvider;
+import com.vaadin.flow.data.provider.ItemCountChangeEvent;
+
+// Originally from com.vaadin.flow.data.provider.AbstractComponentDataViewTest
+// If this breaks, check there for updates
+
+/**
+ * Abstract test class that contains the common tests for all generic data view
+ * component's implementations, i.e. which extends {@link AbstractDataView} and
+ * doesn't contain an in-memory or lazy specific API. Concrete implementations
+ * of this class should provide a particular component to be tested as a
+ * {@link HasDataView} implementation.
+ */
+public abstract class AbstractComponentDataViewJUnit6Test {
+
+    protected List<String> items;
+    protected InMemoryDataProvider<String> dataProvider;
+    protected DataView<String> dataView;
+    protected HasDataView<String, ?, ? extends DataView<String>> component;
+
+    @BeforeEach
+    void init() {
+        items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
+        dataProvider = new CustomInMemoryDataProvider<>(items);
+        component = getVerifiedComponent();
+        dataView = component.setItems(dataProvider);
+    }
+
+    @Test
+    void getItems_noFiltersSet_allItemsObtained() {
+        Stream<String> allItems = dataView.getItems();
+        Assertions.assertArrayEquals(items.toArray(), allItems.toArray(),
+                "Unexpected data set");
+    }
+
+    @Test
+    void getItems_filtersSet_filteredItemsObtained() {
+        dataProvider.setFilter(item -> item.equals("first"));
+        Assertions.assertArrayEquals(new String[] { "first" },
+                dataView.getItems().toArray(),
+                "Unexpected data set after filtering");
+    }
+
+    @Test
+    void getItems_sortingSet_sortedItemsObtained() {
+        dataProvider.setSortComparator(String::compareToIgnoreCase);
+        Assertions.assertArrayEquals(new String[] { "first", "last", "middle" },
+                dataView.getItems().toArray(), "Unexpected items sorting");
+    }
+
+    @Test
+    void addItemCountChangeListener_fireEvent_listenerNotified() {
+        AtomicInteger fired = new AtomicInteger(0);
+        dataView.addItemCountChangeListener(
+                event -> fired.compareAndSet(0, event.getItemCount()));
+
+        ComponentUtil.fireEvent((Component) component,
+                new ItemCountChangeEvent<>((Component) component, 10, false));
+
+        Assertions.assertEquals(10, fired.get());
+    }
+
+    protected abstract HasDataView<String, ?, ? extends DataView<String>> getComponent();
+
+    private HasDataView<String, ?, ? extends DataView<String>> getVerifiedComponent() {
+        HasDataView<String, ?, ? extends DataView<String>> component = getComponent();
+        if (component instanceof Component) {
+            return component;
+        }
+        throw new IllegalArgumentException(String.format(
+                "Component subclass is expected, but was given a '%s'",
+                component.getClass().getSimpleName()));
+    }
+
+    protected static class Item {
+        private long id;
+        private String value;
+
+        public Item(long id) {
+            this.id = id;
+        }
+
+        public Item(long id, String value) {
+            this.id = id;
+            this.value = value;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Item item = (Item) o;
+            return id == item.id && Objects.equals(value, item.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, value);
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractListDataViewListenerJUnit6Test.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/AbstractListDataViewListenerJUnit6Test.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.tests.dataprovider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.data.provider.AbstractListDataView;
+import com.vaadin.flow.data.provider.HasListDataView;
+import com.vaadin.flow.function.SerializablePredicate;
+import com.vaadin.tests.MockUIExtension;
+
+// Originally from com.vaadin.flow.data.provider.AbstractListDataViewListenerTest
+// If this breaks, check there for updates
+
+public abstract class AbstractListDataViewListenerJUnit6Test {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
+
+    @Test
+    void addItemCountChangeListener_itemsCountChanged_listenersAreNotified() {
+        String[] items = new String[] { "item1", "item2", "item3", "item4" };
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+        AbstractListDataView<String> dataView = component
+                .setItems(new ArrayList<>(Arrays.asList(items)));
+
+        AtomicInteger invocationCounter = new AtomicInteger(0);
+
+        dataView.addItemCountChangeListener(
+                event -> invocationCounter.incrementAndGet());
+
+        ui.add((Component) component);
+
+        dataView.setFilter("one"::equals);
+        dataView.setFilter(null);
+        dataView.addItemAfter("item5", "item4");
+        dataView.addItemBefore("item0", "item1");
+        dataView.addItem("last");
+        dataView.removeItem("item0");
+
+        ui.fakeClientCommunication();
+
+        Assertions.assertEquals(1, invocationCounter.get(),
+                "Unexpected number of item count change listener invocations "
+                        + "occurred");
+    }
+
+    @Test
+    void addItemCountChangeListener_itemsCountNotChanged_listenersAreNotNotified() {
+        String[] items = new String[] { "item1", "item2", "item3", "item4" };
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+        AbstractListDataView<String> dataView = component.setItems(items);
+
+        AtomicBoolean invocationChecker = new AtomicBoolean(false);
+
+        ui.add((Component) component);
+
+        // Make initial item count change
+        ui.fakeClientCommunication();
+
+        dataView.addItemCountChangeListener(
+                event -> invocationChecker.getAndSet(true));
+
+        dataView.setSortComparator(String::compareTo);
+
+        // Make item count change after sort. No event should be sent as item
+        // count stays the same.
+        ui.fakeClientCommunication();
+
+        Assertions.assertFalse(invocationChecker.get(),
+                "Unexpected item count listener invocation");
+    }
+
+    @Test
+    void addItemCountChangeListener_itemsCountChanged_newItemCountSuppliedInEvent() {
+        String[] items = new String[] { "item1", "item2", "item3", "item4" };
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+        AbstractListDataView<String> dataView = component.setItems(items);
+
+        AtomicBoolean invocationChecker = new AtomicBoolean(false);
+
+        ui.add((Component) component);
+
+        // Make initial item count event
+        ui.fakeClientCommunication();
+
+        dataView.addItemCountChangeListener(event -> {
+            Assertions.assertEquals(1, event.getItemCount(),
+                    "Unexpected item count");
+            Assertions.assertFalse(event.isItemCountEstimated());
+            invocationChecker.set(true);
+        });
+
+        dataView.setFilter("item1"::equals);
+
+        // Item count change should be sent as item count has changed after
+        // filtering.
+        ui.fakeClientCommunication();
+
+        Assertions.assertTrue(invocationChecker.get(),
+                "Item count change never called");
+    }
+
+    @Test
+    void setItems_setNewItemsToComponent_filteringAndSortingRemoved() {
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getVerifiedComponent();
+
+        AbstractListDataView<String> listDataView = component.setItems("item1",
+                "item2", "item3");
+
+        SerializablePredicate<String> filter = "item2"::equals;
+
+        listDataView.setFilter(filter);
+
+        Assertions.assertEquals(1, listDataView.getItemCount(),
+                "Unexpected filtered item count");
+
+        listDataView = component.setItems("item1", "item2", "item3");
+
+        Assertions.assertEquals(3, listDataView.getItemCount(),
+                "Non-filtered item count expected");
+    }
+
+    protected abstract HasListDataView<String, ? extends AbstractListDataView<String>> getComponent();
+
+    private HasListDataView<String, ? extends AbstractListDataView<String>> getVerifiedComponent() {
+        HasListDataView<String, ? extends AbstractListDataView<String>> component = getComponent();
+        if (component instanceof Component) {
+            return component;
+        }
+        throw new IllegalArgumentException(String.format(
+                "Component subclass is expected, but was given a '%s'",
+                component.getClass().getSimpleName()));
+    }
+}


### PR DESCRIPTION
Convert Checkbox / CheckboxGroup unit tests to JUnit 6.

Also adds `AbstractListDataViewListenerJUnit6Test` / `AbstractComponentDataViewJUnit6Test` as JUnit 6 versions of their JUnit 4 equivalent.