### PR TITLE
chore: bump langchain to 1.12.2 (25.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <jakarta.web.api.version>11.0.0</jakarta.web.api.version>
         <spring-data-commons.version>4.0.3</spring-data-commons.version>
         <reactor-core.version>3.8.3</reactor-core.version>
-        <langchain4j.version>1.11.0</langchain4j.version>
+        <langchain4j.version>1.12.2</langchain4j.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
 
         <!-- spreadsheet -->


### PR DESCRIPTION
https://github.com/vaadin/flow/pull/23958 updates Jackson to 3.1 in flow, which now requires `com.fasterxml.jackson.core:jackson-annotations:2.21 `. However the langchain version in flow-components 25.1 brings in `com.fasterxml.jackson.core:jackson-annotations:2.20`, which is lacking `JsonSerializeAs`.

This bumps langchain in 25.1 to the same version used in `main`, which also makes it use `com.fasterxml.jackson.core:jackson-annotations:2.21 `.